### PR TITLE
Restore X value in contact boolean fields

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -6,7 +6,6 @@
 *   Symfony 4
     *   Symfony deprecations were removed or refactored [https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.0.md](https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.0.md)
     *   Services are now private by default in Symfony 4. Mautic has a "hack" to register its own services as public but dependency injection should be preferred for Commands, Controllers, and services. Some Symfony services may no longer be available to the Controller via the Container.
-    *   \Mautic\CoreBundle\Form\Type\YesNoButtonGroupType now uses false/true values which Symfony 4 will convert to empty values for No in the UI. This shouldn't cause issues for most unless the field is using a NotBlank constraint, which is no longer valid, or submitting a form via a functional test with 0 as the value of a YesNoButtonGroupType field. 
 *   Packages removed
     *   debril/rss-atom-bundle removed
     *   egeloen/ordered-form-bundle removed

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -47,12 +47,12 @@ class MessageApiController extends CommonApiController
             foreach ($channels as $channelType => $channel) {
                 if (!isset($params['channels'][$channelType])) {
                     $params['channels'][$channelType] = [
-                        'isEnabled' => false,
+                        'isEnabled' => 0,
                         'channel'   => $channelType,
                     ];
                 } else {
                     $params['channels'][$channelType]['channel']   = $channelType;
-                    $params['channels'][$channelType]['isEnabled'] = (bool) $params['channels'][$channelType]['isEnabled'];
+                    $params['channels'][$channelType]['isEnabled'] = (int) $params['channels'][$channelType]['isEnabled'];
                 }
             }
         }

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -16,13 +16,14 @@ use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
+use Mautic\CoreBundle\Model\AbstractCommonModel;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 class MessageApiController extends CommonApiController
 {
     /**
-     * @var MessageModel
+     * @var MessageModel|AbstractCommonModel
      */
     protected $model;
 

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -42,10 +42,13 @@ class MessageApiController extends CommonApiController
     {
         parent::prepareParametersFromRequest($form, $params, $entity, $masks);
 
-        $channels = $this->model->getChannels();
-        if (!isset($params['channels'])) {
+        if ('PATCH' === $this->request->getMethod() && !isset($params['channels'])) {
+            return;
+        } elseif (!isset($params['channels'])) {
             $params['channels'] = [];
         }
+
+        $channels = $this->model->getChannels();
 
         foreach ($channels as $channelType => $channel) {
             if (!isset($params['channels'][$channelType])) {

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -48,7 +48,7 @@ class MessageApiController extends CommonApiController
         }
 
         foreach ($channels as $channelType => $channel) {
-            if (!isset($params['channels'][$channelType]) && 'PATCH' != $this->request->getMethod()) {
+            if (!isset($params['channels'][$channelType])) {
                 $params['channels'][$channelType] = ['isEnabled' => 0];
             } else {
                 $params['channels'][$channelType]['isEnabled'] = (int) $params['channels'][$channelType]['isEnabled'];

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -37,7 +37,7 @@ JSON;
 
     /**
      * @dataProvider patchProvider
-     * 
+     *
      * @param mixed[] $payload
      * @param mixed[] $expectedResponsePayload
      */
@@ -70,14 +70,14 @@ JSON;
 
     /**
      * Note: the ID is added to the payload automatically in the test.
-     * 
+     *
      * @return iterable<mixed[]>
      */
     public function patchProvider(): iterable
     {
         yield [
             [
-                'name' => 'API message (updated)'
+                'name' => 'API message (updated)',
             ],
             [
                 'name'        => 'API message (updated)',
@@ -89,7 +89,7 @@ JSON;
                         'isEnabled' => true,
                     ],
                 ],
-            ]
+            ],
         ];
 
         yield [
@@ -113,7 +113,7 @@ JSON;
                         'isEnabled' => false,
                     ],
                 ],
-            ]
+            ],
         ];
     }
 
@@ -148,7 +148,7 @@ JSON;
             ['id' => $message1->getId(), 'name' => 'API message 1 (updated)'],
             ['id' => $message2->getId(), 'channels' => ['email' => ['channelId' => 14, 'isEnabled' => false]]],
         ];
-        $this->client->request('PATCH', "/api/messages/batch/edit", $patchPayload);
+        $this->client->request('PATCH', '/api/messages/batch/edit', $patchPayload);
         $responseJson = $this->client->getResponse()->getContent();
         Assert::assertSame(200, $this->client->getResponse()->getStatusCode(), $responseJson);
         $responseArray = json_decode($responseJson, true);
