### PR TITLE
Heath Dutton: Improve boolean import/API support #7513

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -175,9 +175,8 @@ trait RequestTrait
         }
 
         switch ($leadField['type']) {
-            // Adjust the boolean values from text to boolean. Do not convert null to false.
             case 'boolean':
-                $fieldData[$leadField['alias']] = (int) filter_var($fieldData[$leadField['alias']], FILTER_VALIDATE_BOOLEAN);
+                $fieldData[$leadField['alias']] = InputHelper::boolean($fieldData[$leadField['alias']]);
                 break;
             // Ensure date/time entries match what symfony expects
             case 'datetime':

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -35,6 +35,31 @@ class InputHelper
     private static $strictHtmlFilter;
 
     /**
+     * Adjust the boolean values from text to boolean.
+     * Do not convert null to false.
+     * Do not convert invalid values to false, but return null.
+     *
+     * @param $value
+     *
+     * @return bool|null
+     */
+    public static function boolean($value)
+    {
+        // Common strings used that filter_var does not parse yet.
+        switch (strtoupper((string) $value)) {
+            case 'T':
+            case 'Y':
+                return true;
+
+            case 'F':
+            case 'N':
+                return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+
+    /**
      * @param bool $html
      * @param bool $strict
      *

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -39,7 +39,7 @@ class InputHelper
      * Do not convert null to false.
      * Do not convert invalid values to false, but return null.
      *
-     * @param $value
+     * @param bool|int|string|null $value
      *
      * @return bool|null
      */

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -82,84 +82,88 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedValues, $params);
     }
 
-    public function testCleanFieldsBoolean(): void
+    /**
+     * @dataProvider boolProvider
+     *
+     * @param string|int|bool|null $value
+     */
+    public function testCleanFieldsBoolean(?bool $expected, $value): void
     {
-        $fieldData = [
-            'boolVal' => true,
-        ];
-
+        $fieldData = ['boolVal' => $value];
         $leadField = [
             'alias' => 'boolVal',
             'type'  => 'boolean',
         ];
-        $expectedValues =
-            [
-                'boolVal' => true,
-            ];
+
         $this->cleanFields($fieldData, $leadField);
-        $this->assertSame($expectedValues, $fieldData);
+        $this->assertSame(['boolVal' => $expected], $fieldData);
+    }
+
+    /**
+     * @return iterable<array<?int,int|bool|string|null>>
+     */
+    public function boolProvider(): iterable
+    {
+        yield [true, '1'];
+        yield [true, 1];
+        yield [true, true];
+        yield [true, 'Y'];
+        yield [true, 'y'];
+        yield [true, 'yES'];
+        yield [true, 'T'];
+        yield [true, 't'];
+        yield [true, 'true'];
+        yield [null, null];
+        yield [false, '0'];
+        yield [false, 0];
+        yield [false, false];
+        yield [false, 'N'];
+        yield [false, 'n'];
+        yield [false, 'No'];
+        yield [false, 'F'];
+        yield [false, 'f'];
+        yield [false, 'false'];
     }
 
     public function testCleanFieldsDateTime(): void
     {
-        $fieldData = [
-            'fieldDateTime' => '10/10/2022 05:10:25',
-        ];
-
+        $fieldData = ['fieldDateTime' => '10/10/2022 05:10:25'];
         $leadField = [
             'alias' => 'fieldDateTime',
             'type'  => 'datetime',
         ];
-        $expectedValues =
-            [
-                'fieldDateTime' => '2022-10-10 05:10:25',
-            ];
+        $expectedValues = ['fieldDateTime' => '2022-10-10 05:10:25'];
         $this->cleanFields($fieldData, $leadField);
         $this->assertSame($expectedValues, $fieldData);
     }
 
     public function testCleanFieldsDate(): void
     {
-        $fieldData = [
-            'fieldDate' => '10/10/2022',
-        ];
-
+        $fieldData = ['fieldDate' => '10/10/2022'];
         $leadField = [
             'alias' => 'fieldDate',
             'type'  => 'date',
         ];
-        $expectedValues =
-            [
-                'fieldDate' => '2022-10-10',
-            ];
+        $expectedValues = ['fieldDate' => '2022-10-10'];
         $this->cleanFields($fieldData, $leadField);
         $this->assertSame($expectedValues, $fieldData);
     }
 
     public function testCleanFieldsTime(): void
     {
-        $fieldData = [
-            'fieldTime' => '05:20:10',
-        ];
-
+        $fieldData = ['fieldTime' => '05:20:10'];
         $leadField = [
             'alias' => 'fieldTime',
             'type'  => 'time',
         ];
-        $expectedValues =
-            [
-                'fieldTime' => '05:20:10',
-            ];
+        $expectedValues = ['fieldTime' => '05:20:10'];
         $this->cleanFields($fieldData, $leadField);
         $this->assertSame($expectedValues, $fieldData);
     }
 
     public function testCleanFieldsWrongDateTime(): void
     {
-        $fieldData = [
-            'fieldTime' => 'string',
-        ];
-
+        $fieldData = ['fieldTime' => 'string'];
         $leadField = [
             'alias' => 'fieldTime',
             'type'  => 'time',
@@ -171,10 +175,7 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
 
     public function testCleanFieldsMultiSelectArray(): void
     {
-        $fieldData = [
-            'fieldMultiSelect' => ['o1', 'o2', 'o3'],
-        ];
-
+        $fieldData = ['fieldMultiSelect' => ['o1', 'o2', 'o3']];
         $leadField = [
             'alias' => 'fieldMultiSelect',
             'type'  => 'multiselect',
@@ -186,10 +187,7 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
 
     public function testCleanFieldsMultiSelectString(): void
     {
-        $fieldData = [
-            'fieldMultiSelect' => 'o1|o2|o3',
-        ];
-
+        $fieldData = ['fieldMultiSelect' => 'o1|o2|o3'];
         $leadField = [
             'alias' => 'fieldMultiSelect',
             'type'  => 'multiselect',
@@ -201,10 +199,7 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
 
     public function testCleanFieldsNumber(): void
     {
-        $fieldData = [
-            'fieldFloat' => '3.2',
-        ];
-
+        $fieldData = ['fieldFloat' => '3.2'];
         $leadField = [
             'alias' => 'fieldFloat',
             'type'  => 'number',
@@ -216,10 +211,7 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
 
     public function testCleanFieldsEmail(): void
     {
-        $fieldData = [
-            'fieldEmail' => 'email@domain.com',
-        ];
-
+        $fieldData = ['fieldEmail' => 'email@domain.com'];
         $leadField = [
             'alias' => 'fieldEmail',
             'type'  => 'email',

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -81,4 +81,151 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($expectedValues, $params);
     }
+
+    public function testCleanFieldsBoolean(): void
+    {
+        $fieldData = [
+            'boolVal' => true,
+        ];
+
+        $leadField = [
+            'alias' => 'boolVal',
+            'type'  => 'boolean',
+        ];
+        $expectedValues =
+            [
+                'boolVal' => true,
+            ];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsDateTime(): void
+    {
+        $fieldData = [
+            'fieldDateTime' => '10/10/2022 05:10:25',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldDateTime',
+            'type'  => 'datetime',
+        ];
+        $expectedValues =
+            [
+                'fieldDateTime' => '2022-10-10 05:10:25',
+            ];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsDate(): void
+    {
+        $fieldData = [
+            'fieldDate' => '10/10/2022',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldDate',
+            'type'  => 'date',
+        ];
+        $expectedValues =
+            [
+                'fieldDate' => '2022-10-10',
+            ];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsTime(): void
+    {
+        $fieldData = [
+            'fieldTime' => '05:20:10',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldTime',
+            'type'  => 'time',
+        ];
+        $expectedValues =
+            [
+                'fieldTime' => '05:20:10',
+            ];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsWrongDateTime(): void
+    {
+        $fieldData = [
+            'fieldTime' => 'string',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldTime',
+            'type'  => 'time',
+        ];
+        $expectedValues = [];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsMultiSelectArray(): void
+    {
+        $fieldData = [
+            'fieldMultiSelect' => ['o1', 'o2', 'o3'],
+        ];
+
+        $leadField = [
+            'alias' => 'fieldMultiSelect',
+            'type'  => 'multiselect',
+        ];
+        $expectedValues = ['fieldMultiSelect' => ['o1', 'o2', 'o3']];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsMultiSelectString(): void
+    {
+        $fieldData = [
+            'fieldMultiSelect' => 'o1|o2|o3',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldMultiSelect',
+            'type'  => 'multiselect',
+        ];
+        $expectedValues = ['fieldMultiSelect' => ['o1', 'o2', 'o3']];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsNumber(): void
+    {
+        $fieldData = [
+            'fieldFloat' => '3.2',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldFloat',
+            'type'  => 'number',
+        ];
+        $expectedValues = ['fieldFloat' => 3.2];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testCleanFieldsEmail(): void
+    {
+        $fieldData = [
+            'fieldEmail' => 'email@domain.com',
+        ];
+
+        $leadField = [
+            'alias' => 'fieldEmail',
+            'type'  => 'email',
+        ];
+        $expectedValues = ['fieldEmail' => 'email@domain.com'];
+        $this->cleanFields($fieldData, $leadField);
+        $this->assertSame($expectedValues, $fieldData);
+    }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This is just fork of https://github.com/mautic/mautic/pull/7513  (mission impossible to rebase it) by @heathdutton

When creating leads by imports or APIs, boolean values that don't use "true" or "false" (etc) end up being stored as FALSE, instead of NULL (a more accurate value for a non-answer). This can cause a lot of confusion. This fixes that and also supports values like "T" and "F" which are obviously representative.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a boolean field.
2. Import a CSV with one lead value of "T".
3. Open the lead imported and you'll see "No" (false value) selected.

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Create a boolean field.
3. Import a CSV with one lead value of "T".
4. Open the lead imported and you'll see "Yes" (true value) selected. 

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10866"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

