### PR TITLE
Segment optimization IN to EXISTS

### DIFF
--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -23,6 +23,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     const POINTS_SUBTRACT = 'minus';
     const POINTS_MULTIPLY = 'times';
     const POINTS_DIVIDE   = 'divide';
+    public const DEFAULT_ALIAS = 'l';
 
     /**
      * Used to determine social identity.

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -23,7 +23,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     const POINTS_SUBTRACT = 'minus';
     const POINTS_MULTIPLY = 'times';
     const POINTS_DIVIDE   = 'divide';
-    public const DEFAULT_ALIAS = 'l';
+    const DEFAULT_ALIAS   = 'l';
 
     /**
      * Used to determine social identity.

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -54,13 +54,12 @@ class LeadListFilteringEvent extends CommonEvent
     private $leadsTableAlias;
 
     /**
-     * LeadListFilteringEvent constructor.
-     * @param $details
-     * @param $leadId
-     * @param $alias
-     * @param $func
-     * @param $queryBuilder
-     * @param  EntityManager  $entityManager
+     * @param array         $details
+     * @param int           $leadId
+     * @param string        $alias
+     * @param string        $func
+     * @param QueryBuilder  $queryBuilder
+     * @param EntityManager $entityManager
      */
     public function __construct($details, $leadId, $alias, $func, $queryBuilder, EntityManager $entityManager)
     {

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -2,14 +2,12 @@
 
 namespace Mautic\LeadBundle\Event;
 
-use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Event\CommonEvent;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
 /**
- * Class LeadListFilteringEvent.
- *
- * Please refer to LeadListRepository.php, inside getListFilterExprCombined method, for examples
+ * Please refer to LeadListRepository.php, inside getListFilterExprCombined method, for examples.
  */
 class LeadListFilteringEvent extends CommonEvent
 {
@@ -48,10 +46,7 @@ class LeadListFilteringEvent extends CommonEvent
      */
     protected $func;
 
-    /**
-     * @var string
-     */
-    private $leadsTableAlias;
+    private string $leadsTableAlias;
 
     /**
      * @param array        $details

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -49,11 +49,18 @@ class LeadListFilteringEvent extends CommonEvent
     protected $func;
 
     /**
-     * @param array        $details
-     * @param int          $leadId
-     * @param string       $alias
-     * @param string       $func
-     * @param QueryBuilder $queryBuilder
+     * @var string
+     */
+    private $leadsTableAlias;
+
+    /**
+     * LeadListFilteringEvent constructor.
+     * @param $details
+     * @param $leadId
+     * @param $alias
+     * @param $func
+     * @param $queryBuilder
+     * @param  EntityManager  $entityManager
      */
     public function __construct($details, $leadId, $alias, $func, $queryBuilder, EntityManager $entityManager)
     {
@@ -65,6 +72,7 @@ class LeadListFilteringEvent extends CommonEvent
         $this->em              = $entityManager;
         $this->isFilteringDone = false;
         $this->subQuery        = '';
+        $this->leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
     }
 
     /**
@@ -155,5 +163,13 @@ class LeadListFilteringEvent extends CommonEvent
     public function setDetails($details)
     {
         $this->details = $details;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLeadsTableAlias(): string
+    {
+        return $this->leadsTableAlias;
     }
 }

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -54,12 +54,11 @@ class LeadListFilteringEvent extends CommonEvent
     private $leadsTableAlias;
 
     /**
-     * @param array         $details
-     * @param int           $leadId
-     * @param string        $alias
-     * @param string        $func
-     * @param QueryBuilder  $queryBuilder
-     * @param EntityManager $entityManager
+     * @param array        $details
+     * @param int          $leadId
+     * @param string       $alias
+     * @param string       $func
+     * @param QueryBuilder $queryBuilder
      */
     public function __construct($details, $leadId, $alias, $func, $queryBuilder, EntityManager $entityManager)
     {
@@ -164,9 +163,6 @@ class LeadListFilteringEvent extends CommonEvent
         $this->details = $details;
     }
 
-    /**
-     * @return string
-     */
     public function getLeadsTableAlias(): string
     {
         return $this->leadsTableAlias;

--- a/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
@@ -23,13 +23,22 @@ final class SegmentOperatorQueryBuilderEvent extends Event
     private bool $operatorHandled = false;
 
     /**
-     * @param string|string[] $parameterHolder
+     * @var string
+     */
+    private $leadsTableAlias;
+
+    /**
+     * SegmentOperatorQueryBuilderEvent constructor.
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @param $parameterHolder
      */
     public function __construct(QueryBuilder $queryBuilder, ContactSegmentFilter $filter, $parameterHolder)
     {
         $this->queryBuilder    = $queryBuilder;
         $this->filter          = $filter;
         $this->parameterHolder = $parameterHolder;
+        $this->leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
     }
 
     public function getQueryBuilder(): QueryBuilder
@@ -78,5 +87,13 @@ final class SegmentOperatorQueryBuilderEvent extends Event
     public function wasOperatorHandled(): bool
     {
         return $this->operatorHandled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLeadsTableAlias(): string
+    {
+        return $this->leadsTableAlias;
     }
 }

--- a/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
@@ -22,10 +22,7 @@ final class SegmentOperatorQueryBuilderEvent extends Event
 
     private bool $operatorHandled = false;
 
-    /**
-     * @var string
-     */
-    private $leadsTableAlias;
+    private string $leadsTableAlias;
 
     /**
      * @param string|string[] $parameterHolder

--- a/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentOperatorQueryBuilderEvent.php
@@ -28,10 +28,7 @@ final class SegmentOperatorQueryBuilderEvent extends Event
     private $leadsTableAlias;
 
     /**
-     * SegmentOperatorQueryBuilderEvent constructor.
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @param $parameterHolder
+     * @param string|string[] $parameterHolder
      */
     public function __construct(QueryBuilder $queryBuilder, ContactSegmentFilter $filter, $parameterHolder)
     {
@@ -89,9 +86,6 @@ final class SegmentOperatorQueryBuilderEvent extends Event
         return $this->operatorHandled;
     }
 
-    /**
-     * @return string
-     */
     public function getLeadsTableAlias(): string
     {
         return $this->leadsTableAlias;

--- a/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
@@ -30,13 +30,15 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $event->addExpression(
             new CompositeExpression(
                 CompositeExpression::TYPE_OR,
                 [
-                    $event->getQueryBuilder()->expr()->isNull('l.'.$event->getFilter()->getField()),
+                    $event->getQueryBuilder()->expr()->isNull($leadsTableAlias.'.'.$event->getFilter()->getField()),
                     $event->getQueryBuilder()->expr()->eq(
-                        'l.'.$event->getFilter()->getField(),
+                        $leadsTableAlias.'.'.$event->getFilter()->getField(),
                         $event->getQueryBuilder()->expr()->literal('')
                     ),
                 ]
@@ -52,13 +54,15 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $event->addExpression(
             new CompositeExpression(
                 CompositeExpression::TYPE_AND,
                 [
-                    $event->getQueryBuilder()->expr()->isNotNull('l.'.$event->getFilter()->getField()),
+                    $event->getQueryBuilder()->expr()->isNotNull($leadsTableAlias.'.'.$event->getFilter()->getField()),
                     $event->getQueryBuilder()->expr()->neq(
-                        'l.'.$event->getFilter()->getField(),
+                        $leadsTableAlias.'.'.$event->getFilter()->getField(),
                         $event->getQueryBuilder()->expr()->literal('')
                     ),
                 ]
@@ -79,11 +83,13 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $event->addExpression(
             $event->getQueryBuilder()->expr()->orX(
-                $event->getQueryBuilder()->expr()->isNull('l.'.$event->getFilter()->getField()),
+                $event->getQueryBuilder()->expr()->isNull($leadsTableAlias.'.'.$event->getFilter()->getField()),
                 $event->getQueryBuilder()->expr()->{$event->getFilter()->getOperator()}(
-                    'l.'.$event->getFilter()->getField(),
+                    $leadsTableAlias.'.'.$event->getFilter()->getField(),
                     $event->getParameterHolder()
                 )
             )
@@ -98,11 +104,13 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $operator    = 'multiselect' === $event->getFilter()->getOperator() ? 'regexp' : 'notRegexp';
         $expressions = [];
 
         foreach ($event->getParameterHolder() as $parameter) {
-            $expressions[] = $event->getQueryBuilder()->expr()->$operator('l.'.$event->getFilter()->getField(), $parameter);
+            $expressions[] = $event->getQueryBuilder()->expr()->$operator($leadsTableAlias.'.'.$event->getFilter()->getField(), $parameter);
         }
 
         $event->addExpression($event->getQueryBuilder()->expr()->andX($expressions));
@@ -128,9 +136,11 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $event->addExpression(
             $event->getQueryBuilder()->expr()->{$event->getFilter()->getOperator()}(
-                'l.'.$event->getFilter()->getField(),
+                $leadsTableAlias.'.'.$event->getFilter()->getField(),
                 $event->getParameterHolder()
             )
         );

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -464,7 +464,7 @@ class ListModel extends FormModel
                 $start += $limit;
 
                 // Dispatch batch event
-                if (count($newLeadList[$leadList->getId()]) && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_BATCH_CHANGE)) {
+                if ($this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_BATCH_CHANGE)) {
                     $this->dispatcher->dispatch(
                         LeadEvents::LEAD_LIST_BATCH_CHANGE,
                         new ListChangeEvent($newLeadList[$leadList->getId()], $leadList, true)

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -35,11 +35,6 @@ class ContactSegmentFilter
      */
     private $schemaCache;
 
-    /**
-     * @var string
-     */
-    private $baseAlias;
-
     public function __construct(
         ContactSegmentFilterCrate $contactSegmentFilterCrate,
         FilterDecoratorInterface $filterDecorator,
@@ -239,15 +234,5 @@ class ContactSegmentFilter
     {
         return method_exists($this->filterDecorator, 'getRelationJoinTableField') ?
             $this->filterDecorator->getRelationJoinTableField() : null;
-    }
-
-    public function getBaseAlias(): string
-    {
-        return $this->baseAlias ?? 'l';
-    }
-
-    public function setBaseAlias(string $baseAlias): void
-    {
-        $this->baseAlias = $baseAlias;
     }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilter.php
@@ -35,6 +35,11 @@ class ContactSegmentFilter
      */
     private $schemaCache;
 
+    /**
+     * @var string
+     */
+    private $baseAlias;
+
     public function __construct(
         ContactSegmentFilterCrate $contactSegmentFilterCrate,
         FilterDecoratorInterface $filterDecorator,
@@ -234,5 +239,15 @@ class ContactSegmentFilter
     {
         return method_exists($this->filterDecorator, 'getRelationJoinTableField') ?
             $this->filterDecorator->getRelationJoinTableField() : null;
+    }
+
+    public function getBaseAlias(): string
+    {
+        return $this->baseAlias ?? 'l';
+    }
+
+    public function setBaseAlias(string $baseAlias): void
+    {
+        $this->baseAlias = $baseAlias;
     }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -131,7 +131,7 @@ class ContactSegmentService
         $queryBuilder->setMaxResults($limit);
 
         $this->addMinMaxLimiters($queryBuilder, $batchLimiters);
-        $this->addLeadLimiter($queryBuilder, $batchLimiters);
+        $this->addLeadLimiter($queryBuilder, $batchLimiters, $leadsTableAlias.'.id');
 
         if (!empty($batchLimiters['dateTime'])) {
             // Only leads in the list at the time of count
@@ -239,8 +239,10 @@ class ContactSegmentService
     {
         $segmentFilters = $this->contactSegmentFilterFactory->getSegmentFilters($segment);
 
-        $queryBuilder = $this->contactSegmentQueryBuilder->assembleContactsSegmentQueryBuilder($segment->getId(), $segmentFilters);
-        $this->addLeadLimiter($queryBuilder, $batchLimiters);
+        $queryBuilder    = $this->contactSegmentQueryBuilder->assembleContactsSegmentQueryBuilder($segment->getId(), $segmentFilters);
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
+
+        $this->addLeadLimiter($queryBuilder, $batchLimiters, $leadsTableAlias.'.id');
 
         $this->contactSegmentQueryBuilder->queryBuilderGenerated($segment, $queryBuilder);
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -113,11 +113,12 @@ class ContactSegmentService
     /**
      * @param int $limit
      *
-     * @throws \Exception
+     * @throws DBALException
+     * @throws Exception\SegmentQueryException
      */
     public function getNewLeadListLeads(LeadList $segment, array $batchLimiters, $limit = 1000): array
     {
-        $queryBuilder = $this->getNewSegmentContactsQuery($segment);
+        $queryBuilder    = $this->getNewSegmentContactsQuery($segment);
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
 
         // Prepend the DISTINCT to the beginning of the select array

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -54,7 +54,7 @@ class ContactSegmentService
             ];
         }
 
-        $qb = $this->getNewSegmentContactsQuery($segment);
+        $qb              = $this->getNewSegmentContactsQuery($segment);
         $leadsTableAlias = $qb->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
 
         $this->addMinMaxLimiters($qb, $batchLimiters);

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -36,10 +36,12 @@ class ContactSegmentService
     }
 
     /**
+     * @return array<int,mixed[]>
+     *
      * @throws Exception\SegmentQueryException
      * @throws DBALException
      */
-    public function getNewLeadListLeadsCount(LeadList $segment, array $batchLimiters): array
+    public function getNewLeadListLeadsCount(LeadList $segment, array $batchLimiters)
     {
         $segmentFilters = $this->contactSegmentFilterFactory->getSegmentFilters($segment);
 
@@ -113,10 +115,12 @@ class ContactSegmentService
     /**
      * @param int $limit
      *
+     * @return array<int,mixed[]>
+     *
      * @throws DBALException
      * @throws Exception\SegmentQueryException
      */
-    public function getNewLeadListLeads(LeadList $segment, array $batchLimiters, $limit = 1000): array
+    public function getNewLeadListLeads(LeadList $segment, array $batchLimiters, $limit = 1000)
     {
         $queryBuilder    = $this->getNewSegmentContactsQuery($segment);
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');

--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -55,7 +55,7 @@ class ContactSegmentService
         }
 
         $qb = $this->getNewSegmentContactsQuery($segment);
-        $leadsTableAlias = $qb->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $qb->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
 
         $this->addMinMaxLimiters($qb, $batchLimiters);
         $this->addLeadLimiter($qb, $batchLimiters, $leadsTableAlias.'.id');
@@ -119,7 +119,7 @@ class ContactSegmentService
     public function getNewLeadListLeads(LeadList $segment, array $batchLimiters, $limit = 1000): array
     {
         $queryBuilder    = $this->getNewSegmentContactsQuery($segment);
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
 
         // Prepend the DISTINCT to the beginning of the select array
         $select = $queryBuilder->getQueryPart('select');
@@ -264,7 +264,7 @@ class ContactSegmentService
 
     private function addMinMaxLimiters(QueryBuilder $queryBuilder, array $batchLimiters)
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
 
         if (!empty($batchLimiters['minId']) && !empty($batchLimiters['maxId'])) {
             $queryBuilder->andWhere(
@@ -281,9 +281,9 @@ class ContactSegmentService
         }
     }
 
-    private function excludeVisitors(QueryBuilder $queryBuilder)
+    private function excludeVisitors(QueryBuilder $queryBuilder): void
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $queryBuilder->andWhere($queryBuilder->expr()->isNotNull($leadsTableAlias.'.date_identified'));
     }
 

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -145,7 +145,7 @@ class ContactSegmentQueryBuilder
      */
     public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias    = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $expr               = $queryBuilder->expr();
         $tableAlias         = $this->generateRandomParameterName();
         $segmentIdParameter = ":{$tableAlias}segmentId";

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -47,8 +47,6 @@ class ContactSegmentQueryBuilder
      * @param $segmentId
      * @param $segmentFilters
      *
-     * @return QueryBuilder
-     *
      * @throws SegmentQueryException
      */
     public function assembleContactsSegmentQueryBuilder($segmentId, $segmentFilters, bool $changeAlias = false): QueryBuilder
@@ -143,11 +141,9 @@ class ContactSegmentQueryBuilder
      *
      * @param $segmentId
      *
-     * @return QueryBuilder
-     *
      * @throws QueryException
      */
-    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId)
+    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $expr               = $queryBuilder->expr();
@@ -171,7 +167,7 @@ class ContactSegmentQueryBuilder
     public function addManuallySubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $tableAlias = $this->generateRandomParameterName();
+        $tableAlias      = $this->generateRandomParameterName();
 
         $existsQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
 
@@ -205,7 +201,7 @@ class ContactSegmentQueryBuilder
     public function addManuallyUnsubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $tableAlias = $this->generateRandomParameterName();
+        $tableAlias      = $this->generateRandomParameterName();
         $queryBuilder->leftJoin(
             $leadsTableAlias,
             MAUTIC_TABLE_PREFIX.'lead_lists_leads',

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -166,7 +166,7 @@ class ContactSegmentQueryBuilder
      */
     public function addManuallySubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $tableAlias      = $this->generateRandomParameterName();
 
         $existsQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
@@ -200,7 +200,7 @@ class ContactSegmentQueryBuilder
      */
     public function addManuallyUnsubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $tableAlias      = $this->generateRandomParameterName();
         $queryBuilder->leftJoin(
             $leadsTableAlias,

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -5,6 +5,7 @@ namespace Mautic\LeadBundle\Segment\Query;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\ORM\EntityManager;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Event\LeadListFilteringEvent;
 use Mautic\LeadBundle\Event\LeadListQueryBuilderGeneratedEvent;
@@ -50,7 +51,7 @@ class ContactSegmentQueryBuilder
      *
      * @throws SegmentQueryException
      */
-    public function assembleContactsSegmentQueryBuilder($segmentId, $segmentFilters)
+    public function assembleContactsSegmentQueryBuilder($segmentId, $segmentFilters, bool $changeAlias = false): QueryBuilder
     {
         /** @var Connection $connection */
         $connection = $this->entityManager->getConnection();
@@ -62,7 +63,9 @@ class ContactSegmentQueryBuilder
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = new QueryBuilder($connection);
 
-        $queryBuilder->select('l.id')->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+        $leadsTableAlias = $changeAlias ? $this->generateRandomParameterName() : Lead::DEFAULT_ALIAS;
+
+        $queryBuilder->select($leadsTableAlias.'.id')->from(MAUTIC_TABLE_PREFIX.'leads', $leadsTableAlias);
 
         /*
          * Validate the plan, check for circular dependencies.
@@ -146,6 +149,7 @@ class ContactSegmentQueryBuilder
      */
     public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId)
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $expr               = $queryBuilder->expr();
         $tableAlias         = $this->generateRandomParameterName();
         $segmentIdParameter = ":{$tableAlias}segmentId";
@@ -156,20 +160,17 @@ class ContactSegmentQueryBuilder
             ->andWhere($expr->eq($tableAlias.'.leadlist_id', $segmentIdParameter));
 
         $queryBuilder->setParameter($segmentIdParameter, $segmentId);
-        $queryBuilder->andWhere($expr->notIn('l.id', $segmentQueryBuilder->getSQL()));
+        $queryBuilder->andWhere($expr->notIn($leadsTableAlias.'.id', $segmentQueryBuilder->getSQL()));
 
         return $queryBuilder;
     }
 
     /**
      * @param $leadListId
-     * @param string $defaultAlias
      */
-    public function addManuallySubscribedQuery(
-        QueryBuilder $queryBuilder,
-        $leadListId,
-        $defaultAlias = 'l'
-    ): QueryBuilder {
+    public function addManuallySubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
+    {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $tableAlias = $this->generateRandomParameterName();
 
         $existsQueryBuilder = $queryBuilder->getConnection()->createQueryBuilder();
@@ -186,7 +187,7 @@ class ContactSegmentQueryBuilder
             );
 
         $existingQueryWherePart = $existsQueryBuilder->getQueryPart('where');
-        $existsQueryBuilder->where("$defaultAlias.id = $tableAlias.lead_id");
+        $existsQueryBuilder->where("$leadsTableAlias.id = $tableAlias.lead_id");
         $existsQueryBuilder->andWhere($existingQueryWherePart);
 
         $queryBuilder->orWhere(
@@ -198,21 +199,18 @@ class ContactSegmentQueryBuilder
 
     /**
      * @param $leadListId
-     * @param string $defaultAlias
      *
      * @throws QueryException
      */
-    public function addManuallyUnsubscribedQuery(
-        QueryBuilder $queryBuilder,
-        $leadListId,
-        $defaultAlias = 'l'
-    ): QueryBuilder {
+    public function addManuallyUnsubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
+    {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $tableAlias = $this->generateRandomParameterName();
         $queryBuilder->leftJoin(
-            $defaultAlias,
+            $leadsTableAlias,
             MAUTIC_TABLE_PREFIX.'lead_lists_leads',
             $tableAlias,
-            $defaultAlias.'.id = '.$tableAlias.'.lead_id and '.$tableAlias.'.leadlist_id = '.intval($leadListId)
+            $leadsTableAlias.'.id = '.$tableAlias.'.lead_id and '.$tableAlias.'.leadlist_id = '.intval($leadListId)
         );
         $queryBuilder->addJoinCondition($tableAlias, $queryBuilder->expr()->eq($tableAlias.'.manually_removed', 1));
         $queryBuilder->andWhere($queryBuilder->expr()->isNull($tableAlias.'.lead_id'));

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Event\LeadListFilteringEvent;
 use Mautic\LeadBundle\Event\LeadListQueryBuilderGeneratedEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\ContactSegmentFilters;
 use Mautic\LeadBundle\Segment\Exception\PluginHandledFilterException;
 use Mautic\LeadBundle\Segment\Exception\SegmentQueryException;
 use Mautic\LeadBundle\Segment\RandomParameterName;
@@ -33,9 +34,6 @@ class ContactSegmentQueryBuilder
     /** @var array Contains segment edges mapping */
     private $dependencyMap = [];
 
-    /**
-     * ContactSegmentQueryBuilder constructor.
-     */
     public function __construct(EntityManager $entityManager, RandomParameterName $randomParameterName, EventDispatcherInterface $dispatcher)
     {
         $this->entityManager       = $entityManager;
@@ -44,12 +42,14 @@ class ContactSegmentQueryBuilder
     }
 
     /**
-     * @param $segmentId
-     * @param $segmentFilters
+     * @param int                   $segmentId
+     * @param ContactSegmentFilters $segmentFilters
+     *
+     * @return QueryBuilder
      *
      * @throws SegmentQueryException
      */
-    public function assembleContactsSegmentQueryBuilder($segmentId, $segmentFilters, bool $changeAlias = false): QueryBuilder
+    public function assembleContactsSegmentQueryBuilder($segmentId, $segmentFilters, bool $changeAlias = false)
     {
         /** @var Connection $connection */
         $connection = $this->entityManager->getConnection();
@@ -139,11 +139,13 @@ class ContactSegmentQueryBuilder
     /**
      * Restrict the query to NEW members of segment.
      *
-     * @param $segmentId
+     * @param int $segmentId
+     *
+     * @return QueryBuilder
      *
      * @throws QueryException
      */
-    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId): QueryBuilder
+    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId)
     {
         $leadsTableAlias    = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $expr               = $queryBuilder->expr();
@@ -162,9 +164,11 @@ class ContactSegmentQueryBuilder
     }
 
     /**
-     * @param $leadListId
+     * @param int $leadListId
+     *
+     * @return QueryBuilder
      */
-    public function addManuallySubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
+    public function addManuallySubscribedQuery(QueryBuilder $queryBuilder, $leadListId)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $tableAlias      = $this->generateRandomParameterName();
@@ -194,11 +198,13 @@ class ContactSegmentQueryBuilder
     }
 
     /**
-     * @param $leadListId
+     * @param int $leadListId
+     *
+     * @return QueryBuilder
      *
      * @throws QueryException
      */
-    public function addManuallyUnsubscribedQuery(QueryBuilder $queryBuilder, $leadListId): QueryBuilder
+    public function addManuallyUnsubscribedQuery(QueryBuilder $queryBuilder, $leadListId)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $tableAlias      = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
-use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
 class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
@@ -17,33 +16,33 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
 
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
-        $filterOperator  = $filter->getOperator();
-        $filterChannel   = $this->getChannel($filter->getField());
+        $leadsTableAlias  = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
+        $filterOperator   = $filter->getOperator();
+        $filterChannel    = $this->getChannel($filter->getField());
+        $filterParameters = $filter->getParameterValue();
 
-        $filterParameter = $filter->getParameterValue();
-        $parameter       = $this->generateRandomParameterName();
+        if (is_array($filterParameters)) {
+            $parameters = [];
+            foreach ($filterParameters as $filterParameter) {
+                $parameters[] = $this->generateRandomParameterName();
+            }
+        } else {
+            $parameters = $this->generateRandomParameterName();
+        }
 
         $tableAlias = $this->generateRandomParameterName();
 
-        $subQb = $queryBuilder->getConnection()->createQueryBuilder();
+        $subQb = $queryBuilder->createQueryBuilder($queryBuilder->getConnection());
         $expr  = $subQb->expr()->andX(
             $subQb->expr()->isNotNull($tableAlias.'.redirect_id'),
             $subQb->expr()->isNotNull($tableAlias.'.lead_id'),
             $subQb->expr()->eq($tableAlias.'.source', $subQb->expr()->literal($filterChannel))
         );
 
-        $inExpr = OperatorOptions::NOT_EQUAL_TO === $filterOperator ? 'notIn' : 'in';
         if ($this->isDateBased($filter->getField())) {
             $expr->add(
-                $subQb->expr()->$filterOperator($tableAlias.'.date_hit', $filter->getParameterHolder($parameter))
+                $subQb->expr()->$filterOperator($tableAlias.'.date_hit', $filter->getParameterHolder($parameters))
             );
-        } elseif (empty($filterParameter) && in_array($filterOperator, [OperatorOptions::NOT_EQUAL_TO, OperatorOptions::NOT_EMPTY])) {
-            // value != 0
-            $inExpr = 'in';
-        } elseif (empty($filterParameter) && in_array($filterOperator, [OperatorOptions::EQUAL_TO, OperatorOptions::EMPTY])) {
-            // value = 0
-            $inExpr = 'notIn';
         }
 
         $subQb->select($tableAlias.'.lead_id')
@@ -56,7 +55,7 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
             $queryBuilder->addLogic($queryBuilder->expr()->in($leadsTableAlias.'.id', $subQb->getSQL()), $filter->getGlue());
         }
 
-        $queryBuilder->setParametersPairs($parameter, $filterParameter);
+        $queryBuilder->setParametersPairs($parameters, $filterParameters);
 
         return $queryBuilder;
     }

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -15,11 +15,11 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.channel_click.value';
     }
 
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $filterOperator = $filter->getOperator();
-        $filterChannel  = $this->getChannel($filter->getField());
+        $filterOperator  = $filter->getOperator();
+        $filterChannel   = $this->getChannel($filter->getField());
 
         $filterParameter = $filter->getParameterValue();
         $parameter       = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -15,7 +15,7 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.channel_click.value';
     }
 
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -17,6 +17,7 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
 
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $filterOperator = $filter->getOperator();
         $filterChannel  = $this->getChannel($filter->getField());
 
@@ -49,7 +50,11 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', $tableAlias)
             ->where($expr);
 
-        $queryBuilder->addLogic($queryBuilder->expr()->$inExpr('l.id', $subQb->getSQL()), $filter->getGlue());
+        if ('empty' === $filterOperator && !$this->isDateBased($filter->getField())) {
+            $queryBuilder->addLogic($queryBuilder->expr()->notIn($leadsTableAlias.'.id', $subQb->getSQL()), $filter->getGlue());
+        } else {
+            $queryBuilder->addLogic($queryBuilder->expr()->in($leadsTableAlias.'.id', $subQb->getSQL()), $filter->getGlue());
+        }
 
         $queryBuilder->setParametersPairs($parameter, $filterParameter);
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -17,7 +17,7 @@ class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
 
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();
         $filterChannel   = $this->getChannel($filter->getField());
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Query\Filter;
 
+use Exception;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
@@ -25,9 +26,15 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.complex_relation.value';
     }
 
-    /** {@inheritdoc} */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    /**
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return QueryBuilder
+     * @throws Exception
+     */
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $filterOperator = $filter->getOperator();
 
         $filterParameters = $filter->getParameterValue();
@@ -49,7 +56,7 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
             $tableAlias = $this->generateRandomParameterName();
 
             $relTable = $this->generateRandomParameterName();
-            $queryBuilder->leftJoin('l', $filter->getRelationJoinTable(), $relTable, $relTable.'.lead_id = l.id');
+            $queryBuilder->leftJoin($leadsTableAlias, $filter->getRelationJoinTable(), $relTable, $relTable.'.lead_id = '.$leadsTableAlias.'.id');
             $queryBuilder->leftJoin($relTable, $filter->getTable(), $tableAlias, $tableAlias.'.id = '.$relTable.'.'
                 .$filter->getRelationJoinTableField());
         }
@@ -117,7 +124,7 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
                 $expression = $queryBuilder->expr()->andX($expressions);
                 break;
             default:
-                throw new \Exception('Dunno how to handle operator "'.$filterOperator.'"');
+                throw new Exception('Dunno how to handle operator "'.$filterOperator.'"');
         }
 
         $queryBuilder->addLogic($expression, $filter->getGlue());

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -31,7 +31,7 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();
 
         $filterParameters = $filter->getParameterValue();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -29,7 +29,7 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
     /**
      * @throws Exception
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -27,15 +27,12 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
      * @throws Exception
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $filterOperator = $filter->getOperator();
+        $filterOperator  = $filter->getOperator();
 
         $filterParameters = $filter->getParameterValue();
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
@@ -13,9 +13,12 @@ class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.special.dnc';
     }
 
+    /**
+     * @throws QueryException
+     */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias   = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $doNotContactParts = $filter->getDoNotContactParts();
         $expr              = $queryBuilder->expr();
         $queryAlias        = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
@@ -18,7 +18,7 @@ class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias   = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias   = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $doNotContactParts = $filter->getDoNotContactParts();
         $expr              = $queryBuilder->expr();
         $queryAlias        = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
@@ -4,6 +4,7 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryException;
 
 class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
 {
@@ -14,6 +15,7 @@ class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
 
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $doNotContactParts = $filter->getDoNotContactParts();
         $expr              = $queryBuilder->expr();
         $queryAlias        = $this->generateRandomParameterName();
@@ -30,9 +32,9 @@ class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
             ->andWhere($expr->eq($queryAlias.'.channel', $channelParameter));
 
         if ('eq' === $filter->getOperator() xor !$filter->getParameterValue()) {
-            $expression = $expr->in('l.id', $filterQueryBuilder->getSQL());
+            $expression = $expr->in($leadsTableAlias.'.id', $filterQueryBuilder->getSQL());
         } else {
-            $expression = $expr->notIn('l.id', $filterQueryBuilder->getSQL());
+            $expression = $expr->notIn($leadsTableAlias.'.id', $filterQueryBuilder->getSQL());
         }
 
         $queryBuilder->addLogic($expression, $filter->getGlue());

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -3,7 +3,9 @@
 namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\Exception\FieldNotFoundException;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryException;
 
 /**
  * Class ForeignFuncFilterQueryBuilder.
@@ -19,10 +21,15 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * {@inheritdoc}
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return QueryBuilder
+     * @throws FieldNotFoundException
+     * @throws QueryException
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $filterOperator = $filter->getOperator();
         $filterGlue     = $filter->getGlue();
         $filterAggr     = $filter->getAggregateFunction();
@@ -59,11 +66,11 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
             } else {
                 if ('companies' == $filter->getTable()) {
                     $relTable = $this->generateRandomParameterName();
-                    $queryBuilder->leftJoin('l', MAUTIC_TABLE_PREFIX.'companies_leads', $relTable, $relTable.'.lead_id = l.id');
+                    $queryBuilder->leftJoin($leadsTableAlias, MAUTIC_TABLE_PREFIX.'companies_leads', $relTable, $relTable.'.lead_id = '.$leadsTableAlias.'.id');
                     $queryBuilder->leftJoin($relTable, $filter->getTable(), $tableAlias, $tableAlias.'.id = '.$relTable.'.company_id');
                 } else { // This should never happen
                     $queryBuilder->leftJoin(
-                        $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads'),
+                        $leadsTableAlias,
                         $filter->getTable(),
                         $tableAlias,
                         sprintf('%s.id = %s.lead_id', $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads'), $tableAlias)
@@ -123,13 +130,13 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
 
         if ($queryBuilder->isJoinTable($filter->getTable()) && !$filterAggr) { // This should never happen
             $queryBuilder->addJoinCondition($tableAlias, ' ('.$expression.')');
-            $queryBuilder->addGroupBy('l.id');
+            $queryBuilder->addGroupBy($leadsTableAlias.'.id');
         } else {
             if ($filterAggr) {
                 $expression = $queryBuilder->expr()->exists('SELECT '.$expressionArg.' FROM '.$filter->getTable().' '.
-                    $tableAlias.' WHERE l.id='.$tableAlias.'.lead_id HAVING '.$expression);
+                    $tableAlias.' WHERE '.$leadsTableAlias.'.id='.$tableAlias.'.lead_id HAVING '.$expression);
             } else { // This should never happen
-                $queryBuilder->addGroupBy('l.id');
+                $queryBuilder->addGroupBy($leadsTableAlias.'.id');
             }
 
             $queryBuilder->addLogic($expression, $filter->getGlue());

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -21,18 +21,15 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
      * @throws FieldNotFoundException
      * @throws QueryException
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $filterOperator = $filter->getOperator();
-        $filterGlue     = $filter->getGlue();
-        $filterAggr     = $filter->getAggregateFunction();
+        $filterOperator  = $filter->getOperator();
+        $filterGlue      = $filter->getGlue();
+        $filterAggr      = $filter->getAggregateFunction();
 
         $filterParameters = $filter->getParameterValue();
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -7,14 +7,8 @@ use Mautic\LeadBundle\Segment\Exception\FieldNotFoundException;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryException;
 
-/**
- * Class ForeignFuncFilterQueryBuilder.
- */
 class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
 {
-    /**
-     * {@inheritdoc}
-     */
     public static function getServiceId()
     {
         return 'mautic.lead.query.builder.foreign.func';
@@ -24,7 +18,7 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
      * @throws FieldNotFoundException
      * @throws QueryException
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -26,7 +26,7 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $filterOperator  = $filter->getOperator();
         $filterGlue      = $filter->getGlue();
         $filterAggr      = $filter->getAggregateFunction();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
@@ -20,14 +20,11 @@ class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
      * @throws QueryException
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias          = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $integrationCampaignParts = $filter->getIntegrationCampaignParts();
 
         $integrationNameParameter    = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
@@ -4,6 +4,7 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryException;
 
 /**
  * Class IntegrationCampaignFilterQueryBuilder.
@@ -19,10 +20,14 @@ class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * {@inheritdoc}
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return QueryBuilder
+     * @throws QueryException
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $integrationCampaignParts = $filter->getIntegrationCampaignParts();
 
         $integrationNameParameter    = $this->generateRandomParameterName();
@@ -31,12 +36,12 @@ class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
         $tableAlias = $this->generateRandomParameterName();
 
         $queryBuilder->leftJoin(
-            'l',
+            $leadsTableAlias,
             MAUTIC_TABLE_PREFIX.'integration_entity',
             $tableAlias,
             $tableAlias.'.integration_entity = "CampaignMember" AND '.
             $tableAlias.".internal_entity = 'lead' AND ".
-            $tableAlias.'.internal_entity_id = l.id'
+            $tableAlias.'.internal_entity_id = '.$leadsTableAlias.'.id'
         );
 
         $expression = $queryBuilder->expr()->andX(

--- a/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
@@ -6,14 +6,8 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryException;
 
-/**
- * Class IntegrationCampaignFilterQueryBuilder.
- */
 class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
 {
-    /**
-     * {@inheritdoc}
-     */
     public static function getServiceId()
     {
         return 'mautic.lead.query.builder.special.integration';
@@ -22,7 +16,7 @@ class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
     /**
      * @throws QueryException
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias          = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $integrationCampaignParts = $filter->getIntegrationCampaignParts();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
@@ -24,7 +24,7 @@ class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias          = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias          = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $integrationCampaignParts = $filter->getIntegrationCampaignParts();
 
         $integrationNameParameter    = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
@@ -89,10 +89,10 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
 
             //  If the segment contains no filters; it means its for manually subscribed only
             if (count($filters)) {
-                $segmentQueryBuilder = $this->leadSegmentQueryBuilder->addManuallyUnsubscribedQuery($segmentQueryBuilder, $contactSegment->getId());
+                $segmentQueryBuilder = $this->leadSegmentQueryBuilder->addManuallyUnsubscribedQuery($segmentQueryBuilder, (int) $contactSegment->getId());
             }
 
-            $segmentQueryBuilder = $this->leadSegmentQueryBuilder->addManuallySubscribedQuery($segmentQueryBuilder, $contactSegment->getId());
+            $segmentQueryBuilder = $this->leadSegmentQueryBuilder->addManuallySubscribedQuery($segmentQueryBuilder, (int) $contactSegment->getId());
 
             $parameters = $segmentQueryBuilder->getParameters();
             foreach ($parameters as $key => $value) {
@@ -105,21 +105,17 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
             $segmentQueryBuilder->where("$leadsTableAlias.id = $subSegmentLeadsTableAlias.id");
             $segmentQueryBuilder->andWhere($segmentQueryWherePart);
 
-            $segmentAlias = $this->generateRandomParameterName();
             if ($exclusion) {
                 $expression = $queryBuilder->expr()->notExists($segmentQueryBuilder->getSQL());
             } else {
                 $expression = $queryBuilder->expr()->exists($segmentQueryBuilder->getSQL());
             }
-            $queryBuilder->addSelect($segmentAlias.'.id as '.$segmentAlias.'_id');
 
             $logic[] = $expression;
         }
 
-        if ($exclusion) {
-            $queryBuilder->addLogic(new CompositeExpression(CompositeExpression::TYPE_AND, $logic), $filter->getGlue());
-        } else {
-            $queryBuilder->addLogic(new CompositeExpression(CompositeExpression::TYPE_OR, $logic), $filter->getGlue());
+        if (count($orLogic)) {
+            $queryBuilder->addLogic(new CompositeExpression(CompositeExpression::TYPE_OR, $orLogic), CompositeExpression::TYPE_AND);
         }
 
         return $queryBuilder;

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
@@ -70,8 +70,8 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
             $segmentIds = [intval($segmentIds)];
         }
 
-        $logic     = [];
-        $exclusion = false;
+        $orLogic = [];
+
         foreach ($segmentIds as $segmentId) {
             $exclusion = in_array($filter->getOperator(), ['notExists', 'notIn']);
 
@@ -111,7 +111,11 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
                 $expression = $queryBuilder->expr()->exists($segmentQueryBuilder->getSQL());
             }
 
-            $logic[] = $expression;
+            if (!$exclusion && count($segmentIds) > 1) {
+                $orLogic[] = $expression;
+            } else {
+                $queryBuilder->addLogic($expression, $filter->getGlue());
+            }
         }
 
         if (count($orLogic)) {

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
@@ -61,7 +61,7 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
      * @throws DBALException
      * @throws QueryException
      */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $segmentIds      = $filter->getParameterValue();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
@@ -63,7 +63,7 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
      */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $segmentIds      = $filter->getParameterValue();
 
         if (!is_array($segmentIds)) {
@@ -84,7 +84,7 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
             $filters = $this->leadSegmentFilterFactory->getSegmentFilters($contactSegment);
 
             $segmentQueryBuilder       = $this->leadSegmentQueryBuilder->assembleContactsSegmentQueryBuilder($contactSegment->getId(), $filters, true);
-            $subSegmentLeadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+            $subSegmentLeadsTableAlias = $segmentQueryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
             $segmentQueryBuilder->resetQueryParts(['select'])->select('null');
 
             //  If the segment contains no filters; it means its for manually subscribed only

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
@@ -56,9 +56,6 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
     }
 
     /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
      * @throws SegmentNotFoundException
      * @throws SegmentQueryException
      * @throws DBALException
@@ -67,7 +64,7 @@ class SegmentReferenceFilterQueryBuilder extends BaseFilterQueryBuilder
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
         $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
-        $segmentIds = $filter->getParameterValue();
+        $segmentIds      = $filter->getParameterValue();
 
         if (!is_array($segmentIds)) {
             $segmentIds = [intval($segmentIds)];

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -18,7 +18,7 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
 
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias      = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias      = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $pageHitsAlias        = $this->generateRandomParameterName();
         $exclusionAlias       = $this->generateRandomParameterName();
         $expressionValueAlias = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -5,18 +5,14 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
-/**
- * Class SessionsFilterQueryBuilder.
- */
 class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
 {
-    /** {@inheritdoc} */
     public static function getServiceId()
     {
         return 'mautic.lead.query.builder.special.sessions';
     }
 
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
     {
         $leadsTableAlias      = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
         $pageHitsAlias        = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -16,9 +16,14 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.special.sessions';
     }
 
-    /** {@inheritdoc} */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    /**
+     * @param  QueryBuilder  $queryBuilder
+     * @param  ContactSegmentFilter  $filter
+     * @return QueryBuilder
+     */
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
+        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $pageHitsAlias        = $this->generateRandomParameterName();
         $exclusionAlias       = $this->generateRandomParameterName();
         $expressionValueAlias = $this->generateRandomParameterName();
@@ -35,7 +40,7 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', $exclusionAlias)
             ->where(
                 $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq('l.id', $exclusionAlias.'.lead_id'),
+                    $queryBuilder->expr()->eq($leadsTableAlias.'.id', $exclusionAlias.'.lead_id'),
                     $queryBuilder->expr()->gt(
                         $exclusionAlias.'.date_hit',
                         $pageHitsAlias.'.date_hit - INTERVAL 30 MINUTE'
@@ -50,7 +55,7 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', $pageHitsAlias)
             ->where(
                 $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq('l.id', $pageHitsAlias.'.lead_id'),
+                    $queryBuilder->expr()->eq($leadsTableAlias.'.id', $pageHitsAlias.'.lead_id'),
                     $queryBuilder->expr()->isNull($pageHitsAlias.'.email_id'),
                     $queryBuilder->expr()->isNull($pageHitsAlias.'.redirect_id'),
                     $queryBuilder->expr()->notExists(

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -16,14 +16,9 @@ class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
         return 'mautic.lead.query.builder.special.sessions';
     }
 
-    /**
-     * @param  QueryBuilder  $queryBuilder
-     * @param  ContactSegmentFilter  $filter
-     * @return QueryBuilder
-     */
     public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
-        $leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
+        $leadsTableAlias      = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'.leads');
         $pageHitsAlias        = $this->generateRandomParameterName();
         $exclusionAlias       = $this->generateRandomParameterName();
         $expressionValueAlias = $this->generateRandomParameterName();

--- a/app/bundles/LeadBundle/Tests/Event/SegmentOperatorQueryBuilderEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/SegmentOperatorQueryBuilderEventTest.php
@@ -25,8 +25,14 @@ final class SegmentOperatorQueryBuilderEventTest extends \PHPUnit\Framework\Test
     {
         parent::setUp();
 
+        defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', getenv('MAUTIC_DB_PREFIX') ?: '');
+
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->filter       = $this->createMock(ContactSegmentFilter::class);
+
+        $this->queryBuilder->method('getTableAlias')
+            ->with(MAUTIC_TABLE_PREFIX.'leads')
+            ->willReturn('leads');
     }
 
     public function testConstructGettersSetters(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
@@ -38,12 +38,15 @@ final class SegmentOperatorQuerySubscriberTest extends \PHPUnit\Framework\TestCa
     {
         parent::setUp();
 
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+
         $this->queryBuilder         = $this->createMock(QueryBuilder::class);
         $this->expressionBuilder    = $this->createMock(ExpressionBuilder::class);
         $this->contactSegmentFilter = $this->createMock(ContactSegmentFilter::class);
         $this->subscriber           = new SegmentOperatorQuerySubscriber();
 
         $this->queryBuilder->method('expr')->willReturn($this->expressionBuilder);
+        $this->queryBuilder->method('getTableAlias')->willReturn('l');
     }
 
     public function testOnEmptyOperatorIfNotEmpty(): void

--- a/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticCitrixBundle/EventListener/LeadSubscriber.php
@@ -219,6 +219,8 @@ class LeadSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $leadsTableAlias = $event->getLeadsTableAlias();
+
         $details           = $event->getDetails();
         $leadId            = $event->getLeadId();
         $em                = $event->getEntityManager();
@@ -254,7 +256,7 @@ class LeadSubscriber implements EventSubscriberInterface
                                 $q->expr()->eq($alias.$k.'.product', $q->expr()->literal($product)),
                                 $q->expr()->eq($alias.$k.'.event_type', $q->expr()->literal($eventType)),
                                 $q->expr()->in($alias.$k.'.event_name', $eventNames),
-                                $q->expr()->eq($alias.$k.'.lead_id', 'l.id')
+                                $q->expr()->eq($alias.$k.'.lead_id', $leadsTableAlias.'.id')
                             )
                         );
                     } else {
@@ -262,7 +264,7 @@ class LeadSubscriber implements EventSubscriberInterface
                             $q->expr()->andX(
                                 $q->expr()->eq($alias.$k.'.product', $q->expr()->literal($product)),
                                 $q->expr()->eq($alias.$k.'.event_type', $q->expr()->literal($eventType)),
-                                $q->expr()->eq($alias.$k.'.lead_id', 'l.id')
+                                $q->expr()->eq($alias.$k.'.lead_id', $leadsTableAlias.'.id')
                             )
                         );
                     }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR optimize segment queries from using NOT IN that takes over 8 seconds like this:
```sql
SELECT DISTINCT l.*, l.id, pPioqBGs.lead_id AS pPioqBGs_lead_id
FROM mautic_leads l
    LEFT JOIN mautic_lead_lists_leads pPioqBGs ON pPioqBGs.lead_id = l.id
    and (pPioqBGs.leadlist_id = 600)
WHERE
    (
        (
            (l.last_active >= '2020-09-18')
            AND (
                l.id NOT IN (
                    SELECT l.id
                    FROM mautic_leads l
                    WHERE
                        l.id IN (
                            SELECT rJuvStgT.lead_id
                            FROM mautic_lead_lists_leads rJuvStgT
                            WHERE (rJuvStgT.leadlist_id = 615)
                                AND (
                                    (rJuvStgT.manually_added = 1)
                                    OR (rJuvStgT.manually_removed = '')
                                )
                        )
                )
            )
            AND (
                l.id NOT IN (
                    SELECT l.id
                    FROM mautic_leads l
                        LEFT JOIN mautic_lead_lists_leads EvkrwnPS ON l.id = EvkrwnPS.lead_id
                        and EvkrwnPS.leadlist_id = 653
                        and (EvkrwnPS.manually_removed = 1)
                    WHERE
                        ((l.frequency_field = '1') AND (EvkrwnPS.lead_id IS NULL))
                        OR (
                            l.id IN (
                                SELECT SrEvxNZX.lead_id
                                FROM mautic_lead_lists_leads SrEvxNZX
                                WHERE (SrEvxNZX.leadlist_id = 653)
                                    AND ((SrEvxNZX.manually_added = 1) OR (SrEvxNZX.manually_removed = ''))
                            )
                        )
                )
            )
            AND (
                l.id NOT IN (
                    SELECT l.id
                    FROM mautic_leads l
                        LEFT JOIN mautic_lead_lists_leads SCImFpMA ON l.id = SCImFpMA.lead_id
                        and SCImFpMA.leadlist_id = 655
                        and (SCImFpMA.manually_removed = 1)
                    WHERE
                        ((l.frequency_field = '3') AND (SCImFpMA.lead_id IS NULL))
                        OR (
                            l.id IN (
                                SELECT nMLNxcFU.lead_id
                                FROM mautic_lead_lists_leads nMLNxcFU
                                WHERE (nMLNxcFU.leadlist_id = 655)
                                    AND ((nMLNxcFU.manually_added = 1) OR (nMLNxcFU.manually_removed = ''))
                            )
                        )
                )
            )
            AND (
                l.id NOT IN (
                    SELECT l.id
                    FROM mautic_leads l
                        LEFT JOIN mautic_lead_lists_leads wXoEWQuN ON l.id = wXoEWQuN.lead_id
                        and wXoEWQuN.leadlist_id = 658
                        and (wXoEWQuN.manually_removed = 1)
                    WHERE
                        (
                            (
                                l.id IN (
                                    SELECT mOLWMNqJ.lead_id
                                    FROM mautic_campaign_leads mOLWMNqJ
                                    WHERE (mOLWMNqJ.manually_removed = 0)
                                        AND (mOLWMNqJ.campaign_id IN (655))
                                )
                            )
                            AND (wXoEWQuN.lead_id IS NULL)
                        )
                        OR (
                            l.id IN (
                                SELECT lPxVHLFk.lead_id
                                FROM mautic_lead_lists_leads lPxVHLFk
                                WHERE (lPxVHLFk.leadlist_id = 658)
                                    AND ((lPxVHLFk.manually_added = 1) OR (lPxVHLFk.manually_removed = ''))
                            )
                        )
                )
            )
        )
        OR (l.date_added <= '2020-09-03')
    )
    AND (pPioqBGs.lead_id IS NULL)
LIMIT 10;
```

To using EXISTS like this and takes 300 ms:

```sql
SELECT DISTINCT l.*, l.id, TCajNDXd.lead_id AS TCajNDXd_lead_id
FROM mautic_leads l
    LEFT JOIN mautic_lead_lists_leads TCajNDXd ON TCajNDXd.lead_id = l.id
    and (TCajNDXd.leadlist_id = 600)
WHERE
    (
        (
            (l.last_active >= '2020-09-18')
            AND (
                NOT EXISTS(
                    SELECT null
                    FROM mautic_leads cYevtOdm
                    WHERE (l.id = cYevtOdm.id)
                        AND (
                            EXISTS(
                                SELECT null
                                FROM mautic_lead_lists_leads CpouDtYM
                                WHERE (cYevtOdm.id = CpouDtYM.lead_id)
                                    AND (
                                        (CpouDtYM.leadlist_id = 615)
                                        AND (
                                            (CpouDtYM.manually_added = 1)
                                            OR (CpouDtYM.manually_removed = '')
                                        )
                                    )
                            )
                        )
                )
            )
            AND (
                NOT EXISTS(
                    SELECT null
                    FROM mautic_leads yXMEdCwF
                        LEFT JOIN mautic_lead_lists_leads ThGNexbR ON yXMEdCwF.id = ThGNexbR.lead_id
                        and ThGNexbR.leadlist_id = 653
                        and (ThGNexbR.manually_removed = 1)
                    WHERE (l.id = yXMEdCwF.id)
                        AND (
                            ((l.frequency_field = '1') AND (ThGNexbR.lead_id IS NULL))
                            OR (
                                EXISTS(
                                    SELECT null
                                    FROM mautic_lead_lists_leads wQEZrXxm
                                    WHERE (yXMEdCwF.id = wQEZrXxm.lead_id)
                                        AND (
                                            (wQEZrXxm.leadlist_id = 653)
                                            AND (
                                                (wQEZrXxm.manually_added = 1) OR (wQEZrXxm.manually_removed = '')
                                            )
                                        )
                                )
                            )
                        )
                )
            )
            AND (
                NOT EXISTS(
                    SELECT null
                    FROM mautic_leads sBKDywTn
                        LEFT JOIN mautic_lead_lists_leads MGpBoXJS ON sBKDywTn.id = MGpBoXJS.lead_id
                        and MGpBoXJS.leadlist_id = 655
                        and (MGpBoXJS.manually_removed = 1)
                    WHERE (l.id = sBKDywTn.id)
                        AND (
                            (
                                (l.frequency_field = '3')
                                AND (MGpBoXJS.lead_id IS NULL)
                            )
                            OR (
                                EXISTS(
                                    SELECT null
                                    FROM mautic_lead_lists_leads EIDveBTm
                                    WHERE (sBKDywTn.id = EIDveBTm.lead_id)
                                        AND (
                                            (EIDveBTm.leadlist_id = 655)
                                            AND (
                                                (EIDveBTm.manually_added = 1)
                                                OR (EIDveBTm.manually_removed = '')
                                            )
                                        )
                                )
                            )
                        )
                )
            )
            AND (
                NOT EXISTS(
                    SELECT null
                    FROM mautic_leads skwtADMi
                        LEFT JOIN mautic_lead_lists_leads XLxajDbw ON skwtADMi.id = XLxajDbw.lead_id
                        and XLxajDbw.leadlist_id = 658
                        and (XLxajDbw.manually_removed = 1)
                    WHERE (l.id = skwtADMi.id)
                        AND (
                            (
                                (
                                    l.id IN (
                                        SELECT FvqkwCfx.lead_id
                                        FROM mautic_campaign_leads FvqkwCfx
                                        WHERE (FvqkwCfx.manually_removed = 0)
                                            AND (FvqkwCfx.campaign_id IN (655))
                                    )
                                )
                                AND (XLxajDbw.lead_id IS NULL)
                            )
                            OR (
                                EXISTS(
                                    SELECT null
                                    FROM mautic_lead_lists_leads akQJtKNi
                                    WHERE (skwtADMi.id = akQJtKNi.lead_id)
                                        AND ((akQJtKNi.leadlist_id = 658)
                                            AND ((akQJtKNi.manually_added = 1) OR (akQJtKNi.manually_removed = ''))
                                        )
                                )
                            )
                        )
                )
            )
        )
        OR (l.date_added <= '2020-09-03')
    )
    AND (TCajNDXd.lead_id IS NULL)
LIMIT 10;
```

#### Steps to test this PR:
1. Load DB with more than 100k contacts.
2. Create or use existing segment rebuild which includes segment membership filters.
3. Use `bin/console mautic:segments:update -i [SEGMENT_ID_HERE]` to update just one segment. Use stop watch to get a time it took to execute.
4. Load up this PR
5. Repeat step 3 with the new code.
6. Compare execution times.
7. Check for other segments as well.
8. Check that the results of both version is the same (contacts weren't added nor removed)


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10903"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

