### PR TITLE
Update to use default release notes, remove file

### DIFF
--- a/.github/release-notes.yml
+++ b/.github/release-notes.yml
@@ -1,7 +1,0 @@
-changelog:
-  repository: mautic/mautic
-  sections:
-  - title: "Enhancements"
-    labels: ["enhancement", "feature"]
-  - title: "Bugs"
-    labels: ["bug", "regression"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   release:
     name: Create draft release
     runs-on: ubuntu-latest
+    if: github.repository == 'mautic/mautic'
+
     steps:
     - uses: actions/checkout@v2
       # Our build script needs access to all previous tags, so we add fetch-depth: 0
@@ -58,33 +60,6 @@ jobs:
 
         echo "IS_PRERELEASE=${PRERELEASE}" >> $GITHUB_ENV
 
-    - name: "Try generating the release notes"
-      run: |
-        # Version as indicated in the metadata, e.g., 3.2.5-rc
-        METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
-
-        # We only need the first part of the version, e.g. 3.2.5, for the milestone recognition. Split on the dash (-) character.
-        METADATA_ARRAY=(${METADATA_VERSION//-/ })
-        POTENTIAL_MILESTONE=${METADATA_ARRAY[0]}
-
-        echo "Will try to create changelog based on milestone ${POTENTIAL_MILESTONE} if it exists..."
-
-        # In case the Jar below fails, fall back to a default text
-        echo "MAUTIC_CHANGELOG=\"**Based on Mautic's version number (${POTENTIAL_MILESTONE}), we tried finding a milestone with the same name. We couldn't find it though. Make sure it exists (and re-run GitHub Actions) or add a changelog manually!**\"" >> $GITHUB_ENV
-
-        # Download changelog generator
-        wget -q https://github.com/spring-io/github-changelog-generator/releases/download/v0.0.5/github-changelog-generator.jar
-
-        # Copy of release-notes.yml to root folder needed, since the Jar can't read from hidden folders anymore (bug): https://github.com/Decathlon/release-notes-generator-action/pull/21
-        cp ./.github/release-notes.yml ./release-notes.yml
-        java -jar ./github-changelog-generator.jar --spring.config.location="./release-notes.yml" ${POTENTIAL_MILESTONE} mautic-changelog.txt || true
-
-        if [[ -f mautic-changelog.txt ]]; then
-          echo 'MAUTIC_CHANGELOG<<EOF' >> $GITHUB_ENV
-          cat mautic-changelog.txt >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-        fi
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -131,6 +106,28 @@ jobs:
       with:
         name: ${{ env.MAUTIC_VERSION }}-update.zip
         path: ./build/packages/${{ env.MAUTIC_VERSION }}-update.zip
+
+  changelog:
+    exclude:
+      labels:
+        - chore
+      authors:
+        - github-actions
+    categories:
+      - title: 🛠 Breaking Changes 
+        labels:
+          - bc-break
+      - title: 🔒 Security
+        labels:
+          - security
+      - title: ✨ Features and enhancements
+        labels:
+          - feature
+          - enhancement
+      - title: 🐛 Bugs
+        labels:
+          - bug
+          - regression
 
   test-fresh-install:
     name: Test a fresh installation


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch) ✅ 
| Deprecations?                          | Removing the external release notes generation
| BC breaks? (use the c.x branch)        | ❌ 
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

#### Description:
Some time ago, GitHub introduced an [automated release note generation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#about-automatically-generated-release-notes) feature for creating the list of PRs in releases and the associated contributors. 

We previously did this with an external tool, but the built-in feature is actually much nicer to use I think, as it shows the contributors on the release at the bottom of the page, and also highlights new contributors.

I propose that we move to using the GitHub default release notes tool, pulling in the same categories we currently use.

#### Steps to test this PR:

This one does not need testing per say, but does need reviewing by folks familiar with GitHub Actions!

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10934"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

