### PR TITLE
Fix Filtering by "Integration Campaign Members" in a segment results in a silent error #10740

### DIFF
--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -81,7 +81,14 @@ class LeadListSubscriber implements EventSubscriberInterface
                         );
                     }
 
-                    $choices[$integration->getDisplayName()] = $integrationChoices;
+                    array_walk(
+                        $integrationChoices,
+                        function (&$choice) use ($integrationName) {
+                            $choice['label'] = $integrationName.': '.$choice['label'];
+                        }
+                    );
+
+                    $choices = array_merge($choices, $integrationChoices);
                 }
             }
         }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ x ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] Not really needed
| Issue(s) addressed                     | Fixes #10740.

#### Description:

This PR fixes an issue that occurs when you want to create a segment by an integration campaign membership. This currently returns an error, but this code fixes it. This is the code I first mentioned on the forms, but I did not like that it removed the optiongroup functionality. 

Old look:
<img width="1262" alt="CleanShot 2022-02-05 at 20 42 08@2x" src="https://user-images.githubusercontent.com/45830612/152656474-5fd053fa-c37f-4c13-ab86-89d780f9be82.png">

New look:
<img width="1283" alt="CleanShot 2022-02-05 at 20 40 19@2x" src="https://user-images.githubusercontent.com/45830612/152656414-20bfc7bf-4907-43db-ad4a-e94d8702962d.png">


#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Link your instance to SalesForce
3. Create a segment based on the membership of a integration campaign from SalesForce
4. If you are able to save it, it works.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10836"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

