### PR TITLE
Fix 10455 edit code is broken 4 1 3rd try

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Please write a short README for your feature/bugfix. This will help people under
 <!--
 This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
 -->
-1. Load up [this PR](https://mautibox.com)
+1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
 2.
 
 <!--

--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -152,7 +152,6 @@ class FormType extends AbstractType
         $builder->add('renderStyle', YesNoButtonGroupType::class, [
             'label'      => 'mautic.form.form.renderstyle',
             'data'       => (null === $options['data']->getRenderStyle()) ? true : $options['data']->getRenderStyle(),
-            'empty_data' => true,
             'attr'       => [
                 'tooltip' => 'mautic.form.form.renderstyle.tooltip',
             ],

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,9 +1,9 @@
 {
-  "version": "4.1.0",
+  "version": "4.1.1",
   "stability": "stable",
   "minimum_php_version": "7.4.0",
   "maximum_php_version": "8.0.99",
   "show_php_version_warning_if_under": "7.4.0",
   "minimum_mautic_version": "3.2.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.1.0"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.1.1"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
 	level: 6
 	reportUnmatchedIgnoredErrors: false
 	parallel:
-		maximumNumberOfProcesses: 1
+		maximumNumberOfProcesses: 4
 		processTimeout: 1000.0
 	paths:
 		- app/bundles
@@ -28,6 +28,10 @@ parameters:
 		- app/bundles/CoreBundle/Loader/ParameterLoader.php
 		- app/bundles/CoreBundle/Helper/PathsHelper.php
 		- app/bundles/CoreBundle/Configurator/Configurator.php
+	dynamicConstantNames:
+		- MAUTIC_ENV
+		- MAUTIC_TABLE_PREFIX
+		- MAUTIC_VERSION
 	ignoreErrors:
 		- '#Cannot unset offset#'
 		- '#Undefined variable: \$parameters#'

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -66,16 +66,15 @@ class CodeEditor {
   }
 
   // Load content and show popup
-  showCodePopup() {
+  showCodePopup(editor) {
     this.updateEditorContents();
     // this.codeEditor.editor.refresh();
-    // this.editor.Modal.setContent('');
-    this.editor.Modal.setContent(this.codePopup);
-    this.editor.Modal.setTitle(Mautic.translate('grapesjsbuilder.sourceEditModalTitle'));
-    this.editor.Modal.open();
-    this.editor.Modal.onceClose(() => {
-      this.editor.stopCommand('preset-mautic:code-edit');
-    });
+    // editor.Modal.setContent('');
+    editor.Modal.setContent(this.codePopup);
+    editor.Modal.setTitle(Mautic.translate('grapesjsbuilder.sourceEditModalTitle'));
+    editor.Modal.open();
+
+    editor.Modal.onceClose(() => editor.stopCommand('preset-mautic:code-edit'));
   }
 
   /**
@@ -113,7 +112,6 @@ class CodeEditor {
     let content;
     if (ContentService.isMjmlMode(this.editor)) {
       content = MjmlService.getEditorMjmlContent(this.editor);
-      console.log('loading modal');
     } else {
       content = ContentService.getEditorHtmlContent(this.editor);
     }

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeMode.command.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeMode.command.js
@@ -21,7 +21,7 @@ export default class CodeModeCommand {
       sender.set('active', 0);
     }
 
-    CodeModeCommand.codeEditor.showCodePopup();
+    CodeModeCommand.codeEditor.showCodePopup(editor);
 
     // Transform DC Component to token
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');

--- a/plugins/GrapesJsBuilderBundle/Translations/en_US/javascript.ini
+++ b/plugins/GrapesJsBuilderBundle/Translations/en_US/javascript.ini
@@ -1,4 +1,4 @@
-grapesjsbuilder.sourceEditBtnLabel="Edit"
+grapesjsbuilder.sourceEditBtnLabel="Save"
 grapesjsbuilder.sourceCancelBtnLabel="Cancel"
 grapesjsbuilder.sourceEditModalTitle="Edit code"
 grapesjsbuilder.sourceSyntaxError="Please fix the following error:"


### PR DESCRIPTION
closes #10455

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| Deprecations?                          |  no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | N/A
| Issue(s) addressed                     | Fixes #10455

#### Description:

This fixes an issue where the code editor modal did not open **again** when the grapesjs builder was closed.

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. See steps in the [issue](https://github.com/mautic/mautic/issues/10455)


This PR is the same as https://github.com/mautic/mautic/pull/10564 but based on 4.1 branch


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10706"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

