### PR TITLE
Tags on edit should display same message as other entities, for e.g. xyz has been updated!

### DIFF
--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -178,7 +178,7 @@ class TagController extends FormController
                     $found = $model->getRepository()->countOccurrences($tag->getTag());
                     if (0 !== $found) {
                         $valid = false;
-                        $this->addFlash('mautic.tagmanager.tag.error.already_exists', [
+                        $this->addFlash('mautic.core.notice.updated', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [
@@ -343,7 +343,7 @@ class TagController extends FormController
                     }
 
                     if (!$valid) {
-                        $this->addFlash('mautic.tagmanager.tag.error.already_exists', [
+                        $this->addFlash('mautic.core.notice.updated', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -231,50 +231,6 @@ class TagController extends FormController
     }
 
     /**
-     * Generate's clone form and processes post data.
-     *
-     * @param int  $objectId
-     * @param bool $ignorePost
-     *
-     * @return Response
-     */
-    public function cloneAction($objectId, $ignorePost = false)
-    {
-        if (!$this->get('mautic.security')->isGranted('tagManager:tagManager:create')) {
-            return $this->accessDenied();
-        }
-
-        $postActionVars = $this->getPostActionVars();
-
-        try {
-            $tag   = $this->getTag($objectId);
-            $clone = new Tag();
-            $clone->setTag($tag->getTag());
-
-            return $this->createTagModifyResponse(
-                $clone,
-                $postActionVars,
-                $this->generateUrl('mautic_tagmanager_action', ['objectAction' => 'clone', 'objectId' => $objectId]),
-                $ignorePost
-            );
-        } catch (AccessDeniedException $exception) {
-            return $this->accessDenied();
-        } catch (EntityNotFoundException $exception) {
-            return $this->postActionRedirect(
-                array_merge($postActionVars, [
-                    'flashes' => [
-                        [
-                            'type'    => 'error',
-                            'msg'     => 'mautic.tagmanager.tag.error.notfound',
-                            'msgVars' => ['%id%' => $objectId],
-                        ],
-                    ],
-                ])
-            );
-        }
-    }
-
-    /**
      * Generate's edit form and processes post data.
      *
      * @param int  $objectId
@@ -313,7 +269,7 @@ class TagController extends FormController
     }
 
     /**
-     * Create modifying response for tags - edit/clone.
+     * Create modifying response for tags - edit.
      *
      * @param string $action
      * @param bool   $ignorePost

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -177,7 +177,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $form['tag_entity[tag]']->setValue($TagName);
         $crawler = $this->client->submit($form);
 
-        $this->assertStringContainsString($TagName.' already exists!', $crawler->text(), 'Must contain already exist.');
+        $this->assertStringContainsString($TagName.' has been updated!', $crawler->text(), 'Must contain already exist.');
     }
 
     public function testBatchDeleteAction(): void

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -128,28 +128,6 @@ class TagControllerTest extends MauticMysqlTestCase
     }
 
     /**
-     * Get tag's clone page.
-     */
-    public function testCloneAction(): void
-    {
-        $tag            = $this->tagRepository->findOneBy([]);
-        $crawler        = $this->client->request('GET', '/s/tags/clone/'.$tag->getId());
-        $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
-
-        $form = $crawler->selectButton('Save & Close')->form();
-        $this->assertSame($tag->getTag(), $form['tag_entity[tag]']->getValue());
-    }
-
-    public function testCloneActionNotFound(): void
-    {
-        $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/tags/clone/99999');
-        $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isRedirection(), 'Must be redirect response.');
-    }
-
-    /**
      * Get tag's create page.
      */
     public function testNewAction(): void

--- a/plugins/MauticTagManagerBundle/Translations/en_US/flashes.ini
+++ b/plugins/MauticTagManagerBundle/Translations/en_US/flashes.ini
@@ -1,4 +1,3 @@
 mautic.tagmanager.tag.error.notfound="No tag with an id of %id% was found!"
 mautic.tagmanager.tag.notice.batch_deleted="Successfully deleted %count% tags!"
 mautic.tagmanager.tag.error.cannotbedeleted="Only tag without any contacts can be delete."
-mautic.tagmanager.tag.error.already_exists = "<a href='%url%' data-toggle='ajax' data-menu-link='%menu_link%'><strong>%name%</strong></a> already exists!"

--- a/plugins/MauticTagManagerBundle/Views/Tag/details.html.php
+++ b/plugins/MauticTagManagerBundle/Views/Tag/details.html.php
@@ -26,7 +26,6 @@ $view['slots']->set(
                 'edit'   => $view['security']->isGranted('tagManager:tagManager:edit'),
                 'delete' => $view['security']->isGranted('tagManager:tagManager:delete'),
                 'close'  => $view['security']->isGranted('tagManager:tagManager:edit'),
-                'clone'  => $view['security']->isGranted('tagManager:tagManager:create'),
             ],
             'routeBase' => 'tagmanager',
         ]

--- a/plugins/MauticTagManagerBundle/Views/Tag/list.html.php
+++ b/plugins/MauticTagManagerBundle/Views/Tag/list.html.php
@@ -82,7 +82,6 @@ $listCommand = $view['translator']->trans('mautic.tagmanager.tag.searchcommand.l
                                 'item'            => $item,
                                 'templateButtons' => [
                                     'edit'   => $permissions['tagManager:tagManager:edit'],
-                                    'clone'  => $permissions['tagManager:tagManager:create'],
                                     'delete' => $permissions['tagManager:tagManager:delete'],
                                 ],
                                 'routeBase'  => 'tagmanager',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | ❌ 
| Deprecations?                          | ❌ 
| BC breaks? (use the c.x branch)        | ❌ 
| Automated tests included?              | ✅  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Part 1:
Alert text and behaviour is different than other entities in the application
General message is Entity is updated. In case of tags it say tag already present.

Part 2:
User is unable to clone tag with same text. Application should give meaningful warning or clone functionality shouldn't be present for tags. So, it is better to remove the clone option as this has no significant purpose with tag, which has only 1 field. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new Tag with some text
3. Click on Save button
4. Click on Save and Close button

After PR:
1. The message is '<TAG_NAME> has been updated!'.
2. The clone option is not visible.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10984"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

