### PR TITLE
Fixing issues when using PHPSTAN with more processes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
 	level: 6
 	reportUnmatchedIgnoredErrors: false
 	parallel:
-		maximumNumberOfProcesses: 1
+		maximumNumberOfProcesses: 4
 		processTimeout: 1000.0
 	paths:
 		- app/bundles
@@ -28,6 +28,10 @@ parameters:
 		- app/bundles/CoreBundle/Loader/ParameterLoader.php
 		- app/bundles/CoreBundle/Helper/PathsHelper.php
 		- app/bundles/CoreBundle/Configurator/Configurator.php
+	dynamicConstantNames:
+		- MAUTIC_ENV
+		- MAUTIC_TABLE_PREFIX
+		- MAUTIC_VERSION
 	ignoreErrors:
 		- '#Cannot unset offset#'
 		- '#Undefined variable: \$parameters#'


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We had to run PHPSTAN in a single process because the parallel processes evaluated constants differently every time. Thanks to the discussion in

https://github.com/phpstan/phpstan/discussions/6169

and the docs in 

https://phpstan.org/config-reference#constants

We are able to run PHPSTAN cleanly in multiple processes with baseline as well.

#### Steps to test this PR:
1. See that PHPSTAN is green in the CI and it runs faster (3 minutes) than it used to (4 minutes)

#### Other areas of Mautic that may be affected by the change:
1. None, it's just PHPSTAN configuration change.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10696"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

