### PR TITLE
Campaign events reschedules due to DST

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -124,17 +124,12 @@ class Interval implements ScheduleModeInterface
         $endTime               = $event->getTriggerRestrictedStopHour();
         $daysOfWeek            = $event->getTriggerRestrictedDaysOfWeek();
 
-        // Get the difference between now and the date we're supposed to be executing
-        $compareFromDateTime = $compareFromDateTime ? clone $compareFromDateTime : new \DateTime('now');
-        $diff                = $compareFromDateTime->diff($executionDate);
-        $diff->f             = 0; // we don't care about microseconds
-
         /** @var Lead $contact */
         foreach ($contacts as $contact) {
             $groupExecutionDate = $this->getGroupExecutionDateTime(
                 $event->getId(),
                 $contact,
-                $compareFromDateTime,
+                $executionDate,
                 $hour,
                 $startTime,
                 $endTime,

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -107,6 +107,14 @@ class Interval implements ScheduleModeInterface
             $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
         }
 
+        if ($dateTriggered < $compareFromDateTime) {
+            $this->logger->debug(
+                'CAMPAIGN: ('.$event->getId().') '.$dateTriggered->format('Y-m-d H:i:s T').' is earlier than '
+                .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus setting '.$compareFromDateTime->format('Y-m-d H:i:s T')
+            );
+            $dateTriggered = clone $compareFromDateTime;
+        }
+
         $hour      = $event->getTriggerHour();
         $startTime = $event->getTriggerRestrictedStartHour();
         $endTime   = $event->getTriggerRestrictedStopHour();

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -103,7 +103,9 @@ class Interval implements ScheduleModeInterface
         $interval = $event->getTriggerInterval();
         $unit     = $event->getTriggerIntervalUnit();
 
-        $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
+        if ($interval && $unit) {
+            $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
+        }
 
         $hour      = $event->getTriggerHour();
         $startTime = $event->getTriggerRestrictedStartHour();
@@ -123,6 +125,13 @@ class Interval implements ScheduleModeInterface
         $startTime             = $event->getTriggerRestrictedStartHour();
         $endTime               = $event->getTriggerRestrictedStopHour();
         $daysOfWeek            = $event->getTriggerRestrictedDaysOfWeek();
+
+        $interval = $event->getTriggerInterval();
+        $unit     = $event->getTriggerIntervalUnit();
+
+        if ($interval && $unit) {
+            $executionDate->add((new DateTimeHelper())->buildInterval($interval, $unit));
+        }
 
         /** @var Lead $contact */
         foreach ($contacts as $contact) {

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -54,24 +54,24 @@ class Interval implements ScheduleModeInterface
      */
     public function getExecutionDateTime(Event $event, \DateTime $compareFromDateTime, \DateTime $comparedToDateTime)
     {
-        $interval = $event->getTriggerInterval();
-        $unit     = $event->getTriggerIntervalUnit();
+        $interval      = $event->getTriggerInterval();
+        $unit          = $event->getTriggerIntervalUnit();
+        $logDateFormat = 'Y-m-d H:i:s T';
 
         try {
             $this->logger->debug(
-                'CAMPAIGN: ('.$event->getId().') Adding interval of '.$interval.$unit.' to '.$comparedToDateTime->format('Y-m-d H:i:s T')
+                sprintf('CAMPAIGN: (%s) Adding interval of  %s%s to %s', $event->getId(), $interval, $unit, $comparedToDateTime->format($logDateFormat))
             );
             $comparedToDateTime->add((new DateTimeHelper())->buildInterval($interval, $unit));
         } catch (\Exception $exception) {
-            $this->logger->error('CAMPAIGN: Determining interval scheduled failed with "'.$exception->getMessage().'"');
+            $this->logger->error(sprintf('CAMPAIGN: Determining interval scheduled failed with "%s"', $exception->getMessage()));
 
             throw new NotSchedulableException();
         }
 
         if ($comparedToDateTime > $compareFromDateTime) {
             $this->logger->debug(
-                'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format('Y-m-d H:i:s T').' is later than '
-                .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus returning '.$comparedToDateTime->format('Y-m-d H:i:s T')
+                sprintf('CAMPAIGN: (%s) %s is later than %s and thus returning %s', $event->getId(), $comparedToDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $comparedToDateTime->format($logDateFormat))
             );
 
             //the event is to be scheduled based on the time interval
@@ -79,8 +79,8 @@ class Interval implements ScheduleModeInterface
         }
 
         $this->logger->debug(
-            'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format('Y-m-d H:i:s T').' is earlier than '
-            .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus returning '.$compareFromDateTime->format('Y-m-d H:i:s T')
+            'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format($logDateFormat).' is earlier than '
+            .$compareFromDateTime->format($logDateFormat).' and thus returning '.$compareFromDateTime->format($logDateFormat)
         );
 
         return $compareFromDateTime;
@@ -100,8 +100,9 @@ class Interval implements ScheduleModeInterface
             return $this->getExecutionDateTime($event, $compareFromDateTime, $dateTriggered);
         }
 
-        $interval = $event->getTriggerInterval();
-        $unit     = $event->getTriggerIntervalUnit();
+        $interval      = $event->getTriggerInterval();
+        $unit          = $event->getTriggerIntervalUnit();
+        $logDateFormat = 'Y-m-d H:i:s T';
 
         if ($interval && $unit) {
             $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
@@ -109,8 +110,7 @@ class Interval implements ScheduleModeInterface
 
         if ($dateTriggered < $compareFromDateTime) {
             $this->logger->debug(
-                'CAMPAIGN: ('.$event->getId().') '.$dateTriggered->format('Y-m-d H:i:s T').' is earlier than '
-                .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus setting '.$compareFromDateTime->format('Y-m-d H:i:s T')
+                sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus setting %s', $event->getId(), $dateTriggered->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat))
             );
             $dateTriggered = clone $compareFromDateTime;
         }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -23,6 +23,7 @@ use Psr\Log\LoggerInterface;
 
 class Interval implements ScheduleModeInterface
 {
+    const LOG_DATE_FORMAT = 'Y-m-d H:i:s T';
     /**
      * @var LoggerInterface
      */
@@ -56,11 +57,10 @@ class Interval implements ScheduleModeInterface
     {
         $interval      = $event->getTriggerInterval();
         $unit          = $event->getTriggerIntervalUnit();
-        $logDateFormat = 'Y-m-d H:i:s T';
 
         try {
             $this->logger->debug(
-                sprintf('CAMPAIGN: (%s) Adding interval of  %s%s to %s', $event->getId(), $interval, $unit, $comparedToDateTime->format($logDateFormat))
+                sprintf('CAMPAIGN: (%s) Adding interval of  %s%s to %s', $event->getId(), $interval, $unit, $comparedToDateTime->format(self::LOG_DATE_FORMAT))
             );
             $comparedToDateTime->add((new DateTimeHelper())->buildInterval($interval, $unit));
         } catch (\Exception $exception) {
@@ -71,7 +71,7 @@ class Interval implements ScheduleModeInterface
 
         if ($comparedToDateTime > $compareFromDateTime) {
             $this->logger->debug(
-                sprintf('CAMPAIGN: (%s) %s is later than %s and thus returning %s', $event->getId(), $comparedToDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $comparedToDateTime->format($logDateFormat))
+                sprintf('CAMPAIGN: (%s) %s is later than %s and thus returning %s', $event->getId(), $comparedToDateTime->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT), $comparedToDateTime->format(self::LOG_DATE_FORMAT))
             );
 
             //the event is to be scheduled based on the time interval
@@ -79,7 +79,7 @@ class Interval implements ScheduleModeInterface
         }
 
         $this->logger->debug(
-            sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus returning %s', $event->getId(), $comparedToDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat))
+            sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus returning %s', $event->getId(), $comparedToDateTime->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT))
         );
 
         return $compareFromDateTime;
@@ -101,7 +101,6 @@ class Interval implements ScheduleModeInterface
 
         $interval      = $event->getTriggerInterval();
         $unit          = $event->getTriggerIntervalUnit();
-        $logDateFormat = 'Y-m-d H:i:s T';
 
         if ($interval && $unit) {
             $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
@@ -109,7 +108,7 @@ class Interval implements ScheduleModeInterface
 
         if ($dateTriggered < $compareFromDateTime) {
             $this->logger->debug(
-                sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus setting %s', $event->getId(), $dateTriggered->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat))
+                sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus setting %s', $event->getId(), $dateTriggered->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT))
             );
             $dateTriggered = clone $compareFromDateTime;
         }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -79,8 +79,7 @@ class Interval implements ScheduleModeInterface
         }
 
         $this->logger->debug(
-            'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format($logDateFormat).' is earlier than '
-            .$compareFromDateTime->format($logDateFormat).' and thus returning '.$compareFromDateTime->format($logDateFormat)
+            sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus returning %s', $event->getId(), $comparedToDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat), $compareFromDateTime->format($logDateFormat))
         );
 
         return $compareFromDateTime;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -25,7 +25,6 @@ use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -25,6 +25,7 @@ use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -100,7 +101,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testShouldScheduleIgnoresSeconds()
+    public function testShouldScheduleIgnoresSeconds(): void
     {
         $this->assertFalse(
             $this->scheduler->shouldSchedule(
@@ -110,7 +111,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testShouldSchedule()
+    public function testShouldSchedule(): void
     {
         $this->assertTrue(
             $this->scheduler->shouldSchedule(
@@ -120,7 +121,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testShouldScheduleForInactive()
+    public function testShouldScheduleForInactive(): void
     {
         $date  = new \DateTime();
         $now   = clone $date;
@@ -161,7 +162,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($date, $resultDate);
     }
 
-    public function testEventDoesNotGetRescheduledForRelativeTimeWhenValidated()
+    public function testEventDoesNotGetRescheduledForRelativeTimeWhenValidated(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -214,7 +215,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
 
-    public function testEventIsRescheduledForRelativeTimeIfAppropriate()
+    public function testEventIsRescheduledForRelativeTimeIfAppropriate(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -267,7 +268,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
 
-    public function testEventDoesNotGetRescheduledForRelativeTimeWithDowWhenValidated()
+    public function testEventDoesNotGetRescheduledForRelativeTimeWithDowWhenValidated(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -35,7 +35,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledToDueBeingBeforeSpecificHourRestrictionProvider
      */
-    public function testRescheduledToDueBeingBeforeSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledToDueBeingBeforeSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -86,7 +86,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledDueToBeingAfterSpecificHourRestrictionProvider
      */
-    public function testRescheduledDueToBeingAfterSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledDueToBeingAfterSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -137,7 +137,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider notRescheduledDueToSpecificHourRestrictionProvider
      */
-    public function testNotRescheduledDueToSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
+    public function testNotRescheduledDueToSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -188,7 +188,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledToSameDayDueToStartHourRestrictionProvider
      */
-    public function testRescheduledToSameDayDueToStartHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledToSameDayDueToStartHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -227,7 +227,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange()
+    public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -271,7 +271,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2021-11-08 17:00', $executionDate->format('Y-m-d H:i'));
     }
 
-    public function test()
+    public function testExecutionDateIsValidatedAsExpectedWithTriggerHourAndDaylightSavingsTimeChange(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -332,7 +332,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider isNotRescheduledDueToStartAndStopHourRestrictionsProvider
      */
-    public function testIsNotRescheduledDueToStartAndStopHourRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate)
+    public function testIsNotRescheduledDueToStartAndStopHourRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -383,7 +383,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledToNextDayDueToStopHourRestrictionProvider
      */
-    public function testRescheduledToNextDayDueToStopHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledToNextDayDueToStopHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -434,7 +434,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledDueDayOfWeekRestrictionProvider
      */
-    public function testRescheduledDueDayOfWeekRestriction(int $triggerInterval, string $triggerIntervalUnit, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledDueDayOfWeekRestriction(int $triggerInterval, string $triggerIntervalUnit, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -485,7 +485,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider notRescheduledDueDayOfWeekRestrictionProvider
      */
-    public function testNotRescheduledDueDayOfWeekRestriction(int $triggerInterval, string $triggerIntervalUnit, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testNotRescheduledDueDayOfWeekRestriction(int $triggerInterval, string $triggerIntervalUnit, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -535,7 +535,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider
      */
-    public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -588,7 +588,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider notRescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider
      */
-    public function testNotRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testNotRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -641,7 +641,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider
      */
-    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -694,7 +694,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider notRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider
      */
-    public function testNotRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testNotRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -747,7 +747,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolationProvider
      */
-    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -800,7 +800,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolationProvider
      */
-    public function testRescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -853,7 +853,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider rescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolationProvider
      */
-    public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, array $daysOfWeek, string $executionDate, string $resultedExecutionDate)
+    public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, array $daysOfWeek, string $executionDate, string $resultedExecutionDate): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -893,7 +893,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testContactsAreGrouped()
+    public function testContactsAreGrouped(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -265,7 +265,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
         $interval = $this->getInterval();
 
-        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime());
+        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime('2021-11-08'));
         $executionDate->setTimezone(new \DateTimeZone('UTC'));
 
         $this->assertEquals('2021-11-08 17:00', $executionDate->format('Y-m-d H:i'));
@@ -314,7 +314,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
         $interval = $this->getInterval();
 
-        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime());
+        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime('2021-11-08'));
         $executionDate->setTimezone(new \DateTimeZone('UTC'));
 
         $this->assertEquals('2021-11-08 17:00', $executionDate->format('Y-m-d H:i'));

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -19,7 +19,6 @@ use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Psr\Log\NullLogger;
-use Throwable;
 
 class IntervalTest extends \PHPUnit\Framework\TestCase
 {

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -852,6 +852,8 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider rescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolationProvider
+     *
+     * @param array<int> $daysOfWeek
      */
     public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, array $daysOfWeek, string $executionDate, string $resultedExecutionDate): void
     {

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -23,7 +23,19 @@ use Throwable;
 
 class IntervalTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRescheduledToDueBeingBeforeSpecificHourRestriction()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledToDueBeingBeforeSpecificHourRestrictionProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 09:00:00', '2018-10-18 14:00:00', '2018-10-18 09:00'];
+        yield 'With Interval' => [5, 'D', '1970-01-01 09:00:00', '2018-10-18 14:00:00', '2018-10-23 09:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledToDueBeingBeforeSpecificHourRestrictionProvider
+     */
+    public function testRescheduledToDueBeingBeforeSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -32,9 +44,13 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerHour')
             ->willReturn(
-                new \DateTime('1970-01-01 09:00:00')
+                new \DateTime($triggerHour)
             );
         $event->method('getTriggerRestrictedDaysOfWeek')
             ->willReturn([]);
@@ -50,15 +66,27 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
             ->willReturn('America/Los_Angeles');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC')));
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime($executionDate, new \DateTimeZone('UTC')));
         $firstGroup = reset($grouped);
 
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledDueToBeingAfterSpecificHourRestriction()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledDueToBeingAfterSpecificHourRestrictionProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 09:00:00', '2018-10-18 16:00:00', '2018-10-18 09:00'];
+        yield 'With Interval' => [5, 'D', '1970-01-01 09:00:00', '2018-10-18 16:00:00', '2018-10-23 09:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledDueToBeingAfterSpecificHourRestrictionProvider
+     */
+    public function testRescheduledDueToBeingAfterSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -67,9 +95,13 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerHour')
             ->willReturn(
-                new \DateTime('1970-01-01 09:00:00')
+                new \DateTime($triggerHour)
             );
         $event->method('getTriggerRestrictedDaysOfWeek')
             ->willReturn([]);
@@ -85,15 +117,27 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
             ->willReturn('America/Los_Angeles');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 16:00:00', new \DateTimeZone('UTC')));
+        $grouped    = $interval->groupContactsByDate($event, $contacts, new \DateTime($executionDate, new \DateTimeZone('UTC')));
         $firstGroup = reset($grouped);
 
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testNotRescheduledDueToSpecificHourRestriction()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function notRescheduledDueToSpecificHourRestrictionProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 09:00:00', '2018-10-18 14:00:00', '2018-10-18 09:00'];
+        yield 'With Interval' => [5, 'D', '1970-01-01 09:00:00', '2018-10-18 14:00:00', '2018-10-23 09:00'];
+    }
+
+    /**
+     * @dataProvider notRescheduledDueToSpecificHourRestrictionProvider
+     */
+    public function testNotRescheduledDueToSpecificHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -102,9 +146,13 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerHour')
             ->willReturn(
-                new \DateTime('1970-01-01 09:00:00')
+                new \DateTime($triggerHour)
             );
         $event->method('getTriggerRestrictedDaysOfWeek')
             ->willReturn([]);
@@ -120,15 +168,27 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
             ->willReturn('America/New_York');
         $contacts = new ArrayCollection([$contact1]);
 
-        $grouped       = $interval->groupContactsByDate($event, $contacts, new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC')));
+        $grouped       = $interval->groupContactsByDate($event, $contacts, new \DateTime($executionDate, new \DateTimeZone('UTC')));
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
         // 6am pacific = 9am eastern so don't reschedule
-        $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledToSameDayDueToStartHourRestriction()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledToSameDayDueToStartHourRestrictionProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', '2018-10-18 12:00', '2018-10-18 10:00'];
+        yield 'With Interval' => [5, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00', '2018-10-18 12:00', '2018-10-23 10:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledToSameDayDueToStartHourRestrictionProvider
+     */
+    public function testRescheduledToSameDayDueToStartHourRestriction(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
@@ -137,10 +197,14 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
             ->willReturn([]);
         $event->method('getCampaign')
@@ -154,13 +218,13 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $contacts = new ArrayCollection([$contact1]);
 
         $interval               = $this->getInterval();
-        $scheduledExecutionDate = new \DateTime('2018-10-18 12:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
         $grouped                = $interval->groupContactsByDate($event, $contacts, $scheduledExecutionDate);
 
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
     public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange()

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -523,24 +523,40 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 09:00:00', 6, '2018-10-18 15:00:00', '2018-10-20 09:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 09:00:00',  6,  '2018-10-18 15:00:00', '2018-10-27 09:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider
+     */
+    public function testRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerHour')
             ->willReturn(
-                new \DateTime('1970-01-01 09:00:00')
+                new \DateTime($triggerHour)
             );
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([6]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -557,27 +573,43 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-20 09:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testNotRescheduledDueToSpecificHourAndDayOfWeekRestrictions()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function notRescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', 4, '2018-10-18 15:00:00', '2018-10-18 10:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00',  4,  '2018-10-18 15:00:00', '2018-10-25 10:00'];
+    }
+
+    /**
+     * @dataProvider notRescheduledDueToSpecificHourAndDayOfWeekRestrictionsProvider
+     */
+    public function testNotRescheduledDueToSpecificHourAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerHour')
             ->willReturn(
-                new \DateTime('1970-01-01 10:00:00')
+                new \DateTime($triggerHour)
             );
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([4]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -594,27 +626,43 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictions()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', 6, '2018-10-18 14:00:00', '2018-10-20 10:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00',  6,  '2018-10-18 14:00:00', '2018-10-27 10:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider
+     */
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 14:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([6]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -631,27 +679,43 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testNotRescheduledDueToStartEndHoursAndDayOfWeekRestrictions()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function notRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', 4, '2018-10-18 16:00:00', '2018-10-18 11:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00',  4,  '2018-10-18 16:00:00', '2018-10-25 11:00'];
+    }
+
+    /**
+     * @dataProvider notRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsProvider
+     */
+    public function testNotRescheduledDueToStartEndHoursAndDayOfWeekRestrictions(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 16:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([4]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -668,27 +732,43 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 11:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolation()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolationProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', 6, '2018-10-18 15:00:00', '2018-10-20 10:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00',  6,  '2018-10-18 15:00:00', '2018-10-27 10:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolationProvider
+     */
+    public function testRescheduledDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyDowViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 15:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([6]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -705,27 +785,43 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-20 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolation()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolationProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', 4, '2018-10-18 13:00:00', '2018-10-18 10:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00',  4,  '2018-10-18 13:00:00', '2018-10-25 10:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolationProvider
+     */
+    public function testRescheduledToSameDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyStartHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, int $dayOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
         // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-18 13:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([4]);
+            ->willReturn([$dayOfWeek]);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -742,27 +838,42 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-18 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
-    public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation()
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function rescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolationProvider(): iterable
+    {
+        yield 'Without any Interval' => [0, '', '1970-01-01 10:00:00', '1970-01-01 20:00:00', [4, 5], '2018-10-19 02:00:00', '2018-10-19 10:00'];
+        yield 'With Interval' => [7, 'D', '1970-01-01 10:00:00', '1970-01-01 20:00:00',  [4, 5],  '2018-10-19 02:00:00', '2018-10-26 10:00'];
+    }
+
+    /**
+     * @dataProvider rescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolationProvider
+     */
+    public function testRescheduledToNextDayDueToStartEndHoursAndDayOfWeekRestrictionsWithOnlyEndHourViolation(int $triggerInterval, string $triggerIntervalUnit, string $triggerRestrictedStartHour, string $triggerRestrictedStopHour, array $daysOfWeek, string $executionDate, string $resultedExecutionDate)
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')
             ->willReturn(1);
 
-        // Thursday/4
-        $scheduledExecutionDate = new \DateTime('2018-10-19 02:00:00', new \DateTimeZone('UTC'));
+        $scheduledExecutionDate = new \DateTime($executionDate, new \DateTimeZone('UTC'));
 
         $event = $this->createMock(Event::class);
         $event->method('getTriggerMode')
             ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+            ->willReturn($triggerInterval);
+        $event->method('getTriggerIntervalUnit')
+            ->willReturn($triggerIntervalUnit);
         $event->method('getTriggerRestrictedStartHour')
-            ->willReturn(new \DateTime('1970-01-01 10:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStartHour));
         $event->method('getTriggerRestrictedStopHour')
-            ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+            ->willReturn(new \DateTime($triggerRestrictedStopHour));
         $event->method('getTriggerRestrictedDaysOfWeek')
-            ->willReturn([4, 5]);
+            ->willReturn($daysOfWeek);
         $event->method('getCampaign')
             ->willReturn($campaign);
 
@@ -779,7 +890,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         $firstGroup    = reset($grouped);
         $executionDate = $firstGroup->getExecutionDate();
 
-        $this->assertEquals('2018-10-19 10:00', $executionDate->format('Y-m-d H:i'));
+        $this->assertEquals($resultedExecutionDate, $executionDate->format('Y-m-d H:i'));
     }
 
     public function testContactsAreGrouped()


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Campaign events can get stuck in an hourly rescheduling loop with the following circumstances:

The event was evaluated prior to a time change that falls back an hour to be executed at a time after the time change. E.g. date_triggered = 2021-10-24 17:00:00 and trigger_date = 2021-11-08 14:00:00.
The event is scheduled at a relative time period at a specific hour or between two hours.

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a campaign with event which can be scheduled after 7th November 2021.
4. Add a contact in Eastern time zone where DST changes are applicable and add that contact to the segment which used in above campaign.
3. Change date_triggered date in mautic_campaign_lead_event_log to befoe DST 7th November 2021. and verify event get triggered at correct time

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
