### PR TITLE
Segment delegate decorator event

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -852,7 +852,7 @@ return [
                 'tag'       => 'validator.constraint_validator',
                 'alias'     => 'segment_in_use',
             ],
-            'mautic.lead.event.dispatcher'       => [
+            'mautic.lead.event.dispatcher' => [
                 'class'     => \Mautic\LeadBundle\Helper\LeadChangeEventDispatcher::class,
                 'arguments' => [
                     'event_dispatcher',

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -378,10 +378,10 @@ return [
                 ],
             ],
             'mautic.lead.campaignbundle.action_delete_contacts.subscriber' => [
-                'class'     => CampaignActionDeleteContactSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\CampaignActionDeleteContactSubscriber::class,
                 'arguments' => [
-                   'mautic.lead.model.lead',
-                   'mautic.campaign.helper.removed_contact_tracker',
+                    'mautic.lead.model.lead',
+                    'mautic.campaign.helper.removed_contact_tracker',
                 ],
             ],
             'mautic.lead.campaignbundle.action_dnc.subscriber' => [
@@ -392,7 +392,7 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.subscriber' => [
-                'class'     => ReportSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\ReportSubscriber::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.stage.model.stage',
@@ -405,13 +405,13 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.segment_subscriber' => [
-                'class'     => SegmentReportSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\SegmentReportSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                 ],
             ],
             'mautic.lead.reportbundle.report_dnc_subscriber' => [
-                'class'     => ReportDNCSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\ReportDNCSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                     'mautic.lead.model.company_report_data',
@@ -427,7 +427,7 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.report_utm_tag_subscriber' => [
-                'class'     => ReportUtmTagSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\ReportUtmTagSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                     'mautic.lead.model.company_report_data',
@@ -448,7 +448,7 @@ return [
                 ],
             ],
             'mautic.lead.search.subscriber' => [
-                'class'     => SearchSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\SearchSubscriber::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.email.repository.email',
@@ -480,7 +480,7 @@ return [
                 ],
             ],
             'mautic.lead.stats.subscriber' => [
-                'class'     => StatsSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\StatsSubscriber::class,
                 'arguments' => [
                     'mautic.security',
                     'doctrine.orm.entity_manager',
@@ -520,14 +520,14 @@ return [
                 'class' => Mautic\LeadBundle\EventListener\ConfigSubscriber::class,
             ],
             'mautic.lead.timeline_events.subscriber' => [
-                'class'     => TimelineEventLogSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogSubscriber::class,
                 'arguments' => [
                     'translator',
                     'mautic.lead.repository.lead_event_log',
                 ],
             ],
             'mautic.lead.timeline_events.campaign.subscriber' => [
-                'class'     => TimelineEventLogCampaignSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogCampaignSubscriber::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_event_log',
                     'mautic.helper.user',
@@ -535,7 +535,7 @@ return [
                 ],
             ],
             'mautic.lead.timeline_events.segment.subscriber' => [
-                'class'     => TimelineEventLogSegmentSubscriber::class,
+                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogSegmentSubscriber::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_event_log',
                     'mautic.helper.user',
@@ -670,7 +670,7 @@ return [
                 'arguments' => ['translator', 'doctrine.orm.entity_manager'],
             ],
             'mautic.form.type.lead_quickemail' => [
-                'class'     => EmailType::class,
+                'class'     => \Mautic\LeadBundle\Form\Type\EmailType::class,
                 'arguments' => ['mautic.helper.user'],
             ],
             'mautic.form.type.lead_tag' => [
@@ -706,7 +706,7 @@ return [
                 ],
             ],
             'mautic.form.type.contact_channels' => [
-                'class'     => ContactChannelsType::class,
+                'class'     => \Mautic\LeadBundle\Form\Type\ContactChannelsType::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
                 ],
@@ -799,7 +799,7 @@ return [
             ],
         ],
         'other' => [
-            'mautic.lead.doctrine.subscriber'    => [
+            'mautic.lead.doctrine.subscriber' => [
                 'class'     => 'Mautic\LeadBundle\EventListener\DoctrineSubscriber',
                 'tag'       => 'doctrine.event_subscriber',
                 'arguments' => ['monolog.logger.mautic'],
@@ -826,8 +826,16 @@ return [
                     '@doctrine.orm.entity_manager',
                 ],
             ],
-            FileEncodingValidator::class         => [
-                'class'     => FileEncodingValidator::class,
+            \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
+                'class'     => \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
+                'tag'       => 'validator.constraint_validator',
+                'arguments' => [
+                    'mautic.lead.model.list',
+                    'mautic.helper.field.alias',
+                ],
+            ],
+            \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
+                'class'     => \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
                 'tag'       => 'validator.constraint_validator',
                 'arguments' => [
                     'mautic.lead.model.list',
@@ -858,8 +866,8 @@ return [
                     'event_dispatcher',
                 ],
             ],
-            'mautic.lead.merger'                 => [
-                'class'     => ContactMerger::class,
+            'mautic.lead.merger' => [
+                'class'     => \Mautic\LeadBundle\Deduplicate\ContactMerger::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.lead.repository.merged_records',
@@ -867,8 +875,8 @@ return [
                     'monolog.logger.mautic',
                 ],
             ],
-            'mautic.lead.deduper'                => [
-                'class'     => ContactDeduper::class,
+            'mautic.lead.deduper' => [
+                'class'     => \Mautic\LeadBundle\Deduplicate\ContactDeduper::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'mautic.lead.merger',
@@ -883,12 +891,12 @@ return [
                 ],
             ],
             'mautic.lead.helper.primary_company' => [
-                'class'     => PrimaryCompanyHelper::class,
+                'class'     => \Mautic\LeadBundle\Helper\PrimaryCompanyHelper::class,
                 'arguments' => [
                     'mautic.lead.repository.company_lead',
                 ],
             ],
-            'mautic.lead.validator.length'       => [
+            'mautic.lead.validator.length' => [
                 'class'     => Mautic\LeadBundle\Validator\Constraints\LengthValidator::class,
                 'tag'       => 'validator.constraint_validator',
             ],
@@ -930,7 +938,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    Company::class,
+                    \Mautic\LeadBundle\Entity\Company::class,
                 ],
                 'methodCalls' => [
                     'setUniqueIdentifiersOperator' => [
@@ -942,7 +950,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    CompanyLead::class,
+                    \Mautic\LeadBundle\Entity\CompanyLead::class,
                 ],
             ],
             'mautic.lead.repository.stages_lead_log' => [
@@ -963,7 +971,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    Lead::class,
+                    \Mautic\LeadBundle\Entity\Lead::class,
                 ],
                 'methodCalls' => [
                     'setUniqueIdentifiersOperator' => [
@@ -982,31 +990,31 @@ return [
                 ],
             ],
             'mautic.lead.repository.frequency_rule' => [
-                'class'     => FrequencyRuleRepository::class,
+                'class'     => \Mautic\LeadBundle\Entity\FrequencyRuleRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    FrequencyRule::class,
+                    \Mautic\LeadBundle\Entity\FrequencyRule::class,
                 ],
             ],
             'mautic.lead.repository.lead_event_log' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    LeadEventLog::class,
+                    \Mautic\LeadBundle\Entity\LeadEventLog::class,
                 ],
             ],
             'mautic.lead.repository.lead_device' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    LeadDevice::class,
+                    \Mautic\LeadBundle\Entity\LeadDevice::class,
                 ],
             ],
             'mautic.lead.repository.lead_list' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    LeadList::class,
+                    \Mautic\LeadBundle\Entity\LeadList::class,
                 ],
             ],
             'mautic.lead.repository.points_change_log' => [
@@ -1060,7 +1068,7 @@ return [
                 'arguments' => ['mautic.lead.model.random_parameter_name', 'event_dispatcher'],
             ],
             'mautic.lead.query.builder.special.leadlist' => [
-                'class'     => SegmentReferenceFilterQueryBuilder::class,
+                'class'     => \Mautic\LeadBundle\Segment\Query\Filter\SegmentReferenceFilterQueryBuilder::class,
                 'arguments' => [
                     'mautic.lead.model.random_parameter_name',
                     'mautic.lead.repository.lead_segment_query_builder',
@@ -1097,7 +1105,7 @@ return [
                 'alias'     => 'default_avatar',
             ],
             'mautic.helper.field.alias' => [
-                'class'     => FieldAliasHelper::class,
+                'class'     => \Mautic\LeadBundle\Helper\FieldAliasHelper::class,
                 'arguments' => ['mautic.lead.model.field'],
             ],
             'mautic.helper.template.dnc_reason' => [
@@ -1108,7 +1116,7 @@ return [
         ],
         'models' => [
             'mautic.lead.model.lead' => [
-                'class'     => LeadModel::class,
+                'class'     => \Mautic\LeadBundle\Model\LeadModel::class,
                 'arguments' => [
                     'request_stack',
                     'mautic.helper.cookie',
@@ -1133,13 +1141,13 @@ return [
 
             // Deprecated support for circular dependency
             'mautic.lead.model.legacy_lead' => [
-                'class'     => LegacyLeadModel::class,
+                'class'     => \Mautic\LeadBundle\Model\LegacyLeadModel::class,
                 'arguments' => [
                     'service_container',
                 ],
             ],
             'mautic.lead.model.field' => [
-                'class'     => FieldModel::class,
+                'class'     => \Mautic\LeadBundle\Model\FieldModel::class,
                 'arguments' => [
                     'mautic.schema.helper.column',
                     'mautic.lead.model.list',
@@ -1152,7 +1160,7 @@ return [
                 ],
             ],
             'mautic.lead.model.list' => [
-                'class'     => ListModel::class,
+                'class'     => \Mautic\LeadBundle\Model\ListModel::class,
                 'arguments' => [
                     'mautic.category.model.category',
                     'mautic.helper.core_parameters',
@@ -1162,7 +1170,7 @@ return [
                 ],
             ],
             'mautic.lead.repository.lead_segment_filter_descriptor' => [
-                'class'     => ContactSegmentFilterDictionary::class,
+                'class'     => \Mautic\LeadBundle\Services\ContactSegmentFilterDictionary::class,
                 'arguments' => [
                     'event_dispatcher',
                 ],
@@ -1176,7 +1184,7 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment_service' => [
-                'class'     => ContactSegmentService::class,
+                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentService::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_factory',
                     'mautic.lead.repository.lead_segment_query_builder',
@@ -1184,73 +1192,71 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment_filter_factory' => [
-                'class'     => ContactSegmentFilterFactory::class,
+                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentFilterFactory::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_schema_cache',
                     '@service_container',
                     'mautic.lead.model.lead_segment_decorator_factory',
-                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.model.lead_segment_schema_cache' => [
-                'class'     => TableSchemaColumnsCache::class,
+                'class'     => \Mautic\LeadBundle\Segment\TableSchemaColumnsCache::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                 ],
             ],
             'mautic.lead.model.relative_date' => [
-                'class'     => RelativeDate::class,
+                'class'     => \Mautic\LeadBundle\Segment\RelativeDate::class,
                 'arguments' => [
                     'translator',
                 ],
             ],
             'mautic.lead.model.lead_segment_filter_operator' => [
-                'class'     => ContactSegmentFilterOperator::class,
+                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentFilterOperator::class,
                 'arguments' => [
                     'mautic.lead.provider.fillterOperator',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_factory' => [
-                'class'     => DecoratorFactory::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\DecoratorFactory::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                     'mautic.lead.model.lead_segment_decorator_base',
                     'mautic.lead.model.lead_segment_decorator_custom_mapped',
                     'mautic.lead.model.lead_segment.decorator.date.optionFactory',
                     'mautic.lead.model.lead_segment_decorator_company',
-                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_base' => [
-                'class'     => BaseDecorator::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\BaseDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_custom_mapped' => [
-                'class'     => CustomMappedDecorator::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\CustomMappedDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_company' => [
-                'class'     => CompanyDecorator::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\CompanyDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_date' => [
-                'class'     => DateDecorator::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\DateDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment.decorator.date.optionFactory' => [
-                'class'     => DateOptionFactory::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_decorator_date',
                     'mautic.lead.model.relative_date',
@@ -1258,7 +1264,7 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment.timezoneResolver' => [
-                'class'     => TimezoneResolver::class,
+                'class'     => \Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
                 ],
@@ -1290,10 +1296,10 @@ return [
                 ],
             ],
             'mautic.lead.model.random_parameter_name' => [
-                'class' => RandomParameterName::class,
+                'class'     => \Mautic\LeadBundle\Segment\RandomParameterName::class,
             ],
             'mautic.lead.segment.operator_options' => [
-                'class' => OperatorOptions::class,
+                'class'     => \Mautic\LeadBundle\Segment\OperatorOptions::class,
             ],
             'mautic.lead.model.note' => [
                 'class' => 'Mautic\LeadBundle\Model\NoteModel',
@@ -1324,17 +1330,17 @@ return [
                 ],
             ],
             'mautic.lead.model.tag' => [
-                'class' => TagModel::class,
+                'class' => \Mautic\LeadBundle\Model\TagModel::class,
             ],
             'mautic.lead.model.company_report_data' => [
-                'class'     => CompanyReportData::class,
+                'class'     => \Mautic\LeadBundle\Model\CompanyReportData::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'translator',
                 ],
             ],
             'mautic.lead.reportbundle.fields_builder' => [
-                'class'     => FieldsBuilder::class,
+                'class'     => \Mautic\LeadBundle\Report\FieldsBuilder::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'mautic.lead.model.list',
@@ -1342,14 +1348,14 @@ return [
                 ],
             ],
             'mautic.lead.model.dnc' => [
-                'class'     => DoNotContact::class,
+                'class'     => \Mautic\LeadBundle\Model\DoNotContact::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.lead.repository.dnc',
                 ],
             ],
             'mautic.lead.model.segment.action' => [
-                'class'     => SegmentActionModel::class,
+                'class'     => \Mautic\LeadBundle\Model\SegmentActionModel::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                 ],
@@ -1361,7 +1367,7 @@ return [
                 ],
             ],
             'mautic.lead.service.contact_tracking_service' => [
-                'class'     => ContactTrackingService::class,
+                'class'     => \Mautic\LeadBundle\Tracker\Service\ContactTrackingService\ContactTrackingService::class,
                 'arguments' => [
                     'mautic.helper.cookie',
                     'mautic.lead.repository.lead_device',
@@ -1371,10 +1377,10 @@ return [
                 ],
             ],
             'mautic.lead.service.device_creator_service' => [
-                'class' => DeviceCreatorService::class,
+                'class' => \Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorService::class,
             ],
             'mautic.lead.service.device_tracking_service' => [
-                'class'     => DeviceTrackingService::class,
+                'class'     => \Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService::class,
                 'arguments' => [
                     'mautic.helper.cookie',
                     'doctrine.orm.entity_manager',
@@ -1385,7 +1391,7 @@ return [
                 ],
             ],
             'mautic.tracker.contact' => [
-                'class'     => ContactTracker::class,
+                'class'     => \Mautic\LeadBundle\Tracker\ContactTracker::class,
                 'arguments' => [
                     'mautic.lead.repository.lead',
                     'mautic.lead.service.contact_tracking_service',
@@ -1400,7 +1406,7 @@ return [
                 ],
             ],
             'mautic.tracker.device' => [
-                'class'     => DeviceTracker::class,
+                'class'     => \Mautic\LeadBundle\Tracker\DeviceTracker::class,
                 'arguments' => [
                     'mautic.lead.service.device_creator_service',
                     'mautic.lead.factory.device_detector_factory',
@@ -1505,21 +1511,21 @@ return [
         ],
         'command' => [
             'mautic.lead.command.deduplicate' => [
-                'class'     => DeduplicateCommand::class,
+                'class'     => \Mautic\LeadBundle\Command\DeduplicateCommand::class,
                 'arguments' => [
                     'mautic.lead.deduper',
                     'translator',
                 ],
-                'tag'       => 'console.command',
+                'tag' => 'console.command',
             ],
             'mautic.lead.command.create_custom_field' => [
-                'class'     => CreateCustomFieldCommand::class,
+                'class'     => \Mautic\LeadBundle\Field\Command\CreateCustomFieldCommand::class,
                 'arguments' => [
                     'mautic.lead.field.settings.background_service',
                     'translator',
                     'mautic.lead.repository.field',
                 ],
-                'tag'       => 'console.command',
+                'tag' => 'console.command',
             ],
         ],
         'fixtures' => [

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -834,14 +834,6 @@ return [
                     'mautic.helper.field.alias',
                 ],
             ],
-            \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
-                'class'     => \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
-                'tag'       => 'validator.constraint_validator',
-                'arguments' => [
-                    'mautic.lead.model.list',
-                    'mautic.helper.field.alias',
-                ],
-            ],
             'mautic.lead.constraint.alias' => [
                 'class'     => \Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAliasValidator::class,
                 'arguments' => ['mautic.lead.repository.lead_list', 'mautic.helper.user'],
@@ -861,7 +853,7 @@ return [
                 'alias'     => 'segment_in_use',
             ],
             'mautic.lead.event.dispatcher'       => [
-                'class'     => LeadChangeEventDispatcher::class,
+                'class'     => \Mautic\LeadBundle\Helper\LeadChangeEventDispatcher::class,
                 'arguments' => [
                     'event_dispatcher',
                 ],

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -1225,6 +1225,7 @@ return [
                     'mautic.lead.model.lead_segment_decorator_custom_mapped',
                     'mautic.lead.model.lead_segment.decorator.date.optionFactory',
                     'mautic.lead.model.lead_segment_decorator_company',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_base' => [

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -378,7 +378,7 @@ return [
                 ],
             ],
             'mautic.lead.campaignbundle.action_delete_contacts.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\CampaignActionDeleteContactSubscriber::class,
+                'class'     => CampaignActionDeleteContactSubscriber::class,
                 'arguments' => [
                    'mautic.lead.model.lead',
                    'mautic.campaign.helper.removed_contact_tracker',
@@ -392,7 +392,7 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\ReportSubscriber::class,
+                'class'     => ReportSubscriber::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.stage.model.stage',
@@ -405,13 +405,13 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.segment_subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\SegmentReportSubscriber::class,
+                'class'     => SegmentReportSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                 ],
             ],
             'mautic.lead.reportbundle.report_dnc_subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\ReportDNCSubscriber::class,
+                'class'     => ReportDNCSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                     'mautic.lead.model.company_report_data',
@@ -427,7 +427,7 @@ return [
                 ],
             ],
             'mautic.lead.reportbundle.report_utm_tag_subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\ReportUtmTagSubscriber::class,
+                'class'     => ReportUtmTagSubscriber::class,
                 'arguments' => [
                     'mautic.lead.reportbundle.fields_builder',
                     'mautic.lead.model.company_report_data',
@@ -448,7 +448,7 @@ return [
                 ],
             ],
             'mautic.lead.search.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\SearchSubscriber::class,
+                'class'     => SearchSubscriber::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.email.repository.email',
@@ -480,7 +480,7 @@ return [
                 ],
             ],
             'mautic.lead.stats.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\StatsSubscriber::class,
+                'class'     => StatsSubscriber::class,
                 'arguments' => [
                     'mautic.security',
                     'doctrine.orm.entity_manager',
@@ -520,14 +520,14 @@ return [
                 'class' => Mautic\LeadBundle\EventListener\ConfigSubscriber::class,
             ],
             'mautic.lead.timeline_events.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogSubscriber::class,
+                'class'     => TimelineEventLogSubscriber::class,
                 'arguments' => [
                     'translator',
                     'mautic.lead.repository.lead_event_log',
                 ],
             ],
             'mautic.lead.timeline_events.campaign.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogCampaignSubscriber::class,
+                'class'     => TimelineEventLogCampaignSubscriber::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_event_log',
                     'mautic.helper.user',
@@ -535,7 +535,7 @@ return [
                 ],
             ],
             'mautic.lead.timeline_events.segment.subscriber' => [
-                'class'     => \Mautic\LeadBundle\EventListener\TimelineEventLogSegmentSubscriber::class,
+                'class'     => TimelineEventLogSegmentSubscriber::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_event_log',
                     'mautic.helper.user',
@@ -670,7 +670,7 @@ return [
                 'arguments' => ['translator', 'doctrine.orm.entity_manager'],
             ],
             'mautic.form.type.lead_quickemail' => [
-                'class'     => \Mautic\LeadBundle\Form\Type\EmailType::class,
+                'class'     => EmailType::class,
                 'arguments' => ['mautic.helper.user'],
             ],
             'mautic.form.type.lead_tag' => [
@@ -706,7 +706,7 @@ return [
                 ],
             ],
             'mautic.form.type.contact_channels' => [
-                'class'     => \Mautic\LeadBundle\Form\Type\ContactChannelsType::class,
+                'class'     => ContactChannelsType::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
                 ],
@@ -799,7 +799,7 @@ return [
             ],
         ],
         'other' => [
-            'mautic.lead.doctrine.subscriber' => [
+            'mautic.lead.doctrine.subscriber'    => [
                 'class'     => 'Mautic\LeadBundle\EventListener\DoctrineSubscriber',
                 'tag'       => 'doctrine.event_subscriber',
                 'arguments' => ['monolog.logger.mautic'],
@@ -826,8 +826,8 @@ return [
                     '@doctrine.orm.entity_manager',
                 ],
             ],
-            \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
-                'class'     => \Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
+            FileEncodingValidator::class         => [
+                'class'     => FileEncodingValidator::class,
                 'tag'       => 'validator.constraint_validator',
                 'arguments' => [
                     'mautic.lead.model.list',
@@ -852,14 +852,14 @@ return [
                 'tag'       => 'validator.constraint_validator',
                 'alias'     => 'segment_in_use',
             ],
-            'mautic.lead.event.dispatcher' => [
-                'class'     => \Mautic\LeadBundle\Helper\LeadChangeEventDispatcher::class,
+            'mautic.lead.event.dispatcher'       => [
+                'class'     => LeadChangeEventDispatcher::class,
                 'arguments' => [
                     'event_dispatcher',
                 ],
             ],
-            'mautic.lead.merger' => [
-                'class'     => \Mautic\LeadBundle\Deduplicate\ContactMerger::class,
+            'mautic.lead.merger'                 => [
+                'class'     => ContactMerger::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.lead.repository.merged_records',
@@ -867,8 +867,8 @@ return [
                     'monolog.logger.mautic',
                 ],
             ],
-            'mautic.lead.deduper' => [
-                'class'     => \Mautic\LeadBundle\Deduplicate\ContactDeduper::class,
+            'mautic.lead.deduper'                => [
+                'class'     => ContactDeduper::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'mautic.lead.merger',
@@ -883,12 +883,12 @@ return [
                 ],
             ],
             'mautic.lead.helper.primary_company' => [
-                'class'     => \Mautic\LeadBundle\Helper\PrimaryCompanyHelper::class,
+                'class'     => PrimaryCompanyHelper::class,
                 'arguments' => [
                     'mautic.lead.repository.company_lead',
                 ],
             ],
-            'mautic.lead.validator.length' => [
+            'mautic.lead.validator.length'       => [
                 'class'     => Mautic\LeadBundle\Validator\Constraints\LengthValidator::class,
                 'tag'       => 'validator.constraint_validator',
             ],
@@ -930,7 +930,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\Company::class,
+                    Company::class,
                 ],
                 'methodCalls' => [
                     'setUniqueIdentifiersOperator' => [
@@ -942,7 +942,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\CompanyLead::class,
+                    CompanyLead::class,
                 ],
             ],
             'mautic.lead.repository.stages_lead_log' => [
@@ -963,7 +963,7 @@ return [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\Lead::class,
+                    Lead::class,
                 ],
                 'methodCalls' => [
                     'setUniqueIdentifiersOperator' => [
@@ -982,31 +982,31 @@ return [
                 ],
             ],
             'mautic.lead.repository.frequency_rule' => [
-                'class'     => \Mautic\LeadBundle\Entity\FrequencyRuleRepository::class,
+                'class'     => FrequencyRuleRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\FrequencyRule::class,
+                    FrequencyRule::class,
                 ],
             ],
             'mautic.lead.repository.lead_event_log' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\LeadEventLog::class,
+                    LeadEventLog::class,
                 ],
             ],
             'mautic.lead.repository.lead_device' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\LeadDevice::class,
+                    LeadDevice::class,
                 ],
             ],
             'mautic.lead.repository.lead_list' => [
                 'class'     => Doctrine\ORM\EntityRepository::class,
                 'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
                 'arguments' => [
-                    \Mautic\LeadBundle\Entity\LeadList::class,
+                    LeadList::class,
                 ],
             ],
             'mautic.lead.repository.points_change_log' => [
@@ -1060,7 +1060,7 @@ return [
                 'arguments' => ['mautic.lead.model.random_parameter_name', 'event_dispatcher'],
             ],
             'mautic.lead.query.builder.special.leadlist' => [
-                'class'     => \Mautic\LeadBundle\Segment\Query\Filter\SegmentReferenceFilterQueryBuilder::class,
+                'class'     => SegmentReferenceFilterQueryBuilder::class,
                 'arguments' => [
                     'mautic.lead.model.random_parameter_name',
                     'mautic.lead.repository.lead_segment_query_builder',
@@ -1097,7 +1097,7 @@ return [
                 'alias'     => 'default_avatar',
             ],
             'mautic.helper.field.alias' => [
-                'class'     => \Mautic\LeadBundle\Helper\FieldAliasHelper::class,
+                'class'     => FieldAliasHelper::class,
                 'arguments' => ['mautic.lead.model.field'],
             ],
             'mautic.helper.template.dnc_reason' => [
@@ -1108,7 +1108,7 @@ return [
         ],
         'models' => [
             'mautic.lead.model.lead' => [
-                'class'     => \Mautic\LeadBundle\Model\LeadModel::class,
+                'class'     => LeadModel::class,
                 'arguments' => [
                     'request_stack',
                     'mautic.helper.cookie',
@@ -1133,13 +1133,13 @@ return [
 
             // Deprecated support for circular dependency
             'mautic.lead.model.legacy_lead' => [
-                'class'     => \Mautic\LeadBundle\Model\LegacyLeadModel::class,
+                'class'     => LegacyLeadModel::class,
                 'arguments' => [
                     'service_container',
                 ],
             ],
             'mautic.lead.model.field' => [
-                'class'     => \Mautic\LeadBundle\Model\FieldModel::class,
+                'class'     => FieldModel::class,
                 'arguments' => [
                     'mautic.schema.helper.column',
                     'mautic.lead.model.list',
@@ -1152,7 +1152,7 @@ return [
                 ],
             ],
             'mautic.lead.model.list' => [
-                'class'     => \Mautic\LeadBundle\Model\ListModel::class,
+                'class'     => ListModel::class,
                 'arguments' => [
                     'mautic.category.model.category',
                     'mautic.helper.core_parameters',
@@ -1162,7 +1162,7 @@ return [
                 ],
             ],
             'mautic.lead.repository.lead_segment_filter_descriptor' => [
-                'class'     => \Mautic\LeadBundle\Services\ContactSegmentFilterDictionary::class,
+                'class'     => ContactSegmentFilterDictionary::class,
                 'arguments' => [
                     'event_dispatcher',
                 ],
@@ -1176,7 +1176,7 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment_service' => [
-                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentService::class,
+                'class'     => ContactSegmentService::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_factory',
                     'mautic.lead.repository.lead_segment_query_builder',
@@ -1184,71 +1184,73 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment_filter_factory' => [
-                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentFilterFactory::class,
+                'class'     => ContactSegmentFilterFactory::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_schema_cache',
                     '@service_container',
                     'mautic.lead.model.lead_segment_decorator_factory',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.model.lead_segment_schema_cache' => [
-                'class'     => \Mautic\LeadBundle\Segment\TableSchemaColumnsCache::class,
+                'class'     => TableSchemaColumnsCache::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
                 ],
             ],
             'mautic.lead.model.relative_date' => [
-                'class'     => \Mautic\LeadBundle\Segment\RelativeDate::class,
+                'class'     => RelativeDate::class,
                 'arguments' => [
                     'translator',
                 ],
             ],
             'mautic.lead.model.lead_segment_filter_operator' => [
-                'class'     => \Mautic\LeadBundle\Segment\ContactSegmentFilterOperator::class,
+                'class'     => ContactSegmentFilterOperator::class,
                 'arguments' => [
                     'mautic.lead.provider.fillterOperator',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_factory' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\DecoratorFactory::class,
+                'class'     => DecoratorFactory::class,
                 'arguments' => [
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                     'mautic.lead.model.lead_segment_decorator_base',
                     'mautic.lead.model.lead_segment_decorator_custom_mapped',
                     'mautic.lead.model.lead_segment.decorator.date.optionFactory',
                     'mautic.lead.model.lead_segment_decorator_company',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_base' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\BaseDecorator::class,
+                'class'     => BaseDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_custom_mapped' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\CustomMappedDecorator::class,
+                'class'     => CustomMappedDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_company' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\CompanyDecorator::class,
+                'class'     => CompanyDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment_decorator_date' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\DateDecorator::class,
+                'class'     => DateDecorator::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_filter_operator',
                     'mautic.lead.repository.lead_segment_filter_descriptor',
                 ],
             ],
             'mautic.lead.model.lead_segment.decorator.date.optionFactory' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory::class,
+                'class'     => DateOptionFactory::class,
                 'arguments' => [
                     'mautic.lead.model.lead_segment_decorator_date',
                     'mautic.lead.model.relative_date',
@@ -1256,7 +1258,7 @@ return [
                 ],
             ],
             'mautic.lead.model.lead_segment.timezoneResolver' => [
-                'class'     => \Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver::class,
+                'class'     => TimezoneResolver::class,
                 'arguments' => [
                     'mautic.helper.core_parameters',
                 ],
@@ -1288,10 +1290,10 @@ return [
                 ],
             ],
             'mautic.lead.model.random_parameter_name' => [
-                'class'     => \Mautic\LeadBundle\Segment\RandomParameterName::class,
+                'class' => RandomParameterName::class,
             ],
             'mautic.lead.segment.operator_options' => [
-                'class'     => \Mautic\LeadBundle\Segment\OperatorOptions::class,
+                'class' => OperatorOptions::class,
             ],
             'mautic.lead.model.note' => [
                 'class' => 'Mautic\LeadBundle\Model\NoteModel',
@@ -1322,17 +1324,17 @@ return [
                 ],
             ],
             'mautic.lead.model.tag' => [
-                'class' => \Mautic\LeadBundle\Model\TagModel::class,
+                'class' => TagModel::class,
             ],
             'mautic.lead.model.company_report_data' => [
-                'class'     => \Mautic\LeadBundle\Model\CompanyReportData::class,
+                'class'     => CompanyReportData::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'translator',
                 ],
             ],
             'mautic.lead.reportbundle.fields_builder' => [
-                'class'     => \Mautic\LeadBundle\Report\FieldsBuilder::class,
+                'class'     => FieldsBuilder::class,
                 'arguments' => [
                     'mautic.lead.model.field',
                     'mautic.lead.model.list',
@@ -1340,14 +1342,14 @@ return [
                 ],
             ],
             'mautic.lead.model.dnc' => [
-                'class'     => \Mautic\LeadBundle\Model\DoNotContact::class,
+                'class'     => DoNotContact::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                     'mautic.lead.repository.dnc',
                 ],
             ],
             'mautic.lead.model.segment.action' => [
-                'class'     => \Mautic\LeadBundle\Model\SegmentActionModel::class,
+                'class'     => SegmentActionModel::class,
                 'arguments' => [
                     'mautic.lead.model.lead',
                 ],
@@ -1359,7 +1361,7 @@ return [
                 ],
             ],
             'mautic.lead.service.contact_tracking_service' => [
-                'class'     => \Mautic\LeadBundle\Tracker\Service\ContactTrackingService\ContactTrackingService::class,
+                'class'     => ContactTrackingService::class,
                 'arguments' => [
                     'mautic.helper.cookie',
                     'mautic.lead.repository.lead_device',
@@ -1369,10 +1371,10 @@ return [
                 ],
             ],
             'mautic.lead.service.device_creator_service' => [
-                'class' => \Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorService::class,
+                'class' => DeviceCreatorService::class,
             ],
             'mautic.lead.service.device_tracking_service' => [
-                'class'     => \Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService::class,
+                'class'     => DeviceTrackingService::class,
                 'arguments' => [
                     'mautic.helper.cookie',
                     'doctrine.orm.entity_manager',
@@ -1383,7 +1385,7 @@ return [
                 ],
             ],
             'mautic.tracker.contact' => [
-                'class'     => \Mautic\LeadBundle\Tracker\ContactTracker::class,
+                'class'     => ContactTracker::class,
                 'arguments' => [
                     'mautic.lead.repository.lead',
                     'mautic.lead.service.contact_tracking_service',
@@ -1398,7 +1400,7 @@ return [
                 ],
             ],
             'mautic.tracker.device' => [
-                'class'     => \Mautic\LeadBundle\Tracker\DeviceTracker::class,
+                'class'     => DeviceTracker::class,
                 'arguments' => [
                     'mautic.lead.service.device_creator_service',
                     'mautic.lead.factory.device_detector_factory',
@@ -1503,21 +1505,21 @@ return [
         ],
         'command' => [
             'mautic.lead.command.deduplicate' => [
-                'class'     => \Mautic\LeadBundle\Command\DeduplicateCommand::class,
+                'class'     => DeduplicateCommand::class,
                 'arguments' => [
                     'mautic.lead.deduper',
                     'translator',
                 ],
-                'tag' => 'console.command',
+                'tag'       => 'console.command',
             ],
             'mautic.lead.command.create_custom_field' => [
-                'class'     => \Mautic\LeadBundle\Field\Command\CreateCustomFieldCommand::class,
+                'class'     => CreateCustomFieldCommand::class,
                 'arguments' => [
                     'mautic.lead.field.settings.background_service',
                     'translator',
                     'mautic.lead.repository.field',
                 ],
-                'tag' => 'console.command',
+                'tag'       => 'console.command',
             ],
         ],
         'fixtures' => [

--- a/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
@@ -1,12 +1,6 @@
 <?php
-/*
- * @copyright  2019 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+
+declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Event;
 
@@ -14,52 +8,29 @@ use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 
-class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
+final class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
 {
-    /**
-     * @var FilterDecoratorInterface
-     */
-    private $decorator;
+    private ?FilterDecoratorInterface $decorator;
+    private ContactSegmentFilterCrate $crate;
 
-    /**
-     * @var ContactSegmentFilterCrate
-     */
-    private $crate;
-
-    /**
-     * LeadListFiltersDecoratorDelegateEvent constructor.
-     *
-     * @param ContactSegmentFilterCrate $crate
-     */
     public function __construct(ContactSegmentFilterCrate $crate)
     {
         $this->crate = $crate;
     }
 
-    /**
-     * @return FilterDecoratorInterface|null
-     */
-    public function getDecorator()
+    public function getDecorator(): ?FilterDecoratorInterface
     {
         return $this->decorator;
     }
 
-    /**
-     * @param FilterDecoratorInterface $decorator
-     *
-     * @return LeadListFiltersDecoratorDelegateEvent
-     */
-    public function setDecorator(FilterDecoratorInterface $decorator)
+    public function setDecorator(FilterDecoratorInterface $decorator): self
     {
         $this->decorator = $decorator;
 
         return $this;
     }
 
-    /**
-     * @return ContactSegmentFilterCrate
-     */
-    public function getCrate()
+    public function getCrate(): ContactSegmentFilterCrate
     {
         return $this->crate;
     }

--- a/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * @copyright   2019 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+use Mautic\CoreBundle\Event\CommonEvent;
+use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
+
+class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
+{
+    /**
+     * @var FilterDecoratorInterface
+     */
+    private $decorator;
+
+    /**
+     * @var ContactSegmentFilterCrate
+     */
+    private $crate;
+
+    /**
+     * LeadListFiltersDecoratorDelegateEvent constructor.
+     *
+     * @param ContactSegmentFilterCrate $crate
+     */
+    public function __construct(ContactSegmentFilterCrate $crate)
+    {
+        $this->crate = $crate;
+    }
+
+    /**
+     * @return FilterDecoratorInterface|null
+     */
+    public function getDecorator(): ?FilterDecoratorInterface
+    {
+        return $this->decorator;
+    }
+
+    /**
+     * @param FilterDecoratorInterface $decorator
+     *
+     * @return LeadListFiltersDecoratorDelegateEvent
+     */
+    public function setDecorator(FilterDecoratorInterface $decorator): LeadListFiltersDecoratorDelegateEvent
+    {
+        $this->decorator = $decorator;
+
+        return $this;
+    }
+
+    /**
+     * @return ContactSegmentFilterCrate
+     */
+    public function getCrate(): ContactSegmentFilterCrate
+    {
+        return $this->crate;
+    }
+}

--- a/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
@@ -1,9 +1,9 @@
 <?php
 /*
- * @copyright   2019 Mautic, Inc. All rights reserved
- * @author      Mautic, Inc.
+ * @copyright  2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
  *
- * @link        https://mautic.com
+ * @link        http://mautic.org
  *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
@@ -39,7 +39,7 @@ class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
     /**
      * @return FilterDecoratorInterface|null
      */
-    public function getDecorator(): ?FilterDecoratorInterface
+    public function getDecorator()
     {
         return $this->decorator;
     }
@@ -49,7 +49,7 @@ class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
      *
      * @return LeadListFiltersDecoratorDelegateEvent
      */
-    public function setDecorator(FilterDecoratorInterface $decorator): LeadListFiltersDecoratorDelegateEvent
+    public function setDecorator(FilterDecoratorInterface $decorator)
     {
         $this->decorator = $decorator;
 
@@ -59,7 +59,7 @@ class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
     /**
      * @return ContactSegmentFilterCrate
      */
-    public function getCrate(): ContactSegmentFilterCrate
+    public function getCrate()
     {
         return $this->crate;
     }

--- a/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersDecoratorDelegateEvent.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 
 final class LeadListFiltersDecoratorDelegateEvent extends CommonEvent
 {
-    private ?FilterDecoratorInterface $decorator;
+    private ?FilterDecoratorInterface $decorator = null;
     private ContactSegmentFilterCrate $crate;
 
     public function __construct(ContactSegmentFilterCrate $crate)

--- a/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
@@ -47,12 +47,7 @@ class SegmentDictionaryGenerationEvent extends CommonEvent
         return $this->translations;
     }
 
-    /**
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function hasTranslation($key)
+    public function hasTranslation(string $key): bool
     {
         return isset($this->translations[$key]);
     }

--- a/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
@@ -46,4 +46,14 @@ class SegmentDictionaryGenerationEvent extends CommonEvent
     {
         return $this->translations;
     }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function hasTranslation($key)
+    {
+        return isset($this->translations[$key]);
+    }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -236,7 +236,7 @@ class ContactSegmentFilter
     }
 
     /**
-     * Returns filter value not modified by decorator
+     * Returns filter value not modified by decorator.
      *
      * @return mixed
      */

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -234,4 +234,16 @@ class ContactSegmentFilter
         return method_exists($this->filterDecorator, 'getRelationJoinTableField') ?
             $this->filterDecorator->getRelationJoinTableField() : null;
     }
+
+    /**
+     * Returns filter value not modified by decorator
+     *
+     * @return mixed
+     */
+    public function getCrateFilterValue()
+    {
+        $crateArray = $this->contactSegmentFilterCrate->getArray();
+
+        return $crateArray['filter'];
+    }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment;
 
+use Doctrine\DBAL\Schema\Column;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts;
 use Mautic\LeadBundle\Segment\Exception\FieldNotFoundException;
@@ -47,7 +48,7 @@ class ContactSegmentFilter
     }
 
     /**
-     * @return \Doctrine\DBAL\Schema\Column
+     * @return Column
      *
      * @throws FieldNotFoundException
      */
@@ -210,7 +211,7 @@ class ContactSegmentFilter
     {
         return sprintf(
             'table: %s,  %s on %s %s %s',
-                $this->getTable(),
+            $this->getTable(),
             $this->getField(),
             $this->getQueryType(),
             $this->getOperator(),
@@ -233,17 +234,5 @@ class ContactSegmentFilter
     {
         return method_exists($this->filterDecorator, 'getRelationJoinTableField') ?
             $this->filterDecorator->getRelationJoinTableField() : null;
-    }
-
-    /**
-     * Returns filter value not modified by decorator.
-     *
-     * @return mixed
-     */
-    public function getCrateFilterValue()
-    {
-        $crateArray = $this->contactSegmentFilterCrate->getArray();
-
-        return $crateArray['filter'];
     }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -200,10 +200,7 @@ class ContactSegmentFilterCrate
         return $this->nullValue;
     }
 
-    /**
-     * @return mixed|string|null
-     */
-    public function getObject()
+    public function getObject(): ?string
     {
         return $this->object;
     }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -199,4 +199,12 @@ class ContactSegmentFilterCrate
     {
         return $this->nullValue;
     }
+
+    /**
+     * @return mixed|string|null
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment;
 
+use Exception;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
@@ -25,9 +26,6 @@ class ContactSegmentFilterFactory
      */
     private $decoratorFactory;
 
-    /**
-     * ContactSegmentFilterFactory constructor.
-     */
     public function __construct(
         TableSchemaColumnsCache $schemaCache,
         Container $container,
@@ -41,7 +39,7 @@ class ContactSegmentFilterFactory
     /**
      * @return ContactSegmentFilters
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function getSegmentFilters(LeadList $leadList)
     {
@@ -76,7 +74,7 @@ class ContactSegmentFilterFactory
     /**
      * @return FilterQueryBuilderInterface
      *
-     * @throws \Exception
+     * @throws Exception
      */
     private function getQueryBuilderForFilter(FilterDecoratorInterface $decorator, ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -248,7 +248,7 @@ class ContactSegmentService
         $qbO->select('orp.lead_id as id, orp.leadlist_id')
             ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'orp');
         $qbO->leftJoin('orp', '('.$queryBuilder->getSQL().')', 'members', 'members.id=orp.lead_id');
-        $qbO->setParameters($queryBuilder->getParameters());
+        $qbO->setParameters($queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
         $qbO->andWhere($qbO->expr()->eq('orp.leadlist_id', ':orpsegid'));
         $qbO->andWhere($qbO->expr()->isNull('members.id'));
         $qbO->andWhere($qbO->expr()->eq('orp.manually_added', $qbO->expr()->literal(0)));

--- a/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator;
 
+use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
 use Mautic\LeadBundle\Exception\FilterNotFoundException;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory;
 use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-/**
- * Class DecoratorFactory.
- */
 class DecoratorFactory
 {
     /**
@@ -38,20 +38,24 @@ class DecoratorFactory
     private $dateOptionFactory;
 
     /**
-     * DecoratorFactory constructor.
+     * @var EventDispatcherInterface
      */
+    private $eventDispatcher;
+
     public function __construct(
         ContactSegmentFilterDictionary $contactSegmentFilterDictionary,
         BaseDecorator $baseDecorator,
         CustomMappedDecorator $customMappedDecorator,
         DateOptionFactory $dateOptionFactory,
-        CompanyDecorator $companyDecorator
+        CompanyDecorator $companyDecorator,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->baseDecorator                  = $baseDecorator;
         $this->customMappedDecorator          = $customMappedDecorator;
         $this->dateOptionFactory              = $dateOptionFactory;
         $this->contactSegmentFilterDictionary = $contactSegmentFilterDictionary;
         $this->companyDecorator               = $companyDecorator;
+        $this->eventDispatcher                = $eventDispatcher;
     }
 
     /**
@@ -59,6 +63,13 @@ class DecoratorFactory
      */
     public function getDecoratorForFilter(ContactSegmentFilterCrate $contactSegmentFilterCrate)
     {
+        $decoratorEvent = new LeadListFiltersDecoratorDelegateEvent($contactSegmentFilterCrate);
+
+        $this->eventDispatcher->dispatch(LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE, $decoratorEvent);
+        if ($decorator = $decoratorEvent->getDecorator()) {
+            return $decorator;
+        }
+
         if ($contactSegmentFilterCrate->isDateType()) {
             $dateDecorator = $this->dateOptionFactory->getDateOption($contactSegmentFilterCrate);
 
@@ -75,7 +86,8 @@ class DecoratorFactory
             $this->contactSegmentFilterDictionary->getFilter($originalField);
 
             return $this->customMappedDecorator;
-        } catch (FilterNotFoundException $e) {
+        }
+        catch (FilterNotFoundException $e) {
             if ($contactSegmentFilterCrate->isCompanyType()) {
                 return $this->companyDecorator;
             }

--- a/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
@@ -86,8 +86,7 @@ class DecoratorFactory
             $this->contactSegmentFilterDictionary->getFilter($originalField);
 
             return $this->customMappedDecorator;
-        }
-        catch (FilterNotFoundException $e) {
+        } catch (FilterNotFoundException $e) {
             if ($contactSegmentFilterCrate->isCompanyType()) {
                 return $this->companyDecorator;
             }

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -129,7 +129,8 @@ class ContactSegmentQueryBuilder
 
         $queryBuilder->select('count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId')
             ->from('('.$qb->getSQL().')', 'sss');
-        $queryBuilder->setParameters($qb->getParameters());
+
+        $queryBuilder->setParameters($qb->getParameters(),$qb->getParameterTypes());
 
         return $queryBuilder;
     }

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -130,7 +130,7 @@ class ContactSegmentQueryBuilder
         $queryBuilder->select('count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId')
             ->from('('.$qb->getSQL().')', 'sss');
 
-        $queryBuilder->setParameters($qb->getParameters(),$qb->getParameterTypes());
+        $queryBuilder->setParameters($qb->getParameters(), $qb->getParameterTypes());
 
         return $queryBuilder;
     }

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1593,8 +1593,15 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
         $params = $this->getParameters();
         $sql    = $this->getSQL();
         foreach ($params as $key=>$val) {
-            if (!is_int($val) and !is_float($val)) {
+            if (!is_int($val) and !is_float($val) and !is_array($val)) {
                 $val = "'$val'";
+            } elseif (is_array($val)) {
+                if ($this->getParameterType($key)===102) {
+                    $val = array_map(function ($value){
+                        return "'$value'";
+                    }, $val);
+                }
+                $val = join(', ', $val);
             }
             $sql = str_replace(":{$key}", $val, $sql);
         }

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1596,7 +1596,7 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
             if (!is_int($val) and !is_float($val) and !is_array($val)) {
                 $val = "'$val'";
             } elseif (is_array($val)) {
-                if ($this->getParameterType($key) === Connection::PARAM_STR_ARRAY) {
+                if (Connection::PARAM_STR_ARRAY === $this->getParameterType($key)) {
                     $val = array_map(function ($value) {
                         return "'$value'";
                     }, $val);

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1596,8 +1596,8 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
             if (!is_int($val) and !is_float($val) and !is_array($val)) {
                 $val = "'$val'";
             } elseif (is_array($val)) {
-                if ($this->getParameterType($key)===102) {
-                    $val = array_map(function ($value){
+                if ($this->getParameterType($key) === 102) {
+                    $val = array_map(function ($value) {
                         return "'$value'";
                     }, $val);
                 }

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1593,13 +1593,11 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
         $params = $this->getParameters();
         $sql    = $this->getSQL();
         foreach ($params as $key=>$val) {
-            if (!is_int($val) and !is_float($val) and !is_array($val)) {
+            if (!is_int($val) && !is_float($val) && !is_array($val)) {
                 $val = "'$val'";
             } elseif (is_array($val)) {
                 if (Connection::PARAM_STR_ARRAY === $this->getParameterType($key)) {
-                    $val = array_map(function ($value) {
-                        return "'$value'";
-                    }, $val);
+                    $val = array_map(fn ($value) => "'$value'", $val);
                 }
                 $val = join(', ', $val);
             }

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1596,7 +1596,7 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
             if (!is_int($val) and !is_float($val) and !is_array($val)) {
                 $val = "'$val'";
             } elseif (is_array($val)) {
-                if ($this->getParameterType($key) === 102) {
+                if ($this->getParameterType($key) === Connection::PARAM_STR_ARRAY) {
                     $val = array_map(function ($value) {
                         return "'$value'";
                     }, $val);

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -101,7 +101,7 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
     public function testDateDecoratorWhenNoSubscriberProvidesDecorator(): void
     {
         $filterDecoratorInterface  = $this->createMock(FilterDecoratorInterface::class);
-        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date',]);
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date']);
 
         $this->dateOptionFactory->expects($this->once())
             ->method('getDateOption')
@@ -131,7 +131,7 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
     public function testDateDecoratorWhenSubscriberProvidesDecorator(): void
     {
         $filterDecoratorInterface  = $this->createMock(FilterDecoratorInterface::class);
-        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date',]);
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date']);
 
         $this->dateOptionFactory->expects($this->never())
             ->method('getDateOption');

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
+use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
@@ -11,106 +12,149 @@ use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
 {
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    private $eventDispatcherMock;
+
+    /**
+     * @var ContactSegmentFilterDictionary
+     */
+    private $contactSegmentFilterDictionary;
+
+    /**
+     * @var MockObject|BaseDecorator
+     */
+    private $baseDecorator;
+
+    /**
+     * @var MockObject|CustomMappedDecorator
+     */
+    private $customMappedDecorator;
+
+    /**
+     * @var MockObject|CompanyDecorator
+     */
+    private $companyDecorator;
+
+    /**
+     * @var MockObject|DateOptionFactory
+     */
+    private $dateOptionFactory;
+
+    /**
+     * @var DecoratorFactory
+     */
+    private $decoratorFactory;
+
     protected function setUp(): void
     {
         parent::setUp();
         defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
+        $this->eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
+        $this->contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->eventDispatcherMock);
+        $this->baseDecorator                  = $this->createMock(BaseDecorator::class);
+        $this->customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
+        $this->companyDecorator               = $this->createMock(CompanyDecorator::class);
+        $this->dateOptionFactory              = $this->createMock(DateOptionFactory::class);
+        $this->decoratorFactory               = new DecoratorFactory(
+            $this->contactSegmentFilterDictionary,
+            $this->baseDecorator,
+            $this->customMappedDecorator,
+            $this->dateOptionFactory,
+            $this->companyDecorator,
+            $this->eventDispatcherMock);
     }
 
-    /**
-     * @covers \Mautic\LeadBundle\Segment\Decorator\DecoratorFactory::getDecoratorForFilter
-     */
-    public function testBaseDecorator()
+    public function testBaseDecorator(): void
     {
-        $decoratorFactory = $this->getDecoratorFactory();
-
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([
             'field'    => 'date_identified',
             'type'     => 'number',
         ]);
 
-        $this->assertInstanceOf(BaseDecorator::class, $decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate));
+        $this->assertInstanceOf(
+            BaseDecorator::class,
+            $this->decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate)
+        );
     }
 
-    /**
-     * @covers \Mautic\LeadBundle\Segment\Decorator\DecoratorFactory::getDecoratorForFilter
-     */
-    public function testCustomMappedDecorator()
+    public function testCustomMappedDecorator(): void
     {
-        $decoratorFactory = $this->getDecoratorFactory();
-
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([
             'field'    => 'hit_url_count',
             'type'     => 'number',
         ]);
 
-        $this->assertInstanceOf(CustomMappedDecorator::class, $decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate));
+        $this->assertInstanceOf(
+            CustomMappedDecorator::class,
+            $this->decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate)
+        );
     }
 
-    /**
-     * @covers \Mautic\LeadBundle\Segment\Decorator\DecoratorFactory::getDecoratorForFilter
-     */
-    public function testDateDecorator()
+    public function testDateDecoratorWhenNoSubscriberProvidesDecorator(): void
     {
-        $filterDecoratorInterface       = $this->createMock(FilterDecoratorInterface::class);
+        $filterDecoratorInterface  = $this->createMock(FilterDecoratorInterface::class);
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date',]);
 
-        $eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($eventDispatcherMock);
-        $baseDecorator                  = $this->createMock(BaseDecorator::class);
-        $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
-        $companyDecorator               = $this->createMock(CompanyDecorator::class);
-        $dateOptionFactory              = $this->createMock(DateOptionFactory::class);
-
-        $decoratorFactory = new DecoratorFactory(
-            $contactSegmentFilterDictionary,
-            $baseDecorator,
-            $customMappedDecorator,
-            $dateOptionFactory,
-            $companyDecorator,
-            $eventDispatcherMock);
-
-        $contactSegmentFilterCrate = new ContactSegmentFilterCrate([
-            'type'     => 'date',
-        ]);
-
-        $dateOptionFactory->expects($this->once())
+        $this->dateOptionFactory->expects($this->once())
             ->method('getDateOption')
             ->with($contactSegmentFilterCrate)
             ->willReturn($filterDecoratorInterface);
 
-        $eventDispatcherMock->expects($this->once())
+        $this->eventDispatcherMock->expects($this->once())
             ->method('dispatch')
-            ->with(LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE, $this->isType('object'))
-            ->willReturn(null);
+            ->with(
+                LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE,
+                $this->callback(
+                    function (LeadListFiltersDecoratorDelegateEvent $event) use ($contactSegmentFilterCrate) {
+                        $this->assertNull($event->getDecorator());
+                        $this->assertSame($contactSegmentFilterCrate, $event->getCrate());
 
-        $filterDecorator = $decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate);
+                        return true;
+                    }
+                )
+            );
 
-        $this->assertInstanceOf(FilterDecoratorInterface::class, $filterDecorator);
-        $this->assertSame($filterDecoratorInterface, $filterDecorator);
+        $this->assertSame(
+            $filterDecoratorInterface,
+            $this->decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate)
+        );
     }
 
-    /**
-     * @return DecoratorFactory
-     */
-    private function getDecoratorFactory()
+    public function testDateDecoratorWhenSubscriberProvidesDecorator(): void
     {
-        $eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($eventDispatcherMock);
-        $baseDecorator                  = $this->createMock(BaseDecorator::class);
-        $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
-        $companyDecorator               = $this->createMock(CompanyDecorator::class);
-        $dateOptionFactory              = $this->createMock(DateOptionFactory::class);
+        $filterDecoratorInterface  = $this->createMock(FilterDecoratorInterface::class);
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'date',]);
 
-        return new DecoratorFactory(
-            $contactSegmentFilterDictionary,
-            $baseDecorator,
-            $customMappedDecorator,
-            $dateOptionFactory,
-            $companyDecorator,
-            $eventDispatcherMock);
+        $this->dateOptionFactory->expects($this->never())
+            ->method('getDateOption');
+
+        $this->eventDispatcherMock->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE,
+                $this->callback(
+                    function (LeadListFiltersDecoratorDelegateEvent $event) use ($contactSegmentFilterCrate, $filterDecoratorInterface) {
+                        $this->assertNull($event->getDecorator());
+                        $this->assertSame($contactSegmentFilterCrate, $event->getCrate());
+
+                        $event->setDecorator($filterDecoratorInterface);
+
+                        return true;
+                    }
+                )
+            );
+
+        $this->assertSame(
+            $filterDecoratorInterface,
+            $this->decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate)
+        );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
+use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
 use Mautic\LeadBundle\Segment\Decorator\CompanyDecorator;
@@ -55,14 +57,23 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testDateDecorator()
     {
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->createMock(EventDispatcherInterface::class));
+        $filterDecoratorInterface       = $this->createMock(FilterDecoratorInterface::class);
+
+        $eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
+        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($eventDispatcherMock);
         $baseDecorator                  = $this->createMock(BaseDecorator::class);
         $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
         $companyDecorator               = $this->createMock(CompanyDecorator::class);
         $dateOptionFactory              = $this->createMock(DateOptionFactory::class);
-        $filterDecoratorInterface       = $this->createMock(FilterDecoratorInterface::class);
 
-        $decoratorFactory = new DecoratorFactory($contactSegmentFilterDictionary, $baseDecorator, $customMappedDecorator, $dateOptionFactory, $companyDecorator);
+        $decoratorFactory = new DecoratorFactory(
+            $contactSegmentFilterDictionary,
+            $baseDecorator,
+            $customMappedDecorator,
+            $dateOptionFactory,
+            $companyDecorator,
+            $eventDispatcherMock);
+
 
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([
             'type'     => 'date',
@@ -72,6 +83,11 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
             ->method('getDateOption')
             ->with($contactSegmentFilterCrate)
             ->willReturn($filterDecoratorInterface);
+
+        $eventDispatcherMock->expects($this->once())
+            ->method('dispatch')
+            ->with(LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE, $this->isType('object'))
+            ->willReturn(null);
 
         $filterDecorator = $decoratorFactory->getDecoratorForFilter($contactSegmentFilterCrate);
 
@@ -84,12 +100,19 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
      */
     private function getDecoratorFactory()
     {
-        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->createMock(EventDispatcherInterface::class));
+        $eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
+        $contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($eventDispatcherMock);
         $baseDecorator                  = $this->createMock(BaseDecorator::class);
         $customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
         $companyDecorator               = $this->createMock(CompanyDecorator::class);
         $dateOptionFactory              = $this->createMock(DateOptionFactory::class);
 
-        return new DecoratorFactory($contactSegmentFilterDictionary, $baseDecorator, $customMappedDecorator, $dateOptionFactory, $companyDecorator);
+        return new DecoratorFactory(
+            $contactSegmentFilterDictionary,
+            $baseDecorator,
+            $customMappedDecorator,
+            $dateOptionFactory,
+            $companyDecorator,
+            $eventDispatcherMock);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
-use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
@@ -73,7 +72,6 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
             $dateOptionFactory,
             $companyDecorator,
             $eventDispatcherMock);
-
 
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate([
             'type'     => 'date',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [N]
| New feature/enhancement? (use the a.x branch)      | [Y]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR adds new event that plugins can use to decorator is delegated segment filters. It allows segment filters to be based on objects other than lead and company. This is needed to support the Custom Objects plugin.

#### Steps to test this PR:

Just make sure the segment filters work the same way as before. There should be no change to the UI or behavior.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10890"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