@@ -160,7 +160,7 @@ JSON;
                     'email' => [
                         'channel'   => 'email',
                         'channelId' => 12,
-                        'isEnabled' => true
+                        'isEnabled' => true,
                     ],
                 ],
             ],
@@ -175,7 +175,7 @@ JSON;
                     'email' => [
                         'channel'   => 'email',
                         'channelId' => 14,
-                        'isEnabled' => false
+                        'isEnabled' => false,
                     ],
                 ],
             ],
@@ -187,7 +187,6 @@ JSON;
     /**
      * @param mixed[] $expectedPayload
      * @param mixed[] $actualPayload
-     * @param string  $deliveredPayloadJson
      */
     private function assertMessagePayload(array $expectedPayload, array $actualPayload, string $deliveredPayloadJson): void
     {

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ChannelBundle\Tests\Controller\Api;
+
+use Mautic\ChannelBundle\Entity\Channel;
+use Mautic\ChannelBundle\Entity\Message;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+
+final class MessageApiControllerTest extends MauticMysqlTestCase
+{
+    public function testCreateMessage(): void
+    {
+        $payloadJson = <<<'JSON'
+{
+    "name": "API message",
+    "description": "Marketing message created via API functional test",
+    "channels": {
+        "email": {
+            "channel": "email",
+            "channelId": 12,
+            "isEnabled": true
+        }
+    }
+}
+JSON;
+
+        $payloadArray = json_decode($payloadJson, true);
+
+        $this->client->request('POST', '/api/messages/new', $payloadArray);
+        $responseJson = $this->client->getResponse()->getContent();
+        Assert::assertSame(201, $this->client->getResponse()->getStatusCode(), $responseJson);
+        $this->assertMessagePayload($payloadArray, json_decode($responseJson, true)['message'], $responseJson);
+    }
+
+    /**
+     * @dataProvider patchProvider
+     * 
+     * @param mixed[] $payload
+     * @param mixed[] $expectedResponsePayload
+     */
+    public function testEditMessageWithPatch(array $payload, array $expectedResponsePayload): void
+    {
+        $channel = new Channel();
+        $channel->setChannel('email');
+        $channel->setChannelId(12);
+        $channel->setIsEnabled(true);
+
+        $message = new Message();
+        $message->setName('API message');
+        $message->addChannel($channel);
+
+        $this->em->persist($channel);
+        $this->em->persist($message);
+        $this->em->flush();
+        $this->em->clear();
+
+        $patchPayload = ['id' => $message->getId()] + $payload;
+        $this->client->request('PATCH', "/api/messages/{$message->getId()}/edit", $patchPayload);
+        $responseJson = $this->client->getResponse()->getContent();
+        Assert::assertSame(200, $this->client->getResponse()->getStatusCode(), $responseJson);
+        $this->assertMessagePayload(
+            ['id' => $message->getId()] + $expectedResponsePayload,
+            json_decode($responseJson, true)['message'],
+            $responseJson
+        );
+    }
+
+    /**
+     * Note: the ID is added to the payload automatically in the test.
+     * 
+     * @return iterable<mixed[]>
+     */
+    public function patchProvider(): iterable
+    {
+        yield [
+            [
+                'name' => 'API message (updated)'
+            ],
+            [
+                'name'        => 'API message (updated)',
+                'description' => null,
+                'channels'    => [
+                    'email' => [
+                        'channel'   => 'email',
+                        'channelId' => 12,
+                        'isEnabled' => true,
+                    ],
+                ],
+            ]
+        ];
+
+        yield [
+            [
+                'description' => 'Description (updated)',
+                'channels'    => [
+                    'email' => [
+                        'channel'   => 'email',
+                        'channelId' => 13,
+                        'isEnabled' => false,
+                    ],
+                ],
+            ],
+            [
+                'name'        => 'API message',
+                'description' => 'Description (updated)',
+                'channels'    => [
+                    'email' => [
+                        'channel'   => 'email',
+                        'channelId' => 13,
+                        'isEnabled' => false,
+                    ],
+                ],
+            ]
+        ];
+    }
+
+    public function testEditMessagesWithPatch(): void
+    {
+        $channel1 = new Channel();
+        $channel1->setChannel('email');
+        $channel1->setChannelId(12);
+        $channel1->setIsEnabled(true);
+
+        $message1 = new Message();
+        $message1->setName('API message 1');
+        $message1->addChannel($channel1);
+
+        $channel2 = new Channel();
+        $channel2->setChannel('email');
+        $channel2->setChannelId(13);
+        $channel2->setIsEnabled(true);
+
+        $message2 = new Message();
+        $message2->setName('API message 2');
+        $message2->addChannel($channel2);
+
+        $this->em->persist($channel1);
+        $this->em->persist($channel2);
+        $this->em->persist($message1);
+        $this->em->persist($message2);
+        $this->em->flush();
+        $this->em->clear();
+
+        $patchPayload = [
+            ['id' => $message1->getId(), 'name' => 'API message 1 (updated)'],
+            ['id' => $message2->getId(), 'channels' => ['email' => ['channelId' => 14, 'isEnabled' => false]]],
+        ];
+        $this->client->request('PATCH', "/api/messages/batch/edit", $patchPayload);
+        $responseJson = $this->client->getResponse()->getContent();
+        Assert::assertSame(200, $this->client->getResponse()->getStatusCode(), $responseJson);
+        $responseArray = json_decode($responseJson, true);
+        $this->assertMessagePayload(
+            [
+                'id'       => $message1->getId(),
+                'name'     => 'API message 1 (updated)',
+                'channels' => [
+                    'email' => [
+                        'channel'   => 'email',
+                        'channelId' => 12,
+                        'isEnabled' => true
+                    ],
+                ],
+            ],
+            $responseArray['messages'][0],
+            $responseJson
+        );
+        $this->assertMessagePayload(
+            [
+                'id'       => $message2->getId(),
+                'name'     => 'API message 2',
+                'channels' => [
+                    'email' => [
+                        'channel'   => 'email',
+                        'channelId' => 14,
+                        'isEnabled' => false
+                    ],
+                ],
+            ],
+            $responseArray['messages'][1],
+            $responseJson
+        );
+    }
+
+    /**
+     * @param mixed[] $expectedPayload
+     * @param mixed[] $actualPayload
+     * @param string  $deliveredPayloadJson
+     */
+    private function assertMessagePayload(array $expectedPayload, array $actualPayload, string $deliveredPayloadJson): void
+    {
+        Assert::assertSame($expectedPayload['name'], $actualPayload['name'], $deliveredPayloadJson);
+        Assert::assertSame($expectedPayload['description'], $actualPayload['description'], $deliveredPayloadJson);
+        Assert::assertCount(count($expectedPayload['channels']), $actualPayload['channels'], $deliveredPayloadJson);
+        Assert::assertGreaterThan(0, $actualPayload['id'], $deliveredPayloadJson);
+
+        Assert::assertSame($expectedPayload['channels']['email']['channel'], $actualPayload['channels'][0]['channel'], $deliveredPayloadJson);
+        Assert::assertSame($expectedPayload['channels']['email']['channelId'], $actualPayload['channels'][0]['channelId'], $deliveredPayloadJson);
+        Assert::assertSame($expectedPayload['channels']['email']['isEnabled'], $actualPayload['channels'][0]['isEnabled'], $deliveredPayloadJson);
+        Assert::assertGreaterThan(0, $actualPayload['channels'][0]['id'], $deliveredPayloadJson);
+    }
+}

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -154,9 +154,10 @@ JSON;
         $responseArray = json_decode($responseJson, true);
         $this->assertMessagePayload(
             [
-                'id'       => $message1->getId(),
-                'name'     => 'API message 1 (updated)',
-                'channels' => [
+                'id'          => $message1->getId(),
+                'name'        => 'API message 1 (updated)',
+                'description' => null,
+                'channels'    => [
                     'email' => [
                         'channel'   => 'email',
                         'channelId' => 12,
@@ -169,9 +170,10 @@ JSON;
         );
         $this->assertMessagePayload(
             [
-                'id'       => $message2->getId(),
-                'name'     => 'API message 2',
-                'channels' => [
+                'id'          => $message2->getId(),
+                'name'        => 'API message 2',
+                'description' => null,
+                'channels'    => [
                     'email' => [
                         'channel'   => 'email',
                         'channelId' => 14,

--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -237,7 +237,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         $buttonCrawler  =  $crawler->selectButton('config[buttons][save]');
         $form           = $buttonCrawler->form();
 
-        $send_notification_to_author           = '';
+        $send_notification_to_author           = '0';
         $campaign_notification_email_addresses = 'a@test.com, b@test.com';
         $webhook_notification_email_addresses  = 'a@webhook.com, b@webhook.com';
 

--- a/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
+++ b/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
@@ -54,7 +54,7 @@ class YesNoButtonGroupType extends AbstractType
                         return null;
                     }
 
-                    return (is_string($choiceKey) && !is_numeric($choiceKey)) ? $choiceKey : (bool) $choiceKey;
+                    return (is_string($choiceKey) && !is_numeric($choiceKey)) ? $choiceKey : (int) $choiceKey;
                 },
                 'expanded'          => true,
                 'multiple'          => false,
@@ -63,9 +63,9 @@ class YesNoButtonGroupType extends AbstractType
                 'placeholder'       => false,
                 'required'          => false,
                 'no_label'          => 'mautic.core.form.no',
-                'no_value'          => false,
+                'no_value'          => 0,
                 'yes_label'         => 'mautic.core.form.yes',
-                'yes_value'         => true,
+                'yes_value'         => 1,
             ]
         );
     }

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -45,7 +45,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $form->setValues(
             [
                 'mauticform[name]'        => 'Test',
-                'mauticform[renderStyle]' => '',
+                'mauticform[renderStyle]' => '0',
             ]
         );
         $crawler = $this->client->submit($form);
@@ -54,7 +54,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $form = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $form->setValues(
             [
-                'mauticform[renderStyle]' => '',
+                'mauticform[renderStyle]' => '0',
             ]
         );
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -65,8 +65,8 @@ class LeadControllerTest extends MauticMysqlTestCase
             [
                 'leadlist[name]'               => 'Segment 1',
                 'leadlist[alias]'              => 'segment-1',
-                'leadlist[isGlobal]'           => '',
-                'leadlist[isPreferenceCenter]' => '',
+                'leadlist[isGlobal]'           => '0',
+                'leadlist[isPreferenceCenter]' => '0',
                 'leadlist[isPublished]'        => '1',
                 'leadlist[publicName]'         => 'Segment 1',
                 'leadlist[category]'           => '1',

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -64,7 +64,7 @@ class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->restart();
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$list1->getId());
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
-        $form['leadlist[isPublished]']->setValue('');
+        $form['leadlist[isPublished]']->setValue('0');
         $crawler = $this->client->submit($form);
         $this->assertTrue($this->client->getResponse()->isOk());
         $this->assertStringContainsString($expectedErrorMessage, $this->client->getResponse()->getContent());
@@ -89,7 +89,7 @@ class ListControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$list2->getId());
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
-        $form['leadlist[isPublished]']->setValue('');
+        $form['leadlist[isPublished]']->setValue('0');
         $crawler = $this->client->submit($form);
         $this->assertTrue($this->client->getResponse()->isOk());
 

--- a/app/bundles/ReportBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ReportBundle/Form/Type/ConfigType.php
@@ -14,26 +14,24 @@ namespace Mautic\ReportBundle\Form\Type;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('csv_always_enclose', YesNoButtonGroupType::class, [
-            'label'      => 'mautic.config.tab.form.csv_always_enclose',
-            'label_attr' => ['class' => 'control-label'],
-            'attr'       => [
-                'class'   => 'form-control',
-                'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
+        $builder->add(
+            'csv_always_enclose',
+            YesNoButtonGroupType::class,
+            [
+                'label'      => 'mautic.config.tab.form.csv_always_enclose',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class'   => 'form-control',
+                    'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
                 ],
-            'data'        => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
-            'constraints' => [
-                new NotBlank([
-                    'message' => 'mautic.core.value.required',
-                ]),
-            ],
-        ]);
+                'data'       => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
+            ]
+        );
     }
 
     /**

--- a/app/bundles/ReportBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ReportBundle/Form/Type/ConfigType.php
@@ -14,24 +14,26 @@ namespace Mautic\ReportBundle\Form\Type;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add(
-            'csv_always_enclose',
-            YesNoButtonGroupType::class,
-            [
-                'label'      => 'mautic.config.tab.form.csv_always_enclose',
-                'label_attr' => ['class' => 'control-label'],
-                'attr'       => [
-                    'class'   => 'form-control',
-                    'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
+        $builder->add('csv_always_enclose', YesNoButtonGroupType::class, [
+            'label'      => 'mautic.config.tab.form.csv_always_enclose',
+            'label_attr' => ['class' => 'control-label'],
+            'attr'       => [
+                'class'   => 'form-control',
+                'tooltip' => 'mautic.config.tab.form.csv_always_enclose.tooltip',
                 ],
-                'data'       => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
-            ]
-        );
+            'data'        => isset($options['data']['csv_always_enclose']) ? (bool) $options['data']['csv_always_enclose'] : false,
+            'constraints' => [
+                new NotBlank([
+                    'message' => 'mautic.core.value.required',
+                ]),
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Y
| New feature/enhancement? (use the a.x branch)      | N
| Deprecations?                          | N
| BC breaks? (use the c.x branch)        | N
| Automated tests included?              | N
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10711 #10669 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR reverts changes from #9931 that caused issues with contact boolean fields. `YesNoButtonGroupType` actually uses the Symfony `ChoiceType` and not the `CheckboxType` as assumed in #9931, so the `1` `0` options should be correct.

After applying this PR the boolean fields in the contact edit page should have 3 options again:
![obraz](https://user-images.githubusercontent.com/8580942/147817083-539e1a6b-a782-4c00-8257-c9cb2959a1f8.png)
Before applying this PR:
![obraz](https://user-images.githubusercontent.com/8580942/147817229-cee65a73-2c34-4d9d-83bb-d2528018f67b.png)


I have checked the failing test `Mautic\Tests\Api\MessagesTest::testBatchEndpoints` from Mautic API repo, and it works fine after applying this PR. I couldn't replicate this issue from #9931.
![obraz](https://user-images.githubusercontent.com/8580942/147816107-1dacc943-441c-4d07-a7fd-90b03b0be993.png)



#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add boolean custom field if you don't have any
3. The boolean field in contact edit page should have 3 options `X` `Yes` `No`. Test changing the state.
4. The boolean field in the campaign update contact action should have 3 options `X` `Yes` `No`. Test changing the state.

#9931 Regression tests
4. Browse the UI and toggle the Yes/No buttons in various forms and on the contact edit page. Changing the state, saving, and editing should repopulate the correct state.
5. API functional tests should pass (the 5 tests that failed always fail on my local)
6. Test the Configuration can be saved and manipulated
7. Create a batch of messages via the API
`POST /api/messages/batch/new`
(change channelId to be the ID of an Email and SMS that exists in your Mautic)
```
[{
		"name": "API message",
		"description": "Marketing message created via API unit test",
		"channels": {
			"email": {
				"channel": "email",
				"channelId": 27,
				"isEnabled": false
			},
			"sms": {
				"channel": "sms",
				"channelId": 17,
				"isEnabled": true
			}
		}
	}, {
		"name": "API message",
		"description": "Marketing message created via API unit test",
		"channels": {
			"email": {
				"channel": "email",
				"channelId": 27,
				"isEnabled": false
			},
			"sms": {
				"channel": "sms",
				"channelId": 17,
				"isEnabled": true
			}
		}
	}, {
		"name": "API message",
		"description": "Marketing message created via API unit test",
		"channels": {
			"email": {
				"channel": "email",
				"channelId": 27,
				"isEnabled": false
			},
			"sms": {
				"channel": "sms",
				"channelId": 17,
				"isEnabled": true
			}
		}
	}
]

```
Then try to PATCH by switching the isEnabled of each channel and adding the message ID:
`PATCH /api/messages/batch/edit`
```
[
    {
        "id": 97,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 98,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                 "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 99,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    }
]
```

Then try PUT as well
`PUT /api/messages/batch/edit`
```
[
    {
        "id": 97,
        "isPublished": true,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 98,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                 "channelId": 17,
                "isEnabled": false
            }
        }
    },
    {
        "id": 99,
        "name": "API message",
        "description": "Marketing message created via API unit test",
        "channels": {
            "email": {
                "channel": "email",
                "channelId": 27,
                "isEnabled": true
            },
            "sms": {
                "channel": "sms",
                "channelId": 17,
                "isEnabled": false
            }
        }
    }
]
```
Finally, try using 0/1 instead of true/false.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10716"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

