### PR TITLE
Email-Category unsubscribe: Fixing an issue where contacts who have unsubscribed from a category will still receive emails in that category if they match the segment.

### DIFF
--- a/app/bundles/CampaignBundle/Event/ContextTrait.php
+++ b/app/bundles/CampaignBundle/Event/ContextTrait.php
@@ -17,6 +17,6 @@ trait ContextTrait
 
         $type = ($this->event instanceof Event) ? $this->event->getType() : $this->event['type'];
 
-        return strtolower($eventType) === strtolower($type);
+        return strtolower((string) $eventType) === strtolower((string) $type);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
+++ b/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
@@ -8,11 +8,13 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadCategory;
+use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
 use Mautic\LeadBundle\Entity\LeadList;
-use Mautic\LeadBundle\Entity\ListLead;
 
 trait CreateTestEntitiesTrait
 {

--- a/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
+++ b/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
@@ -8,13 +8,11 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\EmailBundle\Entity\Email;
-use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadCategory;
-use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
 
 trait CreateTestEntitiesTrait
 {
@@ -111,6 +109,7 @@ trait CreateTestEntitiesTrait
     {
         $email = new Email();
         $email->setName($name);
+        $email->setSubject('Test Subject');
         $email->setIsPublished(true);
 
         $this->em->persist($email);

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -65,7 +65,7 @@ class EmailSendEvent extends CommonEvent
         $this->textHeaders = $args['textHeaders'] ?? [];
 
         if (!$this->subject && $this->email instanceof Email) {
-            $this->subject = $args['email']->getSubject();
+            $this->subject = (string) $args['email']->getSubject();
         }
 
         if (isset($args['internalSend'])) {

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -27,6 +27,7 @@ use Mautic\EmailBundle\Helper\UrlMatcher;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -37,8 +38,14 @@ class CampaignSubscriber implements EventSubscriberInterface
         private EmailModel $emailModel,
         private RealTimeExecutioner $realTimeExecutioner,
         private SendEmailToUser $sendEmailToUser,
-        private TranslatorInterface $translator
+        private TranslatorInterface $translator,
+        private LeadModel $leadModel
     ) {
+        $this->emailModel          = $emailModel;
+        $this->realTimeExecutioner = $realTimeExecutioner;
+        $this->sendEmailToUser     = $sendEmailToUser;
+        $this->translator          = $translator;
+        $this->leadModel           = $leadModel;
     }
 
     public static function getSubscribedEvents(): array
@@ -230,7 +237,6 @@ class CampaignSubscriber implements EventSubscriberInterface
 
             return;
         }
-
         $event->setChannel('email', $emailId);
 
         $type    = $config['email_type'] ?? MailHelper::EMAIL_TYPE_TRANSACTIONAL;
@@ -252,6 +258,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $contacts        = $event->getContacts();
         $contactIds      = $event->getContactIds();
         $credentialArray = [];
+        $emailCategory   = $email->getCategory() ? $email->getCategory()->getId() : null;
 
         foreach ($contacts as $logId => $contact) {
             $leadCredentials                      = $contact->getProfileFields();
@@ -268,6 +275,20 @@ class CampaignSubscriber implements EventSubscriberInterface
                     $this->translator->trans(
                         'mautic.email.contact_has_no_email',
                         ['%contact%' => $contact->getPrimaryIdentifier()]
+                    )
+                );
+                unset($contactIds[$contact->getId()]);
+                continue;
+            }
+
+            $categories = $this->leadModel->getUnsubscribedLeadCategoriesIds($contact);
+            if ($emailCategory && !empty($categories) && in_array($emailCategory, $categories)) {
+                // Pass with a note to the UI because no use retrying
+                $event->passWithError(
+                    $pending->get($logId),
+                    $this->translator->trans(
+                        'mautic.email.contact_has_unsubscribed_from_category',
+                        ['%contact%' => $contact->getPrimaryIdentifier(), '%category%' => $emailCategory]
                     )
                 );
                 unset($contactIds[$contact->getId()]);

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -41,11 +41,6 @@ class CampaignSubscriber implements EventSubscriberInterface
         private TranslatorInterface $translator,
         private LeadModel $leadModel
     ) {
-        $this->emailModel          = $emailModel;
-        $this->realTimeExecutioner = $realTimeExecutioner;
-        $this->sendEmailToUser     = $sendEmailToUser;
-        $this->translator          = $translator;
-        $this->leadModel           = $leadModel;
     }
 
     public static function getSubscribedEvents(): array

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -135,7 +135,7 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $result = $this->repository->getEmailPendingQuery($email->getId())
+        $result = $this->emailRepository->getEmailPendingQuery($email->getId())
             ->execute()
             ->fetchAll();
 

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Entity;
 
-use DateTime;
 use Doctrine\ORM\ORMException;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
@@ -136,10 +135,10 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $result = $this->emailRepository->getEmailPendingQuery($email->getId())
-            ->execute()
-            ->fetchAll();
+            ->executeQuery()
+            ->fetchAllAssociative();
 
-        $actualLeadIds  = array_column($result, 'id');
+        $actualLeadIds  = array_map('intval',array_column($result, 'id'));
         sort($actualLeadIds);
 
         $expectedLeadIds = [$leadTwo->getId(), $leadThree->getId(), $leadFour->getId()];
@@ -186,7 +185,7 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
         $listLead = new ListLead();
         $listLead->setLead($leadOne);
         $listLead->setList($sourceList);
-        $listLead->setDateAdded(new DateTime());
+        $listLead->setDateAdded(new \DateTime());
         $this->em->persist($listLead);
     }
 

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -99,50 +99,6 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
         ], $result);
     }
 
