### PR TITLE
Unsubscribe improvement

### DIFF
--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -408,6 +408,8 @@ class MauticFactory
     }
 
     /**
+     * @param string $service
+     *
      * @return object|bool
      */
     public function get($service)

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -60,8 +60,9 @@ return [
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::indexAction',
             ],
             'mautic_email_unsubscribe' => [
-                'path'       => '/email/unsubscribe/{idHash}',
+                'path'       => '/email/unsubscribe/{idHash}/{urlEmail}/{secretHash}',
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::unsubscribeAction',
+                'defaults'   => ['urlEmail' => null, 'secretHash' => null],
             ],
             'mautic_email_resubscribe' => [
                 'path'       => '/email/resubscribe/{idHash}',

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -11,6 +11,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Event\TransportWebhookEvent;
+use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Model\FormModel;
@@ -30,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class PublicController extends CommonFormController
 {
@@ -113,15 +115,8 @@ class PublicController extends CommonFormController
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
      */
-    public function unsubscribeAction(
-        Request $request,
-        ContactTracker $contactTracker,
-        $idHash
-    ) {
-        // Find the email
-        /** @var \Mautic\EmailBundle\Model\EmailModel $model */
-        $model                 = $this->getModel('email');
-        $translator            = $this->translator;
+    public function unsubscribeAction(Request $request, ContactTracker $contactTracker, EmailModel $model, LeadModel $leadModel, MailHashHelper $mailHash, $idHash, string $urlEmail = null, string $secretHash = null)
+    {
         $stat                  = $model->getEmailStatus($idHash);
         $message               = '';
         $email                 = null;
@@ -139,21 +134,24 @@ class PublicController extends CommonFormController
                 return new Response($this->translator->trans('mautic.lead.do.not.contact_unsubscribed'));
             }
 
-            if ($email = $stat->getEmail()) {
-                $template = $email->getTemplate();
-                if ('mautic_code_mode' === $template) {
-                    // Use system default
-                    $template = null;
-                }
+            $email = $stat->getEmail();
+        }
 
-                /** @var \Mautic\FormBundle\Entity\Form $unsubscribeForm */
-                $unsubscribeForm = $email->getUnsubscribeForm();
-                if (null != $unsubscribeForm && $unsubscribeForm->isPublished()) {
-                    $formTemplate = $unsubscribeForm->getTemplate();
-                    $formModel    = $this->getModel('form');
-                    \assert($formModel instanceof FormModel);
-                    $formContent = '<div class="mautic-unsubscribeform">'.$formModel->getContent($unsubscribeForm).'</div>';
-                }
+        $isCorrectHash = $secretHash && $urlEmail && $mailHash->getEmailHash($urlEmail) === $secretHash;
+
+        if ($email) {
+            $template = $email->getTemplate();
+            if ('mautic_code_mode' === $template) {
+                // Use system default
+                $template = null;
+            }
+
+            /** @var \Mautic\FormBundle\Entity\Form $unsubscribeForm */
+            $unsubscribeForm = $email->getUnsubscribeForm();
+            if (null != $unsubscribeForm && $unsubscribeForm->isPublished()) {
+                $formTemplate = $unsubscribeForm->getTemplate();
+                $formModel    = $this->getModel('form');
+                $formContent  = '<div class="mautic-unsubscribeform">'.$formModel->getContent($unsubscribeForm).'</div>';
             }
         } else {
             if ($isOneClickUnsubscribe) {
@@ -172,10 +170,10 @@ class PublicController extends CommonFormController
             $template = $theme->getTheme();
         }
         $contentTemplate = $this->factory->getHelper('theme')->checkForTwigTemplate('@themes/'.$template.'/html/message.html.twig');
-        if (!empty($stat)) {
+        if (!empty($stat) || $isCorrectHash) {
             $successSessionName = 'mautic.email.prefscenter.success';
 
-            if ($lead = $stat->getLead()) {
+            if (!empty($stat) && $lead = $stat->getLead()) {
                 // Set the lead as current lead
                 $contactTracker->setTrackedContact($lead);
 
@@ -187,12 +185,26 @@ class PublicController extends CommonFormController
                 // Add contact ID to the session name in case more contacts
                 // share the same session/device and the contact is known.
                 $successSessionName .= ".{$lead->getId()}";
+            } elseif (empty($stat)) {
+                $leadRepo = $leadModel->getRepository();
+                $contacts = $leadRepo->getContactsByEmail($urlEmail);
+                $lead     = null;
+                if (is_array($contacts) && count($contacts) > 0) {
+                    $lead  = array_pop($contacts);
+                } else {
+                    $message = $translator->trans('mautic.email.stat_record.not_found');
+                }
             }
 
             if (!$this->coreParametersHelper->get('show_contact_preferences')) {
-                $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $translator);
+                if (!empty($stat)) {
+                    $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $translator);
+                } elseif ($lead && $lead instanceof Lead) {
+                    $message = $this->getUnsubscribeMessageLead($idHash, $model, $lead, $translator, $urlEmail);
+                }
             } elseif ($lead) {
-                $action = $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]);
+                $unsubscribeHash = $mailHash->getEmailHash($urlEmail);
+                $action          = $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash, 'urlEmail' => $urlEmail, 'secretHash' => $unsubscribeHash]);
 
                 $viewParameters = [
                     'lead'                         => $lead,
@@ -214,7 +226,7 @@ class PublicController extends CommonFormController
 
                     return $this->postActionRedirect(
                         [
-                            'returnUrl'       => $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]),
+                            'returnUrl'       => $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash, 'urlEmail' => $urlEmail, 'secretHash' => $unsubscribeHash]),
                             'viewParameters'  => $viewParameters,
                             'contentTemplate' => $contentTemplate,
                         ]
