### PR TITLE
Correct bug no forms in the select contact source campaign when the forms have identical names

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -26,9 +26,9 @@ class CampaignLeadSourceType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $sourceType = $options['data']['sourceType'];
+        $sourceType    = $options['data']['sourceType'];
         $sourceChoices = $options['source_choices'] ?? [];
-        foreach($sourceChoices as $key => $val) {
+        foreach ($sourceChoices as $key => $val) {
             $sourceChoices[$key] = $val.' ('.$key.')';
         }
 

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -27,6 +27,10 @@ class CampaignLeadSourceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $sourceType = $options['data']['sourceType'];
+        $sourceChoices = $options['source_choices'] ?? null;
+        foreach($sourceChoices as $key => $val) {
+            $sourceChoices[$key] = $val.' #'.$key;
+        }
 
         switch ($sourceType) {
             case 'lists':
@@ -34,7 +38,7 @@ class CampaignLeadSourceType extends AbstractType
                     'lists',
                     ChoiceType::class,
                     [
-                        'choices'           => array_flip($options['source_choices']),
+                        'choices'           => array_flip($sourceChoices),
                         'multiple'          => true,
                         'label'             => 'mautic.campaign.leadsource.lists',
                         'label_attr'        => ['class' => 'control-label'],

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -60,7 +60,7 @@ class CampaignLeadSourceType extends AbstractType
                     'forms',
                     ChoiceType::class,
                     [
-                        'choices'           => array_flip($options['source_choices']),
+                        'choices'           => array_flip($sourceChoices),
                         'multiple'          => true,
                         'label'             => 'mautic.campaign.leadsource.forms',
                         'label_attr'        => ['class' => 'control-label'],

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -27,9 +27,9 @@ class CampaignLeadSourceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $sourceType = $options['data']['sourceType'];
-        $sourceChoices = $options['source_choices'] ?? null;
+        $sourceChoices = $options['source_choices'] ?? [];
         foreach($sourceChoices as $key => $val) {
-            $sourceChoices[$key] = $val.' #'.$key;
+            $sourceChoices[$key] = $val.' ('.$key.')';
         }
 
         switch ($sourceType) {

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Entity\Form;
+
+use function GuzzleHttp\json_decode;
+
+class SourceControllerTest extends AbstractCampaignTest
+{
+    public function testTwoSourcesWithSameName(): void
+    {
+        $form1 = new Form();
+        $form1->setName('test');
+        $form1->setFormType('campaign');
+
+        $form2 = new Form();
+        $form2->setName('test');
+        $form2->setFormType('campaign');
+
+        $this->em->persist($form1);
+        $this->em->persist($form2);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->request('GET', '/s/campaigns/sources/new/random_object_id?sourceType=forms');
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(200, $clientResponse->getStatusCode(), $this->client->getResponse()->getContent());
+
+        $html = json_decode($clientResponse->getContent(), true)['newContent'];
+        $this->assertStringContainsString("<option value=\"{$form1->getId()}\">test</option></select>", $html);
+        $this->assertStringContainsString("<option value=\"{$form2->getId()}\">test</option></select>", $html);
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
@@ -7,18 +7,18 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 
-use function GuzzleHttp\json_decode;
-
-class SourceControllerTest extends AbstractCampaignTest
+class SourceControllerTest extends MauticMysqlTestCase
 {
     public function testTwoSourcesWithSameName(): void
     {
         $form1 = new Form();
         $form1->setName('test');
+        $form1->setAlias('test');
         $form1->setFormType('campaign');
 
         $form2 = new Form();
         $form2->setName('test');
+        $form2->setAlias('test');
         $form2->setFormType('campaign');
 
         $this->em->persist($form1);
@@ -27,12 +27,13 @@ class SourceControllerTest extends AbstractCampaignTest
         $this->em->flush();
         $this->em->clear();
 
-        $this->client->request('GET', '/s/campaigns/sources/new/random_object_id?sourceType=forms');
-        $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->client->request('GET', '/s/campaigns/sources/new/random_object_id?sourceType=forms', [], [], $this->createAjaxHeaders());
+        $clientResponse  = $this->client->getResponse();
+        $responseContent = $clientResponse->getContent();
+        $this->assertSame(200, $clientResponse->getStatusCode(), $responseContent);
 
-        $html = json_decode($clientResponse->getContent(), true)['newContent'];
-        $this->assertStringContainsString("<option value=\"{$form1->getId()}\">test</option></select>", $html);
-        $this->assertStringContainsString("<option value=\"{$form2->getId()}\">test</option></select>", $html);
+        $html = json_decode($responseContent, true)['newContent'];
+        $this->assertStringContainsString("<option value=\"{$form1->getId()}\" >test ({$form1->getId()})</option>", $html);
+        $this->assertStringContainsString("<option value=\"{$form2->getId()}\" >test ({$form2->getId()})</option>", $html);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [- ]
| Deprecations?                          | [- ]
| BC breaks? (use the c.x branch)        | [-]
| Automated tests included?              | [- ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->



#### Description:
When we have defined the same form names 
![image](https://user-images.githubusercontent.com/39382654/147817702-5c06763c-2a63-461f-9976-1252c112a874.png)

and create campaigns on the basis of contact source, only the forms with the highest ID are displayed in the campaign source step. 

in the case of a predefined form, e.g. id 13 after creating the form, e.g. ID 14 with the same name, the field for the campaign is empty

![image](https://user-images.githubusercontent.com/39382654/147817591-20b6a907-9ae5-4128-9d7c-c81727216861.png)


The fix adds an identifier to the form name and allows you to display and select all campaign forms
![image](https://user-images.githubusercontent.com/39382654/147817777-3c73154c-2665-47ef-a3ba-612f15695aa0.png)





<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10717"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

