### PR TITLE
Fix 500 error on contact API batch endpoint

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -810,6 +810,10 @@ class CommonApiController extends AbstractFOSRestController implements MauticCon
                 $entities = $entities->getIterator()->getArrayCopy();
             }
 
+            if ($entities instanceof \ArrayObject) {
+                $entities = $entities->getArrayCopy();
+            }
+
             return $idHelper->orderByOriginalKey($entities);
         }
 

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -10,6 +10,7 @@ use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use Mautic\ApiBundle\ApiEvents;
 use Mautic\ApiBundle\Event\ApiEntityEvent;
 use Mautic\ApiBundle\Helper\BatchIdToEntityHelper;
+use Mautic\ApiBundle\Helper\EntityResultHelper;
 use Mautic\ApiBundle\Serializer\Exclusion\ParentChildrenExclusionStrategy;
 use Mautic\ApiBundle\Serializer\Exclusion\PublishDetailsExclusionStrategy;
 use Mautic\CategoryBundle\Entity\Category;
@@ -943,8 +944,8 @@ class CommonApiController extends AbstractFOSRestController implements MauticCon
     }
 
     /**
-     * @param      $results
-     * @param null $callback
+     * @param array<mixed[]> $results
+     * @param callable|null  $callback
      *
      * @return array($entities, $totalCount)
      */
@@ -957,6 +958,9 @@ class CommonApiController extends AbstractFOSRestController implements MauticCon
             $totalCount = count($results);
         }
 
+        /**
+         * @var EntityResultHelper
+         */
         $entityResultHelper = $this->get('mautic.api.helper.entity_result');
 
         $entities = $entityResultHelper->getArray($results, $callback);

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -10,7 +10,7 @@ class EntityResultHelper
      * @param array<mixed>|Paginator<mixed> $results
      * @param callable|null                 $callback
      *
-     * @return array<mixed>
+     * @return array<mixed>|\ArrayObject<mixed>
      */
     public function getArray($results, $callback = null)
     {
@@ -24,6 +24,11 @@ class EntityResultHelper
             if (is_callable($callback)) {
                 $callback($entities[$key]);
             }
+        }
+
+        // solving array/object discrepancy for empty values
+        if ($this->isKeyedById($results) && empty($entities)) {
+            $entities = new \ArrayObject();
         }
 
         return $entities;
@@ -73,5 +78,15 @@ class EntityResultHelper
         }
 
         return $object[0];
+    }
+
+    /**
+     * @param array<mixed>|Paginator<int,mixed> $results
+     *
+     * @return bool
+     */
+    private function isKeyedById($results)
+    {
+        return !$results instanceof Paginator;
     }
 }

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -7,10 +7,10 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 class EntityResultHelper
 {
     /**
-     * @param array<mixed[]> $results
-     * @param callable|null  $callback
+     * @param array<mixed>|Paginator<int,mixed> $results
+     * @param callable|null                     $callback
      *
-     * @return array<mixed[]>
+     * @return array<mixed>
      */
     public function getArray($results, $callback = null)
     {
@@ -24,11 +24,6 @@ class EntityResultHelper
             if (is_callable($callback)) {
                 $callback($entities[$key]);
             }
-        }
-
-        // solving array/object discrepancy for empty values
-        if ($this->isKeyedById($results) && empty($entities)) {
-            $entities = [];
         }
 
         return $entities;
@@ -78,19 +73,5 @@ class EntityResultHelper
         }
 
         return $object[0];
