### PR TITLE
Reusable getStandardColumns method

### DIFF
--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
@@ -82,7 +82,7 @@ class SegmentReportSubscriberTest extends \PHPUnit\Framework\TestCase
             ->with('l.', 'lll.')
             ->willReturn($filterColumns);
 
-        $reportBuilderEvent = new ReportBuilderEvent($translatorMock, $channelListHelperMock, 'segment.membership', [], $reportHelperMock);
+        $reportBuilderEvent = new ReportBuilderEvent($translatorMock, $channelListHelperMock, 'segment.membership', [], new ReportHelper());
 
         $segmentReportSubscriber = new SegmentReportSubscriber($fieldsBuilderMock);
         $segmentReportSubscriber->onReportBuilder($reportBuilderEvent);

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentReportSubscriberTest.php
@@ -55,7 +55,6 @@ class SegmentReportSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $translatorMock        = $this->createMock(TranslatorInterface::class);
         $channelListHelperMock = $this->createMock(ChannelListHelper::class);
-        $reportHelperMock      = $this->createMock(ReportHelper::class);
         $fieldsBuilderMock     = $this->createMock(FieldsBuilder::class);
 
         $leadColumns = [

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -155,13 +155,13 @@ class ReportBuilderEvent extends AbstractReportEvent
     /**
      * Returns standard form fields such as id, name, publish_up, etc.
      *
-     * @param $prefix
+     * @param string $prefix
      *
-     * @return array
+     * @return string[]
      */
     public function getStandardColumns($prefix, $removeColumns = [], $idLink = null)
     {
-        return $this->reportHelper->getStandardColumns($prefix, $removeColumns, $idLink);
+        return $this->reportHelper->getStandardColumns($prefix, $removeColumns, (string) $idLink);
     }
 
     /**

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -161,74 +161,7 @@ class ReportBuilderEvent extends AbstractReportEvent
      */
     public function getStandardColumns($prefix, $removeColumns = [], $idLink = null)
     {
-        $aliasPrefix = str_replace('.', '_', $prefix);
-        $columns     = [
-            $prefix.'id' => [
-                'label' => 'mautic.core.id',
-                'type'  => 'int',
-                'link'  => $idLink,
-                'alias' => "{$aliasPrefix}id",
-            ],
-            $prefix.'name' => [
-                'label' => 'mautic.core.name',
-                'type'  => 'string',
-                'alias' => "{$aliasPrefix}name",
-            ],
-            $prefix.'created_by_user' => [
-                'label' => 'mautic.core.createdby',
-                'type'  => 'string',
-                'alias' => "{$aliasPrefix}created_by_user",
-            ],
-            $prefix.'date_added' => [
-                'label' => 'mautic.report.field.date_added',
-                'type'  => 'datetime',
-                'alias' => "{$aliasPrefix}date_added",
-            ],
-            $prefix.'modified_by_user' => [
-                'label' => 'mautic.report.field.modified_by_user',
-                'type'  => 'string',
-                'alias' => "{$aliasPrefix}modified_by_user",
-            ],
-            $prefix.'date_modified' => [
-                'label' => 'mautic.report.field.date_modified',
-                'type'  => 'datetime',
-                'alias' => "{$aliasPrefix}date_modified",
-            ],
-            $prefix.'description' => [
-                'label' => 'mautic.core.description',
-                'type'  => 'string',
-                'alias' => "{$aliasPrefix}description",
-            ],
-            $prefix.'publish_up' => [
-                'label' => 'mautic.report.field.publish_up',
-                'type'  => 'datetime',
-                'alias' => "{$aliasPrefix}publish_up",
-            ],
-            $prefix.'publish_down' => [
-                'label' => 'mautic.report.field.publish_down',
-                'type'  => 'datetime',
-                'alias' => "{$aliasPrefix}publish_down",
-            ],
-            $prefix.'is_published' => [
-                'label' => 'mautic.report.field.is_published',
-                'type'  => 'bool',
-                'alias' => "{$aliasPrefix}is_published",
-            ],
-        ];
-
-        if (empty($idLink)) {
-            unset($columns[$prefix.'id']['link']);
-        }
-
-        if (!empty($removeColumns)) {
-            foreach ($removeColumns as $c) {
-                if (isset($columns[$prefix.$c])) {
-                    unset($columns[$prefix.$c]);
-                }
-            }
-        }
-
-        return $columns;
+        return $this->reportHelper->getStandardColumns($prefix, $removeColumns, $idLink);
     }
 
     /**

--- a/app/bundles/ReportBundle/Helper/ReportHelper.php
+++ b/app/bundles/ReportBundle/Helper/ReportHelper.php
@@ -13,9 +13,6 @@ namespace Mautic\ReportBundle\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
 
-/**
- * Class ReportHelper.
- */
 class ReportHelper extends Helper
 {
     /**
@@ -54,12 +51,12 @@ class ReportHelper extends Helper
 
     /**
      * Returns standard form fields such as id, name, publish_up, etc.
+     * 
+     * @param string[] $removeColumns
      *
-     * @param $prefix
-     *
-     * @return array
+     * @return array<string,array<string,string>>
      */
-    public function getStandardColumns($prefix, $removeColumns = [], $idLink = null)
+    public function getStandardColumns(string $prefix, array $removeColumns = [], string $idLink = ''): array
     {
         $aliasPrefix = str_replace('.', '_', $prefix);
         $columns     = [

--- a/app/bundles/ReportBundle/Helper/ReportHelper.php
+++ b/app/bundles/ReportBundle/Helper/ReportHelper.php
@@ -51,4 +51,83 @@ class ReportHelper extends Helper
 
         return $type;
     }
+
+    /**
+     * Returns standard form fields such as id, name, publish_up, etc.
+     *
+     * @param $prefix
+     *
+     * @return array
+     */
+    public function getStandardColumns($prefix, $removeColumns = [], $idLink = null)
+    {
+        $aliasPrefix = str_replace('.', '_', $prefix);
+        $columns     = [
+            $prefix.'id' => [
+                'label' => 'mautic.core.id',
+                'type'  => 'int',
+                'link'  => $idLink,
+                'alias' => "{$aliasPrefix}id",
+            ],
+            $prefix.'name' => [
+                'label' => 'mautic.core.name',
+                'type'  => 'string',
+                'alias' => "{$aliasPrefix}name",
+            ],
+            $prefix.'created_by_user' => [
+                'label' => 'mautic.core.createdby',
+                'type'  => 'string',
+                'alias' => "{$aliasPrefix}created_by_user",
+            ],
+            $prefix.'date_added' => [
+                'label' => 'mautic.report.field.date_added',
+                'type'  => 'datetime',
+                'alias' => "{$aliasPrefix}date_added",
+            ],
+            $prefix.'modified_by_user' => [
+                'label' => 'mautic.report.field.modified_by_user',
+                'type'  => 'string',
+                'alias' => "{$aliasPrefix}modified_by_user",
+            ],
+            $prefix.'date_modified' => [
+                'label' => 'mautic.report.field.date_modified',
+                'type'  => 'datetime',
+                'alias' => "{$aliasPrefix}date_modified",
+            ],
+            $prefix.'description' => [
+                'label' => 'mautic.core.description',
+                'type'  => 'string',
+                'alias' => "{$aliasPrefix}description",
+            ],
+            $prefix.'publish_up' => [
+                'label' => 'mautic.report.field.publish_up',
+                'type'  => 'datetime',
+                'alias' => "{$aliasPrefix}publish_up",
+            ],
+            $prefix.'publish_down' => [
+                'label' => 'mautic.report.field.publish_down',
+                'type'  => 'datetime',
+                'alias' => "{$aliasPrefix}publish_down",
+            ],
+            $prefix.'is_published' => [
+                'label' => 'mautic.report.field.is_published',
+                'type'  => 'bool',
+                'alias' => "{$aliasPrefix}is_published",
+            ],
+        ];
+
+        if (empty($idLink)) {
+            unset($columns[$prefix.'id']['link']);
+        }
+
+        if (!empty($removeColumns)) {
+            foreach ($removeColumns as $c) {
+                if (isset($columns[$prefix.$c])) {
+                    unset($columns[$prefix.$c]);
+                }
+            }
+        }
+
+        return $columns;
+    }
 }

--- a/app/bundles/ReportBundle/Helper/ReportHelper.php
+++ b/app/bundles/ReportBundle/Helper/ReportHelper.php
@@ -51,7 +51,7 @@ class ReportHelper extends Helper
 
     /**
      * Returns standard form fields such as id, name, publish_up, etc.
-     * 
+     *
      * @param string[] $removeColumns
      *
      * @return array<string,array<string,string>>

--- a/app/bundles/ReportBundle/Tests/Helper/ReportHelperTest.php
+++ b/app/bundles/ReportBundle/Tests/Helper/ReportHelperTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\ReportBundle\Tests\Helper;
+
+use Mautic\ReportBundle\Helper\ReportHelper;
+use PHPUnit\Framework\TestCase;
+
+class ReportHelperTest extends TestCase
+{
+    /**
+     * @var ReportHelper
+     */
+    private $reportHelper;
+
+    protected function setUp(): void
+    {
+        $this->reportHelper = new ReportHelper();
+    }
+
+    public function testGetStandardColumnsMethodReturnsCorrectColumns()
+    {
+        $columns = $this->reportHelper->getStandardColumns('somePrefix');
+
+        $expectedColumnns = [
+            'somePrefixid' => [
+                    'label' => 'mautic.core.id',
+                    'type'  => 'int',
+                    'alias' => 'somePrefixid',
+                ],
+            'somePrefixname' => [
+                    'label' => 'mautic.core.name',
+                    'type'  => 'string',
+                    'alias' => 'somePrefixname',
+                ],
+            'somePrefixcreated_by_user' => [
+                    'label' => 'mautic.core.createdby',
+                    'type'  => 'string',
+                    'alias' => 'somePrefixcreated_by_user',
+                ],
+            'somePrefixdate_added' => [
+                    'label' => 'mautic.report.field.date_added',
+                    'type'  => 'datetime',
+                    'alias' => 'somePrefixdate_added',
+                ],
+            'somePrefixmodified_by_user' => [
+                    'label' => 'mautic.report.field.modified_by_user',
+                    'type'  => 'string',
+                    'alias' => 'somePrefixmodified_by_user',
+                ],
+            'somePrefixdate_modified' => [
+                    'label' => 'mautic.report.field.date_modified',
+                    'type'  => 'datetime',
+                    'alias' => 'somePrefixdate_modified',
+                ],
+            'somePrefixdescription' => [
+                    'label' => 'mautic.core.description',
+                    'type'  => 'string',
+                    'alias' => 'somePrefixdescription',
+                ],
+            'somePrefixpublish_up' => [
+                    'label' => 'mautic.report.field.publish_up',
+                    'type'  => 'datetime',
+                    'alias' => 'somePrefixpublish_up',
+                ],
+            'somePrefixpublish_down' => [
+                    'label' => 'mautic.report.field.publish_down',
+                    'type'  => 'datetime',
+                    'alias' => 'somePrefixpublish_down',
+                ],
+            'somePrefixis_published' => [
+                    'label' => 'mautic.report.field.is_published',
+                    'type'  => 'bool',
+                    'alias' => 'somePrefixis_published',
+                ],
+        ];
+
+        $this->assertEquals($expectedColumnns, $columns);
+    }
+}

--- a/app/bundles/ReportBundle/Tests/Helper/ReportHelperTest.php
+++ b/app/bundles/ReportBundle/Tests/Helper/ReportHelperTest.php
@@ -1,20 +1,13 @@
 <?php
 
-/*
- * @copyright   2020 Mautic Contributors. All rights reserved
- * @author      Mautic, Inc.
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\ReportBundle\Tests\Helper;
 
 use Mautic\ReportBundle\Helper\ReportHelper;
 use PHPUnit\Framework\TestCase;
 
-class ReportHelperTest extends TestCase
+final class ReportHelperTest extends TestCase
 {
     /**
      * @var ReportHelper
@@ -26,7 +19,7 @@ class ReportHelperTest extends TestCase
         $this->reportHelper = new ReportHelper();
     }
 
-    public function testGetStandardColumnsMethodReturnsCorrectColumns()
+    public function testGetStandardColumnsMethodReturnsCorrectColumns(): void
     {
         $columns = $this->reportHelper->getStandardColumns('somePrefix');
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [N]
| New feature/enhancement? (use the a.x branch)      | [Y]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [Y] 
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR moves ReportBuilderEvent::getStandardColumns into the getStandardColumns class.
This way getStandardColumns method can be reused by different parts of the application.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create any report in Mautic and see if it works.



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10898"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

