### PR TITLE
Email dc multi select filter

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -2,6 +2,8 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
+use Mautic\LeadBundle\Segment\OperatorOptions;
+
 /**
  * Trait MatchFilterForLeadTrait.
  */
@@ -141,26 +143,12 @@ trait MatchFilterForLeadTrait
                     $filterVal         = str_replace('%', '.*', $filterVal);
                     $groups[$groupNum] = 1 !== preg_match('/'.$filterVal.'/', $leadVal);
                     break;
-                case 'in':
-                    $leadValMatched = false;
 
-                    if (in_array($leadVal, $filterVal)) {
-                        $leadValMatched = true;
-                    }
-                    $groups[$groupNum] = $leadValMatched;
+                case OperatorOptions::IN:
+                    $groups[$groupNum] = in_array($leadVal, $filterVal);
                     break;
-                case '!in':
-                    $leadValNotMatched = true;
-
-                    foreach ($leadVal as $v) {
-                        if (in_array($v, $filterVal)) {
-                            $leadValNotMatched = false;
-                            // Break once we find a match
-                            break;
-                        }
-                    }
-
-                    $groups[$groupNum] = $leadValNotMatched;
+                case OperatorOptions::NOT_IN:
+                    $groups[$groupNum] = !in_array($leadVal, $filterVal);
                     break;
                 case 'regexp':
                     $groups[$groupNum] = 1 === preg_match('/'.$filterVal.'/i', $leadVal);

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -145,10 +145,10 @@ trait MatchFilterForLeadTrait
                     break;
 
                 case OperatorOptions::IN:
-                    $groups[$groupNum] = in_array($leadVal, $filterVal);
+                    $groups[$groupNum] = $this->checkLeadValueInFilter($leadVal, $filterVal, false);
                     break;
                 case OperatorOptions::NOT_IN:
-                    $groups[$groupNum] = !in_array($leadVal, $filterVal);
+                    $groups[$groupNum] = $this->checkLeadValueInFilter($leadVal, $filterVal, true);
                     break;
                 case 'regexp':
                     $groups[$groupNum] = 1 === preg_match('/'.$filterVal.'/i', $leadVal);
@@ -170,5 +170,52 @@ trait MatchFilterForLeadTrait
         }
 
         return in_array(true, $groups);
+    }
+
+    private function checkLeadValueIsInFilter(array $leadVal, array $filterVal, bool $defaultFlag): bool
+    {
+        $retFlag = $defaultFlag;
+        foreach ($leadVal as $v) {
+            if (in_array($v, $filterVal)) {
+                $retFlag = !$defaultFlag;
+                // Break once we find a match
+                break;
+            }
+        }
+
+        return $retFlag;
+    }
+
+    /**
+     * Duplicate method. Needs refactoring.
+     *
+     * @see \Mautic\LeadBundle\EventListener\DynamicContentSubscriber::isContactSegmentRelationshipValid
+     *
+     * @param string $operator empty, !empty, in, !in
+     */
+    private function isContactSegmentRelationshipValid(int $contactId, string $operator, array $segmentIds = null): bool
+    {
+        switch ($operator) {
+            case OperatorOptions::EMPTY:
+                // Contact is not in any segment
+                $return = $this->segmentRepository->isNotContactInAnySegment($contactId);
+                break;
+            case OperatorOptions::NOT_EMPTY:
+                // Contact is in any segment
+                $return = $this->segmentRepository->isContactInAnySegment($contactId);
+                break;
+            case OperatorOptions::IN:
+                // Contact is in one of the segment provided in $segmentsIds
+                $return = $this->segmentRepository->isContactInSegments($contactId, $segmentIds);
+                break;
+            case OperatorOptions::NOT_IN:
+                // Contact is not in all segments provided in $segmentsIds
+                $return = $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds);
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator));
+        }
+
+        return $return;
     }
 }

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -143,12 +143,8 @@ trait MatchFilterForLeadTrait
                     break;
                 case 'in':
                     $leadValMatched = false;