-    }
-
-    /**
-     * @param mixed $results
-     *
-     * @return bool
-     */
-    private function isKeyedById($results)
-    {
-        if ($results instanceof Paginator) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -7,8 +7,8 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 class EntityResultHelper
 {
     /**
-     * @param array<mixed>|Paginator<int,mixed> $results
-     * @param callable|null                     $callback
+     * @param array<mixed>|Paginator<mixed> $results
+     * @param callable|null                 $callback
      *
      * @return array<mixed>
      */

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -7,10 +7,10 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 class EntityResultHelper
 {
     /**
-     * @param mixed  $results
-     * @param string $callback
+     * @param array<mixed[]> $results
+     * @param callable|null  $callback
      *
-     * @return array
+     * @return array<mixed[]>
      */
     public function getArray($results, $callback = null)
     {

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -10,7 +10,7 @@ class EntityResultHelper
      * @param array<mixed>|Paginator<mixed> $results
      * @param callable|null                 $callback
      *
-     * @return array<mixed>|\ArrayObject<mixed>
+     * @return array<mixed>|\ArrayObject<int,mixed>
      */
     public function getArray($results, $callback = null)
     {
@@ -81,7 +81,7 @@ class EntityResultHelper
     }
 
     /**
-     * @param array<mixed>|Paginator<int,mixed> $results
+     * @param array<mixed>|Paginator<mixed> $results
      *
      * @return bool
      */

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -439,7 +439,8 @@ class CommonRepository extends EntityRepository
             if (in_array($func, ['isNull', 'isNotNull'])) {
                 $expr = $q->expr()->{$func}($filter['column']);
             } elseif (in_array($func, ['in', 'notIn'])) {
-                $expr = $q->expr()->{$func}($filter['column'], $filter['value']);
+                $expr = $q->expr()->{$func}($filter['column'], ':'.$unique);
+                $q->setParameter($unique, $filter['value'], \Doctrine\DBAL\Connection::PARAM_STR_ARRAY);
             } elseif (in_array($func, ['like', 'notLike'])) {
                 if (isset($filter['strict']) && !$filter['strict']) {
                     if (is_numeric($filter['value'])) {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -4,6 +4,7 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Response;
 
 class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
@@ -403,10 +404,8 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
     /**
      * Test creating a new contact with doNotContact information.
      * The API response should include DNC information.
-     *
-     * @return void
      */
-    public function testSingleNewEndpointCreateAndDeleteWithDnc()
+    public function testSingleNewEndpointCreateAndDeleteWithDnc(): void
     {
         $payload = [
             'email'            => 'apidnc@email.com',
@@ -506,7 +505,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
 
-    public function testAddAndRemoveDncToExistingContact()
+    public function testAddAndRemoveDncToExistingContact(): void
     {
         // Create contact
         $payload = [

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -195,6 +195,19 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(null, $response['contacts'][2]['owner']);
     }
 
+    /**
+     * If there are some entities to return then the response returns a hash table (JSON object),
+     * So for response with no entities we must also return a JSON object because some languages
+     * decode it differently then emtpty array.
+     */
+    public function testEmptyResponseReturnsJsonObject(): void
+    {
+        $this->client->request('GET', '/api/contacts?limit=0');
+        $clientResponse = $this->client->getResponse();
+        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertEquals('{"total":"0","contacts":{}}', $clientResponse->getContent());
+    }
+
     public function testBatchEditEndpoint(): void
     {
         $contact = new Lead();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -202,7 +202,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testEmptyResponseReturnsJsonObject(): void
     {
-        $this->client->request('GET', '/api/contacts?limit=0');
+        $this->client->request('GET', '/api/contacts?where[0][val]=unicorn&where[0][col]=email&where[0][expr]=eq');
         $clientResponse = $this->client->getResponse();
         $this->assertTrue($this->client->getResponse()->isOk());
         $this->assertEquals('{"total":"0","contacts":{}}', $clientResponse->getContent());


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

There is a problem with the `PUT|PATCH api/contacts/batch/edit` when pushing one or more contacts with IDs that do not exist in Mautic anymore. It can happen if those contacts were deleted. Then the API returns:

```
{"errors":[{"message":"Looks like I encountered an error (error #500). If I do it again, please report me to the system administrator!","code":500,"type":null}]} 
```

And in the logs we can see this error:
```
Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Mautic\ApiBundle\Helper\BatchIdToEntityHelper::orderByOriginalKey() must be of the type array, object given, called in /app/bundles/ApiBundle/Controller/CommonApiController.php on line 819 in /app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php:94
```

Another but that the test discovered is bad SQL query param handling for in/notIn conditions.


[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Try to edit a contact via the `PUT|PATCH api/contacts/batch/edit` endpoint with ID that does not exist in the Mautic instance. For example ID of a contact you deleted.

You'll get the 500 error

#### Steps to test this PR:
1. Resend the API request once more

You'll get 201 (created) status code and the contact will be created as a new contact with new ID.

#### Other areas of Mautic that may be affected by the change:
1. The SQL fix can affect other parts of Mautic such as reports or segments.

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The `PUT|PATCH api/contacts/batch/edit` API endpoint with rubbish contact ID and with existing ID.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10724"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

