### PR TITLE
Ensure default frequency rules are taken into account correclty

### DIFF
--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -44,7 +44,7 @@ class FrequencyRuleRepository extends CommonRepository
 
         $violations = $this->getCustomFrequencyRuleViolations($channel, $leadIds, $statTable, $statContactColumn, $statSentColumn);
 
-        if ($defaultFrequencyTime && $defaultFrequencyTime) {
+        if ($defaultFrequencyNumber && $defaultFrequencyTime) {
             $violations = array_merge(
                 $violations,
                 $this->getDefaultFrequencyRuleViolations(


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10275 Fixes #10416 Fixes #10637 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The `DefaultFrequencyRuleViolations` are checked if the `defaultFrequencyTime` is present, regardless of the value of `defaultFrequencyNumber` due to an error in the conditional (2 times the same variable is checked)

This results in the issue described in [ #10275](https://github.com/mautic/mautic/issues/10275#issuecomment-903272962) (you can only send 1 mail to a contact, all subsequent attempts are queued), and explains why the mitigation in #10416 doesn't work

> Removing the "0" from the "Do not send me more than", thus setting it to blank, doesnt solve the Issue, I had to manually raise the "Do not contact me more than" ammount, which resulted in me being able to send out emails again.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

see the steps in [ #10275](https://github.com/mautic/mautic/issues/10275#issuecomment-903272962) and #10416
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

#### Extra remarks
The question / suggestion in [#10416](https://github.com/mautic/mautic/issues/10416#issuecomment-915981168) is still valid, as this functionality after this patch works as `0` is interpreted as FALSE.
But what is we want to queue everything for all users that have no custom frequency rule?



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10753"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

