### PR TITLE
restrict workflows with impact to mautic/mautic (4.2)

### DIFF
--- a/.github/workflows/build-grapesjs-assets.yml
+++ b/.github/workflows/build-grapesjs-assets.yml
@@ -14,6 +14,7 @@ defaults:
 jobs:
   build-js:
     runs-on: ubuntu-latest
+    if: github.repository == 'mautic/mautic'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   release:
     name: Create draft release
     runs-on: ubuntu-latest
+    if: github.repository == 'mautic/mautic'
+
     steps:
     - uses: actions/checkout@v2
       # Our build script needs access to all previous tags, so we add fetch-depth: 0

--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
     sync:
-        if: github.repository_owner == 'mautic'
+        if: github.repository == 'mautic/mautic'
         runs-on: ubuntu-latest
         strategy:
             matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         mariadb_port: ${{ job.services.mariadb.ports[3306] }}
 
     - name: Upload coverage report
-      if: ${{ matrix.php-versions == '7.4' && matrix.db-types == 'mysql' }}
+      if: ${{ matrix.php-versions == '7.4' && matrix.db-types == 'mysql' && github.repository == 'mautic/mautic' }}
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Some workflows have a check in the steps to ensure they are only ran on repos's from the `mautic` organisation, e.g. the [subtree split workflow](https://github.com/mautic/mautic/blob/05a1669ac11a51062bec5cb639141fcc878d144f/.github/workflows/split-monorepo-in-multi-repo.yml#L33)  
Limiting to org alone is not enough in this case, as it allows e.g. any mirror of this repo to accidentally execute those workflows.
(these workflows may fail due to a missing API key, but better prevent this in a controlled way)

This PR adds those safeguards.
See [the documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository) for an example

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

The only way to test this is to create an extra repo in the mautic organisation, and check if those workflows aren't triggered.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10894"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10924"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