@@ -326,11 +338,8 @@ class PublicController extends CommonFormController
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
      */
-    public function resubscribeAction(ContactTracker $contactTracker, $idHash): Response
+    public function resubscribeAction(ContactTracker $contactTracker, EmailModel $model, LeadModel $leadModel, MailHashHelper $mailHash, $idHash): Response
     {
-        // find the email
-        $model = $this->getModel('email');
-        \assert($model instanceof EmailModel);
         $stat = $model->getEmailStatus($idHash);
 
         if (!empty($stat)) {
@@ -353,7 +362,10 @@ class PublicController extends CommonFormController
 
             $model->removeDoNotContact($stat->getEmailAddress());
 
-            $message = $this->coreParametersHelper->get('resubscribe_message');
+            $message         = $this->coreParametersHelper->get('resubscribe_message');
+            $toEmail         = $stat->getEmailAddress();
+            $unsubscribeHash = $mailHash->getEmailHash($toEmail);
+
             if (!$message) {
                 $message = $this->translator->trans(
                     'mautic.email.resubscribed.success',
@@ -369,7 +381,7 @@ class PublicController extends CommonFormController
                     '|EMAIL|',
                 ],
                 [
-                    $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash]),
+                    $this->generateUrl('mautic_email_unsubscribe', ['idHash' => $idHash, 'urlEmail' => $toEmail, 'secretHash' => $unsubscribeHash]),
                     $stat->getEmailAddress(),
                 ],
                 $message
@@ -709,6 +721,18 @@ class PublicController extends CommonFormController
     {
         $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
+        return $this->getUnsubscribeText($translator, $stat->getEmailAddress(), $idHash);
+    }
+
+    public function getUnsubscribeMessageLead(string $idHash, EmailModel $model, Lead $lead, TranslatorInterface $translator, string $urlEmail): string
+    {
+        $model->setDoNotContactLead($lead, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
+
+        return $this->getUnsubscribeText($translator, $urlEmail, $idHash);
+    }
+
+    private function getUnsubscribeText(TranslatorInterface $translator, string $email, string $idHash): string
+    {
         $message = $this->coreParametersHelper->get('unsubscribe_message');
         if (!$message) {
             $message = $translator->trans(
@@ -727,7 +751,7 @@ class PublicController extends CommonFormController
             ],
             [
                 $this->generateUrl('mautic_email_resubscribe', ['idHash' => $idHash]),
-                $stat->getEmailAddress(),
+                $email,
             ],
             $message
         );

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -206,7 +206,7 @@ class EmailSendEvent extends CommonEvent
     }
 
     /**
-     * @return array|object|null
+     * @return array|Lead|null
      */
     public function getLead()
     {

--- a/app/bundles/EmailBundle/Helper/MailHashHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHashHelper.php
@@ -6,13 +6,10 @@ namespace Mautic\EmailBundle\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-class MailHashHelper
+final class MailHashHelper
 {
-    private CoreParametersHelper $coreParametersHelper;
-
-    public function __construct(CoreParametersHelper $coreParametersHelper)
+    public function __construct(private CoreParametersHelper $coreParametersHelper)
     {
-        $this->coreParametersHelper = $coreParametersHelper;
     }
 
     public function getEmailHash(string $email): string

--- a/app/bundles/EmailBundle/Helper/MailHashHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHashHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Helper;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+
+class MailHashHelper
+{
+    private CoreParametersHelper $coreParametersHelper;
+
+    public function __construct(CoreParametersHelper $coreParametersHelper)
+    {
+        $this->coreParametersHelper = $coreParametersHelper;
+    }
+
+    public function getEmailHash(string $email): string
+    {
+        $secret = $this->coreParametersHelper->get('secret_key');
+
+        return self::getEmailHashForSecret($email, $secret);
+    }
+
+    public static function getEmailHashForSecret(string $email, string $secret): string
+    {
+        return hash_hmac('sha256', $email, $secret);
+    }
+}

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1686,6 +1686,16 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
     }
 
     /**
+     * @return bool|DoNotContact
+     */
+    public function setDoNotContactLead(Lead $lead, string $comments, int $reason = DoNotContact::BOUNCED, bool $flush = true)
+    {
+        $channel = 'email';
+
+        return $this->doNotContact->addDncForContact($lead->getId(), $channel, $reason, $comments, $flush);
+    }
+
+    /**
      * Remove a Lead's EMAIL DNC entry.
      *
      * @param string $email

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1685,14 +1685,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         return false;
     }
 
-    /**
-     * @return bool|DoNotContact
-     */
-    public function setDoNotContactLead(Lead $lead, string $comments, int $reason = DoNotContact::BOUNCED, bool $flush = true)
+    public function setDoNotContactLead(Lead $lead, string $comments, int $reason = DoNotContact::BOUNCED, bool $flush = true): false|DoNotContact
     {
-        $channel = 'email';
-
-        return $this->doNotContact->addDncForContact($lead->getId(), $channel, $reason, $comments, $flush);
+        return $this->doNotContact->addDncForContact($lead->getId(), 'email', $reason, $comments, $flush);
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Controller;
 
+use Doctrine\ORM\ORMException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
@@ -11,16 +12,36 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\TransportWebhookEvent;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class PublicControllerFunctionalTest extends MauticMysqlTestCase
 {
+    /**
+     * @var int
+     */
+    private $leadId;
+
+    /**
+     * Tests that use the classic unsubscribe page. Not preference center.
+     */
+    private const UNSUBSCRIBE_TESTS = [
+        'testUnsubscribeWithEmailStat',
+        'testUnsubscribeEmail',
+    ];
+
     protected function setUp(): void
     {
-        $this->configParams['show_contact_preferences'] = 1;
+        if (in_array($this->getName(), self::UNSUBSCRIBE_TESTS)) {
+            $this->configParams['show_contact_preferences'] = 0;
+        } else {
+            $this->configParams['show_contact_preferences'] = 1;
+        }
+
         parent::setUp();
     }
 
@@ -178,7 +199,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     protected function getForm(?string $formTemplate): Form
     {
@@ -257,5 +278,164 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/email/preview/'.$email->getId());
         $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+    }
+
+    /**
+     * @throws ORMException
+     */
+    public function testUnsubscribeEmail(): void
+    {
+        foreach ($this->getUnsubscribeProvider() as $parameters) {
+            $this->runTestUnsubscribeAction(...$parameters);
+        }
+    }
+
+    /**
+     * @throws ORMException
+     */
+    public function runTestUnsubscribeAction(
+        string $statHash,
+        string $email,
+        string $emailHash,
+        string $message,
+        bool $addedRow
+    ): void {
+        $uri = '/email/unsubscribe/'.$statHash.'/'.$email.'/'.$emailHash;
+        $this->client->request(Request::METHOD_GET, $uri);
+        $clientResponse = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertStringContainsString($message, $clientResponse->getContent());
+        $doNotContacts       = $this->em->getRepository(DoNotContact::class)->findBy(['lead' => $this->leadId]);
+        $isAddedDoNotContact = (bool) count($doNotContacts);
+        $addedDoNotContact   = $isAddedDoNotContact ? $doNotContacts[0] : null;
+        $this->assertSame($addedRow, $isAddedDoNotContact);
+        // Cleaning
+        if ($isAddedDoNotContact) {
+            $this->em->remove($addedDoNotContact);
+            $this->em->flush();
+        }
+    }
+
+    /**
+     * @return array<string,array<string|bool>>
+     *
+     * @throws ORMException
+     *
+     * @see self::testUnsubscribeEmail()
+     */
+    private function getUnsubscribeProvider(): array
+    {
+        // Emails
+        $wrongEmail = 'test@mautictest.sk';
+        $rightEmail = 'test@mautictest.cz';
+        $lead       = new Lead();
+        $lead->setEmail($rightEmail);
+        $this->em->persist($lead);
+        // Email hash
+        $coreParametersHelper   = self::$container->get('mautic.helper.core_parameters');
+        $configSecretEmailHash  = $coreParametersHelper->get('secret_key');
+        $rightHashForWrongEmail = hash_hmac('sha256', $wrongEmail, $configSecretEmailHash);
+        $rightHashForRightEmail = hash_hmac('sha256', $rightEmail, $configSecretEmailHash);
+        $wrongHash              = hash_hmac('sha256', 'wrong', $configSecretEmailHash);
+        // Stat hash
+        $wrongStatHash = 'wrong';
+        $rightStatHash = 'right';
+        $stat          = new Stat();
+        $stat->setTrackingHash($rightStatHash);
+        $stat->setLead($lead);
+        $stat->setEmailAddress($rightEmail);
+        $stat->setDateSent(new \DateTime());
+        $this->em->persist($stat);
+        // Flush
+        $this->em->flush();
+        $this->leadId = $lead->getId();
+
+        return [
+            'ok' => [
+                $rightStatHash,
+                $rightEmail,
+                $rightHashForRightEmail,
+                'We are sorry to see you go!',
+                true,
+            ],
+            'ok_right_stat_hash' => [
+                $rightStatHash,
+                $wrongEmail,
+                $wrongHash,
+                'We are sorry to see you go!',
+                true,
+            ],
+            'ok_right_email_and_hash' => [
+                $wrongStatHash,
+                $rightEmail,
+                $rightHashForRightEmail,
+                'We are sorry to see you go!',
+                true,
+            ],
+            'ko_right_email_and_wrong_hash' => [
+                $wrongStatHash,
+                $rightEmail,
+                $wrongHash,
+                'Record not found',
+                false,
+            ],
+            'ko_wrong_email_and_right_hash' => [
+                $wrongStatHash,
+                $wrongEmail,
+                $rightHashForWrongEmail,
+                'Record not found',
+                false,
+            ],
+        ];
+    }
+
+    public function testUnsubscribeNotFoundEmailStat(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/email/unsubscribe/non-existant-hash');
+        Assert::assertStringContainsString(
+            'Record not found.',
+            strip_tags((string) $this->client->getResponse()->getContent())
+        );
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testUnsubscribeWithEmailStat(): void
+    {
+        $email = new Email();
+        $email->setName('Email A');
+        $email->setSubject('Email A Subject');
+        $email->setEmailType('template');
+        $contact = new Lead();
+        $contact->setEmail('john@doe.email');
+        $emailStat = new Stat();
+        $emailStat->setEmail($email);
+        $emailStat->setLead($contact);
+        $emailStat->setEmailAddress($contact->getEmail());
+        $emailStat->setDateSent(new \DateTime());
+        $emailStat->setTrackingHash('existing-tracking-hash');
+        $this->em->persist($email);
+        $this->em->persist($contact);
+        $this->em->persist($emailStat);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, '/email/unsubscribe/existing-tracking-hash');
+
+        Assert::assertStringContainsString(
+            'We are sorry to see you go! john@doe.email will no longer receive emails from us. If this was by mistake, click here to re-subscribe.',
+            strip_tags((string) $this->client->getResponse()->getContent())
+        );
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        /** @var DoNotContactRepository $dncRepository */
+        $dncRepository = $this->em->getRepository(DoNotContact::class);
+
+        /** @var DoNotContact[] $dncRecords */
+        $dncRecords = $dncRepository->findAll();
+
+        Assert::assertCount(1, $dncRecords);
+        Assert::assertSame($contact->getId(), $dncRecords[0]->getLead()->getId());
+        Assert::assertSame('email', $dncRecords[0]->getChannel());
+        Assert::assertSame((int) $email->getId(), (int) $dncRecords[0]->getChannelId());
+        Assert::assertSame('User unsubscribed.', $dncRecords[0]->getComments());
     }
 }

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\EventListener\BuilderSubscriber;
+use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
@@ -25,12 +26,14 @@ class BuilderSubscriberTest extends \PHPUnit\Framework\TestCase
         $trackableModel       = $this->createMock(TrackableModel::class);
         $redirectModel        = $this->createMock(RedirectModel::class);
         $translator           = $this->createMock(TranslatorInterface::class);
+        $mailHashHelper       = new MailHashHelper($coreParametersHelper);
         $builderSubscriber    = new BuilderSubscriber(
             $coreParametersHelper,
             $emailModel,
             $trackableModel,
             $redirectModel,
-            $translator
+            $translator,
+            $mailHashHelper
         );
 
         $emailModel->method('buildUrl')->willReturn('https://some.url');

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -8,6 +8,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\EventListener\TokenSubscriber;
 use Mautic\EmailBundle\Helper\FromEmailHelper;
+use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
@@ -37,6 +38,9 @@ class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
         /** @var MockObject&LoggerInterface $logger */
         $logger = $this->createMock(LoggerInterface::class);
 
+        /** @var MockObject&MailHashHelper $logger */
+        $mailHashHelper = $this->createMock(MailHashHelper::class);
+
         $coreParametersHelper->method('get')
             ->willReturnMap(
                 [
@@ -47,7 +51,7 @@ class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $tokens = ['{test}' => 'value'];
 
-        $mailHelper = new MailHelper($mockFactory, new Mailer(new SmtpTransport()), $fromEmailHelper, $coreParametersHelper, $mailbox, $logger);
+        $mailHelper = new MailHelper($mockFactory, new Mailer(new SmtpTransport()), $fromEmailHelper, $coreParametersHelper, $mailbox, $logger, $mailHashHelper);
         $mailHelper->setTokens($tokens);
 
         $email = new Email();

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -38,8 +38,7 @@ class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
         /** @var MockObject&LoggerInterface $logger */
         $logger = $this->createMock(LoggerInterface::class);
 
-        /** @var MockObject&MailHashHelper $logger */
-        $mailHashHelper = $this->createMock(MailHashHelper::class);
+        $mailHashHelper = new MailHashHelper($coreParametersHelper);
 
         $coreParametersHelper->method('get')
             ->willReturnMap(

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -74,6 +74,8 @@ class MailHelperTest extends TestCase
      */
     private MockObject $logger;
 
+    private MailHashHelper $mailHashHelper;
+
     /**
      * @var array<array<string,string|int>>
      */
@@ -118,6 +120,7 @@ class MailHelperTest extends TestCase
         $this->mockFactory          = $this->createMock(MauticFactory::class);
         $this->mailbox              = $this->createMock(Mailbox::class);
         $this->logger               = $this->createMock(LoggerInterface::class);
+        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
     }
 
     public function testQueueModeThrowsExceptionWhenBatchLimitHit(): void
@@ -134,7 +137,7 @@ class MailHelperTest extends TestCase
                 )
             );
 
-        $batchMailHelper = new MailHelper($this->mockFactory, new Mailer(new BatchTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $batchMailHelper = new MailHelper($this->mockFactory, new Mailer(new BatchTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $batchMailHelper->enableQueue();
         $batchMailHelper->addTo('somebody@somewhere.com');
         $batchMailHelper->addTo('somebodyelse@somewhere.com');
@@ -155,7 +158,7 @@ class MailHelperTest extends TestCase
                 )
             );
 
-        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
 
         try {
             $singleMailHelper->addTo('somebody@somewhere.com');
@@ -172,7 +175,7 @@ class MailHelperTest extends TestCase
     {
         $this->coreParametersHelper->method('get')->will($this->returnValueMap($this->defaultParams));
 
-        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $singleMailHelper->enableQueue();
 
         $email = new Email();
@@ -208,7 +211,7 @@ class MailHelperTest extends TestCase
 
     public function testBatchMode(): void
     {
-        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $singleMailHelper = new MailHelper($this->mockFactory, new Mailer(new BcInterfaceTokenTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $singleMailHelper->enableQueue();
 
         $email = new Email();
@@ -244,7 +247,7 @@ class MailHelperTest extends TestCase
         $transport     = new BatchTransport();
         $symfonyMailer = new Mailer($transport);
 
-        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
 
         $email = new Email();
         $email->setUseOwnerAsMailer(true);
@@ -319,7 +322,7 @@ class MailHelperTest extends TestCase
         $transport     = new BatchTransport();
         $symfonyMailer = new Mailer($transport);
 
-        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email  = new Email();
         $email->setUseOwnerAsMailer(true);
 
@@ -354,7 +357,7 @@ class MailHelperTest extends TestCase
                 ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => 'owner 2', 'last_name' => '', 'signature' => 'owner 2'],
             );
         $transport = new BatchTransport();
-        $mailer    = new MailHelper($this->mockFactory, new Mailer($transport), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer    = new MailHelper($this->mockFactory, new Mailer($transport), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email     = new Email();
 
         $email->setUseOwnerAsMailer(true);
@@ -395,7 +398,7 @@ class MailHelperTest extends TestCase
         $transport     = new BcInterfaceTokenTransport();
         $symfonyMailer = new Mailer($transport);
 
-        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $mailer->enableQueue();
         $mailer->setSubject('Hello');
         $mailer->setFrom('override@owner.com');
@@ -417,7 +420,7 @@ class MailHelperTest extends TestCase
     {
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email         = new Email();
 
         $email->setUseOwnerAsMailer(false);
@@ -443,7 +446,7 @@ class MailHelperTest extends TestCase
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email         = new Email();
 
         $email->setSubject('Subject');
@@ -466,7 +469,7 @@ class MailHelperTest extends TestCase
         $this->coreParametersHelper->method('get')->will($this->returnValueMap($this->defaultParams));
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email         = new Email();
 
         // From address is set
@@ -491,7 +494,7 @@ class MailHelperTest extends TestCase
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $email         = new Email();
 
         // From address is set
@@ -520,7 +523,7 @@ class MailHelperTest extends TestCase
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
 
         $email = new Email();
         $email->setUseOwnerAsMailer(true);
@@ -665,7 +668,7 @@ class MailHelperTest extends TestCase
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $mailer->setBody('{signature}');
         $mailer->addTo($this->contacts[0]['email']);
         $mailer->send();
@@ -694,7 +697,7 @@ class MailHelperTest extends TestCase
         $this->coreParametersHelper->method('get')->will($this->returnValueMap($params));
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $mailer->addTo($this->contacts[0]['email']);
 
         $email = new Email();
@@ -726,7 +729,7 @@ class MailHelperTest extends TestCase
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $mailer->addTo($this->contacts[0]['email']);
 
         $email = new Email();
@@ -756,34 +759,26 @@ class MailHelperTest extends TestCase
 
     public function testUnsubscribeHeader(): void
     {
-        $this->coreParametersHelper->expects($this->at(0))
-            ->method('get')
-            ->with('secret_key')
-            ->willReturn('secret');
+        $params = [
+            ['mailer_custom_headers', [], ['X-Mautic-Test' => 'test', 'X-Mautic-Test2' => 'test']],
+            ['secret_key', null, 'secret'],
+        ];
+        $this->coreParametersHelper->method('get')->will($this->returnValueMap($params));
 
-        $mockRouter  = $this->createMock(Router::class);
         $emailSecret = hash_hmac('sha256', 'someemail@email.test', 'secret');
+        $mockRouter  = $this->createMock(Router::class);
         $mockRouter->expects($this->once())
             ->method('generate')
             ->with('mautic_email_unsubscribe',
                 ['idHash' => 'hash', 'urlEmail' => 'someemail@email.test', 'secretHash' => $emailSecret],
                 UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://www.somedomain.cz/email/unsubscribe/hash/someemail@email.test/'.$emailSecret);
-            // ->willReturn('https://example.com/email/unsubscribe/65842d012b5b5772172137');
 
-        $parameterMap = [
-            ['mailer_custom_headers', [], ['X-Mautic-Test' => 'test', 'X-Mautic-Test2' => 'test']],
-        ];
-
-        /** @var MockObject|MauticFactory $mockFactory */
-        $mockFactory = $this->getMockFactory(true, $parameterMap);
-
-        $mockFactory->method('getRouter')
-            ->willReturnOnConsecutiveCalls($mockRouter);
+        $this->mockFactory->method('getRouter')->willReturnOnConsecutiveCalls($mockRouter);
 
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $mailer->setIdHash('hash');
 
         $email = new Email();
@@ -797,8 +792,8 @@ class MailHelperTest extends TestCase
 
         $mailer->setEmailType(MailHelper::EMAIL_TYPE_MARKETING);
         $headers = $mailer->getCustomHeaders();
+
         $this->assertSame('<http://www.somedomain.cz/email/unsubscribe/hash/someemail@email.test/'.$emailSecret.'>', $headers['List-Unsubscribe']);
-        // $this->assertSame('<https://example.com/email/unsubscribe/65842d012b5b5772172137>', $headers['List-Unsubscribe']);
         $this->assertSame('List-Unsubscribe=One-Click', $headers['List-Unsubscribe-Post']);
 
         // There are no unsubscribe headers in transactional emails.
@@ -813,7 +808,7 @@ class MailHelperTest extends TestCase
         $transport     = new SmtpTransport();
         $symfonyMailer = new Mailer($transport);
 
-        return new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        return new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
     }
 
     /**
@@ -895,7 +890,7 @@ class MailHelperTest extends TestCase
             );
 
         $symfonyMailer = new Mailer(new SmtpTransport());
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
 
         $mailer->setTo(['sombody@somewhere.com', 'sombodyelse@somewhere.com'], 'test');
 
@@ -926,7 +921,7 @@ class MailHelperTest extends TestCase
         $params[] = ['mailer_append_tracking_pixel', null, false];
         $this->coreParametersHelper->method('get')->will($this->returnValueMap($params));
         $symfonyMailer = new Mailer(new SmtpTransport());
-        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
 
         $mailer->addTo($this->contacts[0]['email']);
 
@@ -963,7 +958,7 @@ class MailHelperTest extends TestCase
                 )
             );
 
-        $smtpMailHelper = new MailHelper($this->mockFactory, new Mailer(new SmtpTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger);
+        $smtpMailHelper = new MailHelper($this->mockFactory, new Mailer(new SmtpTransport()), $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper);
         $smtpMailHelper->addTo($this->contacts[0]['email']);
 
         $email = new Email();

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -32,6 +32,7 @@ use Mautic\EmailBundle\Model\SendEmailToContact;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Entity\DoNotContact as DoNotContactEntity;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -582,6 +583,21 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue(1));
 
         $this->assertTrue(0 === count($this->emailModel->sendEmail($this->emailEntity, [1 => ['id' => 1, 'email' => 'someone@domain.com']])));
+    }
+
+    /**
+     * Test that DoNotContact works just with lead.
+     */
+    public function testDoNotContactLead(): void
+    {
+        $lead = new Lead();
+        $lead->setId(42);
+        $this->dncModel->expects($this->at(0))
+            ->method('addDncForContact')
+            ->with(42, 'email', DoNotContactEntity::BOUNCED, 'comment', true)
+            ->willReturn(true);
+
+        $this->assertTrue($this->emailModel->setDoNotContactLead($lead, 'comment'));
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -592,12 +592,12 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
     {
         $lead = new Lead();
         $lead->setId(42);
-        $this->dncModel->expects($this->at(0))
+        $this->doNotContact->expects($this->once())
             ->method('addDncForContact')
             ->with(42, 'email', DoNotContactEntity::BOUNCED, 'comment', true)
-            ->willReturn(true);
+            ->willReturn(false);
 
-        $this->assertTrue($this->emailModel->setDoNotContactLead($lead, 'comment'));
+        $this->assertFalse($this->emailModel->setDoNotContactLead($lead, 'comment'));
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -14,6 +14,7 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Exception\FailedToSendToContactException;
 use Mautic\EmailBundle\Helper\DTO\AddressDTO;
 use Mautic\EmailBundle\Helper\FromEmailHelper;
+use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToContact;
@@ -253,6 +254,15 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
+        
+        /**
+         * @var CoreParametersHelper&MockObject $mockParameterHelper
+         */
+        $mockParameterHelper = $this->createMock(CoreParametersHelper::class);
+        $mockParameterHelper->expects($this->any())
+            ->method('get')
+            ->with('secret_key')
+            ->willReturn('secret');
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock])
@@ -405,6 +415,12 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
+        $mockParameterHelper = $this->createMock(CoreParametersHelper::class);
+        $mockParameterHelper->expects($this->any())
+            ->method('get')
+            ->with('secret_key')
+            ->willReturn('secret');
+
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock])
             ->onlyMethods([])
@@ -499,6 +515,12 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
+
+        $mockParameterHelper = $this->createMock(CoreParametersHelper::class);
+        $mockParameterHelper->expects($this->any())
+            ->method('get')
+            ->with('secret_key')
+            ->willReturn('secret');
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
             ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock])
@@ -610,6 +632,13 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                     default => '',
                 }
             );
+
+        $mockParameterHelper = $this->createMock(CoreParametersHelper::class);
+        $mockParameterHelper->expects($this->any())
+            ->method('get')
+            ->with('secret_key')
+            ->willReturn('secret');
+
 
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')->willReturn(new AddressDTO('someone@somewhere.com'));
         $factoryMock->method('getLogger')->willReturn(new NullLogger());

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Helper\FromEmailHelper;
+use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
@@ -63,9 +64,15 @@ class OwnerSubscriberTest extends \PHPUnit\Framework\TestCase
         ],
     ];
 
+    /** @var MockObject&CoreParametersHelper */
+    private $coreParametersHelper;
+
+    private MailHashHelper $mailHashHelper;
+
     public function setUp(): void
     {
-        defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
     }
 
     public function testOnEmailBuild(): void
@@ -303,7 +310,7 @@ class OwnerSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $transport    = new SmtpTransport();
         $mailer       = new Mailer($transport);
-        $mailerHelper = new MailHelper($mockFactory, $mailer, $fromEmaiHelper, $coreParametersHelper, $mailbox, $logger);
+        $mailerHelper = new MailHelper($mockFactory, $mailer, $fromEmaiHelper, $coreParametersHelper, $mailbox, $logger, $this->mailHashHelper);
         $mailerHelper->setLead($lead);
 
         return $mailerHelper;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y 
| Automated tests included? | Y 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | /
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description 

⚠️ ~~This needs `FromEmailHelper` service that is introduced in https://github.com/mautic/mautic/pull/7811 so it must be merged first.~~

**Acceptance Criteria**

- User is able to unsubscribe from an old email, even if the specific email stat has been deleted
Contact identifier is hashed
- The unsubscribe URLs are generated using the hash stored in an email stat. If the email stat is deleted, the unsubscribe URL will no longer function as it will not be able to find the contact to unsubscribe.

We should change the format of the unsubscribe URL to also include a means to identify the contact to unsubscribe in the case the stat hash is not found. For example /email/unsubscribe/$STAT_HASH/$EMAIL_ADDRESS/$SECRET_HASH In Mautic's routing config.

$EMAIL_ADDRESS/$SECRET_HASH would be made optional for BC purposes so that Symfony continues to recognize the old URL. If a stat is not found, we then find the contact using $EMAIL_ADDRESS/$SECRET_HASH.

$SECRET_HASH is just for verification so anyone who would know just the email address cannot unsubscribe it.

The $SECRET_HASH would be generated from the instance's secret_key and the email address. Hash the email address using the secret_key. This hashing mechanism should be the best, but make a quick research: https://www.php.net/manual/en/function.hash-hmac.php. (sha256) It must be secure and fast.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Send email with unsubscribe link
3. Click link - it should look like /email/unsubscribe/$STAT_HASH/$EMAIL_ADDRESS/$SECRET_HASH
4. It should unsubscribe you even if:
 4.a. you use just /email/unsubscribe/$STAT_HASH
 4.b. you use wrong hash but right email with right $SECRET_HASH

#### Other areas of Mautic that may be affected by the change:
1. Email unsubscribe only


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10846"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

