### PR TITLE
Migration fixes

### DIFF
--- a/app/migrations/Version20201120122846.php
+++ b/app/migrations/Version20201120122846.php
@@ -24,12 +24,7 @@ final class Version20201120122846 extends AbstractMauticMigration
 
     public function preUp(Schema $schema): void
     {
-        $campaignSummaryTableName = $this->generateTableName(Summary::TABLE_NAME);
-        $campaignIdFK             = $this->getForeignKeyName($campaignSummaryTableName, 'campaign_id');
-        $eventIdFK                = $this->getForeignKeyName($campaignSummaryTableName, 'event_id');
-        if ($schema->hasTable($this->generateTableName(Summary::TABLE_NAME))
-            && $schema->getTable($campaignSummaryTableName)->hasForeignKey($campaignIdFK)
-            && $schema->getTable($campaignSummaryTableName)->hasForeignKey($eventIdFK)) {
+        if ($schema->hasTable($this->generateTableName(Summary::TABLE_NAME))) {
             throw new SkipMigration('Schema includes this migration');
         }
     }

--- a/app/migrations/Version20201125155904.php
+++ b/app/migrations/Version20201125155904.php
@@ -34,8 +34,13 @@ final class Version20201125155904 extends AbstractMauticMigration
         );
 
         $this->skipIf(
+            $schema->getTable($this->getTableName())->hasIndex($this->getIndexWithPrefix()),
+            sprintf("Index %s already exists. Skipping the migration", $this->getIndexWithPrefix())
+        );
+
+        $this->skipIf(
             !$schema->getTable($this->getTableName())->hasIndex(LeadEventLog::INDEX_SEARCH),
-            sprintf("Index %s doesn't exists. Skipping the migration", LeadEventLog::INDEX_SEARCH)
+            sprintf("Index %s does not exist. Skipping the migration", LeadEventLog::INDEX_SEARCH)
         );
     }
 

--- a/app/migrations/Version20201125155904.php
+++ b/app/migrations/Version20201125155904.php
@@ -35,12 +35,12 @@ final class Version20201125155904 extends AbstractMauticMigration
 
         $this->skipIf(
             $schema->getTable($this->getTableName())->hasIndex($this->getIndexWithPrefix()),
-            sprintf("Index %s already exists. Skipping the migration", $this->getIndexWithPrefix())
+            sprintf('Index %s already exists. Skipping the migration', $this->getIndexWithPrefix())
         );
 
         $this->skipIf(
             !$schema->getTable($this->getTableName())->hasIndex(LeadEventLog::INDEX_SEARCH),
-            sprintf("Index %s does not exist. Skipping the migration", LeadEventLog::INDEX_SEARCH)
+            sprintf('Index %s does not exist. Skipping the migration', LeadEventLog::INDEX_SEARCH)
         );
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/mysql-error-upgrading-to-4-2/22867/13

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There are 2 problematic migrations:

```sql
Table ‘[prefix]campaign_summary’ already exists
```

The summary table check was generating the foreign key names with double-prefixed table. So if the table prefix was `m_` then it was generating the name of `m_m_campaign_summrary`. So the migration was checking for different FK names then it was later creating.

```sql
An exception occurred while executing 'ALTER TABLE `[prefix]lead_event_log` RENAME  
   INDEX `IDX_SEARCH` TO `[prefix]IDX_SEARCH`'
```

The renaming of the INDEX_SEARCH on the lead_event_log table had similar issue with table prefix. I fortified the check.

#### Steps to test this PR:

This will be hard to test on GitPod.

1. Create fresh Mautic installation from version 4.2 with a table prefix set
2. Run `bin/console mautic:migrations:migrate`


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10931"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