-                    foreach ($leadVal as $v) {
-                        if (in_array($v, $filterVal)) {
-                            $leadValMatched = true;
-                            // Break once we find a match
-                            break;
-                        }
+                    if (in_array($leadVal, $filterVal)) {
+                        $leadValMatched = true;
                     }
                     $groups[$groupNum] = $leadValMatched;
                     break;

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -194,37 +194,4 @@ trait MatchFilterForLeadTrait
 
         return $retFlag;
     }
-
-    /**
-     * Duplicate method. Needs refactoring.
-     *
-     * @see \Mautic\LeadBundle\EventListener\DynamicContentSubscriber::isContactSegmentRelationshipValid
-     *
-     * @param string $operator empty, !empty, in, !in
-     */
-    private function isContactSegmentRelationshipValid(int $contactId, string $operator, array $segmentIds = null): bool
-    {
-        switch ($operator) {
-            case OperatorOptions::EMPTY:
-                // Contact is not in any segment
-                $return = $this->segmentRepository->isNotContactInAnySegment($contactId);
-                break;
-            case OperatorOptions::NOT_EMPTY:
-                // Contact is in any segment
-                $return = $this->segmentRepository->isContactInAnySegment($contactId);
-                break;
-            case OperatorOptions::IN:
-                // Contact is in one of the segment provided in $segmentsIds
-                $return = $this->segmentRepository->isContactInSegments($contactId, $segmentIds);
-                break;
-            case OperatorOptions::NOT_IN:
-                // Contact is not in all segments provided in $segmentsIds
-                $return = $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds);
-                break;
-            default:
-                throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator));
-        }
-
-        return $return;
-    }
 }

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -143,6 +143,7 @@ trait MatchFilterForLeadTrait
                     break;
                 case 'in':
                     $leadValMatched = false;
+
                     if (in_array($leadVal, $filterVal)) {
                         $leadValMatched = true;
                     }

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -83,7 +83,6 @@ trait MatchFilterForLeadTrait
                     if (!is_array($leadVal)) {
                         $leadVal = explode('|', $leadVal);
                     }
-
                     if (!is_array($filterVal)) {
                         $filterVal = explode('|', $filterVal);
                     }
@@ -93,6 +92,10 @@ trait MatchFilterForLeadTrait
                     $filterVal = (int) $filterVal;
                     break;
                 case 'select':
+                    if (!is_array($filterVal)) {
+                        $filterVal = explode('|', $filterVal);
+                    }
+                    break;
                 default:
                     if (is_numeric($leadVal)) {
                         $leadVal   = (int) $leadVal;
@@ -172,9 +175,15 @@ trait MatchFilterForLeadTrait
         return in_array(true, $groups);
     }
 
