### PR TITLE
Add RedisAdapter from Symfony 4 for CacheBundle

### DIFF
--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Mautic\CacheBundle\Cache\Adapter;
 
 use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
-use Mautic\CoreBundle\Helper\PRedisConnectionHelper;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
@@ -27,7 +26,7 @@ class RedisTagAwareAdapter extends TagAwareAdapter
 
         $options = array_key_exists('options', $servers) ? $servers['options'] : [];
 
-        $client = new \Predis\Client(PRedisConnectionHelper::getRedisEndpoints($servers['dsn']), $options);
+        $client  = RedisAdapter::createConnection($servers['dsn'], $options);
 
         parent::__construct(
             new RedisAdapter($client, $namespace, $lifetime),

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Helper;
 
 /**
+ * @depreacated in Mautic 5. Use Symfony 4 RedisAdapter for multiple instances https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html
+ *
  * Helper functions for simpler operations with arrays.
  */
 class PRedisConnectionHelper


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/mautic-cache-redis-config/20176/2

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
 
Current Redis integration with CacheBundle return  error on `clear:cache` command https://forum.mautic.org/t/mautic-cache-redis-config/20176

Instead of fixing it We noticed Redis Cache Adapter in Symfony 4 is able to do it the same
 https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html

It support multiple servers too.  PRedisConnectionHelper marked depreacated  (probably build for Mautic 3/Symfony 4) 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Setup Redis 
3. Try `clear:cache` command

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10889"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

