### PR TITLE
Fixes 500 error in forms when render style is deactivated against 4.1

### DIFF
--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -152,7 +152,6 @@ class FormType extends AbstractType
         $builder->add('renderStyle', YesNoButtonGroupType::class, [
             'label'      => 'mautic.form.form.renderstyle',
             'data'       => (null === $options['data']->getRenderStyle()) ? true : $options['data']->getRenderStyle(),
-            'empty_data' => true,
             'attr'       => [
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip',
             ],


### PR DESCRIPTION
Same as https://github.com/mautic/mautic/pull/10673 but we need to get it to the 4.1 branch too.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10697"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

