### PR TITLE
Stop unnecessary query

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1016,9 +1016,17 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      * Updates lead's lastActive with now date/time.
      *
      * @param int $leadId
+     *
+     * @return void
      */
     public function updateLastActive($leadId)
     {
+        if (!$leadId) {
+            // Prevent unnecessary queries like:
+            // `UPDATE leads SET last_active = ... WHERE id IS NULL`
+            return;
+        }
+
         $dt     = new DateTimeHelper();
         $fields = ['last_active' => $dt->toUtcString()];
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
@@ -113,43 +113,29 @@ class LeadRepositoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetLeadsByFieldValueArrayMapReturn(): void
     {
-        $mock = $this->getMockBuilder(LeadRepository::class)
+        /** @var MockObject&LeadRepository */
+        $repository = $this->getMockBuilder(LeadRepository::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getEntities', 'buildQueryForGetLeadsByFieldValue'])
             ->getMock();
 
-        // Mock the
-        $mockEntity = $this->getMockBuilder(Lead::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['loadMetadata'])
-            ->getMock();
+        $contact = new Lead();
+        $contact->setEmail('test@example.com');
 
-        $mockEntity->setEmail('test@example.com');
+        $contact2 = new Lead();
+        $contact2->setEmail('test2@example.com');
 
-        $mockEntity2 = clone $mockEntity;
-        $mockEntity2->setEmail('test2@example.com');
+        $entities = [$contact, $contact2];
 
-        $entities = [
-            $mockEntity,
-            $mockEntity2,
-        ];
+        $repository->method('getEntities')->will($this->returnValue($entities));
+        $repository->method('buildQueryForGetLeadsByFieldValue')->will($this->returnValue(null));
 
-        $mock->method('getEntities')
-            ->will($this->returnValue($entities));
-
-        $mock->method('buildQueryForGetLeadsByFieldValue')
-            ->will($this->returnValue(null));
-
-        $contacts = $mock->getLeadsByFieldValue('email', ['test@example.com', 'test2@example.com']);
+        $contacts = $repository->getLeadsByFieldValue('email', ['test@example.com', 'test2@example.com']);
 
         $this->assertSame($entities, $contacts, 'When getting leads without indexing by column, it should match the expected result.');
 
-        $contacts = $mock->getLeadsByFieldValue('email', ['test@example.com', 'test2@example.com'], null, true);
-
-        $expected = [
-            'test@example.com',
-            'test2@example.com',
-        ];
+        $contacts = $repository->getLeadsByFieldValue('email', ['test@example.com', 'test2@example.com'], null, true);
+        $expected = ['test@example.com', 'test2@example.com'];
 
         $this->assertSame($expected, array_keys($contacts), 'When getting leads with indexing by column, it should match the expected result.');
     }


### PR DESCRIPTION
UPDATE leads SET last_active = ... WHERE id IS NULL

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 4.x
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included? | yes
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | /


#### Description:
During a release our DB server started falling. I checked the process log and there was a lot of these:

```sql
Waiting for table metadata lock	UPDATE mautic_leads SET last_active = '2022-02-10 18:10:59' WHERE id IS NULL 
```

It doesn't make sense to run such queries as ID is never NULL. These queries are unnecessary and are overloading database when the leads table is locked like it was during the release where some migrations were running alter table queries on the leads table.

#### Steps to test this PR:
1. Unknown. Confirm that the dateLastActive is getting updated on page hits, email clicks, form submissions and other activities the contacts do

#### Other areas of Mautic that may be affected by the change:
1. Just contact updates. Probably coming from page hits.

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The unit tests ensure that the update query is executed only when there is some ID provided.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10876"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

