### PR TITLE
Add headers on SendGrid emails sent via Sendgrid API

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Please write a short README for your feature/bugfix. This will help people under
 <!--
 This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
 -->
-1. Load up [this PR](https://mautibox.com)
+1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
 2.
 
 <!--

--- a/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
+++ b/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
@@ -144,8 +144,8 @@ class BatchIdToEntityHelper
             return;
         }
 
-        // ['ids' => '1,2,3']
-        if (false !== strpos($ids, ',')) {
+        // ['ids' => '1,2,3'] OR ['ids' => '1']
+        if (false !== strpos($ids, ',') || is_numeric($ids)) {
             $this->ids           = str_getcsv($ids);
             $this->originalKeys  = array_keys($this->ids);
             $this->isAssociative = false;

--- a/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
@@ -36,6 +36,13 @@ class BatchIdToEntityHelperTest extends TestCase
         $this->assertEquals([1, 2, 3], $helper->getIds());
     }
 
+    public function testIdIsExtractedFromIdKeyWithNumericValue(): void
+    {
+        $parameters = ['ids' => '12'];
+        $helper     = new BatchIdToEntityHelper($parameters);
+        $this->assertEquals([12], $helper->getIds());
+    }
+
     public function testErrorSetForIdKeyThatsNotRecognized()
     {
         $parameters = ['ids' => 'foo'];

--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -188,6 +188,10 @@ class ReportSubscriber implements EventSubscriberInterface
             if ($this->companyReportData->eventHasCompanyColumns($event)) {
                 $event->addCompanyLeftJoin($queryBuilder);
             }
+
+            if (!$event->hasGroupBy()) {
+                $queryBuilder->groupBy('ad.asset_id');
+            }
         }
 
         $event->setQueryBuilder($queryBuilder);

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -8,13 +8,48 @@ use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\AssetBundle\EventListener\ReportSubscriber;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\LeadBundle\Model\CompanyReportData;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
+use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var ChannelListHelper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $channelListHelper;
+
+    /**
+     * @var CompanyReportData|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $companyReportData;
+
+    /**
+     * @var DownloadRepository|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $downloadRepository;
+
+    /**
+     * @var QueryBuilder|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $queryBuilder;
+
+    public function setUp(): void
+    {
+        $this->queryBuilder       = $this->createMock(QueryBuilder::class);
+        $this->channelListHelper  = $this->createMock(ChannelListHelper::class);
+        $this->companyReportData  = $this->createMock(CompanyReportData::class);
+        $this->downloadRepository = $this->createMock(DownloadRepository::class);
+
+        if (!defined('MAUTIC_TABLE_PREFIX')) {
+            define('MAUTIC_TABLE_PREFIX', '');
+        }
+    }
+
     public function testOnReportBuilderWithUnknownContext(): void
     {
         $companyReportData = new class() extends CompanyReportData {
@@ -50,7 +85,10 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             {
             }
 
-            public function getCompanyData()
+            /**
+             * @return array<mixed>
+             */
+            public function getCompanyData(): array
             {
                 return [];
             }
@@ -122,23 +160,61 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     private function createTranslatorMock(): TranslatorInterface
     {
         return new class() implements TranslatorInterface {
-            public function trans($id, array $parameters = [], $domain = null, $locale = null)
+            /**
+             * @param array<int|string> $parameters
+             */
+            public function trans($id, array $parameters = [], $domain = null, $locale = null): string
             {
                 return '[trans]'.$id.'[/trans]';
             }
 
+            /**
+             * @param array<int|string> $parameters
+             *
+             * @return string
+             */
             public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
             {
                 return '[trans]'.$id.'[/trans]';
             }
 
-            public function setLocale($locale)
+            public function setLocale($locale): void
             {
             }
 
             public function getLocale()
             {
+                return '';
             }
         };
+    }
+
+    public function testGroupByDefaultConfigured(): void
+    {
+        $report             = new Report();
+        $report->setSource(ReportSubscriber::CONTEXT_ASSET_DOWNLOAD);
+        $event              = new ReportGeneratorEvent($report, [], $this->queryBuilder, $this->channelListHelper);
+        $subscriber         = new ReportSubscriber($this->companyReportData, $this->downloadRepository);
+        $this->queryBuilder->method('from')->willReturn($this->queryBuilder);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('groupBy')
+            ->with('ad.asset_id');
+
+        $this->assertFalse($event->hasGroupBy());
+
+        $subscriber->onReportGenerate($event);
+    }
+
+    public function testGroupByNotDefaultConfigured(): void
+    {
+        $report             = new Report();
+        $report->setSource(ReportSubscriber::CONTEXT_ASSET_DOWNLOAD);
+        $this->queryBuilder->method('from')->willReturn($this->queryBuilder);
+        $report->setGroupBy(['a.id' => 'desc']);
+        $event              = new ReportGeneratorEvent($report, [], $this->queryBuilder, $this->channelListHelper);
+        $subscriber         = new ReportSubscriber($this->companyReportData, $this->downloadRepository);
+        $subscriber->onReportGenerate($event);
+        $this->assertTrue($event->hasGroupBy());
     }
 }

