### PR TITLE
Fix contact batch api for single id value

### DIFF
--- a/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
+++ b/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
@@ -144,8 +144,8 @@ class BatchIdToEntityHelper
             return;
         }
 
-        // ['ids' => '1,2,3']
-        if (false !== strpos($ids, ',')) {
+        // ['ids' => '1,2,3'] OR ['ids' => '1']
+        if (false !== strpos($ids, ',') || is_numeric($ids)) {
             $this->ids           = str_getcsv($ids);
             $this->originalKeys  = array_keys($this->ids);
             $this->isAssociative = false;

--- a/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
@@ -36,6 +36,13 @@ class BatchIdToEntityHelperTest extends TestCase
         $this->assertEquals([1, 2, 3], $helper->getIds());
     }
 
+    public function testIdIsExtractedFromIdKeyWithNumericValue(): void
+    {
+        $parameters = ['ids' => '12'];
+        $helper     = new BatchIdToEntityHelper($parameters);
+        $this->assertEquals([12], $helper->getIds());
+    }
+
     public function testErrorSetForIdKeyThatsNotRecognized()
     {
         $parameters = ['ids' => 'foo'];


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |[x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
API endpoint: /api/contacts/batch/* - It works only if the ids value contains at least one comma ['id' => '1,2,3'].
It is not working with single id value. ['id' => '1'].
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->


#### Steps to reproduce the bug:
1. Open postman
2. Create a request for contacts batch delete api with single id [Ex. https://your.mautic.net/api/contacts/batch/delete?ids=1 ]
3. Click on send.
4. Verify the response - Contact is not deleted for requested Id.


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Load up [this PR](https://mautibox.com)
2. Follow the steps to reproduce the bug.
3. Verify the response - Contact should deleted for requested Id.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10700"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

