### PR TITLE
Fix "keep me logged in"

### DIFF
--- a/app/bundles/CoreBundle/Tests/Functional/RememberMe/RememberMeTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/RememberMe/RememberMeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Mautic\CoreBundle\Tests\Functional;
+
+    use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+        class RememberMeTest extends WebTestCase
+        {
+            public function testRemembermeLifetime(): void
+            {
+                $parameterLoader    = new \Mautic\CoreBundle\Loader\ParameterLoader();
+                $this->assertGreaterThan(0, $parameterLoader->getParameterBag()->get('rememberme_lifetime'));
+            }
+        }

--- a/app/config/security.php
+++ b/app/config/security.php
@@ -1,5 +1,17 @@
 <?php
 
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+$parameterLoader    = new \Mautic\CoreBundle\Loader\ParameterLoader();
+$configParameterBag = $parameterLoader->getParameterBag();
+
 $firewalls = [
     'install' => [
         'pattern'   => '^/installer',
@@ -82,10 +94,10 @@ $firewalls = [
             'target' => '/s/login',
         ],
         'remember_me' => [
-            'secret'   => '%mautic.rememberme_key%',
-            'lifetime' => (int) $container->getParameter('mautic.rememberme_lifetime'),
-            'path'     => '%mautic.rememberme_path%',
-            'domain'   => '%mautic.rememberme_domain%',
+            'secret'   => $configParameterBag->get('rememberme_key'),
+            'lifetime' => $configParameterBag->get('rememberme_lifetime'),
+            'path'     => $configParameterBag->get('rememberme_path'),
+            'domain'   => $configParameterBag->get('rememberme_domain'),
         ],
         'fos_oauth'     => true,
         'context'       => 'mautic',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When people log in, there is an option to "keep me logged in". This used to add a cookie to the browner named REMEMBERME, but this behavior broke somewhere down the line. Now people are getting logged out soon and having to log back in, often losing work.

Look at [this issue](https://github.com/mautic/mautic/issues/9804#issuecomment-1025756557) and [this issue](https://github.com/mautic/mautic/issues/9011#issuecomment-1009051271) for reference.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Before logging in, open the cookie viewer. You can do this by right click -> Inspect -> and go to Application. Scroll down to Storage -> Cookies and there you can see browser cookies
3. Log in and click "keep me logged in". You should see a cookie named REMEMBERME added to the browser cookies
4. Delete all cookies except the REMEMBERME cookie (click on the cookie, then Backspace). Reload the page. You should still be logged in
5. Delete all cookies (including REMEMBERME) and reload the page. You should be logged out


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10994"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