--- a/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
@@ -46,7 +46,7 @@ class CampaignExecutionEvent extends Event
     protected $systemTriggered;
 
     /**
-     * @var bool|array
+     * @var bool|mixed[]|string|null
      */
     protected $result;
 
@@ -76,7 +76,7 @@ class CampaignExecutionEvent extends Event
     protected $channelId;
 
     /**
-     * @param bool $result
+     * @param bool|mixed[]|string|null $result
      */
     public function __construct(array $args, $result, LeadEventLog $log = null)
     {
@@ -151,7 +151,7 @@ class CampaignExecutionEvent extends Event
     }
 
     /**
-     * @return bool
+     * @return bool|mixed[]|string|null
      */
     public function getResult()
     {
@@ -159,7 +159,7 @@ class CampaignExecutionEvent extends Event
     }
 
     /**
-     * @param $result
+     * @param bool|mixed[]|string|null $result
      *
      * @return $this
      */
@@ -173,7 +173,7 @@ class CampaignExecutionEvent extends Event
     /**
      * Set the result to failed.
      *
-     * @param null $reason
+     * @param string|null $reason
      *
      * @return $this
      */

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -12,6 +12,7 @@
 namespace Mautic\CoreBundle\Command;
 
 use Doctrine\DBAL\DBALException;
+use Mautic\LeadBundle\Model\IpAddressModel;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -22,12 +23,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UnusedIpDeleteCommand extends ContainerAwareCommand
 {
-    const DEFAULT_LIMIT = 10000;
+    private const DEFAULT_LIMIT = 10000;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('mautic:unusedip:delete')
             ->setDescription('Deletes IP addresses that are not used in any other database table')
@@ -47,17 +45,15 @@ EOT
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $em             = $this->getContainer()->get('doctrine')->getManager();
-        $ipAddressRepo  = $em->getRepository('MauticCoreBundle:IpAddress');
+        $container = $this->getContainer();
+        /** @var IpAddressModel $ipAddressModel */
+        $ipAddressModel = $container->get('mautic.lead.model.ipaddress');
 
         try {
             $limit       = $input->getOption('limit');
-            $deletedRows = $ipAddressRepo->deleteUnusedIpAddresses($limit);
+            $deletedRows = $ipAddressModel->deleteUnusedIpAddresses((int) $limit);
             $output->writeln(sprintf('<info>%s unused IP addresses have been deleted</info>', $deletedRows));
         } catch (DBALException $e) {
             $output->writeln(sprintf('<error>Deletion of unused IP addresses failed because of database error: %s</error>', $e->getMessage()));

--- a/app/bundles/CoreBundle/Entity/IpAddress.php
+++ b/app/bundles/CoreBundle/Entity/IpAddress.php
@@ -90,7 +90,7 @@ class IpAddress
     /**
      * IpAddress constructor.
      *
-     * @param null $ipAddress
+     * @param string|null $ipAddress
      */
     public function __construct($ipAddress = null)
     {

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -11,6 +11,9 @@
 
 namespace Mautic\CoreBundle\Entity;
 
+use Doctrine\DBAL\Exception;
+use PDO;
+
 /**
  * IpAddressRepository.
  */
@@ -35,72 +38,82 @@ class IpAddressRepository extends CommonRepository
     }
 
     /**
-     * Deletes duplicate IP addresses that are not being used in any other table.
+     * Get IP addresses that are not being used in any other table.
      *
-     * @param int $limit
+     * @return array<int, array<int>>
      *
-     * @return int Number of deleted rows
-     *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws Exception
      */
-    public function deleteUnusedIpAddresses($limit)
+    public function getUnusedIpAddressesIds(int $limit): array
     {
         $prefix = MAUTIC_TABLE_PREFIX;
 
         $sql = <<<SQL
-            DELETE {$prefix}ip_addresses FROM {$prefix}ip_addresses
-            JOIN (
-                SELECT {$prefix}ip_addresses.id FROM {$prefix}ip_addresses
-                    LEFT JOIN {$prefix}asset_downloads 
-                      ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}campaign_lead_event_log 
-                      ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}email_stats 
-                      ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}email_stats_devices 
-                      ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}form_submissions 
-                      ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}lead_ips_xref 
-                      ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}lead_points_change_log 
-                      ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}page_hits 
-                      ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
-                    LEFT JOIN {$prefix}point_lead_action_log 
-                      ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}point_lead_event_log 
-                      ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}push_notification_stats 
-                      ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}sms_message_stats 
-                      ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}stage_lead_action_log 
-                      ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id 
-                    LEFT JOIN {$prefix}video_hits 
-                      ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id 
-                   WHERE {$prefix}asset_downloads.id IS NULL 
-                     AND {$prefix}campaign_lead_event_log.id IS NULL 
-                     AND {$prefix}email_stats.id IS NULL 
-                     AND {$prefix}email_stats_devices.id IS NULL 
-                     AND {$prefix}form_submissions.id IS NULL 
-                     AND {$prefix}lead_ips_xref.lead_id IS NULL 
-                     AND {$prefix}lead_points_change_log.id IS NULL 
-                     AND {$prefix}page_hits.id IS NULL 
-                     AND {$prefix}point_lead_action_log.point_id IS NULL 
-                     AND {$prefix}point_lead_event_log.event_id IS NULL 
-                     AND {$prefix}push_notification_stats.id IS NULL 
-                     AND {$prefix}sms_message_stats.id IS NULL 
-                     AND {$prefix}stage_lead_action_log.stage_id IS NULL 
-                     AND {$prefix}video_hits.id IS NULL 
-                   LIMIT :limit
-                ) sq
-            ON {$prefix}ip_addresses.id = sq.id;
+            SELECT {$prefix}ip_addresses.id FROM {$prefix}ip_addresses
+                LEFT JOIN {$prefix}asset_downloads
+                    ON {$prefix}asset_downloads.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}campaign_lead_event_log
+                    ON {$prefix}campaign_lead_event_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}email_stats
+                    ON {$prefix}email_stats.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}email_stats_devices
+                    ON {$prefix}email_stats_devices.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}form_submissions
+                    ON {$prefix}form_submissions.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}lead_ips_xref
+                    ON {$prefix}lead_ips_xref.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}lead_points_change_log
+                    ON {$prefix}lead_points_change_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}page_hits
+                    ON {$prefix}page_hits.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}point_lead_action_log
+                    ON {$prefix}point_lead_action_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}point_lead_event_log
+                    ON {$prefix}point_lead_event_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}push_notification_stats
+                    ON {$prefix}push_notification_stats.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}sms_message_stats
+                    ON {$prefix}sms_message_stats.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}stage_lead_action_log
+                    ON {$prefix}stage_lead_action_log.ip_id = {$prefix}ip_addresses.id
+                LEFT JOIN {$prefix}video_hits
+                    ON {$prefix}video_hits.ip_id = {$prefix}ip_addresses.id
+            WHERE {$prefix}asset_downloads.id IS NULL
+              AND {$prefix}campaign_lead_event_log.id IS NULL
+              AND {$prefix}email_stats.id IS NULL
+              AND {$prefix}email_stats_devices.id IS NULL
+              AND {$prefix}form_submissions.id IS NULL
+              AND {$prefix}lead_ips_xref.lead_id IS NULL
+              AND {$prefix}lead_points_change_log.id IS NULL
+              AND {$prefix}page_hits.id IS NULL
+              AND {$prefix}point_lead_action_log.point_id IS NULL
+              AND {$prefix}point_lead_event_log.event_id IS NULL
+              AND {$prefix}push_notification_stats.id IS NULL
+              AND {$prefix}sms_message_stats.id IS NULL
+              AND {$prefix}stage_lead_action_log.stage_id IS NULL
+              AND {$prefix}video_hits.id IS NULL
+            LIMIT :limit
 SQL;
