### PR TITLE
Confirmation unpublishing campaign workflow

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2076,7 +2076,7 @@ Mautic.showCampaignConfirmation = function (el) {
 };
 
 /**
- * Cancel Callback to trigger the yes button and dismiss the confirmation window.
+ * Cancel Callback to trigger the yes button and dismiss the confirmation modal.
  */
 Mautic.setPublishedButtonToYes = function (el) {
     // Dismiss the confirmation
@@ -2090,6 +2090,9 @@ Mautic.setPublishedButtonToYes = function (el) {
     }
 };
 
+/**
+ * Onclick Callback to show the confirmation modal during toggling campaign status.
+ */
 Mautic.confirmationCampaignPublishStatus = function (el) {
     let element = mQuery(el);
 
@@ -2103,6 +2106,9 @@ Mautic.confirmationCampaignPublishStatus = function (el) {
     }
 }
 
+/**
+ * Confirm Callback to toggling campaign status if user chooses Yes.
+ */
 Mautic.confirmCallbackCampaignPublishStatus = function (action, el) {
     let element = mQuery(el);
 

--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2065,58 +2065,27 @@ Mautic.highlightJumpTarget = function(event, el) {
     }
 };
 
+/**
+ * Display confirmation modal if user wishes to unpublish the campaign.
+ */
 Mautic.showCampaignConfirmation = function (el) {
-    if (mQuery(el).prop('checked')) {
-        if (mQuery(el).val() === "0") {
-            var message = mQuery(el).data('message');
-            var confirmText = mQuery(el).data('confirm-text');
-            var cancelText = mQuery(el).data('cancel-text');
-            var cancelCallback = mQuery(el).data('cancel-callback');
+    let element = mQuery(el);
+    if (element.prop('checked') && element.val() === "0") {
+        Mautic.showConfirmation(element);
+    }
+};
 
-            var confirmContainer = mQuery("<div />").attr({"class": "modal fade confirmation-modal"});
-            var confirmDialogDiv = mQuery("<div />").attr({"class": "modal-dialog"});
-            var confirmContentDiv = mQuery("<div />").attr({"class": "modal-content"});
-            var confirmFooterDiv = mQuery("<div />").attr({"class": "modal-body text-center"});
-            var confirmHeaderDiv = mQuery("<div />").attr({"class": "modal-header"});
-            confirmHeaderDiv.append(mQuery('<h4 />').attr({"class": "modal-title"}).text(message));
-            var confirmButton = mQuery('<button type="button" />')
-                .addClass("btn btn-danger")
-                .css("marginRight", "5px")
-                .css("marginLeft", "5px")
-                .click(function () {
-                    Mautic.dismissConfirmation();
-                })
-                .html(confirmText);
-            var cancelButton = mQuery('<button type="button" />')
-                .addClass("btn btn-primary")
-                .click(function (e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    mQuery(el).prop('checked', false);
-                    mQuery(el).parent().toggleClass('active');
-                    // Undo to the click, i.e. choose Yes and make it default correct the form value as well.
-                    if (cancelCallback && typeof Mautic[cancelCallback] === "function") {
-                        window["Mautic"][cancelCallback].apply('window', []);
-                    } else {
-                        Mautic.dismissConfirmation();
-                    }
-                })
-                .html(cancelText);
+/**
+ * Cancel Callback to trigger the yes button and dismiss the confirmation window.
+ */
+Mautic.setPublishedButtonToYes = function (el) {
+    // Dismiss the confirmation
+    Mautic.dismissConfirmation();
 
-            confirmFooterDiv.append(confirmButton);
-            confirmFooterDiv.append(cancelButton);
-
-            confirmContentDiv.append(confirmHeaderDiv);
-            confirmContentDiv.append(confirmFooterDiv);
-
-            confirmContainer.append(confirmDialogDiv.append(confirmContentDiv));
-            mQuery('body').append(confirmContainer);
-
-            mQuery('.confirmation-modal').on('hidden.bs.modal', function () {
-                mQuery(this).remove();
-            });
-
-            mQuery('.confirmation-modal').modal('show');
-        }
+    // Find the yes button id and trigger click event
+    var yesButton  = mQuery(el).parent('.btn-no').siblings('.btn-yes').children('input');
+    var yesButtonId = mQuery(yesButton).attr('id');
+    if (yesButtonId !== undefined) {
+        mQuery('#' + yesButtonId).trigger('click');
     }
 };

--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2070,7 +2070,7 @@ Mautic.highlightJumpTarget = function(event, el) {
  */
 Mautic.showCampaignConfirmation = function (el) {
     let element = mQuery(el);
-    if (element.prop('checked') && element.val() === "0") {
+    if (element.prop('checked') && element.val() !== "1") {
         Mautic.showConfirmation(element);
     }
 };
@@ -2087,6 +2087,8 @@ Mautic.setPublishedButtonToYes = function (el) {
     var yesButtonId = mQuery(yesButton).attr('id');
     if (yesButtonId !== undefined) {
         mQuery('#' + yesButtonId).trigger('click');
+        mQuery(el).parent('.btn-no').removeClass('active');
+        mQuery(el).parent('.btn-no').siblings('.btn-yes').addClass('active');
     }
 };
 

--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2065,5 +2065,58 @@ Mautic.highlightJumpTarget = function(event, el) {
     }
 };
 
+Mautic.showCampaignConfirmation = function (el) {
+    if (mQuery(el).prop('checked')) {
+        if (mQuery(el).val() === "0") {
+            var message = mQuery(el).data('message');
+            var confirmText = mQuery(el).data('confirm-text');
+            var cancelText = mQuery(el).data('cancel-text');
+            var cancelCallback = mQuery(el).data('cancel-callback');
 
+            var confirmContainer = mQuery("<div />").attr({"class": "modal fade confirmation-modal"});
+            var confirmDialogDiv = mQuery("<div />").attr({"class": "modal-dialog"});
+            var confirmContentDiv = mQuery("<div />").attr({"class": "modal-content"});
+            var confirmFooterDiv = mQuery("<div />").attr({"class": "modal-body text-center"});
+            var confirmHeaderDiv = mQuery("<div />").attr({"class": "modal-header"});
+            confirmHeaderDiv.append(mQuery('<h4 />').attr({"class": "modal-title"}).text(message));
+            var confirmButton = mQuery('<button type="button" />')
+                .addClass("btn btn-danger")
+                .css("marginRight", "5px")
+                .css("marginLeft", "5px")
+                .click(function () {
+                    Mautic.dismissConfirmation();
+                })
+                .html(confirmText);
+            var cancelButton = mQuery('<button type="button" />')
+                .addClass("btn btn-primary")
+                .click(function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    mQuery(el).prop('checked', false);
+                    mQuery(el).parent().toggleClass('active');
+                    // Undo to the click, i.e. choose Yes and make it default correct the form value as well.
+                    if (cancelCallback && typeof Mautic[cancelCallback] === "function") {
+                        window["Mautic"][cancelCallback].apply('window', []);
+                    } else {
+                        Mautic.dismissConfirmation();
+                    }
+                })
+                .html(cancelText);
 
+            confirmFooterDiv.append(confirmButton);
+            confirmFooterDiv.append(cancelButton);
+
+            confirmContentDiv.append(confirmHeaderDiv);
+            confirmContentDiv.append(confirmFooterDiv);
+
+            confirmContainer.append(confirmDialogDiv.append(confirmContentDiv));
+            mQuery('body').append(confirmContainer);
+
+            mQuery('.confirmation-modal').on('hidden.bs.modal', function () {
+                mQuery(this).remove();
+            });
+
+            mQuery('.confirmation-modal').modal('show');
+        }
+    }
+};

--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2089,3 +2089,32 @@ Mautic.setPublishedButtonToYes = function (el) {
         mQuery('#' + yesButtonId).trigger('click');
     }
 };
