### PR TITLE
Fix reply-to only set to default reply-to

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1233,6 +1233,7 @@ class MailHelper
         try {
             $name = $this->cleanName($name);
             $this->message->setReplyTo($addresses, $name);
+            $this->replyTo=$addresses;
         } catch (\Exception $e) {
             $this->logError($e, 'reply to');
         }


### PR DESCRIPTION
Reply-to is not set in form results for example

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [ N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [N] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

#### Description:
When you add "send form results" and you choose to reply to contact, the reply-to field in the email is not set to the contact email. 
This problem is fixed with this modification.

#### Steps to test this PR:

1. Create a form with an "email" field linked to contact email field
2. Add "Send form results" action and check "Reply to contact"
3. Complete the form
4. Check the email received has the field "Reply-to" with the email entered in the form