-        $params = [':limit' => (int) $limit];
-        $types  = [':limit' => \PDO::PARAM_INT];
-        $stmt   = $this->_em->getConnection()->executeQuery($sql, $params, $types);
 
-        return $stmt->rowCount();
+        $params = [':limit' => $limit];
+        $types  = [':limit' => PDO::PARAM_INT];
+
+        return $this->_em->getConnection()->executeQuery($sql, $params, $types)->fetchAll(PDO::FETCH_COLUMN, 0);
+    }
+
+    /**
+     * @param array<int, array<int>> $ids
+     *
+     * @throws Exception
+     */
+    public function deleteUnusedIpAddresses(array $ids): int
+    {
+        $prefix    = MAUTIC_TABLE_PREFIX;
+        $ids       = implode(',', $ids);
+        $deleteSql = <<<SQL
+                DELETE FROM {$prefix}ip_addresses WHERE {$prefix}ip_addresses.id IN ({$ids});
+SQL;
+
+        return $this->_em->getConnection()->executeUpdate($deleteSql);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Command;
+
+use Exception;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Entity\IpAddressRepository;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class UnusedIpDeleteCommandFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testUnusedIpDeleteCommand(): void
+    {
+        // Emulate unused IP address.
+        /** @var IpAddressRepository $ipAddressRepo */
+        $ipAddressRepo = $this->em->getRepository(IpAddress::class);
+        $ipAddressRepo->saveEntity(new IpAddress('127.0.0.1'));
+        $count = $ipAddressRepo->count(['ipAddress' => '127.0.0.1']);
+        self::assertSame(1, $count);
+
+        // Delete unused IP address.
+        $this->runCommand('mautic:unusedip:delete');
+
+        $count = $ipAddressRepo->count(['ipAddress' => '127.0.0.1']);
+        self::assertSame(0, $count);
+    }
+}

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
@@ -27,28 +27,30 @@ class SendGridMailMetadata
         // Some headers headers are reserved and cannot be sent via API
         // -> https://docs.sendgrid.com/api-reference/mail-send/mail-send
         // 'mime-version', 'date' are allowed, but not needed to be when using API, is put by their server
-        $skip_headers = array(
+        $skip_headers = [
             'x-sg-id', 'x-sg-eid', 'received', 'dkim-signature', 'content-type',
             'content-transfer-encoding', 'to', 'from', 'subject', 'reply-to', 'cc', 'bcc',
             'mime-version', 'date',
-        );
+        ];
 