-    public function testGetEmailPendingQueryWithExcludedLists(): void
-    {
-        // create some leads
-        $leadOne   = $this->createLead('one');
-        $leadTwo   = $this->createLead('two');
-        $leadThree = $this->createLead('three');
-        $leadFour  = $this->createLead('four');
-        $leadFive  = $this->createLead('five');
-        $leadSix   = $this->createLead('six');
-
-        // add some leads in lists for inclusion
-        $sourceListOne  = $this->createLeadList('Source', $leadOne, $leadTwo, $leadThree);
-        $sourceListTwo  = $this->createLeadList('Source', $leadOne, $leadFour, $leadFive, $leadSix);
-
-        // add some leads in lists for exclusion
-        $excludeListOne = $this->createLeadList('Exclude', $leadTwo, $leadSix);
-        $excludeListTwo = $this->createLeadList('Exclude', $leadTwo, $leadThree);
-
-        // create an email with included/excluded lists
-        $email = new Email();
-        $email->setName('Email');
-        $email->setSubject('Subject');
-        $email->setEmailType('list');
-        $email->addList($sourceListOne);
-        $email->addList($sourceListTwo);
-        $email->addExcludedList($excludeListOne);
-        $email->addExcludedList($excludeListTwo);
-        $this->em->persist($email);
-
-        $this->em->flush();
-        $this->em->clear();
-
-        $result = $this->repository->getEmailPendingQuery($email->getId())
-            ->execute()
-            ->fetchAll();
-        $actualLeadIds  = array_column($result, 'id');
-        sort($actualLeadIds);
-
-        $expectedLeadIds = [$leadOne->getId(), $leadFour->getId(), $leadFive->getId()];
-        sort($expectedLeadIds);
-
-        Assert::assertSame($expectedLeadIds, $actualLeadIds);
-    }
-
     public function testGetEmailPendingQueryWithSubscribedCategory(): void
     {
         // create some leads
@@ -214,6 +170,7 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
     {
         $leadList = new LeadList();
         $leadList->setName($name);
+        $leadList->setPublicName($name);
         $leadList->setAlias(mb_strtolower($name));
         $this->em->persist($leadList);
 

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Entity;
 
+use DateTime;
+use Doctrine\ORM\ORMException;
+use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadCategory;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Assert;
 
 class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
@@ -91,5 +97,168 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
             'manual'       => false,
             'comments'     => $doNotContact->getComments(),
         ], $result);
