### PR TITLE
process booleans correctly in the install command to prevent unwanted actions and incorrect data

### DIFF
--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -117,7 +117,7 @@ class InstallCommand extends ContainerAwareCommand
                 '--db_backup_tables',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Backup database tables if they exist; otherwise drop them.',
+                'Backup database tables if they exist; otherwise drop them. (true|false)',
                 null
             )
             ->addOption(
@@ -276,6 +276,9 @@ class InstallCommand extends ContainerAwareCommand
         $output->writeln('Parsing options and arguments...');
         $options = $input->getOptions();
 
+        // Convert boolean options to actual booleans.
+        $options['db_backup_tables'] = (bool) filter_var($options['db_backup_tables'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
         /**
          * We need to have some default database parameters, as it could be the case that the
          * user didn't set them both in local.php and the command line options.
@@ -309,7 +312,7 @@ class InstallCommand extends ContainerAwareCommand
 
         // Initialize DB and admin params from cli options
         foreach ($options as $opt => $value) {
-            if (!empty($value)) {
+            if (isset($value)) {
                 if (0 === strpos($opt, 'db_')) {
                     $dbParams[substr($opt, 3)] = $value;
                     $allParams[$opt]           = $value;


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The CLI installer has a ​flag to specify wether or not to backup the database.
The processing of this flag is incorrect, as you pass a string, but the code expect it to be a boolean.

This leads to following issues:
- the value `FALSE` (e.g. `--db_backup_tables="false"` or `--db_backup_tables=false`) is seen as `true` in the [SchemaHelper:installSchema()](https://github.com/mautic/mautic/blob/dc152081cdbf212ea502bb954452600885334192/app/bundles/InstallBundle/Helper/SchemaHelper.php#L173) resulting in
  - a db backup is taken ( = bad)
  - `local.php` value `'db_backup_tables' => 'false'` (bad, wrong value and type)
- the value `0`,  (e.g. `--db_backup_tables="0"` or `--db_backup_tables=0` ) is filtered out by the [`!empty` check](https://github.com/mautic/mautic/blob/dc152081cdbf212ea502bb954452600885334192/app/bundles/InstallBundle/Command/InstallCommand.php#L312), resulting in 
  - no db backup is taken ( = good)
  - `local.php` value `'db_backup_tables' => true` (bad, wrong value)
  
This PR addresses this issue, by ensuring that the boolean options  are casted, stored and used correctly

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

(be aware that during testing you may hit issue #8457, which can be fixed with #10747)
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
- start from a vanilla mautic without an `app/config/local.php` file
- install Mautic via CLI without a `--db_backup_tables` option in the commnad
- verify the content in the `app/config/local.php` file, it should be correct (`'db_backup_tables' => true`)
- remove the `app/config/local.php` file
- reinstall Mautic via CLI, using the `--db_backup_tables="false"` flag, to specify we don't want to backup
- verify the database, you will see all previous tables backed up
- verify the content in the `app/config/local.php` file, it should be incorrect (`'db_backup_tables' => 'false'`)
- apply the patch and clear the database, and start the scenario again

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

#### Other info
- The `--db_backup_tables="false"` is documented in the [How to install Mautic documentation](
https://docs.mautic.org/en/setup/how-to-install-mautic/install-mautic-from-package#providing-settings-in-the-install-command), but as explained above doesn't work as expected

- Symfony has a command option that would make more sense, `InputOption::VALUE_NEGATABLE`  , but it is [introduced in 5.3](https://symfony.com/blog/new-in-symfony-5-3-negatable-command-options)


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10757"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