-    private function checkLeadValueIsInFilter(array $leadVal, array $filterVal, bool $defaultFlag): bool
+    /**
+     * @param mixed $leadVal
+     * @param mixed $filterVal
+     */
+    private function checkLeadValueIsInFilter($leadVal, $filterVal, bool $defaultFlag): bool
     {
-        $retFlag = $defaultFlag;
+        $leadVal    = !is_array($leadVal) ? [$leadVal] : $leadVal;
+        $filterVal  = !is_array($filterVal) ? [$filterVal] : $filterVal;
+        $retFlag    = $defaultFlag;
         foreach ($leadVal as $v) {
             if (in_array($v, $filterVal)) {
                 $retFlag = !$defaultFlag;

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -145,10 +145,10 @@ trait MatchFilterForLeadTrait
                     break;
 
                 case OperatorOptions::IN:
-                    $groups[$groupNum] = $this->checkLeadValueInFilter($leadVal, $filterVal, false);
+                    $groups[$groupNum] = $this->checkLeadValueIsInFilter($leadVal, $filterVal, false);
                     break;
                 case OperatorOptions::NOT_IN:
-                    $groups[$groupNum] = $this->checkLeadValueInFilter($leadVal, $filterVal, true);
+                    $groups[$groupNum] = $this->checkLeadValueIsInFilter($leadVal, $filterVal, true);
                     break;
                 case 'regexp':
                     $groups[$groupNum] = 1 === preg_match('/'.$filterVal.'/i', $leadVal);

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -105,6 +105,7 @@ class TokenSubscriber implements EventSubscriberInterface
             foreach ($data['filters'] as $filter) {
                 if ($this->matchFilterForLead($filter['filters'], $lead)) {
                     $filterContent = $filter['content'];
+                    break;
                 }
             }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\EmailBundle\EventListener\MatchFilterForLeadTrait;
+use Mautic\LeadBundle\Entity\LeadListRepository;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\TestCase;
 
 class MatchFilterForLeadTraitTest extends TestCase
@@ -45,11 +47,174 @@ class MatchFilterForLeadTraitTest extends TestCase
 
         self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
+
+    public function testIsContactSegmentRelationshipValidEmpty(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::EMPTY;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isNotContactInAnySegment')
+            ->with($lead['id'])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidNotEmpty(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::NOT_EMPTY;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isContactInAnySegment')
+            ->with($lead['id'])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidIn(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::IN;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isContactInSegments')
+            ->with($lead['id'], [0 => $segmentId])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidNotIn(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::NOT_IN;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isNotContactInSegments')
+            ->with($lead['id'], [0 => $segmentId])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidInvalidOperator(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = 'invalid';
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $trait->match($filter, $lead);
+    }
 }
 
 class MatchFilterForLeadTraitTestable
 {
     use MatchFilterForLeadTrait;
+
+    public function setRepository($segmentRepository): void
+    {
+        $this->segmentRepository = $segmentRepository;
+    }
 
     public function match(array $filter, array $lead): bool
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -45,69 +45,6 @@ class MatchFilterForLeadTraitTest extends TestCase
 
         self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
-
-    public function testDWCContactEndWidth(): void
-    {
-        $this->filter[0]['operator'] = 'endsWith';
-        $this->filter[0]['filter']   = 'text';
-
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
-
-        $this->lead['custom'] = 'another words';
-
-        self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
-    }
-
-    public function testDWCContactContains(): void
-    {
-        $this->filter[0]['operator'] = 'contains';
-        $this->filter[0]['filter']   = 'custom';
-
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
-
-        $this->lead['custom'] = 'another words';
-
-        self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
-    }
-
-    /**
-     * @dataProvider dateMatchTestProvider
-     */
-    public function testMatchFilterForLeadTraitForDate(?string $value, string $operator, bool $expect)
-    {
-        $filters = [
-            [
-                'glue'     => 'and',
-                'field'    => 'date',
-                'object'   => 'lead',
-                'type'     => 'date',
-                'filter'   => '2021-05-01',
-                'display'  => null,
-                'operator' => $operator,
-            ],
-        ];
-
-        $lead = [
-            'id'   => 1,
-            'date' => $value,
-        ];
-
-        $this->assertEquals($expect, $this->matchFilterForLeadTrait->match($filters, $lead));
-    }
-
-    public function dateMatchTestProvider(): iterable
-    {
-        $date = '2021-05-01';
-
-        yield [$date, '=', true];
-        yield [$date, '!=', false];
-        yield ['2020-02-02', '!=', true];
-        yield [$date, '!=', false];
-        yield [null, 'empty', true];
-        yield [$date, 'empty', false];
-        yield [$date, '!empty', true];
-        yield [null, '!empty', false];
-    }
 }
 
 class MatchFilterForLeadTraitTestable

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -208,6 +208,9 @@ class MatchFilterForLeadTraitTest extends TestCase
 
     /**
      * @dataProvider dataForInNotInOperatorFilter
+     *
+     * @param array<string,string> $fieldDetails
+     * @param array<string,string> $filterDetails
      */
     public function testCheckLeadValueIsInFilter(array $fieldDetails, array $filterDetails, bool $expected): void
     {
@@ -233,6 +236,9 @@ class MatchFilterForLeadTraitTest extends TestCase
         $this->assertSame($expected, $trait->match($filter, $lead));
     }
 
+    /**
+     * @return mixed[]
+     */
     public function dataForInNotInOperatorFilter(): iterable
     {
         // field details, filter details, expected.

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -205,6 +205,98 @@ class MatchFilterForLeadTraitTest extends TestCase
 
         $trait->match($filter, $lead);
     }
+
+    /**
+     * @dataProvider dataForInNotInOperatorFilter
+     */
+    public function testCheckLeadValueIsInFilter(array $fieldDetails, array $filterDetails, bool $expected): void
+    {
+        $lead = [
+            'id'                    => 1,
+            $fieldDetails['name']   => $fieldDetails['value'],
+        ];
+
+        $filter = [
+            0 => [
+                'display'   => null,
+                'field'     => $fieldDetails['name'],
+                'filter'    => $filterDetails['value'],
+                'glue'      => 'and',
+                'object'    => 'lead',
+                'operator'  => $filterDetails['operator'],
+                'type'      => $fieldDetails['type'],
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+
+        $this->assertSame($expected, $trait->match($filter, $lead));
+    }
+
+    public function dataForInNotInOperatorFilter(): iterable
+    {
+        // field details, filter details, expected.
+        yield [
+            [
+                'name'  => 'field_select',
+                'type'  => 'select',
+                'value' => 'one',
+            ],
+            [
+                'operator'  => OperatorOptions::IN,
+                'value'     => 'one',
+            ],
+            true,
+        ];
+        yield [
+            [
+                'name'  => 'field_multiselect',
+                'type'  => 'multiselect',
+                'value' => 'one|two',
+            ],
+            [
+                'operator'  => OperatorOptions::NOT_IN,
+                'value'     => 'three',
+            ],
+            true,
+        ];
+        yield [
+            [
+                'name'  => 'field_multiselect',
+                'type'  => 'multiselect',
+                'value' => 'one|two|three',
+            ],
+            [
+                'operator'  => OperatorOptions::NOT_IN,
+                'value'     => 'one|four',
+            ],
+            false,
+        ];
+        yield [
+            [
+                'name'  => 'field_country',
+                'type'  => 'country',
+                'value' => 'Some country',
+            ],
+            [
+                'operator'  => OperatorOptions::IN,
+                'value'     => 'Some country',
+            ],
+            true,
+        ];
+        yield [
+            [
+                'name'  => 'field_country',
+                'type'  => 'country',
+                'value' => 'Some country',
+            ],
+            [
+                'operator'  => OperatorOptions::IN,
+                'value'     => 'Some other country',
+            ],
+            false,
+        ];
+    }
 }
 
 class MatchFilterForLeadTraitTestable


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅ ]
| New feature/enhancement? (use the a.x branch)      | [4.3]
| Deprecations?                          | [:x:]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [Yes] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/10797

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The multi-select field is not working as expected with the dynamic content block. 

**This must be tested in the legacy builder as GrapeJS does not have dynamic content yet (I think). So go to plugins and disable the GrapeJS plugin**

#### Steps to test this PR:

Tip for testing:

> When testing dynamic web content visit the page in an incognito browser window. Then go to the Mautic administration and view anonymous contacts ordered by date last active. Edit the contact you just created in the anonymous window. It should be the one on the top of the list as it was just active. Now edit it to fit your dynamic content filters and test that they show up.

DWC docs: https://docs.mautic.org/en/components/dynamic-web-content

##### Test 1:
1. Open this PR on Gitpod or pull-down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom field of type multiple-select
3. Update contacts for a newly created custom field.
4. Create an email with a dynamic content block, add variants based on multi-select field filter criteria 

##### Test 2:

Step 1: Create a slot-based dynamic web content block
Step 2: Set the filter to Country Including [your country] [another country]
Step 3: Embed the slot on a web page
Step 4: validate content does load

##### Test 3:

Step 1: Create a slot-based dynamic web content block
Step 2: Use the Multiselect field from Test 1 and set including operator and some value from the multiselect.
Step 3: Embed the slot on a web page
Step 6: validate content does load

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10871"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>