### PR TITLE
Change field definition for column_value to longtext instead of varchar

### DIFF
--- a/app/bundles/IntegrationsBundle/Entity/FieldChange.php
+++ b/app/bundles/IntegrationsBundle/Entity/FieldChange.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Entity;
 
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 
@@ -99,7 +100,7 @@ class FieldChange
             ->build();
 
         $builder
-            ->createField('columnValue', Type::STRING)
+            ->createField('columnValue', Types::TEXT)
             ->columnName('column_value')
             ->build();
     }

--- a/app/migrations/Version20200729170800.php
+++ b/app/migrations/Version20200729170800.php
@@ -11,7 +11,7 @@
 namespace Mautic\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Types\TextType;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
@@ -30,7 +30,7 @@ class Version20200729170800 extends AbstractMauticMigration
      */
     public function preUp(Schema $schema): void
     {
-        if ($schema->getTable($this->prefix.$this->table)->getColumn('column_value')->getType() instanceof Doctrine\DBAL\Types\TextType) {
+        if ($schema->getTable($this->prefix.$this->table)->getColumn('column_value')->getType() instanceof TextType) {
             throw new SkipMigration('column_value is already the correct type.');
         }
     }

--- a/app/migrations/Version20200729170800.php
+++ b/app/migrations/Version20200729170800.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * @copyright   2020 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Migration for changing column_value to a longtext from varchar.
+ */
+class Version20200729170800 extends AbstractMauticMigration
+{
+    /**
+     * @var string
+     */
+    private $table = 'sync_object_field_change_report';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preUp(Schema $schema): void
+    {
+        if (Types::TEXT === $schema->getTable($this->prefix.$this->table)->getColumn('column_value')->getType()) {
+            throw new SkipMigration('column_value is already the correct type.');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}{$this->table} MODIFY column_value LONGTEXT NOT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}{$this->table} MODIFY column_value VARCHAR(255) NOT NULL");
+    }
+}

--- a/app/migrations/Version20200729170800.php
+++ b/app/migrations/Version20200729170800.php
@@ -30,7 +30,7 @@ class Version20200729170800 extends AbstractMauticMigration
      */
     public function preUp(Schema $schema): void
     {
-        if (Types::TEXT === $schema->getTable($this->prefix.$this->table)->getColumn('column_value')->getType()) {
+        if ($schema->getTable($this->prefix.$this->table)->getColumn('column_value')->getType() instanceof Doctrine\DBAL\Types\TextType) {
             throw new SkipMigration('column_value is already the correct type.');
         }
     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | https://github.com/mautic/mautic/pull/10227
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Fixes this error: 

```
Uncaught PHP Exception Doctrine\DBAL\Exception\DriverException: "An exception occurred while executing 'INSERT INTO mautic_sync_object_field_change_report (integration, object_id, object_type, modified_at, column_name, column_type, column_value) VALUES (?, ?, ?, ?, ?, ?, ?)' with params ["Salesforce2", 12999, "Mautic\\LeadBundle\\Entity\\Lead", "2020-07-29 15:09:08", "most_recent_referrer", "string", "http:\/\/em.acquia.com\/dc\/EcTfRE0WDaAEB1CFD7cuk9zwNakwD32v7WShNoDZKOWXk01rdYRnMWjfhvSUhXwQkC-11EViafnb4uavY4mU1YJioUCkATc5R1l7KaJxKKl7Sq-lNDE4dBsED2ww1ztMqjBEcQwvlyWG0OYywfAyQQdOZccKsk-CeV5p68vSXSrtrlBze4Yt8gHmiQ8nu05wRoeWNoj1bTKGXwkZiPCYhTJ7MV7mQPGklqTn-_SRx7b-j_sjic9FnT7ZCbGWnUAu3P-WdGrc4OgjoQ5valof7BIgftfI0yv0w4yDNwZ9Y8c=\/hLu09ZR02E000CKW4010CRY"]: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'column_value' at row 1" at /usr/local/share/mautic/preproduction/releases/Mautic-2020.06.01-4/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 106 
```

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Configure any sync Pluggin
3. Try to sync a Contact with a long text field (for example a TEXTAREA message field)
4. The value stored in sync_object_field_change_report will be trimed.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10778"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