+    }
+
+    public function testGetEmailPendingQueryWithExcludedLists(): void
+    {
+        // create some leads
+        $leadOne   = $this->createLead('one');
+        $leadTwo   = $this->createLead('two');
+        $leadThree = $this->createLead('three');
+        $leadFour  = $this->createLead('four');
+        $leadFive  = $this->createLead('five');
+        $leadSix   = $this->createLead('six');
+
+        // add some leads in lists for inclusion
+        $sourceListOne  = $this->createLeadList('Source', $leadOne, $leadTwo, $leadThree);
+        $sourceListTwo  = $this->createLeadList('Source', $leadOne, $leadFour, $leadFive, $leadSix);
+
+        // add some leads in lists for exclusion
+        $excludeListOne = $this->createLeadList('Exclude', $leadTwo, $leadSix);
+        $excludeListTwo = $this->createLeadList('Exclude', $leadTwo, $leadThree);
+
+        // create an email with included/excluded lists
+        $email = new Email();
+        $email->setName('Email');
+        $email->setSubject('Subject');
+        $email->setEmailType('list');
+        $email->addList($sourceListOne);
+        $email->addList($sourceListTwo);
+        $email->addExcludedList($excludeListOne);
+        $email->addExcludedList($excludeListTwo);
+        $this->em->persist($email);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->getEmailPendingQuery($email->getId())
+            ->execute()
+            ->fetchAll();
+        $actualLeadIds  = array_column($result, 'id');
+        sort($actualLeadIds);
+
+        $expectedLeadIds = [$leadOne->getId(), $leadFour->getId(), $leadFive->getId()];
+        sort($expectedLeadIds);
+
+        Assert::assertSame($expectedLeadIds, $actualLeadIds);
+    }
+
+    public function testGetEmailPendingQueryWithSubscribedCategory(): void
+    {
+        // create some leads
+        $leadOne   = $this->createLead('one');
+        $leadTwo   = $this->createLead('two');
+        $leadThree = $this->createLead('three');
+        $leadFour  = $this->createLead('four');
+
+        // create some categories
+        $catOne     = $this->createCategory('one');
+        $catTwo     = $this->createCategory('two');
+        $catThree   = $this->createCategory('three');
+
+        // lead to subscribe categories
+        $this->subscribeCategory($leadOne, true, $catOne, $catTwo);
+        $this->subscribeCategory($leadTwo, true, $catOne, $catThree);
+        $this->subscribeCategory($leadThree, true, $catTwo, $catThree);
+        $this->subscribeCategory($leadFour, true, $catOne, $catThree);
+
+        // lead to unsubscribe categories
+        $this->subscribeCategory($leadOne, false, $catThree);
+
+        $sourceListOne  = $this->createLeadList('Source', $leadOne, $leadTwo, $leadThree, $leadFour);
+
+        // create an email with included/excluded lists
+        $email = new Email();
+        $email->setName('Email');
+        $email->setSubject('Subject');
+        $email->setEmailType('list');
+        $email->addList($sourceListOne);
+        $email->setCategory($catThree);
+        $this->em->persist($email);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $result = $this->repository->getEmailPendingQuery($email->getId())
+            ->execute()
+            ->fetchAll();
+
+        $actualLeadIds  = array_column($result, 'id');
+        sort($actualLeadIds);
+
+        $expectedLeadIds = [$leadTwo->getId(), $leadThree->getId(), $leadFour->getId()];
+        sort($expectedLeadIds);
+
+        $this->assertSame($expectedLeadIds, $actualLeadIds);
+    }
+
+    /**
+     * @throws ORMException
+     */
+    private function createLead(string $lastName): Lead
+    {
+        $lead = new Lead();
+        $lead->setLastname($lastName);
+        $lead->setEmail(sprintf('%s@mail.tld', $lastName));
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    /**
+     * @param Lead ...$leads
+     *
+     * @throws ORMException
+     */
+    private function createLeadList(string $name, ...$leads): LeadList
+    {
+        $leadList = new LeadList();
+        $leadList->setName($name);
+        $leadList->setAlias(mb_strtolower($name));
+        $this->em->persist($leadList);
+
+        foreach ($leads as $lead) {
+            $this->addLeadToList($lead, $leadList);
+        }
+
+        return $leadList;
+    }
+
+    private function addLeadToList(Lead $leadOne, LeadList $sourceList): void
+    {
+        $listLead = new ListLead();
+        $listLead->setLead($leadOne);
+        $listLead->setList($sourceList);
+        $listLead->setDateAdded(new DateTime());
+        $this->em->persist($listLead);
+    }
+
+    private function createCategory(string $string): Category
+    {
+        $category = new Category();
+        $category->setTitle('Category '.$string);
+        $category->setAlias('category-'.$string);
+        $category->setBundle('global');
+        $this->em->persist($category);
+
+        return $category;
+    }
+
+    /**
+     * @param Category ...$categories
+     */
+    private function subscribeCategory(Lead $lead, bool $subscribed, ...$categories): void
+    {
+        foreach ($categories as $category) {
+            $leadCategory = new LeadCategory();
+            $leadCategory->setLead($lead);
+            $leadCategory->setCategory($category);
+            $leadCategory->setDateAdded(new \DateTime());
+            $leadCategory->setManuallyAdded($subscribed);
+            $leadCategory->setManuallyRemoved(!$subscribed);
+            $this->em->persist($leadCategory);
+        }
+
+        $this->em->flush();
     }
 }

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -138,7 +138,7 @@ class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
             ->executeQuery()
             ->fetchAllAssociative();
 
-        $actualLeadIds  = array_map('intval',array_column($result, 'id'));
+        $actualLeadIds  = array_map('intval', array_column($result, 'id'));
         sort($actualLeadIds);
 
         $expectedLeadIds = [$leadTwo->getId(), $leadThree->getId(), $leadFour->getId()];

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -39,12 +39,12 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
         $this->em->flush();
         $this->em->clear();
 
-        $this->runCommand('mautic:segments:update', ['--list-id' => $segment->getId()]);
-        $this->runCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
-        $this->runCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
+        $this->testSymfonyCommand('mautic:segments:update', ['--list-id' => $segment->getId()]);
+        $this->testSymfonyCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+        $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
         /** @var LeadEventLogRepository $logRepo */
-        $logRepo  = self::$container->get('mautic.campaign.repository.lead_event_log');
+        $logRepo  = static::getContainer()->get('mautic.campaign.repository.lead_event_log');
         $metaData = [];
         foreach ($logRepo->getLeadLogs() as $leadLog) {
             if ($leadLog['metadata']) {

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -52,7 +52,7 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
             }
         }
 
