### PR TITLE
 fix salesforce integration refresh token

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -81,6 +81,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Used for notifications.
+     *
+     * @var \Doctrine\ORM\Tools\Pagination\Paginator<\Mautic\UserBundle\Entity\User>
      */
     protected ?\Doctrine\ORM\Tools\Pagination\Paginator $adminUsers = null;
 

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -82,7 +82,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Used for notifications.
      */
-    protected ?array $adminUsers;
+    protected ?\Doctrine\ORM\Tools\Pagination\Paginator $adminUsers = null;
 
     protected array $notifications = [];
     protected ?string $lastIntegrationError;

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -520,7 +520,17 @@ class SalesforceApi extends CrmApi
             }
 
             foreach ($response as $lineItem) {
-                if (is_array($lineItem) && !empty($lineItem['errorCode']) && $error = $this->processError($lineItem, $isRetry)) {
+                if (!is_array($lineItem)) {
+                    continue;
+                }
+                $lineItemForInvalidSession              = $lineItem;
+                $lineItemForInvalidSession['errorCode'] = 'INVALID_SESSION_ID';
+                if (!empty($lineItemForInvalidSession['message']) && str_contains($lineItemForInvalidSession['message'], '"errorCode":"INVALID_SESSION_ID"') && $error = $this->processError($lineItemForInvalidSession, $isRetry)) {
+                    $errors[] = $error;
+                    continue;
+                }
+
+                if (!empty($lineItem['errorCode']) && $error = $this->processError($lineItem, $isRetry)) {
                     $errors[] = $error;
                 }
             }

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -525,7 +525,7 @@ class SalesforceApi extends CrmApi
                 }
                 $lineItemForInvalidSession              = $lineItem;
                 $lineItemForInvalidSession['errorCode'] = 'INVALID_SESSION_ID';
-                if (!empty($lineItemForInvalidSession['message']) && str_contains($lineItemForInvalidSession['message'], '"errorCode":"INVALID_SESSION_ID"') && $error = $this->processError($lineItemForInvalidSession, $isRetry)) {
+                if (!empty($lineItemForInvalidSession['message']) && false !== strpos($lineItemForInvalidSession['message'], '"errorCode":"INVALID_SESSION_ID"') && $error = $this->processError($lineItemForInvalidSession, $isRetry)) {
                     $errors[] = $error;
                     continue;
                 }

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -118,7 +118,7 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
     public function testSessionExpiredIsRefreshed(): void
     {
         $integration = $this->createMock(SalesforceIntegration::class);
-        $message     = 'Session expired';
+        $message     = '["errorCode":"INVALID_SESSION_ID","body":"Session expired or invalid"]';
 
         $integration->expects($this->exactly(2))
             ->method('authCallback');
@@ -128,7 +128,6 @@ class SalesforceApiTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 [
                     [
-                        'errorCode' => 'INVALID_SESSION_ID',
                         'message'   => $message,
                     ],
                 ]


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10989 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fix Salesforce integration error on Mautic 4.
If integration fails, fails also the log integration error:
```
[Error]                                                                                                                     
  Typed property Mautic\PluginBundle\Integration\AbstractIntegration::$adminUsers must not be accessed before initialization  
```

adminUsers needs to be defined as Paginator variable and needs to be null at default.

Furthermore if access token expires it will never refreshed.
If token expires the call to Salesforce fails and response is analyzed (method analyzeResponse of SalesforceApi.php file).
Method tries to find INVALID_SESSION_ID inside errorCode field but it is contained inside 'message' field, so INVALID_SESSION_ID is never found and token is never refreshed.

Fix this error founding INVALID_SESSION_ID inside the correct field 'message'.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1) Install Salesforce plugin
2) Wait that token expires
3) Try to sync some contacts

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

