### PR TITLE
Dynamics integration does not fetch leads

### DIFF
--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -413,7 +413,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
      */
     public function getLeads($params = [], $query = null, &$executed = null, $result = [], $object = 'contacts')
     {
-        if ('Contact' === $object) {
+        if ('Contact' === substr($object, 0, 7)) {
             $object = 'contacts';
         }
         $executed    = 0;


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I just tried the Dynamics integration with mautic today, and it didn't work as expected.
In my Dynamics configuration (in database) I do have {object: "contacts", ...}. That said, with the "magic" that is done here: https://github.com/mautic/mautic/blob/10141afbf8163282928592407a2f7c6825467e8b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php#L165 it is transformed into "Contacts", which isn't the good key to get back the contact fields. The "$select" parameter of the final request is then empty insead of having the mapping fields.
The result is that the request to https://[DYNAMICS URL]/api/data/v8.2/contacts produces a 400 error from Dynamics with the message: "The provided query options are not valid: System.ArgumentException: 'select' and 'expa...".

There are several ways to actually fix this issue, I tried to propose the one that is imo the best upgrade safe.

A cleaner way would be like "if ('Contacts' === $object)" (note the "s"), but I think this may break for some people that would already have the Dynamics config with {object: "contact"}.

Just tell me if you think there is a better/cleaner way to fix this issue and I'll update my PR.

#### Steps to test this PR:

1. Install Mautic with this PR
2. Install/Configure Dynamics 365
3. Configure the Dynamics 365 plugin integration in Mautic to work with Dynamics Contacts
4. Create some Leads on Dynamics
5. Run command: php bin/console mautic:integration:fetchleads --fetch-all --integration=Dynamics --time-interval=1day


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10848"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