-        $translator = self::$container->get('translator');
+        $translator = static::getContainer()->get('translator');
         $noEmailLog = $translator->trans(
             'mautic.email.contact_has_no_email',
             ['%contact%' => $leadB->getPrimaryIdentifier()]

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\EmailBundle\Entity\Email;
+
+final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticMysqlTestCase
+{
+    use CreateTestEntitiesTrait;
+
+    public function testOnCampaignTriggerActionSendEmailToContact(): void
+    {
+        $leadA = $this->createLead('Lead A', 'A', 'lead-a@test.com');
+        $leadB = $this->createLead('Lead B');
+        $leadC = $this->createLead('Lead C', 'D', 'lead-c@test.com');
+
+        $campaign = $this->createCampaign('Campaign');
+
+        $segment  = $this->createSegment('Segment A', [['object' => 'lead', 'glue' => 'and', 'field' => 'firstname', 'type' => 'text', 'operator' => 'startsWith', 'properties' => ['filter' => 'Lead']]]);
+
+        $campaign->addList($segment);
+
+        $category = $this->createCategory('CategoryA', 'category-a');
+
+        $this->createLeadCategory($leadA, $category, true);
+        $this->createLeadCategory($leadB, $category, true);
+        $this->createLeadCategory($leadC, $category, false);
+
+        $email      = $this->createEmailWithCategory('Email', $category);
+        $property   = ['email' => $email->getId()];
+        $this->createEvent('Event 1', $campaign, 'email.send', 'action', $property);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->runCommand('mautic:segments:update', ['--list-id' => $segment->getId()]);
+        $this->runCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+        $this->runCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
+
+        /** @var LeadEventLogRepository $logRepo */
+        $logRepo  = $this->container->get('mautic.campaign.repository.lead_event_log');
+        $metaData = [];
+        foreach ($logRepo->getLeadLogs() as $leadLog) {
+            if ($leadLog['metadata']) {
+                $metaData[$leadLog['lead_id']] = $leadLog['metadata']['reason'];
+            }
+        }
+
+        $translator = $this->container->get('translator');
+        $noEmailLog = $translator->trans(
+            'mautic.email.contact_has_no_email',
+            ['%contact%' => $leadB->getPrimaryIdentifier()]
+        );
+        $this->assertSame($noEmailLog, $metaData[$leadB->getId()], 'here');
+
+        $unsubscribedLog = $translator->trans(
+            'mautic.email.contact_has_unsubscribed_from_category',
+            ['%contact%' => $leadC->getPrimaryIdentifier(), '%category%' => $category->getId()]
+        );
+        $this->assertSame($unsubscribedLog, $metaData[$leadC->getId()], 'here 2');
+    }
+
+    private function createEmailWithCategory(string $name, Category $category): Email
+    {
+        $email = $this->createEmail($name);
+        $email->setCategory($category);
+
+        $this->em->persist($email);
+        $this->em->flush();
+
+        return $email;
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -44,7 +44,7 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
         $this->runCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
         /** @var LeadEventLogRepository $logRepo */
-        $logRepo  = $this->container->get('mautic.campaign.repository.lead_event_log');
+        $logRepo  = self::$container->get('mautic.campaign.repository.lead_event_log');
         $metaData = [];
         foreach ($logRepo->getLeadLogs() as $leadLog) {
             if ($leadLog['metadata']) {
@@ -52,7 +52,7 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
             }
         }
 
-        $translator = $this->container->get('translator');
+        $translator = self::$container->get('translator');
         $noEmailLog = $translator->trans(
             'mautic.email.contact_has_no_email',
             ['%contact%' => $leadB->getPrimaryIdentifier()]

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -53,11 +53,6 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private \Mautic\EmailBundle\EventListener\CampaignSubscriber $subscriber;
 
-    /**
-     * @var LeadModel|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $leadModel;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -66,14 +61,14 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
         $this->sendEmailToUser     = $this->createMock(SendEmailToUser::class);
         $this->translator          = $this->createMock(TranslatorInterface::class);
-        $this->leadModel           = $this->createMock(LeadModel::class);
+        $leadModel                 = $this->createMock(LeadModel::class);
 
         $this->subscriber = new CampaignSubscriber(
             $this->emailModel,
             $this->realTimeExecutioner,
             $this->sendEmailToUser,
             $this->translator,
-            $this->leadModel
+            $leadModel
         );
     }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -8,8 +8,6 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
 use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
-use Mautic\CategoryBundle\Entity\Category;
-use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\EventListener\CampaignSubscriber;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
 use Mautic\EmailBundle\Model\EmailModel;

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -8,11 +8,14 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
 use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\EventListener\CampaignSubscriber;
 use Mautic\EmailBundle\Exception\EmailCouldNotBeSentException;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
@@ -52,6 +55,11 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private \Mautic\EmailBundle\EventListener\CampaignSubscriber $subscriber;
 
+    /**
+     * @var LeadModel|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $leadModel;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -60,12 +68,14 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
         $this->sendEmailToUser     = $this->createMock(SendEmailToUser::class);
         $this->translator          = $this->createMock(TranslatorInterface::class);
+        $this->leadModel           = $this->createMock(LeadModel::class);
 
         $this->subscriber = new CampaignSubscriber(
             $this->emailModel,
             $this->realTimeExecutioner,
             $this->sendEmailToUser,
-            $this->translator
+            $this->translator,
+            $this->leadModel
         );
     }
 
@@ -161,5 +171,32 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
         $failedLead = $failure->getLead();
 
         $this->assertSame('tester@mautic.org', $failedLead->getEmail());
+    }
+
+    /**
+     * @throws \Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function testOnCampaignTriggerActionSendEmailToContactWithWrongEventType(): void
+    {
+        $eventAccessor = $this->createMock(ActionAccessor::class);
+        $event         = new Event();
+        $lead          = (new Lead())->setEmail('tester@mautic.org');
+
+        $leadEventLog = $this->createMock(LeadEventLog::class);
+        $leadEventLog
+            ->method('getLead')
+            ->willReturn($lead);
+        $leadEventLog
+            ->method('getId')
+            ->willReturn(6);
+
+        $logs = new ArrayCollection([$leadEventLog]);
+
+        $pendingEvent = new PendingEvent($eventAccessor, $event, $logs);
+        $this->subscriber->onCampaignTriggerActionSendEmailToContact($pendingEvent);
+
+        $this->assertCount(0, $pendingEvent->getSuccessful());
+        $this->assertCount(0, $pendingEvent->getFailures());
     }
 }

--- a/app/bundles/EmailBundle/Translations/en_US/messages.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/messages.ini
@@ -57,6 +57,7 @@ mautic.email.complaint.reason.fraud="Mail provider indicated some kind of fraud 
 mautic.email.complaint.reason.virus="Mail provider reports that a virus is found in the originating message"
 mautic.email.contact_already_received_marketing_email="%contact% has already received this marketing email."
 mautic.email.contact_has_no_email="%contact% has no email address."
+mautic.email.contact_has_unsubscribed_from_category="%contact% has unsubscribed the category %category%."
 mautic.email.builder.addcontent="Click to add content"
 mautic.email.builder.index="Extras"
 mautic.email.campaign.event.open="Opens email"

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -72,6 +72,8 @@ class DoctrineStep implements StepInterface
      */
     public $backup_prefix = 'bak_';
 
+    public ?string $server_version;
+
     public function __construct(Configurator $configurator)
     {
         $parameters = $configurator->getParameters();

--- a/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
@@ -22,8 +22,8 @@ class LeadCategoryRepository extends CommonRepository
             ->andWhere('lc.manually_removed = 0')
             ->setParameter('lead', $lead->getId());
 
-        $results = $q->execute()
-            ->fetchAll();
+        $results = $q->executeQuery()
+            ->fetchAllAssociative();
 
         $categories = [];
         foreach ($results as $category) {
@@ -45,7 +45,6 @@ class LeadCategoryRepository extends CommonRepository
             ->where('lc.lead_id = :lead')
             ->andWhere('lc.manually_removed = 1')
             ->setParameter('lead', $lead->getId());
-
 
         $results = $q->executeQuery()->fetchAllAssociative();
 

--- a/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
@@ -18,7 +18,10 @@ class LeadCategoryRepository extends CommonRepository
             ->select('lc.id, lc.category_id, lc.date_added, lc.manually_added, lc.manually_removed, c.alias, c.title')
             ->from(MAUTIC_TABLE_PREFIX.'lead_categories', 'lc')
             ->join('lc', MAUTIC_TABLE_PREFIX.'categories', 'c', 'c.id = lc.category_id')
-            ->where('lc.lead_id = :lead')->setParameter('lead', $lead->getId());
+            ->where('lc.lead_id = :lead')
+            ->andWhere('lc.manually_removed = 0')
+            ->setParameter('lead', $lead->getId());
+
 
         $results = $q->executeQuery()->fetchAllAssociative();
 

--- a/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadCategoryRepository.php
@@ -22,6 +22,30 @@ class LeadCategoryRepository extends CommonRepository
             ->andWhere('lc.manually_removed = 0')
             ->setParameter('lead', $lead->getId());
 
+        $results = $q->execute()
+            ->fetchAll();
+
+        $categories = [];
+        foreach ($results as $category) {
+            $categories[$category['category_id']] = $category;
+        }
+
+        return $categories;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getUnsubscribedLeadCategories(Lead $lead): array
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder()
+            ->select('lc.id, lc.category_id, lc.date_added, lc.manually_added, lc.manually_removed, c.alias, c.title')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_categories', 'lc')
+            ->join('lc', MAUTIC_TABLE_PREFIX.'categories', 'c', 'c.id = lc.category_id')
+            ->where('lc.lead_id = :lead')
+            ->andWhere('lc.manually_removed = 1')
+            ->setParameter('lead', $lead->getId());
+
 
         $results = $q->executeQuery()->fetchAllAssociative();
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1006,11 +1006,12 @@ class LeadModel extends FormModel
             $this->addToCategory($lead, $data['global_categories']);
         }
         $leadCategories = $this->getLeadCategories($lead);
-        // Delete categories that were removed
-        $deletedCategories = array_diff($leadCategories, $data['global_categories']);
 
-        if (!empty($deletedCategories)) {
-            $this->removeFromCategories($deletedCategories);
+        // Update categories relations as removed those are removed.
+        $unsubscribedCategories = array_diff($leadCategories, $data['global_categories']);
+
+        if (!empty($unsubscribedCategories)) {
+            $this->unsubscribeCategories($unsubscribedCategories);
         }
 
         // Delete channels that were removed
@@ -1055,6 +1056,34 @@ class LeadModel extends FormModel
     }
 
     public function removeFromCategories($categories): void
+    /**
+     * @param mixed[] $categories
+     */
+    private function unsubscribeCategories(array $categories): void
+    {
+        $unsubscribedCats = [];
+        foreach ($categories as $key => $category) {
+            /** @var LeadCategory $category */
+            $category     = $this->getLeadCategoryRepository()->getEntity($key);
+            $category->setManuallyRemoved(true);
+            $category->setManuallyAdded(false);
+
+            $unsubscribedCats[] = $category;
+
+            if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
+                $this->dispatcher->dispatch(LeadEvents::LEAD_CATEGORY_CHANGE, new CategoryChangeEvent($category->getLead(), $category->getCategory(), false));
+            }
+        }
+
+        if (!empty($unsubscribedCats)) {
+            $this->getLeadCategoryRepository()->saveEntities($unsubscribedCats);
+        }
+    }
+
+    /**
+     * @param $categories
+     */
+    public function removeFromCategories($categories)
     {
         $deleteCats = [];
         if (is_array($categories)) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1055,7 +1055,6 @@ class LeadModel extends FormModel
         return $results;
     }
 
-    public function removeFromCategories($categories): void
     /**
      * @param mixed[] $categories
      */
@@ -1071,7 +1070,7 @@ class LeadModel extends FormModel
             $unsubscribedCats[] = $category;
 
             if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
-                $this->dispatcher->dispatch(LeadEvents::LEAD_CATEGORY_CHANGE, new CategoryChangeEvent($category->getLead(), $category->getCategory(), false));
+                $this->dispatcher->dispatch(new CategoryChangeEvent($category->getLead(), $category->getCategory(), false), LeadEvents::LEAD_CATEGORY_CHANGE);
             }
         }
 
@@ -1080,10 +1079,7 @@ class LeadModel extends FormModel
         }
     }
 
