### PR TITLE
Add tag creation behavior for leads in edit page

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -147,6 +147,27 @@ Mautic.leadOnLoad = function (container, response) {
     if (mQuery(container + ' .panel-companies').length) {
         mQuery(container + ' .panel-companies .fa-check').tooltip({html: true});
     }
+
+    // Adding behavior to be able to create new tags by pressing the `Escape` key
+    // when the search field is active (ie: the tag name we are typing is a substring of an existing tag)
+    mQuery('#lead_tags_chosen input').keyup(function(el) {
+        const newTag = mQuery('#lead_tags_chosen input').val();
+        if (el.key === "Escape" && newTag !== '') {
+            const selectElement = mQuery('#lead_tags').get();
+            const selectedValues = mQuery('#lead_tags').val();
+            const payload = [...selectedValues, newTag];
+
+            Mautic.activateLabelLoadingIndicator(mQuery(selectElement).attr('id'));
+            Mautic.ajaxActionRequest('lead:addLeadTags', {tags: JSON.stringify(payload)}, function(response) {
+                if (response.tags) {
+                    mQuery('#' + mQuery(selectElement).attr('id')).html(response.tags);
+                    mQuery('#' + mQuery(selectElement).attr('id')).trigger('chosen:updated');
+                }
+
+                Mautic.removeLabelLoadingIndicator();
+            });
+        }
+    });
 };
 
 Mautic.leadTimelineOnLoad = function (container, response) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->


<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
At the moment we cannot create tags that are a substring of an existing tag, due to the select search mechanism we have on this field.
With this PR we can now do that by pressing the "Escape" key while typing.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to a contact page
3. Create a tag (eg: TestTag)
4. Start typing another tag (eg: Test)
5. Press the Escape key
6. The tag should be created and added to the selected tags.

Remarks: We have tag creation fields in many places (campaign and form actions, segments ...) but I did't manage to create  code working for all so I only made it for leads. (Mainly because campaign and form actions are in modals that closes when pressing Escape)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10969"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

