### PR TITLE
Fixes updating the contact's primary company when all companies are removed or one of many companies are removed

### DIFF
--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
@@ -85,6 +85,7 @@ class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface
                     $companyLead->setLead($lead);
                     $companyLead->setCompany($this->getReference('company-'.$lastCharacter));
                     $companyLead->setDateAdded($today);
+                    $companyLead->setPrimary(true);
                     $companyLeadRepo->saveEntity($companyLead);
                 }
             }

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -22,13 +22,20 @@ class CompanyLeadRepository extends CommonRepository
     {
         // Get a list of contacts and set primary to 0
         if ($new) {
-            $contacts = [];
+            $contacts  = [];
+            $contactId = null;
             foreach ($entities as $entity) {
-                $contactId            = $entity->getLead()->getId();
+                $contactId = $entity->getLead()->getId();
+                if (!isset($contacts[$contactId])) {
+                    // Set one company from the batch as as primary
+                    $entity->setPrimary(true);
+                }
+
                 $contacts[$contactId] = $contactId;
-                $entity->setPrimary(true);
             }
+
             if ($contactId) {
+                // Only one company should be set as primary so reset all in order to let the entity update the one
                 $qb = $this->getEntityManager()->getConnection()->createQueryBuilder()
                     ->update(MAUTIC_TABLE_PREFIX.'companies_leads')
                     ->set('is_primary', 0);

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -397,7 +397,12 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 $contactAdded     = true;
                 $persistCompany[] = $companyLead;
                 $dispatchEvents[] = $companyId;
-                $companyName      = $companyLeadAdd[$companyId]->getName();
+
+                if (!$companyName) {
+                    // CompanyLeadRepository::saveEntities will set the first company of the batch as primary so
+                    // use the first company name to ensure they match
+                    $companyName = $companyLeadAdd[$companyId]->getName();
+                }
             }
         }
 
@@ -488,11 +493,13 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         $deleteCompany  = [];
         $dispatchEvents = [];
 
+        $primaryRemoved = false;
         foreach ($companies as $companyId) {
             if (!isset($companyLeadRemove[$companyId])) {
                 continue;
             }
 
+            /** @var CompanyLead $companyLead */
             $companyLead = $this->getCompanyLeadRepository()->findOneBy(
                 [
                     'lead'    => $lead,
@@ -505,9 +512,14 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 continue;
             }
 
-            //lead was manually added and now manually removed or was not manually added and now being removed
+            // Lead was manually added and now manually removed or was not manually added and now being removed
             $deleteCompanyLead[] = $companyLead;
             $dispatchEvents[]    = $companyId;
+
+            // Update the Lead's primary company name if removed from the primary company
+            if (!$primaryRemoved) {
+                $primaryRemoved = $companyLead->getPrimary();
+            }
 
             unset($companyLead);
         }
@@ -516,12 +528,16 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             $this->getCompanyLeadRepository()->deleteEntities($deleteCompanyLead);
         }
 
+        if ($primaryRemoved) {
+            $this->updateContactAfterPrimaryCompanyWasRemoved($lead);
+        }
+
         // Clear CompanyLead entities from Doctrine memory
         $this->em->clear(CompanyLead::class);
 
         if (!empty($dispatchEvents) && ($this->dispatcher->hasListeners(LeadEvents::LEAD_COMPANY_CHANGE))) {
-            foreach ($dispatchEvents as $listId) {
-                $event = new LeadChangeCompanyEvent($lead, $companyLeadRemove[$listId], false);
+            foreach ($dispatchEvents as $companyId) {
+                $event = new LeadChangeCompanyEvent($lead, $companyLeadRemove[$companyId], false);
                 $this->dispatcher->dispatch(LeadEvents::LEAD_COMPANY_CHANGE, $event);
 
                 unset($event);
@@ -905,5 +921,34 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         }
 
         return $fieldData;
+    }
+
+    private function updateContactAfterPrimaryCompanyWasRemoved(Lead $lead)
+    {
+        $primaryCompanyName = '';
+
+        // Find another company to make primary if applicable
+        $leadCompanies = $this->getCompanyLeadRepository()->getCompaniesByLeadId($lead->getId());
+        if (count($leadCompanies)) {
+            $newPrimaryArray   = reset($leadCompanies);
+            $newPrimaryCompany = $this->em->getReference(Company::class, $newPrimaryArray['company_id']);
+
+            /** @var CompanyLead $companyLead */
+            $companyLead = $this->getCompanyLeadRepository()->findOneBy(
+                [
+                    'lead'    => $lead,
+                    'company' => $newPrimaryCompany,
+                ]
+            );
+
+            $companyLead->setPrimary(true);
+            $this->getCompanyLeadRepository()->saveEntity($companyLead);
+
+            $primaryCompanyName = $newPrimaryArray['companyname'];
+        }
+
+        $lead->addUpdatedField('company', $primaryCompanyName)
+            ->setDateModified(new \DateTime());
+        $this->em->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
     }
 }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -23,6 +23,7 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Event\CompanyEvent;
 use Mautic\LeadBundle\Event\LeadChangeCompanyEvent;
 use Mautic\LeadBundle\Exception\UniqueFieldNotFoundException;
@@ -417,7 +418,10 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             if ($currentCompanyName !== $companyName) {
                 $lead->addUpdatedField('company', $companyName)
                     ->setDateModified(new \DateTime());
-                $this->em->getRepository('MauticLeadBundle:Lead')->saveEntity($lead);
+
+                /** @var LeadRepository */
+                $leadRepository = $this->em->getRepository(Lead::class);
+                $leadRepository->saveEntity($lead);
             }
         }
 