-    /**
-     * @param $categories
-     */
-    public function removeFromCategories($categories)
+    public function removeFromCategories($categories): void
     {
         $deleteCats = [];
         if (is_array($categories)) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1121,6 +1121,20 @@ class LeadModel extends FormModel
     }
 
     /**
+     * @return mixed[]
+     */
+    public function getUnsubscribedLeadCategoriesIds(Lead $lead): array
+    {
+        $leadCategories   = $this->getLeadCategoryRepository()->getUnsubscribedLeadCategories($lead);
+        $leadCategoryList = [];
+        foreach ($leadCategories as $category) {
+            $leadCategoryList[$category['id']] = $category['category_id'];
+        }
+
+        return $leadCategoryList;
+    }
+
+    /**
      * @param array $fields
      * @param array $data
      * @param bool  $persist

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1841,7 +1841,7 @@ class LeadModel extends FormModel
         $chartQuery->applyFilters($q, $filters);
         $chartQuery->applyDateFilters($q, 'date_added');
 
-        $results   = $q->execute()->fetchAllAssociative();
+        $results   = $q->executeQuery()->fetchAllAssociative();
         $countries = array_flip(Countries::getNames('en'));
         $mapData   = [];
 
@@ -1882,7 +1882,7 @@ class LeadModel extends FormModel
         $chartQuery->applyFilters($q, $filters);
         $chartQuery->applyDateFilters($q, 'date_added');
 
-        return $q->execute()->fetchAllAssociative();
+        return $q->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -1910,7 +1910,7 @@ class LeadModel extends FormModel
         $chartQuery->applyFilters($q, $filters);
         $chartQuery->applyDateFilters($q, 'date_added');
 
-        return $q->execute()->fetchAllAssociative();
+        return $q->executeQuery()->fetchAllAssociative();
     }
 
     /**
@@ -1941,7 +1941,7 @@ class LeadModel extends FormModel
             $q->andWhere($q->expr()->isNotNull('t.date_identified'));
         }
 
-        $results = $q->execute()->fetchAllAssociative();
+        $results = $q->executeQuery()->fetchAllAssociative();
 
         if ($results) {
             foreach ($results as &$result) {

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -9,6 +9,11 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
+ */
 class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;
