### PR TITLE
Fix group by If you use count columns for assets download

### DIFF
--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -188,6 +188,10 @@ class ReportSubscriber implements EventSubscriberInterface
             if ($this->companyReportData->eventHasCompanyColumns($event)) {
                 $event->addCompanyLeftJoin($queryBuilder);
             }
+
+            if (!$event->hasGroupBy()) {
+                $queryBuilder->groupBy('ad.asset_id');
+            }
         }
 
         $event->setQueryBuilder($queryBuilder);

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -44,6 +44,10 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->channelListHelper  = $this->createMock(ChannelListHelper::class);
         $this->companyReportData  = $this->createMock(CompanyReportData::class);
         $this->downloadRepository = $this->createMock(DownloadRepository::class);
+
+        if (!defined('MAUTIC_TABLE_PREFIX')) {
+            define('MAUTIC_TABLE_PREFIX', '');
+        }
     }
 
     public function testOnReportBuilderWithUnknownContext(): void
@@ -185,7 +189,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         };
     }
 
-    public function testGroupByIfNotConfigured(): void
+    public function testGroupByDefaultConfigured(): void
     {
         $report             = new Report();
         $report->setSource(ReportSubscriber::CONTEXT_ASSET_DOWNLOAD);
@@ -200,7 +204,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber->onReportGenerate($event);
     }
 
-    public function testGroupByIfConfigured(): void
+    public function testGroupByNotDefaultConfigured(): void
     {
         $report             = new Report();
         $report->setSource(ReportSubscriber::CONTEXT_ASSET_DOWNLOAD);
@@ -209,9 +213,8 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $event              = new ReportGeneratorEvent($report, [], $this->queryBuilder, $this->channelListHelper);
         $subscriber         = new ReportSubscriber($this->companyReportData, $this->downloadRepository);
 
-        $this->queryBuilder->expects($this->once())
-            ->method('groupBy')
-            ->with('a.id');
+        $this->queryBuilder->expects($this->never())
+            ->method('groupBy');
 
         $subscriber->onReportGenerate($event);
     }

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -16,8 +16,6 @@ use Mautic\ReportBundle\Helper\ReportHelper;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Translation\TranslatorInterface;
 
-define('MAUTIC_TABLE_PREFIX', '');
-
 class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -209,9 +209,9 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $event              = new ReportGeneratorEvent($report, [], $this->queryBuilder, $this->channelListHelper);
         $subscriber         = new ReportSubscriber($this->companyReportData, $this->downloadRepository);
 
-        $this->queryBuilder->expects($this->never())
+        $this->queryBuilder->expects($this->once())
             ->method('groupBy')
-            ->with('ad.asset_id');
+            ->with('a.id');
 
         $subscriber->onReportGenerate($event);
     }

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -201,6 +201,8 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('groupBy')
             ->with('ad.asset_id');
 
+        $this->assertFalse($event->hasGroupBy());
+
         $subscriber->onReportGenerate($event);
     }
 
@@ -212,10 +214,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $report->setGroupBy(['a.id' => 'desc']);
         $event              = new ReportGeneratorEvent($report, [], $this->queryBuilder, $this->channelListHelper);
         $subscriber         = new ReportSubscriber($this->companyReportData, $this->downloadRepository);
-
-        $this->queryBuilder->expects($this->never())
-            ->method('groupBy');
-
         $subscriber->onReportGenerate($event);
+        $this->assertTrue($event->hasGroupBy());
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | no
| Related user documentation PR URL      | no need
| Related developer documentation PR URL | no need
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Just follow up fix for already merged https://github.com/mautic/mautic/pull/9641
If we use assets downloads or unique downloads - these fields are COUNT type. And 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. Use more assets with few downloads
3. Create report assets downloads
<img width="455" alt="Capture d’écran 2021-12-24 à 08 55 24" src="https://user-images.githubusercontent.com/14075239/147331731-6c136236-a234-4ade-89d2-8cbd40526e45.png">
4. Add download count and unique download count columns
<img width="427" alt="Capture d’écran 2021-12-24 à 08 55 37" src="https://user-images.githubusercontent.com/14075239/147331754-459af92b-5965-4ba3-8bbe-42043aa062ec.png">
5. Your results should be group to one results
<img width="1058" alt="Capture d’écran 2021-12-24 à 08 55 49" src="https://user-images.githubusercontent.com/14075239/147331771-0b9f7858-77d6-4ce1-8f01-82a2be63ffda.png">
6. After PR you see correct numbers

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10693"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

