### PR TITLE
Fix MJML email builder - "Edit Code" is broken

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -66,16 +66,15 @@ class CodeEditor {
   }
 
   // Load content and show popup
-  showCodePopup() {
+  showCodePopup(editor) {
     this.updateEditorContents();
     // this.codeEditor.editor.refresh();
-    // this.editor.Modal.setContent('');
-    this.editor.Modal.setContent(this.codePopup);
-    this.editor.Modal.setTitle(Mautic.translate('grapesjsbuilder.sourceEditModalTitle'));
-    this.editor.Modal.open();
-    this.editor.Modal.onceClose(() => {
-      this.editor.stopCommand('preset-mautic:code-edit');
-    });
+    // editor.Modal.setContent('');
+    editor.Modal.setContent(this.codePopup);
+    editor.Modal.setTitle(Mautic.translate('grapesjsbuilder.sourceEditModalTitle'));
+    editor.Modal.open();
+
+    editor.Modal.onceClose(() => editor.stopCommand('preset-mautic:code-edit'));
   }
 
   /**
@@ -113,7 +112,6 @@ class CodeEditor {
     let content;
     if (ContentService.isMjmlMode(this.editor)) {
       content = MjmlService.getEditorMjmlContent(this.editor);
-      console.log('loading modal');
     } else {
       content = ContentService.getEditorHtmlContent(this.editor);
     }

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeMode.command.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeMode.command.js
@@ -21,7 +21,7 @@ export default class CodeModeCommand {
       sender.set('active', 0);
     }
 
-    CodeModeCommand.codeEditor.showCodePopup();
+    CodeModeCommand.codeEditor.showCodePopup(editor);
 
     // Transform DC Component to token
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');


### PR DESCRIPTION
closes #10455

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| Deprecations?                          |  no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | N/A
| Issue(s) addressed                     | Fixes #10455

#### Description:

This fixes an issue where the code editor modal did not open **again** when the grapesjs builder was closed.

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. See steps in the [issue](https://github.com/mautic/mautic/issues/10455)


This PR is the same as https://github.com/mautic/mautic/pull/10564 but now based on 4.x branch

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10842"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