+
+Mautic.confirmationCampaignPublishStatus = function (el) {
+    let element = mQuery(el);
+
+    // Add the confirmation modal, if current status is published
+    if (element.data('status') === 'published') {
+        Mautic.showConfirmation(element);
+    }
+    else {
+        // Otherwise just change the status.
+        Mautic.confirmCallbackCampaignPublishStatus('', el);
+    }
+}
+
+Mautic.confirmCallbackCampaignPublishStatus = function (action, el) {
+    let element = mQuery(el);
+
+    let idClass = element.data('id-class');
+    let model = element.data('model');
+    let itemId = element.data('item-id');
+    let query = element.data('query');
+    let backdrop = element.data('backdrop');
+
+    // Toggles published status of an campaign
+    Mautic.togglePublishStatus(event, idClass, model, itemId, query, backdrop);
+
+    // Dismiss the confirmation
+    Mautic.dismissConfirmation();
+}

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -196,7 +196,10 @@ return [
         'forms'        => [
             'mautic.campaign.type.form'                 => [
                 'class'     => 'Mautic\CampaignBundle\Form\Type\CampaignType',
-                'arguments' => 'mautic.security',
+                'arguments' => [
+                    'mautic.security',
+                    'translator',
+                ],
             ],
             'mautic.campaignrange.type.action'          => [
                 'class' => 'Mautic\CampaignBundle\Form\Type\EventType',

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
+use Mautic\CoreBundle\Entity\PublishStatusIconAttributesInterface;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Lead as Contact;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -26,7 +27,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 /**
  * Class Campaign.
  */
-class Campaign extends FormEntity
+class Campaign extends FormEntity implements PublishStatusIconAttributesInterface
 {
     /**
      * @var int
@@ -639,5 +640,28 @@ class Campaign extends FormEntity
                     )
                     ->orderBy(['dateAdded' => Criteria::DESC])
         );
+    }
+
+    public function getOnclickMethod(): string
+    {
+        return 'Mautic.confirmationCampaignPublishStatus(mQuery(this));';
+    }
+
+    public function getDataAttributes(): array
+    {
+        return [
+            'data-toggle'           => 'confirmation',
+            'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
+            'data-cancel-callback'  => 'dismissConfirmation',
+        ];
+    }
+
+    public function getTranslationKeysDataAttributes(): array
+    {
+        return [
+            'data-message'      => 'mautic.campaign.form.confirmation.message',
+            'data-confirm-text' => 'mautic.campaign.form.confirmation.confirm_text',
+            'data-cancel-text'  => 'mautic.campaign.form.confirmation.cancel_text',
+        ];
     }
 }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -80,21 +80,11 @@ class CampaignType extends AbstractType
             'bundle' => 'campaign',
         ]);
 
+        $attr = [];
         if (!empty($options['data']) && $options['data']->getId()) {
             $readonly = !$this->security->isGranted('campaign:campaigns:publish');
             $data     = $options['data']->isPublished(false);
-        } elseif (!$this->security->isGranted('campaign:campaigns:publish')) {
-            $readonly = true;
-            $data     = false;
-        } else {
-            $readonly = false;
-            $data     = false;
-        }
-
-        $builder->add('isPublished', YesNoButtonGroupType::class, [
-            'data' => $data,
-            'attr' => [
-                'readonly'              => $readonly,
+            $attr     = [
                 'onchange'              => 'Mautic.showCampaignConfirmation(mQuery(this));',
                 'data-toggle'           => 'confirmation',
                 'data-message'          => $this->translator->trans('mautic.campaign.form.confirmation.message'),
@@ -103,7 +93,20 @@ class CampaignType extends AbstractType
                 'data-cancel-text'      => $this->translator->trans('mautic.campaign.form.confirmation.cancel_text'),
                 'data-cancel-callback'  => 'setPublishedButtonToYes',
                 'class'                 => 'btn btn-default',
-            ],
+            ];
+        } elseif (!$this->security->isGranted('campaign:campaigns:publish')) {
+            $readonly = true;
+            $data     = false;
+        } else {
+            $readonly = false;
+            $data     = false;
+        }
+
+        $attr['readonly'] = $readonly;
+
+        $builder->add('isPublished', YesNoButtonGroupType::class, [
+            'data' => $data,
+            'attr' => $attr,
         ]);
 
         $builder->add('publishUp', DateTimeType::class, [

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class CampaignType.
@@ -35,9 +36,15 @@ class CampaignType extends AbstractType
      */
     private $security;
 
-    public function __construct(CorePermissions $security)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(CorePermissions $security, TranslatorInterface $translator)
     {
         $this->security   = $security;
+        $this->translator = $translator;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -87,7 +94,15 @@ class CampaignType extends AbstractType
         $builder->add('isPublished', YesNoButtonGroupType::class, [
             'data' => $data,
             'attr' => [
-                'readonly' => $readonly,
+                'readonly'              => $readonly,
+                'onchange'              => 'Mautic.showCampaignConfirmation(mQuery(this));',
+                'data-toggle'           => 'confirmation',
+                'data-message'          => $this->translator->trans('mautic.campaign.form.confirmation.message'),
+                'data-confirm-text'     => $this->translator->trans('mautic.campaign.form.confirmation.confirm_text'),
+                'data-confirm-callback' => 'executeAction',
+                'data-cancel-text'      => $this->translator->trans('mautic.campaign.form.confirmation.cancel_text'),
+                'data-cancel-callback'  => 'dismissConfirmation()',
+                'class'                 => 'btn btn-default',
             ],
         ]);
 

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -99,9 +99,9 @@ class CampaignType extends AbstractType
                 'data-toggle'           => 'confirmation',
                 'data-message'          => $this->translator->trans('mautic.campaign.form.confirmation.message'),
                 'data-confirm-text'     => $this->translator->trans('mautic.campaign.form.confirmation.confirm_text'),
-                'data-confirm-callback' => 'executeAction',
+                'data-confirm-callback' => 'dismissConfirmation',
                 'data-cancel-text'      => $this->translator->trans('mautic.campaign.form.confirmation.cancel_text'),
-                'data-cancel-callback'  => 'dismissConfirmation()',
+                'data-cancel-callback'  => 'setPublishedButtonToYes',
                 'class'                 => 'btn btn-default',
             ],
         ]);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -11,7 +11,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignEditPageCheckUnpublishWorkflowAttributesPresent(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();
-        $translator = $this->container->get('translator');
+        $translator = $this->getContainer()->get('translator');
 
         // Check the message in the Campaign edit page
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns/edit/%d', $campaign->getId()));
@@ -41,7 +41,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignListPageCheckUnpublishWorkflowAttributesPresent(): void
     {
         $this->saveSomeCampaignLeadEventLogs();
-        $translator = $this->container->get('translator');
+        $translator = $this->getContainer()->get('translator');
 
         // Check the message in the Campaign listing page
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns'));
@@ -67,7 +67,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignUnpublishToggle(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();
-        $translator = $this->container->get('translator');
+        $translator = $this->getContainer()->get('translator');
 
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'campaign', 'id' => $campaign->getId()]);
         $response = $this->client->getResponse();

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -8,6 +8,32 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTest
 {
+    public function testCreateCampaignPageShouldNotContainConformation(): void
+    {
+        // Check the message in the Campaign edit page
+        $crawler  = $this->client->request('GET', '/s/campaigns/new');
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isOk());
+
+        $attributes = [
+            'data-toggle',
+            'data-message',
+            'data-confirm-text',
+            'data-confirm-callback',
+            'data-cancel-text',
+            'data-cancel-callback',
+        ];
+
+        $elements = $crawler->filter('form input[name*="campaign[isPublished]"]')->getIterator();
+
+        /** @var DOMElement $element */
+        foreach ($elements as $element) {
+            foreach ($attributes as $attribute) {
+                $this->assertFalse($element->hasAttribute($attribute), sprintf('The "%s" attribute is present.', $attribute));
+            }
+        }
+    }
+
     public function testCampaignEditPageCheckUnpublishWorkflowAttributesPresent(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -4,6 +4,7 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 
 use DOMElement;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTest;
+use Symfony\Component\HttpFoundation\Request;
 
 final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTest
 {
@@ -60,6 +61,34 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
         $toggleElement = $crawler->filter('.toggle-publish-status');
         foreach ($attributes as $key => $val) {
             $this->assertStringContainsString($val, $toggleElement->attr($key));
+        }
+    }
+
+    public function testCampaignUnpublishToggle(): void
+    {
+        $campaign   = $this->saveSomeCampaignLeadEventLogs();
+        $translator = $this->container->get('translator');
+
+        $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'campaign', 'id' => $campaign->getId()]);
+        $response = $this->client->getResponse();
+
+        $this->assertTrue($response->isOk());
+
+        $attributes    = [
+            'onclick'               => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',
+            'data-toggle'           => 'confirmation',
+            'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
+            'data-cancel-callback'  => 'dismissConfirmation',
+            'data-message'          => $translator->trans('mautic.campaign.form.confirmation.message'),
+            'data-confirm-text'     => $translator->trans('mautic.campaign.form.confirmation.confirm_text'),
+            'data-cancel-text'      => $translator->trans('mautic.campaign.form.confirmation.cancel_text'),
+        ];
+
+        $content = $response->getContent();
+
+        foreach ($attributes as $key => $val) {
+            $this->assertStringContainsString($key, $content);
+            $this->assertStringContainsString($val, $content);
         }
     }
 }

--- a/app/bundles/CampaignBundle/Translations/en_US/messages.ini
+++ b/app/bundles/CampaignBundle/Translations/en_US/messages.ini
@@ -171,3 +171,6 @@ mautic.campaign.campaign.jump_to_event.target_not_exist="Jump to target no longe
 mautic.campaign.event.jump_to_event_descr="Jump to the chosen event within the campaign flow."
 mautic.campaign.form.jump_to_event="Event to jump to"
 mautic.campaign.message.send="Messages sent"
+mautic.campaign.form.confirmation.message="Are you sure you want to unpublish this campaign and stop processing contacts and campaign events (including scheduled emails) immediately?"
+mautic.campaign.form.confirmation.confirm_text="Yes"
+mautic.campaign.form.confirmation.cancel_text="No"

--- a/app/bundles/CampaignBundle/Translations/en_US/messages.ini
+++ b/app/bundles/CampaignBundle/Translations/en_US/messages.ini
@@ -171,6 +171,6 @@ mautic.campaign.campaign.jump_to_event.target_not_exist="Jump to target no longe
 mautic.campaign.event.jump_to_event_descr="Jump to the chosen event within the campaign flow."
 mautic.campaign.form.jump_to_event="Event to jump to"
 mautic.campaign.message.send="Messages sent"
-mautic.campaign.form.confirmation.message="Are you sure you want to unpublish this campaign and stop processing contacts and campaign events (including scheduled emails) immediately?"
+mautic.campaign.form.confirmation.message="Are you sure you want to unpublish this campaign and stop processing contact(s) and campaign event(s) (including scheduled event(s)) immediately?"
 mautic.campaign.form.confirmation.confirm_text="Yes"
 mautic.campaign.form.confirmation.cancel_text="No"

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -133,6 +133,9 @@ if ('index' == $tmpl) {
                                 [
                                     'item'          => $item,
                                     'model'         => 'campaign',
+                                    'onclick'       => $item->getOnclickMethod(),
+                                    'attributes'    => $item->getDataAttributes(),
+                                    'transKeys'     => $item->getTranslationKeysDataAttributes(),
                                 ]
                             ); ?>
                             <a href="<?php echo $view['router']->path(

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -133,15 +133,6 @@ if ('index' == $tmpl) {
                                 [
                                     'item'          => $item,
                                     'model'         => 'campaign',
-                                    'attributes'    => [
-                                        'onclick'               => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',
-                                        'data-toggle'           => 'confirmation',
-                                        'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
-                                        'data-cancel-callback'  => 'dismissConfirmation',
-                                        'data-message'          => $view['translator']->trans('mautic.campaign.form.confirmation.message'),
-                                        'data-confirm-text'     => $view['translator']->trans('mautic.campaign.form.confirmation.confirm_text'),
-                                        'data-cancel-text'      => $view['translator']->trans('mautic.campaign.form.confirmation.cancel_text'),
-                                    ],
                                 ]
                             ); ?>
                             <a href="<?php echo $view['router']->path(

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -131,8 +131,17 @@ if ('index' == $tmpl) {
                             <?php echo $view->render(
                                 'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                                 [
-                                    'item'  => $item,
-                                    'model' => 'campaign',
+                                    'item'          => $item,
+                                    'model'         => 'campaign',
+                                    'attributes'    => [
+                                        'data-onclick'          => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',
+                                        'data-toggle'           => 'confirmation',
+                                        'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
+                                        'data-cancel-callback'  => 'dismissConfirmation',
+                                        'data-message'          => $view['translator']->trans('mautic.campaign.form.confirmation.message'),
+                                        'data-confirm-text'     => $view['translator']->trans('mautic.campaign.form.confirmation.confirm_text'),
+                                        'data-cancel-text'      => $view['translator']->trans('mautic.campaign.form.confirmation.cancel_text'),
+                                    ],
                                 ]
                             ); ?>
                             <a href="<?php echo $view['router']->path(

--- a/app/bundles/CampaignBundle/Views/Campaign/list.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/list.html.php
@@ -134,7 +134,7 @@ if ('index' == $tmpl) {
                                     'item'          => $item,
                                     'model'         => 'campaign',
                                     'attributes'    => [
-                                        'data-onclick'          => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',
+                                        'onclick'               => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',
                                         'data-toggle'           => 'confirmation',
                                         'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
                                         'data-cancel-callback'  => 'dismissConfirmation',

--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -293,7 +293,7 @@ Mautic.showConfirmation = function (el) {
             .addClass("btn btn-primary")
             .click(function () {
                 if (cancelCallback && typeof Mautic[cancelCallback] === "function") {
-                    window["Mautic"][cancelCallback].apply('window', []);
+                    window["Mautic"][cancelCallback].apply('window', [el]);
                 } else {
                     Mautic.dismissConfirmation();
                 }

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -293,14 +293,21 @@ class AjaxController extends CommonController
                     if (!empty($refresh)) {
                         $dataArray['reload'] = 1;
                     } else {
+                        $onclickMethod  = (method_exists($entity, 'getOnclickMethod')) ? $entity->getOnclickMethod() : '';
+                        $dataAttr       = (method_exists($entity, 'getDataAttributes')) ? $entity->getDataAttributes() : [];
+                        $attrTransKeys  = (method_exists($entity, 'getTranslationKeysDataAttributes')) ? $entity->getTranslationKeysDataAttributes() : [];
+
                         //get updated icon HTML
                         $html = $this->renderView(
                             'MauticCoreBundle:Helper:publishstatus_icon.html.php',
                             [
-                                'item'  => $entity,
-                                'model' => $name,
-                                'query' => $extra,
-                                'size'  => (isset($post['size'])) ? $post['size'] : '',
+                                'item'          => $entity,
+                                'model'         => $name,
+                                'query'         => $extra,
+                                'size'          => (isset($post['size'])) ? $post['size'] : '',
+                                'onclick'       => $onclickMethod,
+                                'attributes'    => $dataAttr,
+                                'transKeys'     => $attrTransKeys,
                             ]
                         );
                         $dataArray['statusHtml'] = $html;

--- a/app/bundles/CoreBundle/Entity/PublishStatusIconAttributesInterface.php
+++ b/app/bundles/CoreBundle/Entity/PublishStatusIconAttributesInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mautic\CoreBundle\Entity;
+
+interface PublishStatusIconAttributesInterface
+{
+    public function getOnclickMethod(): string;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDataAttributes(): array;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getTranslationKeysDataAttributes(): array;
+}

--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
@@ -70,7 +70,7 @@ $idClass     = str_replace('.', '-', $model).'-publish-icon'.$item->getId().md5(
 
 $backdropFlag = (isset($backdrop)) ? 'true' : 'false';
 
-$onclick = "Mautic.togglePublishStatus(event, '.{$idClass}', '{$model}', '{$item->getId()}', '{$query}', {$backdropFlag})";
+$onclick = $onclick ?? "Mautic.togglePublishStatus(event, '.{$idClass}', '{$model}', '{$item->getId()}', '{$query}', {$backdropFlag})";
 
 $defaultAttributes = [
     'data-container' => 'body',
@@ -79,24 +79,20 @@ $defaultAttributes = [
     'data-status'    => $status,
 ];
 
-$attributes = [];
+$attributes = $attributes ?? [];
 
-// Update the attribute for campaign.
-if ('campaign' === $model) {
-    $onclick    = 'Mautic.confirmationCampaignPublishStatus(mQuery(this));';
-    $attributes = [
-        'data-toggle'           => 'confirmation',
-        'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
-        'data-cancel-callback'  => 'dismissConfirmation',
-        'data-message'          => $view['translator']->trans('mautic.campaign.form.confirmation.message'),
-        'data-confirm-text'     => $view['translator']->trans('mautic.campaign.form.confirmation.confirm_text'),
-        'data-cancel-text'      => $view['translator']->trans('mautic.campaign.form.confirmation.cancel_text'),
-        'data-id-class'         => '.'.$idClass,
-        'data-model'            => $model,
-        'data-item-id'          => $item->getId(),
-        'data-query'            => $query,
-        'data-backdrop'         => $backdropFlag,
-    ];
+if (!empty($attributes)) {
+    $attributes['data-id-class']    = '.'.$idClass;
+    $attributes['data-model']       = $model;
+    $attributes['data-item-id']     = $item->getId();
+    $attributes['data-query']       = $query;
+    $attributes['data-backdrop']    = $backdropFlag;
+}
+
+if (!empty($transKeys)) {
+    foreach ($transKeys as $k => $v) {
+        $attributes[$k] = $view['translator']->trans($v);
+    }
 }
 
 $allDataAttrs = array_merge($attributes + $defaultAttributes);

--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
@@ -79,18 +79,24 @@ $defaultAttributes = [
     'data-status'    => $status,
 ];
 
-// Get the attributes if set.
-$attributes = $attributes ?? [];
+$attributes = [];
 
-if (!empty($attributes)) {
-    $onclick = $attributes['onclick'] ?? '';
-    unset($attributes['onclick']);
-
-    $attributes['data-id-class']    = '.'.$idClass;
-    $attributes['data-model']       = $model;
-    $attributes['data-item-id']     = $item->getId();
-    $attributes['data-query']       = $query;
-    $attributes['data-backdrop']    = $backdropFlag;
+// Update the attribute for campaign.
+if ('campaign' === $model) {
+    $onclick    = 'Mautic.confirmationCampaignPublishStatus(mQuery(this));';
+    $attributes = [
+        'data-toggle'           => 'confirmation',
+        'data-confirm-callback' => 'confirmCallbackCampaignPublishStatus',
+        'data-cancel-callback'  => 'dismissConfirmation',
+        'data-message'          => $view['translator']->trans('mautic.campaign.form.confirmation.message'),
+        'data-confirm-text'     => $view['translator']->trans('mautic.campaign.form.confirmation.confirm_text'),
+        'data-cancel-text'      => $view['translator']->trans('mautic.campaign.form.confirmation.cancel_text'),
+        'data-id-class'         => '.'.$idClass,
+        'data-model'            => $model,
+        'data-item-id'          => $item->getId(),
+        'data-query'            => $query,
+        'data-backdrop'         => $backdropFlag,
+    ];
 }
 
 $allDataAttrs = array_merge($attributes + $defaultAttributes);

--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
@@ -72,26 +72,34 @@ $backdropFlag = (isset($backdrop)) ? 'true' : 'false';
 
 $onclick = "Mautic.togglePublishStatus(event, '.{$idClass}', '{$model}', '{$item->getId()}', '{$query}', {$backdropFlag})";
 
+$defaultAttributes = [
+    'data-container' => 'body',
+    'data-placement' => 'right',
+    'data-toggle'    => 'tooltip',
+    'data-status'    => $status,
+];
+
 // Get the attributes if set.
 $attributes = $attributes ?? [];
 
-$additionalAttrs = '';
 if (!empty($attributes)) {
-    $onclick = $attributes['data-onclick'] ?? '';
-    unset($attributes['data-onclick']);
+    $onclick = $attributes['onclick'] ?? '';
+    unset($attributes['onclick']);
 
     $attributes['data-id-class']    = '.'.$idClass;
     $attributes['data-model']       = $model;
     $attributes['data-item-id']     = $item->getId();
     $attributes['data-query']       = $query;
     $attributes['data-backdrop']    = $backdropFlag;
-
-    $additionalAttrs = implode(' ', array_map(
-        function ($v, $k) { return sprintf("%s='%s'", $k, $v); },
-        $attributes,
-        array_keys($attributes)
-    ));
 }
+
+$allDataAttrs = array_merge($attributes + $defaultAttributes);
+
+$dataAttributes = implode(' ', array_map(
+    function ($v, $k) { return sprintf("%s='%s'", $k, $v); },
+    $allDataAttrs,
+    array_keys($allDataAttrs)
+));
 ?>
 
-<i class="fa fa-fw <?php echo $size.' '.$icon.$clickAction.' '.$idClass; ?>" data-toggle="tooltip" data-container="body" data-placement="right" data-status="<?php echo $status; ?>" title="<?php echo $text; ?>" <?php echo $additionalAttrs; ?> <?php if (empty($disableToggle)): ?> onclick="<?php echo $onclick; ?>"<?php endif; ?>></i>
+<i class="fa fa-fw <?php echo $size.' '.$icon.$clickAction.' '.$idClass; ?> toggle-publish-status"  title="<?php echo $text; ?>" <?php echo $dataAttributes; ?> <?php if (empty($disableToggle)): ?> onclick="<?php echo $onclick; ?>"<?php endif; ?>></i>

--- a/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
+++ b/app/bundles/CoreBundle/Views/Helper/publishstatus_icon.html.php
@@ -67,6 +67,31 @@ if (!empty($disableToggle)) {
 
 $clickAction = (isset($disableToggle) && true === $disableToggle) ? ' disabled' : ' has-click-event';
 $idClass     = str_replace('.', '-', $model).'-publish-icon'.$item->getId().md5($query);
+
+$backdropFlag = (isset($backdrop)) ? 'true' : 'false';
+
+$onclick = "Mautic.togglePublishStatus(event, '.{$idClass}', '{$model}', '{$item->getId()}', '{$query}', {$backdropFlag})";
+
+// Get the attributes if set.
+$attributes = $attributes ?? [];
+
+$additionalAttrs = '';
+if (!empty($attributes)) {
+    $onclick = $attributes['data-onclick'] ?? '';
+    unset($attributes['data-onclick']);
+
+    $attributes['data-id-class']    = '.'.$idClass;
+    $attributes['data-model']       = $model;
+    $attributes['data-item-id']     = $item->getId();
+    $attributes['data-query']       = $query;
+    $attributes['data-backdrop']    = $backdropFlag;
+
+    $additionalAttrs = implode(' ', array_map(
+        function ($v, $k) { return sprintf("%s='%s'", $k, $v); },
+        $attributes,
+        array_keys($attributes)
+    ));
+}
 ?>
 
-<i class="fa fa-fw <?php echo $size.' '.$icon.$clickAction.' '.$idClass; ?>" data-toggle="tooltip" data-container="body" data-placement="right" data-status="<?php echo $status; ?>" title="<?php echo $text; ?>"<?php if (empty($disableToggle)): ?> onclick="Mautic.togglePublishStatus(event, '.<?php echo $idClass; ?>', '<?php echo $model; ?>', '<?php echo $item->getId(); ?>', '<?php echo $query; ?>', <?php echo (isset($backdrop)) ? 'true' : 'false'; ?>);"<?php endif; ?>></i>
+<i class="fa fa-fw <?php echo $size.' '.$icon.$clickAction.' '.$idClass; ?>" data-toggle="tooltip" data-container="body" data-placement="right" data-status="<?php echo $status; ?>" title="<?php echo $text; ?>" <?php echo $additionalAttrs; ?> <?php if (empty($disableToggle)): ?> onclick="<?php echo $onclick; ?>"<?php endif; ?>></i>


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bugfix? | No
| New feature? | Yes
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | | BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As a mautic user, I need to be aware of the impact unpublishing a live campaign may have. A user may unpublish for the following reasons: end of a campaign, someone made a mistake in building, the campaign isn't effective and they want to make changes for new contacts (or just want to make changes for any reason).

Proposing a confirmation modal while unpublish the campaign.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a few campaigns.

Listing Page
1.  Navigate to the campaign listing page
1.  Click on the toggle button to change the status
  a. If a campaign is published, it will ask for confirmation. If you click on Yes, it will unpublish the campaign
  b. Otherwise it will publish the camping.

Edit page
1. Edit any published campaign
1. Click on No choice under a Published button
1. It pops open the confirmation modal,
  a.  If you click on Yes, it will unpublish the campaign after saving.
  b. If you click on No, after saving the campaign, it remains published.


#### Other areas of Mautic that may be affected by the change:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backward compatibility breaks:
1. 
2. 

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. Checking the campaign list and edit page for the confirmation elements.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10705"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

