### PR TITLE
Segment query optimizatioin 

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -55,7 +55,7 @@ class ContactSegmentService
             ];
         }
 
-        $qb = $this->getNewSegmentContactsQuery($segment, $batchLimiters);
+        $qb = $this->getNewSegmentContactsQuery($segment);
 
         $this->addMinMaxLimiters($qb, $batchLimiters);
         $this->addLeadLimiter($qb, $batchLimiters);
@@ -119,7 +119,7 @@ class ContactSegmentService
      */
     public function getNewLeadListLeads(LeadList $segment, array $batchLimiters, $limit = 1000)
     {
-        $queryBuilder = $this->getNewSegmentContactsQuery($segment, $batchLimiters);
+        $queryBuilder = $this->getNewSegmentContactsQuery($segment);
 
         // Prepend the DISTINCT to the beginning of the select array
         $select = $queryBuilder->getQueryPart('select');
@@ -197,14 +197,14 @@ class ContactSegmentService
      * @throws Exception\SegmentQueryException
      * @throws \Exception
      */
-    private function getNewSegmentContactsQuery(LeadList $segment, $batchLimiters)
+    private function getNewSegmentContactsQuery(LeadList $segment)
     {
         $queryBuilder = $this->contactSegmentQueryBuilder->assembleContactsSegmentQueryBuilder(
             $segment->getId(),
             $this->contactSegmentFilterFactory->getSegmentFilters($segment)
         );
 
-        $queryBuilder = $this->contactSegmentQueryBuilder->addNewContactsRestrictions($queryBuilder, $segment->getId(), $batchLimiters);
+        $queryBuilder = $this->contactSegmentQueryBuilder->addNewContactsRestrictions($queryBuilder, $segment->getId());
 
         $this->contactSegmentQueryBuilder->queryBuilderGenerated($segment, $queryBuilder);
 

--- a/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
+++ b/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
@@ -21,9 +21,16 @@ class DoNotContactParts
      */
     public function __construct($field)
     {
-        $parts         = explode('_', $field);
-        $this->type    = $parts[1];
-        $this->channel = 3 === count($parts) ? $parts[2] : 'email';
+        $parts = explode('_', $field);
+        switch (true) {
+            case preg_match('/_manually$/', $field):
+                $this->type    = DoNotContact::MANUAL;
+                $this->channel = 4 === count($parts) ? $parts[2] : 'email';
+                break;
+            default:
+                $this->type    = 'bounced' === $parts[1] ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
+                $this->channel = 3 === count($parts) ? $parts[2] : 'email';
+        }
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
+++ b/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
@@ -6,30 +6,25 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 
 class DoNotContactParts
 {
-    /**
-     * @var string
-     */
-    private $channel;
+    private string $channel = 'email';
 
-    /**
-     * @var string
-     */
-    private $type;
+    private int $type = DoNotContact::UNSUBSCRIBED;
 
     /**
      * @param string $field
      */
     public function __construct($field)
     {
-        $parts = explode('_', $field);
-        switch (true) {
-            case preg_match('/_manually$/', $field):
-                $this->type    = DoNotContact::MANUAL;
-                $this->channel = 4 === count($parts) ? $parts[2] : 'email';
-                break;
-            default:
-                $this->type    = 'bounced' === $parts[1] ? DoNotContact::BOUNCED : DoNotContact::UNSUBSCRIBED;
-                $this->channel = 3 === count($parts) ? $parts[2] : 'email';
+        if (false !== strpos($field, '_manual')) {
+            $this->type = DoNotContact::MANUAL;
+        }
+
+        if (false !== strpos($field, '_bounced')) {
+            $this->type = DoNotContact::BOUNCED;
+        }
+
+        if (false !== strpos($field, '_sms')) {
+            $this->channel = 'sms';
         }
     }
 
@@ -46,15 +41,6 @@ class DoNotContactParts
      */
     public function getParameterType()
     {
-        switch ($this->type) {
-            case 'bounced':
-            case DoNotContact::BOUNCED:
-                return DoNotContact::BOUNCED;
-            case 'manual':
-            case DoNotContact::MANUAL:
-                return DoNotContact::MANUAL;
-            default:
-                return DoNotContact::UNSUBSCRIBED;
-        }
+        return $this->type;
     }
 }

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -138,32 +138,24 @@ class ContactSegmentQueryBuilder
      * Restrict the query to NEW members of segment.
      *
      * @param $segmentId
-     * @param $batchRestrictions
      *
      * @return QueryBuilder
      *
      * @throws QueryException
      */
-    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId, $batchRestrictions)
+    public function addNewContactsRestrictions(QueryBuilder $queryBuilder, $segmentId)
     {
-        $parts     = $queryBuilder->getQueryParts();
-        $setHaving = (count($parts['groupBy']) || !is_null($parts['having']));
+        $expr               = $queryBuilder->expr();
+        $tableAlias         = $this->generateRandomParameterName();
+        $segmentIdParameter = ":{$tableAlias}segmentId";
 
-        $tableAlias = $this->generateRandomParameterName();
-        $queryBuilder->leftJoin('l', MAUTIC_TABLE_PREFIX.'lead_lists_leads', $tableAlias, $tableAlias.'.lead_id = l.id');
-        $queryBuilder->addSelect($tableAlias.'.lead_id AS '.$tableAlias.'_lead_id');
+        $segmentQueryBuilder = $queryBuilder->createQueryBuilder()
+            ->select($tableAlias.'.lead_id')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', $tableAlias)
+            ->andWhere($expr->eq($tableAlias.'.leadlist_id', $segmentIdParameter));
 
-        $expression = $queryBuilder->expr()->eq($tableAlias.'.leadlist_id', $segmentId);
-
-        $queryBuilder->addJoinCondition($tableAlias, $expression);
-
-        if ($setHaving) {
-            $restrictionExpression = $queryBuilder->expr()->isNull($tableAlias.'_lead_id');
-            $queryBuilder->andHaving($restrictionExpression);
-        } else {
-            $restrictionExpression = $queryBuilder->expr()->isNull($tableAlias.'.lead_id');
-            $queryBuilder->andWhere($restrictionExpression);
-        }
+        $queryBuilder->setParameter($segmentIdParameter, $segmentId);
+        $queryBuilder->andWhere($expr->notIn('l.id', $segmentQueryBuilder->getSQL()));
 
         return $queryBuilder;
     }

--- a/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
@@ -5,50 +5,37 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
-/**
- * Class DoNotContactFilterQueryBuilder.
- */
 class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
 {
-    /**
-     * {@inheritdoc}
-     */
-    public static function getServiceId()
+    public static function getServiceId(): string
     {
         return 'mautic.lead.query.builder.special.dnc';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter)
+    public function applyQuery(QueryBuilder $queryBuilder, ContactSegmentFilter $filter): QueryBuilder
     {
         $doNotContactParts = $filter->getDoNotContactParts();
+        $expr              = $queryBuilder->expr();
+        $queryAlias        = $this->generateRandomParameterName();
+        $reasonParameter   = ":{$queryAlias}reason";
+        $channelParameter  = ":{$queryAlias}channel";
 
-        $tableAlias = $this->generateRandomParameterName();
-        $queryBuilder->leftJoin('l', MAUTIC_TABLE_PREFIX.'lead_donotcontact', $tableAlias, $tableAlias.'.lead_id = l.id');
+        $queryBuilder->setParameter($reasonParameter, $doNotContactParts->getParameterType());
+        $queryBuilder->setParameter($channelParameter, $doNotContactParts->getChannel());
 
-        $exprParameter    = $this->generateRandomParameterName();
-        $channelParameter = $this->generateRandomParameterName();
+        $filterQueryBuilder = $queryBuilder->createQueryBuilder()
+            ->select($queryAlias.'.lead_id')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', $queryAlias)
+            ->andWhere($expr->eq($queryAlias.'.reason', $reasonParameter))
+            ->andWhere($expr->eq($queryAlias.'.channel', $channelParameter));
 
-        $expression = $queryBuilder->expr()->andX(
-            $queryBuilder->expr()->eq($tableAlias.'.reason', ":$exprParameter"),
-            $queryBuilder->expr()
-              ->eq($tableAlias.'.channel', ":$channelParameter")
-        );
-
-        $queryBuilder->addJoinCondition($tableAlias, $expression);
-
-        if ('eq' === $filter->getOperator()) {
-            $queryType = $filter->getParameterValue() ? 'isNotNull' : 'isNull';
+        if ('eq' === $filter->getOperator() xor !$filter->getParameterValue()) {
+            $expression = $expr->in('l.id', $filterQueryBuilder->getSQL());
         } else {
-            $queryType = $filter->getParameterValue() ? 'isNull' : 'isNotNull';
+            $expression = $expr->notIn('l.id', $filterQueryBuilder->getSQL());
         }
 
-        $queryBuilder->addLogic($queryBuilder->expr()->$queryType($tableAlias.'.id'), $filter->getGlue());
-
-        $queryBuilder->setParameter($exprParameter, $doNotContactParts->getParameterType());
-        $queryBuilder->setParameter($channelParameter, $doNotContactParts->getChannel());
+        $queryBuilder->addLogic($expression, $filter->getGlue());
 
         return $queryBuilder;
     }

--- a/app/bundles/LeadBundle/Tests/Segment/DoNotContact/DoNotContactPartsTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/DoNotContact/DoNotContactPartsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\DoNotContact;
 
 use Mautic\LeadBundle\Entity\DoNotContact;
@@ -8,56 +10,60 @@ use Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts;
 class DoNotContactPartsTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @covers \Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts::getChannel
-     * @covers \Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts::getParameterType
+     * @dataProvider dataProvider
      */
-    public function testDncBouncedEmail()
+    public function testParts(string $field, string $channel, int $type): void
     {
-        $field             = 'dnc_bounced';
         $doNotContactParts = new DoNotContactParts($field);
-
-        $this->assertSame('email', $doNotContactParts->getChannel());
-        $this->assertSame(
-            DoNotContact::BOUNCED,
-            $doNotContactParts->getParameterType(),
-            'Type for dnc_bounced should be bounced'
-        );
-
-        $field             = 'dnc_unsubscribed';
-        $doNotContactParts = new DoNotContactParts($field);
-
-        $this->assertSame('email', $doNotContactParts->getChannel());
-        $this->assertSame(
-            DoNotContact::UNSUBSCRIBED,
-            $doNotContactParts->getParameterType(),
-            'Type for dnc_unsubscribed should be unsubscribed'
-        );
+        $this->assertSame($channel, $doNotContactParts->getChannel());
+        $this->assertSame($type, $doNotContactParts->getParameterType());
     }
 
     /**
-     * @covers \Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts::getChannel
-     * @covers \Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts::getParameterType
+     * @return iterable<array<string,string|int>>
      */
-    public function testDncBouncedSms()
+    public function dataProvider(): iterable
     {
-        $field             = 'dnc_bounced_sms';
-        $doNotContactParts = new DoNotContactParts($field);
+        yield [
+            'field'   => 'dnc_bounced',
+            'channel' => 'email',
+            'type'    => DoNotContact::BOUNCED,
+        ];
 
-        $this->assertSame('sms', $doNotContactParts->getChannel());
-        $this->assertSame(
-            DoNotContact::BOUNCED,
-            $doNotContactParts->getParameterType(),
-            'Type for dnc_bounced_sms should be bounced'
-        );
+        yield [
+            'field'   => 'dnc_unsubscribed',
+            'channel' => 'email',
+            'type'    => DoNotContact::UNSUBSCRIBED,
+        ];
 
-        $field             = 'dnc_unsubscribed_sms';
-        $doNotContactParts = new DoNotContactParts($field);
+        yield [
+            'field'   => 'dnc_manual_email',
+            'channel' => 'email',
+            'type'    => DoNotContact::MANUAL,
+        ];
 
-        $this->assertSame('sms', $doNotContactParts->getChannel());
-        $this->assertSame(
-            DoNotContact::UNSUBSCRIBED,
-            $doNotContactParts->getParameterType(),
-            'Type for dnc_unsubscribed_sms should be unsubscribed'
-        );
+        yield [
+            'field'   => 'dnc_bounced_sms',
+            'channel' => 'sms',
+            'type'    => DoNotContact::BOUNCED,
+        ];
+
+        yield [
+            'field'   => 'dnc_unsubscribed_sms',
+            'channel' => 'sms',
+            'type'    => DoNotContact::UNSUBSCRIBED,
+        ];
+
+        yield [
+            'field'   => 'dnc_manual_sms',
+            'channel' => 'sms',
+            'type'    => DoNotContact::MANUAL,
+        ];
+
+        yield [
+            'field'   => 'dnc_unsubscribed_sms_manually',
+            'channel' => 'sms',
+            'type'    => DoNotContact::MANUAL,
+        ];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Tests\Segment\Query;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
@@ -33,12 +33,13 @@ class ContactSegmentQueryBuilderTest extends TestCase
     {
         $queryBuilder = new QueryBuilder($this->createConnection());
         $queryBuilder->select('1');
+        $queryBuilder->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
         $queryBuilder->where('NULL');
 
         $filterQueryBuilder = new ContactSegmentQueryBuilder($this->createMock(EntityManager::class), new RandomParameterName(), new EventDispatcher());
 
         Assert::assertSame($queryBuilder, $filterQueryBuilder->addNewContactsRestrictions($queryBuilder, 8));
-        Assert::assertSame('SELECT 1 WHERE (NULL) AND (l.id NOT IN (SELECT par0.lead_id FROM lead_lists_leads par0 WHERE par0.leadlist_id = 8))', $queryBuilder->getDebugOutput());
+        Assert::assertSame('SELECT 1 FROM leads l WHERE (NULL) AND (l.id NOT IN (SELECT par0.lead_id FROM lead_lists_leads par0 WHERE par0.leadlist_id = 8))', $queryBuilder->getDebugOutput());
     }
 
     private function createConnection(): Connection

--- a/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Segment\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Mautic\LeadBundle\Segment\Query\ContactSegmentQueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class ContactSegmentQueryBuilderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+
+    public function testAddNewContactsRestrictions(): void
+    {
+        $queryBuilder = new QueryBuilder($this->createConnection());
+        $queryBuilder->select('1');
+        $queryBuilder->where('NULL');
+
+        $filterQueryBuilder = new ContactSegmentQueryBuilder($this->createMock(EntityManager::class), new RandomParameterName(), new EventDispatcher());
+
+        Assert::assertSame($queryBuilder, $filterQueryBuilder->addNewContactsRestrictions($queryBuilder, 8));
+        Assert::assertSame('SELECT 1 WHERE (NULL) AND (l.id NOT IN (SELECT par0.lead_id FROM lead_lists_leads par0 WHERE par0.leadlist_id = 8))', $queryBuilder->getDebugOutput());
+    }
+
+    private function createConnection(): Connection
+    {
+        return new class() extends Connection {
+            /** @noinspection PhpMissingParentConstructorInspection */
+            public function __construct()
+            {
+            }
+        };
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Tests\Segment\Query\Filter;
 
 use Doctrine\DBAL\Connection;
@@ -51,6 +42,9 @@ class DoNotContactFilterQueryBuilderTest extends TestCase
         Assert::assertSame($expectedQuery, $queryBuilder->getDebugOutput());
     }
 
+    /**
+     * @return iterable<array<string>>
+     */
     public function dataApplyQuery(): iterable
     {
         yield ['eq', '1', 'SELECT 1 FROM leads l WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * @copyright   2020 Mautic. All rights reserved
  * @author      Mautic

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -42,6 +42,7 @@ class DoNotContactFilterQueryBuilderTest extends TestCase
     {
         $queryBuilder = new QueryBuilder($this->createConnection());
         $queryBuilder->select('1');
+        $queryBuilder->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
 
         $filter             = $this->createFilter($operator, $parameterValue);
         $filterQueryBuilder = new DoNotContactFilterQueryBuilder(new RandomParameterName(), new EventDispatcher());
@@ -52,10 +53,10 @@ class DoNotContactFilterQueryBuilderTest extends TestCase
 
     public function dataApplyQuery(): iterable
     {
-        yield ['eq', '1', 'SELECT 1 WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
-        yield ['eq', '0', 'SELECT 1 WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
-        yield ['neq', '1', 'SELECT 1 WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
-        yield ['neq', '0', 'SELECT 1 WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['eq', '1', 'SELECT 1 FROM leads l WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['eq', '0', 'SELECT 1 FROM leads l WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['neq', '1', 'SELECT 1 FROM leads l WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['neq', '0', 'SELECT 1 FROM leads l WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
     }
 
     private function createConnection(): Connection

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -85,7 +85,7 @@ class DoNotContactFilterQueryBuilderTest extends TestCase
 
             public function getDoNotContactParts()
             {
-                return new DoNotContactParts('some');
+                return new DoNotContactParts('dnc_unsubscribed');
             }
 
             public function getOperator()

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Segment\Query\Filter;
+
+use Doctrine\DBAL\Connection;
+use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\DoNotContact\DoNotContactParts;
+use Mautic\LeadBundle\Segment\Query\Filter\DoNotContactFilterQueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class DoNotContactFilterQueryBuilderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+
+    public function testGetServiceId(): void
+    {
+        Assert::assertSame('mautic.lead.query.builder.special.dnc', DoNotContactFilterQueryBuilder::getServiceId());
+    }
+
+    /**
+     * @dataProvider dataApplyQuery
+     */
+    public function testApplyQuery(string $operator, string $parameterValue, string $expectedQuery): void
+    {
+        $queryBuilder = new QueryBuilder($this->createConnection());
+        $queryBuilder->select('1');
+
+        $filter             = $this->createFilter($operator, $parameterValue);
+        $filterQueryBuilder = new DoNotContactFilterQueryBuilder(new RandomParameterName(), new EventDispatcher());
+
+        Assert::assertSame($queryBuilder, $filterQueryBuilder->applyQuery($queryBuilder, $filter));
+        Assert::assertSame($expectedQuery, $queryBuilder->getDebugOutput());
+    }
+
+    public function dataApplyQuery(): iterable
+    {
+        yield ['eq', '1', 'SELECT 1 WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['eq', '0', 'SELECT 1 WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['neq', '1', 'SELECT 1 WHERE l.id NOT IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+        yield ['neq', '0', 'SELECT 1 WHERE l.id IN (SELECT par0.lead_id FROM lead_donotcontact par0 WHERE (par0.reason = 1) AND (par0.channel = \'email\'))'];
+    }
+
+    private function createConnection(): Connection
+    {
+        return new class() extends Connection {
+            /** @noinspection PhpMissingParentConstructorInspection */
+            public function __construct()
+            {
+            }
+        };
+    }
+
+    private function createFilter(string $operator, string $parameterValue): ContactSegmentFilter
+    {
+        return new class($operator, $parameterValue) extends ContactSegmentFilter {
+            /**
+             * @var string
+             */
+            private $operator;
+
+            /**
+             * @var string
+             */
+            private $parameterValue;
+
+            /** @noinspection PhpMissingParentConstructorInspection */
+            public function __construct(string $operator, string $parameterValue)
+            {
+                $this->operator       = $operator;
+                $this->parameterValue = $parameterValue;
+            }
+
+            public function getDoNotContactParts()
+            {
+                return new DoNotContactParts('some');
+            }
+
+            public function getOperator()
+            {
+                return $this->operator;
+            }
+
+            public function getParameterValue()
+            {
+                return $this->parameterValue;
+            }
+
+            public function getGlue()
+            {
+                return 'and';
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [enhancement]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR optimizes two DB queries used when adding contacts into a segment.

#### Steps to test this PR:

Create a segment with a filter Unsubscribed - Email.
Check if proper contacts are added into the segment.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10904"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