@@ -927,7 +931,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         return $fieldData;
     }
 
-    private function updateContactAfterPrimaryCompanyWasRemoved(Lead $lead)
+    private function updateContactAfterPrimaryCompanyWasRemoved(Lead $lead): void
     {
         $primaryCompanyName = '';
 

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -411,6 +411,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         }
 
         if (!empty($companyName)) {
+            // Set the contact's primary company to the first company added in the batch
+            // This must happen before LeadEvents::LEAD_COMPANY_CHANGE to ensure the Lead::getCompany has the correct value
             $currentCompanyName = $lead->getCompany();
             if ($currentCompanyName !== $companyName) {
                 $lead->addUpdatedField('company', $companyName)
@@ -529,6 +531,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         }
 
         if ($primaryRemoved) {
+            // Set the contact's primary company to a remaining company or empty it out if none are left
+            // This must happen before LeadEvents::LEAD_COMPANY_CHANGE to ensure the Lead::getCompany has the correct value
             $this->updateContactAfterPrimaryCompanyWasRemoved($lead);
         }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -13,6 +13,7 @@ namespace Mautic\LeadBundle\Model;
 
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Illuminate\Support\Collection;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
@@ -1817,26 +1818,35 @@ class LeadModel extends FormModel
 
     /**
      * Modify companies for lead.
-     *
-     * @param $companies
      */
-    public function modifyCompanies(Lead $lead, $companies)
+    public function modifyCompanies(Lead $lead, array $companies)
     {
         // See which companies belong to the lead already
         $leadCompanies = $this->companyModel->getCompanyLeadRepository()->getCompaniesByLeadId($lead->getId());
 
-        foreach ($leadCompanies as $leadCompany) {
-            if (false === array_search($leadCompany['company_id'], $companies)) {
-                $this->companyModel->removeLeadFromCompany([$leadCompany['company_id']], $lead);
+        $requestedCompanies = new Collection($companies);
+        $currentCompanies   = (new Collection($leadCompanies))->keyBy('company_id');
+
+        // Remove companies that are not in the array of given companies
+        $removeCompanies = $currentCompanies->reject(
+            function (array $company) use ($requestedCompanies) {
+                // Reject if the found company is still in the list of companies given
+                return $requestedCompanies->contains($company['company_id']);
             }
+        );
+        if ($removeCompanies->count()) {
+            $this->companyModel->removeLeadFromCompany($removeCompanies->keys()->toArray(), $lead);
         }
 
-        if (count($companies)) {
-            $this->companyModel->addLeadToCompany($companies, $lead);
-        } else {
-            // update the lead's company name to nothing
-            $lead->addUpdatedField('company', '');
-            $this->getRepository()->saveEntity($lead);
+        // Add companies that are not in the array of found companies
+        $addCompanies = $requestedCompanies->reject(
+            function ($companyId) use ($currentCompanies) {
+                // Reject if the lead is already in the given company
+                return $currentCompanies->has($companyId);
+            }
+        );
+        if ($addCompanies->count()) {
+            $this->companyModel->addLeadToCompany($addCompanies->toArray(), $lead);
         }
     }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1818,6 +1818,8 @@ class LeadModel extends FormModel
 
     /**
      * Modify companies for lead.
+     *
+     * @param int[] $companies
      */
     public function modifyCompanies(Lead $lead, array $companies)
     {
@@ -1840,10 +1842,8 @@ class LeadModel extends FormModel
 
         // Add companies that are not in the array of found companies
         $addCompanies = $requestedCompanies->reject(
-            function ($companyId) use ($currentCompanies) {
-                // Reject if the lead is already in the given company
-                return $currentCompanies->has($companyId);
-            }
+            // Reject if the lead is already in the given company
+            fn ($companyId) => $currentCompanies->has($companyId)
         );
         if ($addCompanies->count()) {
             $this->companyModel->addLeadToCompany($addCompanies->toArray(), $lead);

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -5,24 +5,22 @@ namespace Mautic\LeadBundle\Tests\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\DataFixtures\ORM\LoadCategorizedLeadListData;
-use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
-use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
-use Illuminate\Support\Collection;
 use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
 use Mautic\InstallBundle\InstallFixtures\ORM\RoleData;
+use Mautic\LeadBundle\DataFixtures\ORM\LoadCategorizedLeadListData;
+use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCompanyData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
+use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tightenco\Collect\Support\Collection;
 
-/**
- * @IgnoreAnnotation("covers")
- */
 class LeadControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void
@@ -302,13 +300,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $this->assertEquals(true, (strlen($content) > 10000));
     }
 
-    /**
-     * @covers \Mautic\LeadBundle\Model\CompanyModel::addLeadToCompany
-     * @covers \Mautic\LeadBundle\Model\CompanyModel::removeLeadFromCompany
-     * @covers \Mautic\LeadBundle\Model\CompanyModel::updateContactAfterPrimaryCompanyWasRemoved
-     * @covers \Mautic\LeadBundle\Model\LeadModel::modifyCompanies
-     */
-    public function testContactsAreAddedAndRemovedFromCompanies()
+    public function testContactsAreAddedAndRemovedFromCompanies(): void
     {
         // Running all these in one test to avoid having to re-load fixtures multiple time
         $this->loadFixtures(
@@ -366,7 +358,7 @@ class LeadControllerTest extends MauticMysqlTestCase
     {
         return $this->connection->createQueryBuilder()
             ->select('ll.id', 'll.name', 'll.category_id')
-            ->from('lead_lists', 'll')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists', 'll')
             ->execute()
             ->fetchAllAssociative();
     }
@@ -467,6 +459,9 @@ class LeadControllerTest extends MauticMysqlTestCase
         return $campaign;
     }
 
+    /**
+     * @return Lead[]
+     */
     private function getCompanyLeads(int $leadId): array
     {
         return $this->connection->createQueryBuilder()
@@ -489,7 +484,10 @@ class LeadControllerTest extends MauticMysqlTestCase
             ->fetchColumn();
     }
 
-    private function assertCompanyAssociation(array $expectedCompanies, int $leadId)
+    /**
+     * @param int[] $expectedCompanies
+     */
+    private function assertCompanyAssociation(array $expectedCompanies, int $leadId): void
     {
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/1');
         $saveButton = $crawler->selectButton('lead[buttons][save]');
@@ -513,6 +511,6 @@ class LeadControllerTest extends MauticMysqlTestCase
         $this->assertEquals($primary->first()['companyname'], $primaryCompanyName);
         // Primary company should be in the UI of the details dropdown tray
         $details = $crawler->filter('#lead-details')->html();
-        $this->assertContains($primaryCompanyName, $details);
+        $this->assertStringContainsString($primaryCompanyName, $details);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -5,8 +5,6 @@ namespace Mautic\LeadBundle\Tests\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
-use Mautic\InstallBundle\InstallFixtures\ORM\RoleData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategorizedLeadListData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCompanyData;
@@ -14,8 +12,6 @@ use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
-use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -303,9 +299,7 @@ class LeadControllerTest extends MauticMysqlTestCase
     public function testContactsAreAddedAndRemovedFromCompanies(): void
     {
         // Running all these in one test to avoid having to re-load fixtures multiple time
-        $this->loadFixtures(
-            [LeadFieldData::class, RoleData::class, LoadRoleData::class, LoadUserData::class, LoadLeadData::class, LoadCompanyData::class]
-        );
+        $this->loadFixtures([LoadLeadData::class, LoadCompanyData::class]);
 
         $this->client->catchExceptions(false);
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -323,19 +323,19 @@ class LeadControllerTest extends MauticMysqlTestCase
             ->execute();
 
         // Test a single company is added and is set as primary
-        $this->testCompanyAssociation([1], 1);
+        $this->assertCompanyAssociation([1], 1);
 
         // Test that a company a contact is already part of does not change anything
-        $this->testCompanyAssociation([1], 1);
+        $this->assertCompanyAssociation([1], 1);
 
         // Test that multiple companies are added and one primary is set
-        $this->testCompanyAssociation([1, 2, 3], 1);
+        $this->assertCompanyAssociation([1, 2, 3], 1);
 
         // Test that removing a company will leave the two remaining with one set as primary
-        $this->testCompanyAssociation([1, 3], 1);
+        $this->assertCompanyAssociation([1, 3], 1);
 
         // Test that adding a company in addition to others will set it as primary
-        $this->testCompanyAssociation([1, 2, 3], 1);
+        $this->assertCompanyAssociation([1, 2, 3], 1);
 
         // Test that removing all companies will empty the lead's primary company
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/1');
@@ -489,7 +489,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             ->fetchColumn();
     }
 
-    private function testCompanyAssociation(array $expectedCompanies, int $leadId)
+    private function assertCompanyAssociation(array $expectedCompanies, int $leadId)
     {
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/1');
         $saveButton = $crawler->selectButton('lead[buttons][save]');


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
This fixes the scenario that will ensure that https://github.com/mautic/mautic/pull/8644 will pick up the correct company. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
2. Edit a contact that has a company associated and remove it
5. Add a second company to the contact and it should be set as the primary company both in the companies_leads table and as the company field on the lead in the leads table. 
6. Edit the contact and remove that company
7. Notice that the remaining company is not set as the primary in either the database or in the leads table (the old value remains)

#### Steps to test this PR:
Repeat the steps above and the following situations should happen
1. Add a single company to a contact and the company should be set as primary in the companies_leads table or in the UI, there should be a green checkmark by the company on the contact details UI. And the company name should be set as the contact's primary company in the leads table (or in the details drop down in the contact detail page).
2. Add a second company and it should be set as primary in both tables and the other removed as primary in both tables. 
3. Remove the second company and the first company should be automatically set as primary in both tables.
4. Remove all companies and the primary `company` should now be empty in the leads table.
5. Review the functional tests

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11000"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