@@ -25,7 +30,6 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testCategoriesOnContactPreferences(): void
     {
         $lead       = $this->createLead('John', 'Doe', 'john@doe.com');
-
         $categories = $this->createCategories();
         $this->setLeadCategories($lead, $categories);
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Entity;
 
-use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadCategory;
 use Symfony\Component\HttpFoundation\Request;
 
 class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 {
+    use CreateTestEntitiesTrait;
+
     /**
      * @var array<string, bool>
      */
@@ -23,7 +24,8 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testCategoriesOnContactPreferences(): void
     {
-        $lead       = $this->createLead();
+        $lead       = $this->createLead('John', 'Doe', 'john@doe.com');
+
         $categories = $this->createCategories();
         $this->setLeadCategories($lead, $categories);
 
@@ -37,19 +39,6 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->assertCount(2, $subscribedCats);
     }
 
-    private function createLead(): Lead
-    {
-        $lead = new Lead();
-        $lead->setFirstname('John');
-        $lead->setLastname('Doe');
-        $lead->setEmail('john.doe@test.com');
-
-        $this->em->persist($lead);
-        $this->em->flush();
-
-        return $lead;
-    }
-
     /**
      * @return mixed[]
      */
@@ -57,12 +46,7 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
     {
         $categories = [];
         foreach ($this->categoryFlags as $suffix => $name) {
-            $category = new Category();
-            $category->setTitle('Category '.$suffix);
-            $category->setAlias('category-'.$suffix);
-            $category->setBundle('global');
-            $this->em->persist($category);
-            $categories[$suffix] = $category;
+            $categories[$suffix] = $this->createCategory('Category '.$suffix, 'category '.$suffix);
         }
 
         $this->em->flush();
@@ -76,14 +60,9 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
     private function setLeadCategories(Lead $lead, array $categories): void
     {
         foreach ($this->categoryFlags as $key => $flag) {
-            $newLeadCategory = new LeadCategory();
-            $newLeadCategory->setLead($lead);
-            $newLeadCategory->setCategory($categories[$key]);
-            $newLeadCategory->setDateAdded(new \DateTime());
-            $newLeadCategory->setManuallyAdded($flag);
-            $newLeadCategory->setManuallyRemoved(!$flag);
-            $this->em->persist($newLeadCategory);
+            $this->createLeadCategory($lead, $categories[$key], $flag);
         }
+
         $this->em->flush();
     }
 }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -36,7 +36,7 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 
         $subscribedCats = $crawler->filter('select[id="lead_contact_frequency_rules_global_categories"]')->filter('option[selected="selected"]');
 
-        $this->assertCount(2, $subscribedCats);
+        $this->assertCount(2, $subscribedCats, $crawler->html());
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadCategory;
+use Symfony\Component\HttpFoundation\Request;
+
+class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @var array<string, bool>
+     */
+    private $categoryFlags = [
+        'one'   => true,
+        'two'   => false,
+        'three' => true,
+    ];
+
+    public function testCategoriesOnContactPreferences(): void
+    {
+        $lead       = $this->createLead();
+        $categories = $this->createCategories();
+        $this->setLeadCategories($lead, $categories);
+
+        $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/contactFrequency/'.$lead->getId());
+        $response   = $this->client->getResponse();
+
+        $this->assertTrue($response->isOk());
+
+        $subscribedCats = $crawler->filter('select[id="lead_contact_frequency_rules_global_categories"]')->filter('option[selected="selected"]');
+
+        $this->assertCount(2, $subscribedCats);
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('John');
+        $lead->setLastname('Doe');
+        $lead->setEmail('john.doe@test.com');
+
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function createCategories(): array
+    {
+        $categories = [];
+        foreach ($this->categoryFlags as $suffix => $name) {
+            $category = new Category();
+            $category->setTitle('Category '.$suffix);
+            $category->setAlias('category-'.$suffix);
+            $category->setBundle('global');
+            $this->em->persist($category);
+            $categories[$suffix] = $category;
+        }
+
+        $this->em->flush();
+
+        return $categories;
+    }
+
+    /**
+     * @param mixed[] $categories
+     */
+    private function setLeadCategories(Lead $lead, array $categories): void
+    {
+        foreach ($this->categoryFlags as $key => $flag) {
+            $newLeadCategory = new LeadCategory();
+            $newLeadCategory->setLead($lead);
+            $newLeadCategory->setCategory($categories[$key]);
+            $newLeadCategory->setDateAdded(new \DateTime());
+            $newLeadCategory->setManuallyAdded($flag);
+            $newLeadCategory->setManuallyRemoved(!$flag);
+            $this->em->persist($newLeadCategory);
+        }
+        $this->em->flush();
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -48,14 +48,14 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
 
         /** @var LeadModel $model */
         $model = self::$container->get('mautic.lead.model.lead');
-        $model->setFrequencyRules($lead, $data);
+        $model->setFrequencyRules($lead, $data, [], []);
 
         $subscribedCategories   = $model->getLeadCategories($lead);
         $this->assertEmpty(array_diff($subscribedCategories, array_keys($categoriesToSubscribe)));
 
         // Unsubscribe categories.
         $data['global_categories'] = array_keys($categoriesToUnsubscribe);
-        $model->setFrequencyRules($lead, $data);
+        $model->setFrequencyRules($lead, $data, [], []);
 
         $unsubscribedCategories = $model->getUnsubscribedLeadCategoriesIds($lead);
         $this->assertEmpty(array_diff($unsubscribedCategories, array_keys($categoriesToSubscribe)));

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Model;
+
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+
+final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
+{
+    public function testSetFrequencyRulesForCategorySubscriptionUnsubscription(): void
+    {
+        // Create category
+        $categories = $this->createCategories();
+        // Create lead
+        $lead = $this->createLead();
+
+        shuffle($categories);
+
+        // Subscribe categories.
+        $categoriesToSubscribe = [];
+        /** @var Category $category */
+        foreach (array_slice($categories, 0, 3) as $category) {
+            $categoriesToSubscribe[$category->getId()] = $category->getId();
+        }
+
+        $data = [
+            'global_categories' => array_keys($categoriesToSubscribe),
+            'lead_lists'        => [],
+        ];
+
+        /** @var LeadModel $model */
+        $model = $this->container->get('mautic.lead.model.lead');
+        $model->setFrequencyRules($lead, $data);
+
+        $subscribedCategories   = $model->getLeadCategories($lead);
+        $this->assertEmpty(array_diff($subscribedCategories, array_keys($categoriesToSubscribe)));
+
+        // Unsubscribe categories.
+        unset($categoriesToSubscribe[$category->getId()]);
+        $data['global_categories'] = $categoriesToSubscribe;
+        $model->setFrequencyRules($lead, $data);
+        $unsubscribedCategories = $model->getLeadCategories($lead);
+        $this->assertEmpty(array_diff($unsubscribedCategories, array_keys($categoriesToSubscribe)));
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('John');
+        $lead->setLastname('Doe');
+        $lead->setEmail('john.doe@test.com');
+
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
+    }
+
+    /**
+     * @return Category[]
+     */
+    private function createCategories(): array
+    {
+        $categories = [];
+        foreach (['one', 'two', 'three', 'four'] as $suffix) {
+            $category = new Category();
+            $category->setTitle('Category '.$suffix);
+            $category->setAlias('category-'.$suffix);
+            $category->setBundle('global');
+            $this->em->persist($category);
+            $categories[$suffix] = $category;
+        }
+
+        $this->em->flush();
+
+        return $categories;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -23,10 +23,8 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
             'five'  => false,
         ];
 
-        // Create category
         $categories = $this->createCategories($categoriesFlags);
 
-        // Create lead
         $lead = $this->createLead('John', 'Doe', 'some@test.com');
 
         $this->em->flush();
@@ -47,7 +45,7 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
         ];
 
         /** @var LeadModel $model */
-        $model = self::$container->get('mautic.lead.model.lead');
+        $model = static::getContainer()->get('mautic.lead.model.lead');
         $model->setFrequencyRules($lead, $data, [], []);
 
         $subscribedCategories   = $model->getLeadCategories($lead);

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -6,11 +6,13 @@ namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\Entity\Lead;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Model\LeadModel;
 
 final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
 {
+    use CreateTestEntitiesTrait;
+
     public function testSetFrequencyRulesForCategorySubscriptionUnsubscription(): void
     {
         $categoriesFlags = [
@@ -25,7 +27,9 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
         $categories = $this->createCategories($categoriesFlags);
 
         // Create lead
-        $lead = $this->createLead();
+        $lead = $this->createLead('John', 'Doe', 'some@test.com');
+
+        $this->em->flush();
 
         // Subscribe categories.
         $categoriesToSubscribe   = [];
@@ -52,21 +56,9 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
         // Unsubscribe categories.
         $data['global_categories'] = array_keys($categoriesToUnsubscribe);
         $model->setFrequencyRules($lead, $data);
+
         $unsubscribedCategories = $model->getUnsubscribedLeadCategoriesIds($lead);
         $this->assertEmpty(array_diff($unsubscribedCategories, array_keys($categoriesToSubscribe)));
-    }
-
-    private function createLead(): Lead
-    {
-        $lead = new Lead();
-        $lead->setFirstname('John');
-        $lead->setLastname('Doe');
-        $lead->setEmail('john.doe@test.com');
-
-        $this->em->persist($lead);
-        $this->em->flush();
-
-        return $lead;
     }
 
     /**
@@ -78,12 +70,7 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
     {
         $categories = [];
         foreach ($cats as $suffix => $flag) {
-            $category = new Category();
-            $category->setTitle($suffix);
-            $category->setAlias('category-'.$suffix);
-            $category->setBundle('global');
-            $this->em->persist($category);
-            $categories[$suffix] = $category;
+            $categories[$suffix] = $this->createCategory($suffix, $suffix);
         }
 
         $this->em->flush();

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -47,7 +47,7 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
         ];
 
         /** @var LeadModel $model */
-        $model = $this->container->get('mautic.lead.model.lead');
+        $model = self::$container->get('mautic.lead.model.lead');
         $model->setFrequencyRules($lead, $data);
 
         $subscribedCategories   = $model->getLeadCategories($lead);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Yes]
| New feature/enhancement? (use the a.x branch)      | [4.x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [Yes] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

An issue where contacts who have unsubscribed from a category will still receive emails in that category if they match the segment.

#### Steps to reproduce the bug:

1. Create 2 (or more) global categories
2. On your test contact record, ensure that the contact has both categories selected/available
3. Create a preference center page that includes the categories block
4. Create an email with that preference center attached
5. Create a segment with your contact
6. Send the email to that segment
7. From the email (in a different browser, to be safe), click the unsubscribe link to get to the preference center
8. Deselect one of the categories and save preferences. Be sure that Email is still selected as a channel you can receive messages on
9. Check the contact record to see if the deselected category is no longer available
10. Create another email, and assign the deselected category to that email
11. Send the email to the same contact
12. Check the contact’s preferences again.

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. Create 2 (or more) global categories
3. Create Contacts and update their category preferences
    1. To do so, navigate to the contact page
    2. Navigate to the contact detail page and select preference from the context menu
    3. In the category tab, select all that apply and Save.
    4. Redo the above steps to unsubscribe from the category.
4. Create a segment with your contact; the segment should have the mix of leads subscribed/ unsubscribed category
5. Create an email
    1. Segment email
        1. Create a segment type email with
            1. Selecting created segment
            2. Select the category that the user unsubscribed from
        2. Schedule the email
        3. Check the
    2. For Campaign Action: Sent Email
        1. Create a template email
            1. Selecting created segment
            2. Selecting Preference center
        2. Create a campaign with Segment
        3. Add Action *Send email* selecting the above template email
        4. Save and trigger the campaign.

#### List of areas covered by the unit and/or functional tests:

1. Functional test cases covering new changes:
    1. `\Mautic\EmailBundle\Entity\EmailRepository::getEmailPendingQuery`
    2. `\Mautic\LeadBundle\Entity\LeadCategoryRepository::getLeadCategories`
    3. `\Mautic\LeadBundle\Model\LeadModel::setFrequencyRules`
    4. `\Mautic\EmailBundle\EventListener\CampaignSubscriber::onCampaignTriggerActionSendEmailToContact`
2. Create `\Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait` trait class for creating different entities to avoid duplication in the function testcases.



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10879"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>