### PR TITLE
 fix segments list order

### DIFF
--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -68,7 +68,7 @@ class ListController extends FormController
         $this->setListFilters();
 
         //set limits
-        $limit = $session->get('mautic.segment.limit', $this->coreParametersHelper->get('default_pagelimit'));
+        $limit = $session->get('mautic.lead.list.limit', $this->coreParametersHelper->get('default_pagelimit'));
         $start = (1 === $page) ? 0 : (($page - 1) * $limit);
         if ($start < 0) {
             $start = 0;
@@ -78,8 +78,8 @@ class ListController extends FormController
         $session->set('mautic.segment.filter', $search);
 
         //do some default filtering
-        $orderBy    = $session->get('mautic.segment.orderby', 'l.dateModified');
-        $orderByDir = $session->get('mautic.segment.orderbydir', 'DESC');
+        $orderBy    = $session->get('mautic.lead.list.orderby', 'l.dateModified');
+        $orderByDir = $session->get('mautic.lead.list.orderbydir', $this->getDefaultOrderDirection());
 
         $filter = [
             'string' => $search,
@@ -996,5 +996,10 @@ class ListController extends FormController
             'leadlist_id',
             $listFilters
         );
+    }
+
+    protected function getDefaultOrderDirection()
+    {
+        return 'DESC';
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -3,10 +3,33 @@
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Traits\ControllerTrait;
 use Mautic\LeadBundle\Entity\LeadList;
 
 class ListControllerTest extends MauticMysqlTestCase
 {
+    use ControllerTrait;
+
+    /**
+     * Index action should return status code 200.
+     */
+    public function testIndexAction(): void
+    {
+        $list = $this->createList();
+
+        $this->em->persist($list);
+        $this->em->flush();
+        $this->em->clear();
+
+        $urlAlias   = 'segments';
+        $routeAlias = 'leadlist';
+        $column     = 'dateModified';
+        $column2    = 'name';
+        $tableAlias = 'l.';
+
+        $this->getControllerColumnTests($urlAlias, $routeAlias, $column, $tableAlias, $column2);
+    }
+
     /**
      * Check if list contains correct values.
      */
@@ -48,6 +71,9 @@ class ListControllerTest extends MauticMysqlTestCase
         $list->setName("Segment $suffix");
         $list->setPublicName("Segment $suffix");
         $list->setAlias("segment-$suffix");
+        $list->setDateAdded(new \DateTime('2020-02-07 20:29:02'));
+        $list->setDateModified(new \DateTime('2020-03-21 20:29:02'));
+        $list->setCreatedByUser('Test User');
 
         return $list;
     }

--- a/app/bundles/LeadBundle/Views/List/list.html.php
+++ b/app/bundles/LeadBundle/Views/List/list.html.php
@@ -41,7 +41,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'orderBy'    => 'l.name',
                         'text'       => 'mautic.core.name',
                         'class'      => 'col-leadlist-name',
@@ -51,7 +51,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'text'       => 'mautic.lead.list.thead.leadcount',
                         'class'      => 'visible-md visible-lg col-leadlist-leadcount',
                     ]
@@ -60,7 +60,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'orderBy'    => 'l.dateAdded',
                         'text'       => 'mautic.lead.import.label.dateAdded',
                         'class'      => 'visible-md visible-lg col-leadlist-dateAdded',
@@ -70,7 +70,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'orderBy'    => 'l.dateModified',
                         'text'       => 'mautic.lead.import.label.dateModified',
                         'class'      => 'visible-md visible-lg col-leadlist-dateModified',
@@ -81,7 +81,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'orderBy'    => 'l.createdByUser',
                         'text'       => 'mautic.core.createdby',
                         'class'      => 'visible-md visible-lg col-leadlist-createdByUser',
@@ -91,7 +91,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                 echo $view->render(
                     'MauticCoreBundle:Helper:tableheader.html.php',
                     [
-                        'sessionVar' => 'segment',
+                        'sessionVar' => 'lead.list',
                         'orderBy'    => 'l.id',
                         'text'       => 'mautic.core.id',
                         'class'      => 'visible-md visible-lg col-leadlist-id',
@@ -214,7 +214,7 @@ $now         = (new DateTimeHelper())->getUtcDateTime();
                     'page'       => $page,
                     'limit'      => $limit,
                     'baseUrl'    => $view['router']->path('mautic_segment_index'),
-                    'sessionVar' => 'segment',
+                    'sessionVar' => 'lead.list',
                 ]
             ); ?>
         </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | yes
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10925 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This is a follow up of PR from @kuzmany ( https://github.com/mautic/mautic/pull/10862 ) and of my PRs for modify order columns.

It resolve issue #10925 , I noticed that on 4.x order of segments doesn't work on any column because the session being retrieved is different from the one being saved.

setListFilters method save session as 'lead.list', but session was retrieved as 'segment'




<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create two or more segments
3. Go to segments list page
4. Check if order is correct and try to click on the columns to change order

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10938"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