-        // remove list-unsubscribe header when not Bulk
-        if ('Bulk' != $headers->get('Precedence')) {
-            $skip_headers[] = 'list-unsubscribe';
-            // Mail sent directly should  try to send each time, IMHO, eg: password reset forms!
-            // TODO: turn on BypassBounceManagement
-            // however, current version of vendor SendGrid does not support this object yet
-        }
-
-        foreach ($headers->getAll() as $header) {
-            $key = $header->getFieldName();
-            $value = $header->getFieldBody();
-
-            if (in_array(strtolower($key), $skip_headers) || $value === '') {
-                continue;
+        if (isset($headers)){
+            // remove list-unsubscribe header when not Bulk
+            if ('Bulk' != $headers->get('Precedence')) {
+                $skip_headers[] = 'list-unsubscribe';
+                // Mail sent directly should  try to send each time, IMHO, eg: password reset forms!
+                // TODO: turn on BypassBounceManagement
+                // however, current version of vendor SendGrid does not support this object yet
             }
-            $mail->addHeader($key, $value);
+
+            foreach ($headers->getAll() as $header) {
+                $key   = $header->getFieldName();
+                $value = $header->getFieldBody();
+
+                if (in_array(strtolower($key), $skip_headers) || '' === $value) {
+                    continue;
+                }
+                $mail->addHeader($key, $value);
+            }
         }
 
         if ($message->getReplyTo()) {

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
@@ -22,6 +22,35 @@ class SendGridMailMetadata
     {
         $mail_settings = new MailSettings();
 
+        $headers = $message->getHeaders();
+
+        // Some headers headers are reserved and cannot be sent via API
+        // -> https://docs.sendgrid.com/api-reference/mail-send/mail-send
+        // 'mime-version', 'date' are allowed, but not needed to be when using API, is put by their server
+        $skip_headers = array(
+            'x-sg-id', 'x-sg-eid', 'received', 'dkim-signature', 'content-type',
+            'content-transfer-encoding', 'to', 'from', 'subject', 'reply-to', 'cc', 'bcc',
+            'mime-version', 'date',
+        );
+
+        // remove list-unsubscribe header when not Bulk
+        if ('Bulk' != $headers->get('Precedence')) {
+            $skip_headers[] = 'list-unsubscribe';
+            // Mail sent directly should  try to send each time, IMHO, eg: password reset forms!
+            // TODO: turn on BypassBounceManagement
+            // however, current version of vendor SendGrid does not support this object yet
+        }
+
+        foreach ($headers->getAll() as $header) {
+            $key = $header->getFieldName();
+            $value = $header->getFieldBody();
+
+            if (in_array(strtolower($key), $skip_headers) || $value === '') {
+                continue;
+            }
+            $mail->addHeader($key, $value);
+        }
+
         if ($message->getReplyTo()) {
             $replyTo = new ReplyTo(key($message->getReplyTo()));
             $mail->setReplyTo($replyTo);

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
@@ -34,7 +34,7 @@ class SendGridMailMetadata
         ];
 
         // in prod, this is always defined, but not all tests are mocking headers
-        if (isset($headers)) {
+        if (false === is_null($headers)) {
             /* if ('Bulk' != $headers->get('Precedence')) {
                 // IMHO we should also remove list-unsubscribe header when Precedence != Bulk, but this should be done
                 // where list-unsubscribe is created at no in each transport!

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
@@ -33,14 +33,15 @@ class SendGridMailMetadata
             'mime-version', 'date',
         ];
 
-        if (isset($headers)){
-            // remove list-unsubscribe header when not Bulk
-            if ('Bulk' != $headers->get('Precedence')) {
-                $skip_headers[] = 'list-unsubscribe';
-                // Mail sent directly should  try to send each time, IMHO, eg: password reset forms!
+        // in prod, this is always defined, but not all tests are mocking headers
+        if (isset($headers)) {
+            /* if ('Bulk' != $headers->get('Precedence')) {
+                // IMHO we should also remove list-unsubscribe header when Precedence != Bulk, but this should be done
+                // where list-unsubscribe is created at no in each transport!
+                // However, mail sent directly should  try to send each time, even if address have active bounces
                 // TODO: turn on BypassBounceManagement
-                // however, current version of vendor SendGrid does not support this object yet
-            }
+                // current version of vendor "sendgrid/sendgrid": "~6.0" do not support this feature
+            } */
 
             foreach ($headers->getAll() as $header) {
                 $key   = $header->getFieldName();

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailMetadata.php
@@ -33,25 +33,22 @@ class SendGridMailMetadata
             'mime-version', 'date',
         ];
 
-        // in prod, this is always defined, but not all tests are mocking headers
-        if (false === is_null($headers)) {
-            /* if ('Bulk' != $headers->get('Precedence')) {
-                // IMHO we should also remove list-unsubscribe header when Precedence != Bulk, but this should be done
-                // where list-unsubscribe is created at no in each transport!
-                // However, mail sent directly should  try to send each time, even if address have active bounces
-                // TODO: turn on BypassBounceManagement
-                // current version of vendor "sendgrid/sendgrid": "~6.0" do not support this feature
-            } */
+        /* if ('Bulk' != $headers->get('Precedence')) {
+            // IMHO we should also remove list-unsubscribe header when Precedence != Bulk, but this should be done
+            // where list-unsubscribe is created at no in each transport!
+            // However, mail sent directly should  try to send each time, even if address have active bounces
+            // TODO: turn on BypassBounceManagement
+            // current version of vendor "sendgrid/sendgrid": "~6.0" do not support this feature
+        } */
 
-            foreach ($headers->getAll() as $header) {
-                $key   = $header->getFieldName();
-                $value = $header->getFieldBody();
+        foreach ($headers->getAll() as $header) {
+            $key   = $header->getFieldName();
+            $value = $header->getFieldBody();
 
-                if (in_array(strtolower($key), $skip_headers) || '' === $value) {
-                    continue;
-                }
-                $mail->addHeader($key, $value);
+            if (in_array(strtolower($key), $skip_headers) || '' === $value) {
+                continue;
             }
+            $mail->addHeader($key, $value);
         }
 
         if ($message->getReplyTo()) {

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -31,11 +31,16 @@ class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
     {
         $sendGridMailMetadata = new SendGridMailMetadata();
 
-        $headers = $this->createMock(\Swift_Mime_SimpleHeaderSet::class);
+        $randomvalue = rand(-100, 100);
+        $headers     = $this->createMock(\Swift_Mime_SimpleHeaderSet::class);
 
         $headers->expects($this->once())
             ->method('getAll')
-            ->willReturn([$this->make_header('X-FOO', 'Bar'), $this->make_header('to', 'nobody@email.com')]);
+            ->willReturn([
+                $this->make_header('X-FOO', 'Bar'),
+                $this->make_header('X-rand', $randomvalue),
+                $this->make_header('to', 'nobody@email.com'),
+            ]);
 
         $message = $this->getMockBuilder(\Swift_Mime_SimpleMessage::class)
             ->disableOriginalConstructor()
@@ -61,6 +66,12 @@ class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
 
         $replyTo = new ReplyTo('email@example.com');
         $this->assertEquals($replyTo, $mail->getReplyTo());
+
+        // Header "to" should be ignored
+        $this->assertEquals([
+            'X-FOO'  => 'Bar',
+            'X-rand' => $randomvalue,
+        ], $mail->getheaders());
 
         /**
          * @var MailSettings

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -31,7 +31,7 @@ class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
     {
         $sendGridMailMetadata = new SendGridMailMetadata();
 
-        $randomvalue = rand(-100, 100);
+        $randomvalue = rand(-100, 100) . "";
         $headers     = $this->createMock(\Swift_Mime_SimpleHeaderSet::class);
 
         $headers->expects($this->once())

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -12,7 +12,6 @@
 namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Mail;
 
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
-use PHPUnit\Framework\MockObject\MockObject;
 use SendGrid\BccSettings;
 use SendGrid\Mail;
 use SendGrid\MailSettings;

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -12,6 +12,7 @@
 namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Mail;
 
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
 use SendGrid\BccSettings;
 use SendGrid\Mail;
 use SendGrid\MailSettings;
@@ -19,7 +20,7 @@ use SendGrid\ReplyTo;
 
 class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
 {
-    private function make_header($key, $value)
+    private function make_header(string $key, string $value): MockObject
     {
         $an_header = $this->getMockBuilder(\Swift_Mime_Header::class)
             ->disableOriginalConstructor()

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -19,9 +19,32 @@ use SendGrid\ReplyTo;
 
 class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
 {
+    private function make_header($key, $value)
+    {
+        $an_header = $this->getMockBuilder(\Swift_Mime_Header::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $an_header->method('getFieldName')
+            ->willReturn($key);
+
+        $an_header->method('getFieldBody')
+            ->willReturn($value);
+
+        return $an_header;
+    }
+
     public function testBaseMessage()
     {
         $sendGridMailMetadata = new SendGridMailMetadata();
+
+        $headers = $this->getMockBuilder(\Swift_Mime_SimpleHeaderSet::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $headers->expects($this->once())
+            ->method('getAll')
+            ->willReturn([$this->make_header('X-FOO', 'Bar'), $this->make_header('to', 'nobody@email.com')]);
 
         $message = $this->getMockBuilder(\Swift_Mime_SimpleMessage::class)
             ->disableOriginalConstructor()
@@ -36,6 +59,10 @@ class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
             ->method('getBcc')
             ->with()
             ->willReturn(['bcc@example.com' => 'bcc@example.com']);
+
+        $message->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn($headers);
 
         $mail = new Mail('from', 'subject', 'to', 'content');
 

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -20,19 +20,12 @@ use SendGrid\ReplyTo;
 
 class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
 {
-    private function make_header(string $key, string $value): MockObject
+    private function make_header(string $key, string $value): \Swift_Mime_Header
     {
-        $an_header = $this->getMockBuilder(\Swift_Mime_Header::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $header = new \Swift_Mime_Headers_OpenDKIMHeader($key);
+        $header->setValue($value);
 
-        $an_header->method('getFieldName')
-            ->willReturn($key);
-
-        $an_header->method('getFieldBody')
-            ->willReturn($value);
-
-        return $an_header;
+        return $header;
     }
 
     public function testBaseMessage()

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailMetadataTest.php
@@ -39,9 +39,7 @@ class SendGridMailMetadataTest extends \PHPUnit\Framework\TestCase
     {
         $sendGridMailMetadata = new SendGridMailMetadata();
 
-        $headers = $this->getMockBuilder(\Swift_Mime_SimpleHeaderSet::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $headers = $this->createMock(\Swift_Mime_SimpleHeaderSet::class);
 
         $headers->expects($this->once())
             ->method('getAll')

--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -152,7 +152,6 @@ class FormType extends AbstractType
         $builder->add('renderStyle', YesNoButtonGroupType::class, [
             'label'      => 'mautic.form.form.renderstyle',
             'data'       => (null === $options['data']->getRenderStyle()) ? true : $options['data']->getRenderStyle(),
-            'empty_data' => true,
             'attr'       => [
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip',
             ],

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -244,7 +244,7 @@ class LeadTimelineEvent extends Event
             return [];
         }
 
-        $events = call_user_func_array('array_merge', $this->events);
+        $events = call_user_func_array('array_merge', array_values($this->events));
 
         foreach ($events as &$e) {
             if (!$e['timestamp'] instanceof \DateTime) {

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -238,6 +238,18 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface
                 $contacts[$contact->getId()] = $contact;
             }
         }
+
+        if (!$sms->isPublished()) {
+            foreach ($contacts as $leadId => $lead) {
+                $results[$leadId] = [
+                    'sent'   => false,
+                    'status' => 'mautic.sms.campaign.failed.unpublished',
+                ];
+            }
+
+            return $results;
+        }
+
         $contactIds = array_keys($contacts);
 
         /** @var DoNotContactRepository $dncRepo */

--- a/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\SmsBundle\Tests\EventListener;
+
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\SmsBundle\Entity\Sms;
+use Mautic\SmsBundle\EventListener\CampaignSendSubscriber;
+use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Sms\TransportChain;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var mixed[]
+     */
+    private $args;
+
+    /**
+     * @var MockObject|SmsModel
+     */
+    private $smsModel;
+
+    /**
+     * @var MockObject|TransportChain
+     */
+    private $transportChain;
+
+    protected function setUp(): void
+    {
+        $this->smsModel       = $this->createMock(SmsModel::class);
+        $this->transportChain = $this->createMock(TransportChain::class);
+
+        $lead = new Lead();
+        $lead->setId(1);
+        $this->args = [
+            'lead'            => $lead,
+            'event'           => [
+                'type'       => 'sms.send_text_sms',
+                'properties' => ['sms' => 1],
+            ],
+            'eventDetails'    => [],
+            'systemTriggered' => true,
+            'eventSettings'   => [],
+        ];
+    }
+
+    public function testSendDeletedSms(): void
+    {
+        $this->smsModel->expects(self::once())->method('getEntity')->willReturn(null);
+
+        $event = new CampaignExecutionEvent($this->args, false, null);
+
+        $this->CampaignSendSubscriber()->onCampaignTriggerAction($event);
+        self::assertTrue((bool) $event->getResult()['failed']);
+        self::assertSame('mautic.sms.campaign.failed.missing_entity', $event->getResult()['reason']);
+    }
+
+    public function testSendUnpublishedSms(): void
+    {
+        $lead = new Lead();
+        $lead->setId(1);
+        $sms = new Sms();
+        $sms->setIsPublished(false);
+        $this->smsModel->expects(self::once())->method('getEntity')->willReturn($sms);
+
+        $event = new CampaignExecutionEvent($this->args, false, null);
+
+        $this->CampaignSendSubscriber()->onCampaignTriggerAction($event);
+        self::assertTrue((bool) $event->getResult()['failed']);
+        self::assertSame('mautic.sms.campaign.failed.unpublished', $event->getResult()['reason']);
+    }
+
+    private function CampaignSendSubscriber(): CampaignSendSubscriber
+    {
+        return new CampaignSendSubscriber($this->smsModel, $this->transportChain);
+    }
+}

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -1,37 +1,116 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\Model;
 
+use Doctrine\ORM\EntityManager;
+use Mautic\ChannelBundle\Model\MessageQueueModel;
+use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\PageBundle\Model\TrackableModel;
+use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\SmsRepository;
 use Mautic\SmsBundle\Form\Type\SmsType;
 use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Sms\TransportChain;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SmsModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * @var MockObject|CacheStorageHelper
+     */
+    private $cacheStorageHelper;
+
+    /**
+     * @var MockObject|EntityManager
+     */
+    private $entityManger;
+
+    /**
+     * @var MockObject|LeadModel
+     */
+    private $leadModel;
+
+    /**
+     * @var MockObject|MessageQueueModel
+     */
+    private $messageQueueModel;
+
+    /**
+     * @var MockObject|TrackableModel
+     */
+    private $pageTrackableModel;
+
+    /**
+     * @var MockObject|TransportChain
+     */
+    private $transport;
+
+    private SmsModel $smsModel;
+
+    protected function setUp(): void
+    {
+        $this->pageTrackableModel = $this->createMock(TrackableModel::class);
+        $this->leadModel          = $this->createMock(LeadModel::class);
+        $this->messageQueueModel  = $this->createMock(MessageQueueModel::class);
+        $this->transport          = $this->createMock(TransportChain::class);
+        $this->cacheStorageHelper = $this->createMock(CacheStorageHelper::class);
+        $this->entityManger       = $this->createMock(EntityManager::class);
+        $this->smsModel           = new SmsModel(
+            $this->pageTrackableModel,
+            $this->leadModel,
+            $this->messageQueueModel,
+            $this->transport,
+            $this->cacheStorageHelper
+        );
+    }
+
+    /**
      * Test to get lookup results when class name is sent as a parameter.
      */
-    public function testGetLookupResultsWhenTypeIsClass()
+    public function testGetLookupResultsWhenTypeIsClass(): void
     {
-        $entities       = [['name' => 'Mautic', 'id' => 1, 'language' => 'cs']];
+        $entities = [['name' => 'Mautic', 'id' => 1, 'language' => 'cs']];
+
+        /** @var MockObject|SmsRepository $repositoryMock */
         $repositoryMock = $this->createMock(SmsRepository::class);
         $repositoryMock->method('getSmsList')
             ->with('', 10, 0, true, false)
             ->willReturn($entities);
+
         // Partial mock, mocks just getRepository
+        /** @var MockObject|SmsModel $smsModel */
         $smsModel = $this->getMockBuilder(SmsModel::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getRepository'])
             ->getMock();
         $smsModel->method('getRepository')
             ->willReturn($repositoryMock);
+
         $securityMock = $this->createMock(CorePermissions::class);
+
         $securityMock->method('isGranted')
             ->with('sms:smses:viewother')
             ->willReturn(true);
         $smsModel->setSecurity($securityMock);
+
         $textMessages = $smsModel->getLookupResults(SmsType::class);
         $this->assertSame('Mautic', $textMessages['cs'][1], 'Mautic is the right text message name');
+    }
+
+    public function testSendSmsNotPublished(): void
+    {
+        $sms = new Sms();
+        $sms->setIsPublished(false);
+        $lead = new Lead();
+        $lead->setId(1);
+        $this->smsModel->setEntityManager($this->entityManger);
+        $results = $this->smsModel->sendSms($sms, $lead);
+        self::assertFalse((bool) $results[1]['sent']);
+        self::assertSame('mautic.sms.campaign.failed.unpublished', $results[1]['status']);
     }
 }

--- a/app/bundles/SmsBundle/Translations/en_US/messages.ini
+++ b/app/bundles/SmsBundle/Translations/en_US/messages.ini
@@ -104,6 +104,7 @@ mautic.sms.create.in.campaign.builder="Seems there are none! Try changing a filt
 mautic.sms.campaign.failed.not_contactable="Contact is not contactable on the SMS channel."
 mautic.sms.campaign.failed.missing_number="Missing phone number for contact."
 mautic.sms.campaign.failed.missing_entity="The specified SMS entity does not exist."
+mautic.sms.campaign.failed.unpublished="The specified SMS was unpublished."
 mautic.sms.show.total.sent="Total sent"
 mautic.sms.show.failed="Failed"
 mautic.sms.permissions.header="Text Message Permissions"

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -117,11 +117,6 @@ class UserApiController extends CommonApiController
                 if (!empty($parameters['username'])) {
                     unset($parameters['username']);
                 }
-
-                //Changing the role via the API is forbidden
-                if (!empty($parameters['role'])) {
-                    unset($parameters['role']);
-                }
             } else {
                 //PUT requires the entire entity so overwrite the username with the original
                 $parameters['username'] = $entity->getUsername();

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\UserBundle\Tests\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\UserBundle\Entity\Permission;
+use Mautic\UserBundle\Entity\Role;
+use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UserApiControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testRoleUpdateByApiGivesErrorResponseIfUserDoesNotExist(): void
+    {
+        // Assuming user with id 99999 does not exist
+        $this->client->request(Request::METHOD_PATCH, '/api/users/99999/edit', ['role' => 1]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString('"message":"Item was not found."', $clientResponse->getContent());
+    }
+
+    public function testRoleUpdateByApiGivesErrorResponseIfRoleDoesNotExist(): void
+    {
+        // Assuming role with id 99999 does not exist
+        $this->client->request(Request::METHOD_PATCH, '/api/users/1/edit', ['role' => 99999]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString('"message":"role: This value is not valid."', $clientResponse->getContent());
+    }
+
+    public function testRoleUpdateByApiGivesErrorResponseWithInvalidRequestFormat(): void
+    {
+        // Correct request format is ['role' => 2]
+        $this->client->request(Request::METHOD_PATCH, '/api/users/1/edit', ['role' => ['id' => 2]]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString('"message":"role: This value is not valid."', $clientResponse->getContent());
+    }
+
+    public function testRoleUpdateByApiGivesErrorResponseIfUserDoesNotHaveValidPermissionToUpdate(): void
+    {
+        // Create non-admin role
+        $role = $this->createRole();
+        // Create permissions for the role
+        $this->createPermission('lead:leads:viewown', $role, 1024);
+        // Create non-admin user
+        $user = $this->createUser($role);
+        $this->em->flush();
+        $this->em->clear();
+
+        // Login newly created non-admin user
+        $this->loginUser($user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_USER', $user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_PW', 'mautic');
+
+        $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString(
+            '"message":"You do not have access to the requested area\/action."',
+            $clientResponse->getContent()
+        );
+    }
+
+    public function testRoleUpdateByApiThroughAdminUserGivesSuccessResponse(): void
+    {
+        // Create admin role
+        $role = $this->createRole(true);
+        // Create admin user
+        $user = $this->createUser($role);
+        $this->em->flush();
+        $this->em->clear();
+
+        // Login newly created admin user
+        $this->loginUser($user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_USER', $user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_PW', 'mautic');
+
+        $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString('"username":"'.$user->getUsername().'"', $clientResponse->getContent());
+    }
+
+    public function testRoleUpdateByApiThroughNonAdminUserGivesSuccessResponse(): void
+    {
+        // Create non-admin role
+        $role = $this->createRole();
+        // Create permissions to update user for the role
+        $this->createPermission('user:users:edit', $role, 52);
+        // Create non-admin user
+        $user = $this->createUser($role);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->loginUser($user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_USER', $user->getUsername());
+        $this->client->setServerParameter('PHP_AUTH_PW', 'mautic');
+
+        $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
+        $clientResponse = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        Assert::assertStringContainsString('"username":"'.$user->getUsername().'"', $clientResponse->getContent());
+    }
+
+    private function createRole(bool $isAdmin = false): Role
+    {
+        $role = new Role();
+        $role->setName('Role');
+        $role->setIsAdmin($isAdmin);
+        $this->em->persist($role);
+
+        return $role;
+    }
+
+    private function createPermission(string $rawPermission, Role $role, int $bitwise): void
+    {
+        $parts      = explode(':', $rawPermission);
+        $permission = new Permission();
+        $permission->setBundle($parts[0]);
+        $permission->setName($parts[1]);
+        $permission->setRole($role);
+        $permission->setBitwise($bitwise);
+        $this->em->persist($permission);
+    }
+
+    private function createUser(Role $role): User
+    {
+        $user = new User();
+        $user->setFirstName('John');
+        $user->setLastName('Doe');
+        $user->setUsername('john.doe');
+        $user->setEmail('john.doe@email.com');
+        $encoder = self::$container->get('security.encoder_factory')->getEncoder($user);
+        $user->setPassword($encoder->encodePassword('mautic', null));
+        $user->setRole($role);
+        $this->em->persist($user);
+
+        return $user;
+    }
+}

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,9 +1,9 @@
 {
-  "version": "4.1.0",
+  "version": "4.1.1",
   "stability": "stable",
   "minimum_php_version": "7.4.0",
   "maximum_php_version": "8.0.99",
   "show_php_version_warning_if_under": "7.4.0",
   "minimum_mautic_version": "3.2.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.1.0"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.1.1"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
 	level: 6
 	reportUnmatchedIgnoredErrors: false
 	parallel:
-		maximumNumberOfProcesses: 1
+		maximumNumberOfProcesses: 4
 		processTimeout: 1000.0
 	paths:
 		- app/bundles
@@ -28,6 +28,10 @@ parameters:
 		- app/bundles/CoreBundle/Loader/ParameterLoader.php
 		- app/bundles/CoreBundle/Helper/PathsHelper.php
 		- app/bundles/CoreBundle/Configurator/Configurator.php
+	dynamicConstantNames:
+		- MAUTIC_ENV
+		- MAUTIC_TABLE_PREFIX
+		- MAUTIC_VERSION
 	ignoreErrors:
 		- '#Cannot unset offset#'
 		- '#Undefined variable: \$parameters#'

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/grapesjs-custom.css
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/grapesjs-custom.css
@@ -183,7 +183,6 @@ html {
 
 .gjs-field-radio {
   width: 100%;
-  background: #f0f0f0;
 }
 
 .gjs-field-radio #gjs-sm-input-holder {

--- a/plugins/GrapesJsBuilderBundle/Translations/en_US/javascript.ini
+++ b/plugins/GrapesJsBuilderBundle/Translations/en_US/javascript.ini
@@ -1,4 +1,4 @@
-grapesjsbuilder.sourceEditBtnLabel="Edit"
+grapesjsbuilder.sourceEditBtnLabel="Save"
 grapesjsbuilder.sourceCancelBtnLabel="Cancel"
 grapesjsbuilder.sourceEditModalTitle="Edit code"
 grapesjsbuilder.sourceSyntaxError="Please fix the following error:"


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ yes ]
| Deprecations?                          | [ no ]
| BC breaks? (use the c.x branch)        | [ no ]
| Automated tests included?              | [ code is called on addMetadataToMail on SendGridApiMessageTest.php  ] 
| Issue(s) addressed                     | Fixes #10688

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This fix missing header `list-unsubscribe` when using transport set `Sendgrid API`.

New behavior to be discussed if should be merged: I'm removing `list-unsubscribe` if the `Precedence` is `Bulk`

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. See steps in the #10688 



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10690"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

