### PR TITLE
Campaign membership query optimization

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -529,7 +529,7 @@ class LeadRepository extends CommonRepository
         return $segments;
     }
 
-    private function updateQueryWithExistingMembershipExclusion(int $campaignId, QueryBuilder $qb, bool $campaignCanBeRestarted = false)
+    private function updateQueryWithExistingMembershipExclusion(int $campaignId, QueryBuilder $qb, bool $campaignCanBeRestarted = false): void
     {
         $qb->leftJoin(
             'll',

--- a/app/bundles/CampaignBundle/Membership/Action/Adder.php
+++ b/app/bundles/CampaignBundle/Membership/Action/Adder.php
@@ -48,7 +48,7 @@ class Adder
         // Start the new rotation at 2
         if ($this->leadEventLogRepository->hasBeenInCampaignRotation($contact->getId(), $campaign->getId(), 1)) {
             if (!$campaign->allowRestart()) {
-                $campaignMember->setManuallyRemoved(1);
+                $campaignMember->setManuallyRemoved(true);
                 $campaignMember->setDateLastExited(new \DateTime());
             } else {
                 $campaignMember->setRotation(2);

--- a/app/bundles/CampaignBundle/Membership/Action/Adder.php
+++ b/app/bundles/CampaignBundle/Membership/Action/Adder.php
@@ -42,7 +42,7 @@ class Adder
         $rotation = 1;
         if ($this->leadEventLogRepository->hasBeenInCampaignRotation($contact->getId(), $campaign->getId(), 1)) {
             if (!$campaign->allowRestart()) {
-                throw new ContactCannotBeAddedToCampaignException("Contact {$contact->getId()} could not be added to the campaign {$campaign->getId()} because it should start new campaign rotation but is not configured to be repetable.");
+                throw new ContactCannotBeAddedToCampaignException("Contact {$contact->getId()} could not be added to the campaign {$campaign->getId()} because it should start new campaign rotation but is not configured to be repeatable.");
             }
 
             $rotation = 2;

--- a/app/bundles/CampaignBundle/Membership/Action/Adder.php
+++ b/app/bundles/CampaignBundle/Membership/Action/Adder.php
@@ -23,9 +23,6 @@ class Adder
      */
     private $leadEventLogRepository;
 
-    /**
-     * Adder constructor.
-     */
     public function __construct(LeadRepository $leadRepository, LeadEventLogRepository $leadEventLogRepository)
     {
         $this->leadRepository         = $leadRepository;
@@ -33,7 +30,7 @@ class Adder
     }
 
     /**
-     * @param $isManualAction
+     * @param bool $isManualAction
      *
      * @return CampaignMember
      */
@@ -44,6 +41,10 @@ class Adder
         // Start the new rotation at 2
         $rotation = 1;
         if ($this->leadEventLogRepository->hasBeenInCampaignRotation($contact->getId(), $campaign->getId(), 1)) {
+            if (!$campaign->allowRestart()) {
+                throw new ContactCannotBeAddedToCampaignException("Contact {$contact->getId()} could not be added to the campaign {$campaign->getId()} because it should start new campaign rotation but is not configured to be repetable.");
+            }
+
             $rotation = 2;
         }
 

--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -146,8 +146,14 @@ class MembershipManager
                 continue;
             }
 
-            // Existing membership does not exist so create a new one
-            $this->adder->createNewMembership($contact, $campaign, $isManualAction);
+            try {
+                // Existing membership does not exist so create a new one
+                $this->adder->createNewMembership($contact, $campaign, $isManualAction);
+            } catch (ContactCannotBeAddedToCampaignException $exception) {
+                $this->logger->debug("CAMPAIGN: {$exception->getMessage()}}");
+
+                continue;
+            }
 
             $this->logger->debug("CAMPAIGN: Contact ID {$contact->getId()} was added to campaign ID {$campaign->getId()} as a new member.");
         }

--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -99,17 +99,8 @@ class MembershipManager
             return;
         }
 
-        try {
-            // Contact is not already in the campaign so create a new entry
-            $this->adder->createNewMembership($contact, $campaign, $isManualAction);
-        } catch (ContactCannotBeAddedToCampaignException $exception) {
-            // Do nothing
-            $this->logger->debug(
-                "CAMPAIGN: Contact ID {$contact->getId()} could not be added to campaign ID {$campaign->getId()}."
-            );
-
-            return;
-        }
+        // Contact is not already in the campaign so create a new entry
+        $this->adder->createNewMembership($contact, $campaign, $isManualAction);
 
         $this->logger->debug("CAMPAIGN: Contact ID {$contact->getId()} was added to campaign ID {$campaign->getId()} as a new member.");
 
@@ -146,14 +137,7 @@ class MembershipManager
                 continue;
             }
 
-            try {
-                // Existing membership does not exist so create a new one
-                $this->adder->createNewMembership($contact, $campaign, $isManualAction);
-            } catch (ContactCannotBeAddedToCampaignException $exception) {
-                $this->logger->debug("CAMPAIGN: {$exception->getMessage()}}");
-
-                continue;
-            }
+            $this->adder->createNewMembership($contact, $campaign, $isManualAction);
 
             $this->logger->debug("CAMPAIGN: Contact ID {$contact->getId()} was added to campaign ID {$campaign->getId()} as a new member.");
         }

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -733,6 +733,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $segment = new LeadList();
         $segment->setAlias($alias);
         $segment->setName($alias);
+        $segment->setPublicName($alias);
         $segment->setFilters($filters);
         $this->em->persist($segment);
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -4,6 +4,9 @@ namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
+use DateTime;
+use DateTimeZone;
+use Doctrine\DBAL\Connection;
 
 class TriggerCampaignCommandTest extends AbstractCampaignCommand
 {
@@ -72,8 +75,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
             ->fetchAll();
         $this->assertCount(0, $stats);
 
-        // Wait 20 seconds then execute the campaign again to send scheduled events
-        sleep(20);
+        $this->shiftEmailEventsToThePast();
+
+        // Execute the campaign again to send scheduled events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '-l' => 10]);
 
         // Send email 1 should no longer be scheduled
@@ -115,8 +119,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(25, $byEvent[3]);
         $this->assertCount(25, $byEvent[10]);
 
-        // Wait 20 seconds to go beyond the inaction timeframe
-        sleep(20);
+        $this->shiftEventsToThePast([4, 5]);
+        $eventDate = clone $this->eventDate;
+        $eventDate->modify('-40 second');
 
         // Execute the command again to trigger inaction related events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '-l' => 10]);
@@ -138,14 +143,14 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(25, $byEvent[14]);
         $this->assertCount(25, $byEvent[15]);
 
-        $utcTimezone = new \DateTimeZone('UTC');
+        $utcTimezone = new DateTimeZone('UTC');
         foreach ($byEvent[14] as $log) {
             if (0 === (int) $log['is_scheduled']) {
                 $this->fail('Tag EmailNotOpen is not scheduled for lead ID '.$log['lead_id']);
             }
 
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
+            $scheduledFor = new DateTime($log['trigger_date'], $utcTimezone);
+            $diff         = $eventDate->diff($scheduledFor);
 
             if (2 !== $diff->i) {
                 $this->fail('Tag EmailNotOpen should be scheduled for around 2 minutes ('.$diff->i.' minutes)');
@@ -157,8 +162,8 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
                 $this->fail('Tag EmailNotOpen Again is not scheduled for lead ID '.$log['lead_id']);
             }
 
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
+            $scheduledFor = new DateTime($log['trigger_date'], $utcTimezone);
+            $diff         = $eventDate->diff($scheduledFor);
 
             if (6 !== $diff->i) {
                 $this->fail('Tag EmailNotOpen Again should be scheduled for around 6 minutes ('.$diff->i.' minutes)');
@@ -237,8 +242,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
             ->fetchAll();
         $this->assertCount(0, $stats);
 
-        // Wait 20 seconds then execute the campaign again to send scheduled events
-        sleep(20);
+        $this->shiftEmailEventsToThePast();
+
+        // Execute the campaign again to send scheduled events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
 
         // Send email 1 should no longer be scheduled
@@ -280,8 +286,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(1, $byEvent[3]);
         $this->assertCount(1, $byEvent[10]);
 
-        // Wait 20 seconds to go beyond the inaction timeframe
-        sleep(20);
+        $this->shiftEventsToThePast([4, 5]);
 
         // Execute the command again to trigger inaction related events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
@@ -300,32 +305,6 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $byEvent[14]);
         $this->assertCount(0, $byEvent[15]);
 
-        $utcTimezone = new \DateTimeZone('UTC');
-        foreach ($byEvent[14] as $log) {
-            if (0 === (int) $log['is_scheduled']) {
-                $this->fail('Tag EmailNotOpen is not scheduled for lead ID '.$log['lead_id']);
-            }
-
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
-
-            if (2 !== $diff->i) {
-                $this->fail('Tag EmailNotOpen should be scheduled for around 2 minutes ('.$diff->i.' minutes)');
-            }
-        }
-
-        foreach ($byEvent[15] as $log) {
-            if (0 === (int) $log['is_scheduled']) {
-                $this->fail('Tag EmailNotOpen Again is not scheduled for lead ID '.$log['lead_id']);
-            }
-
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
-
-            if (6 !== $diff->i) {
-                $this->fail('Tag EmailNotOpen Again should be scheduled for around 6 minutes ('.$diff->i.' minutes)');
-            }
-        }
         $byEvent = $this->getCampaignEventLogs([6, 7, 8, 9]);
         $tags    = $this->getTagCounts();
 
@@ -396,8 +375,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
             ->fetchAll();
         $this->assertCount(0, $stats);
 
-        // Wait 20 seconds then execute the campaign again to send scheduled events
-        sleep(20);
+        $this->shiftEmailEventsToThePast();
+
+        // Execute the campaign again to send scheduled events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3,4,19']);
 
         // Send email 1 should no longer be scheduled
@@ -439,8 +419,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(2, $byEvent[3]);
         $this->assertCount(2, $byEvent[10]);
 
-        // Wait 20 seconds to go beyond the inaction timeframe
-        sleep(20);
+        $this->shiftEventsToThePast([4, 5]);
+        $eventDate = clone $this->eventDate;
+        $eventDate->modify('-40 second');
 
         // Execute the command again to trigger inaction related events
         $this->runCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3,4,19']);
@@ -462,14 +443,14 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(3, $byEvent[14]);
         $this->assertCount(3, $byEvent[15]);
 
-        $utcTimezone = new \DateTimeZone('UTC');
+        $utcTimezone = new DateTimeZone('UTC');
         foreach ($byEvent[14] as $log) {
             if (0 === (int) $log['is_scheduled']) {
                 $this->fail('Tag EmailNotOpen is not scheduled for lead ID '.$log['lead_id']);
             }
 
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
+            $scheduledFor = new DateTime($log['trigger_date'], $utcTimezone);
+            $diff         = $eventDate->diff($scheduledFor);
 
             if (2 !== $diff->i) {
                 $this->fail('Tag EmailNotOpen should be scheduled for around 2 minutes ('.$diff->i.' minutes)');
@@ -481,8 +462,8 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
                 $this->fail('Tag EmailNotOpen Again is not scheduled for lead ID '.$log['lead_id']);
             }
 
-            $scheduledFor = new \DateTime($log['trigger_date'], $utcTimezone);
-            $diff         = $this->eventDate->diff($scheduledFor);
+            $scheduledFor = new DateTime($log['trigger_date'], $utcTimezone);
+            $diff         = $eventDate->diff($scheduledFor);
 
             if (6 !== $diff->i) {
                 $this->fail('Tag EmailNotOpen Again should be scheduled for around 6 minutes ('.$diff->i.' minutes)');
@@ -569,5 +550,34 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         }
 
         return $nonActionCount;
+    }
+
+    private function shiftEmailEventsToThePast(): void
+    {
+        $this->shiftEventsToThePast([2]);
+        $this->db->createQueryBuilder()->update(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log')
+            ->set('trigger_date', ':trigger')
+            ->where('campaign_id = :id')
+            ->andWhere('trigger_date IS NOT NULL')
+            ->andWhere('event_id IN (:eventId)')
+            ->setParameter('trigger', (new DateTime('-40 second'))->format('Y-m-d H:i:s'))
+            ->setParameter('id', 1)
+            ->setParameter('eventId', [2], Connection::PARAM_INT_ARRAY)
+            ->execute();
+
+        $this->em->clear();
+    }
+
+    private function shiftEventsToThePast(array $ids): void
+    {
+        $this->db->createQueryBuilder()->update(MAUTIC_TABLE_PREFIX.'campaign_events')
+            ->set('trigger_date', ':trigger')
+            ->where('trigger_date IS NOT NULL')
+            ->andWhere('id IN (:id)')
+            ->setParameter('trigger', (new DateTime('-40 second'))->format('Y-m-d H:i:s'))
+            ->setParameter('id', $ids, Connection::PARAM_INT_ARRAY)
+            ->execute();
+
+        $this->em->clear();
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -7,7 +7,6 @@ use DateTimeZone;
 use Doctrine\DBAL\Connection;
 use Mautic\CampaignBundle\Entity\Lead;
 use Mautic\CampaignBundle\Entity\LeadRepository;
-use Mautic\LeadBundle\Command\SegmentCountCacheCommand;
 use Mautic\LeadBundle\Entity\Lead as Contact;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadRepository as ContactRepository;


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | query optimization
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | https://backlog.acquia.com/browse/MAUT-6055
| BC breaks? | Hopefully not, must be tested well
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The query to build the campaign membership includes an exclusion subquery on mautic_campaign_lead_event_log to ensure no contact has history logged because prior to Mautic 2.13, campaigns were not repeatable and membership entries were deleted. However, since then, membership entries are not deleted and now just marked as removed with an exit date. The subquery was kept for BC but I think enough time has passed (changed in 2018) that we should evaluate if we can remove that NOT EXISTS subquery when building membership.

This query takes minutes when a campaign runs on 100% CPU but takes seconds when run normally:
```sql
SELECT min(ll.lead_id) as min_id, max(ll.lead_id) as max_id, count(distinct(ll.lead_id)) as the_count
FROM lead_lists_leads ll
WHERE (ll.manually_removed = 0)
    AND (ll.leadlist_id IN (48))
    AND (ll.lead_id BETWEEN '6817781' AND '6850936')
    AND (
        NOT EXISTS (
            SELECT null
            FROM campaign_leads cl
            WHERE (cl.lead_id = ll.lead_id) AND (cl.campaign_id = 51)
        )
    )
    AND (
        NOT EXISTS (
            SELECT null
            FROM campaign_lead_event_log el
            WHERE (el.lead_id = ll.lead_id) AND (el.campaign_id = 51)
        )
    )
```
This PR will remove the last subquery on the `campaign_lead_event_log` table.

The next optimization step: remaining NOT EXISTS were rewritten to JOIN as it has much improved cost:

The query with NOT EXISTS:
```sql
SELECT count(distinct(ll.lead_id)) as id FROM mautic_lead_lists_leads ll WHERE (ll.manually_removed = 0) AND (ll.leadlist_id IN (48)) AND (ll.lead_id BETWEEN '2023769' AND '2062403') AND (NOT EXISTS (SELECT null FROM mautic_campaign_leads cl WHERE (cl.lead_id = ll.lead_id) AND (cl.campaign_id = 66))) ORDER BY ll.lead_id ASC; #74.3 #23255
-> Aggregate: count(distinct ll.lead_id)

    -> Nested loop antijoin  (cost=23982413.65 rows=239683065)
        -> Filter: ((ll.leadlist_id = 48) and (ll.manually_removed = 0) and (ll.lead_id between 2023769 and 2062403))  (cost=9419.18 rows=46880)
            -> Index range scan on ll using PRIMARY  (cost=9419.18 rows=46880)
        -> Single-row index lookup on <subquery2> using <auto_distinct_key> (lead_id=ll.lead_id)
            -> Materialize with deduplication  (cost=1037.56..1037.56 rows=5113)
                -> Filter: (cl.lead_id is not null)  (cost=526.29 rows=5113)
                    -> Index lookup on cl using PRIMARY (campaign_id=66)  (cost=526.29 rows=5113)
```

The query rewritten with JOIN:
```sql
SELECT count(distinct(ll.lead_id)) as id FROM lead_lists_leads ll left join campaign_leads cl on cl.lead_id = ll.lead_id and cl.campaign_id = 66 WHERE ll.leadlist_id IN (48) and (ll.manually_removed = 0) AND (ll.lead_id BETWEEN '2023769' AND '2062403') and (cl.lead_id is null or cl.manually_removed = 1) ORDER BY ll.lead_id ASC; #96.7 #23255

-> Aggregate: count(distinct ll.lead_id)
    -> Filter: ((cl.lead_id is null) or (cl.manually_removed = 1))  (cost=58262.15 rows=46880)
        -> Nested loop left join  (cost=58262.15 rows=46880)
            -> Filter: ((ll.manually_removed = 0) and (ll.leadlist_id = 48) and (ll.lead_id between 2023769 and 2062403))  (cost=9419.18 rows=46880)
                -> Index range scan on ll using PRIMARY  (cost=9419.18 rows=46880)
            -> Single-row index lookup on cl using PRIMARY (campaign_id=66, lead_id=ll.lead_id)  (cost=0.94 rows=1)
```

In our scale testing instance with 75M rows in the `campaign_leads` table and 144M rows in the `lead_lists_leads` table it's improving the already improved query from 6 seconds to 230 milliseconds.

This is the new query:
```sql
SELECT min(ll.lead_id) as min_id, max(ll.lead_id) as max_id, count(distinct(ll.lead_id)) as the_count
FROM mautic_lead_lists_leads ll
LEFT JOIN mautic_campaign_leads cl ON cl.lead_id = ll.lead_id AND cl.campaign_id = 2
WHERE (ll.manually_removed = 0) AND (ll.leadlist_id IN (2)) AND (cl.lead_id IS NULL);
```

#### Steps to test this PR:
Create some campaigns before applying this change to test also backwards compatibility. In the previous Mautic versions, before the repeatable campaigns were implemented, we were removing campaign members instead of setting those records as `manually_removed`. So that's what we mainly focussed on during dev testing.

The query that is being optimized in this PR is handling adding the right campaign members to the campaign. Ignoring those that were added already. It behaves differently for repeatable and non-repeatable campaigns, so we must test both.

To test that the changes work also for the campaign members that were removed before the repeatable campaigns were implemented (2 years ago) here is what to test:
1. Create a segment with some contacts.
2. Create a campaign with some events and that segment as a source.
3. Let the segment and campaign build.
4. Check that the campaign membership checks out.
5. Delete manually all or some records from the `campaign_leads` table for that campaign.
6. Update the campaign members (by removing contacts from the source segment and adding the same contacts back for the cloud or by re-running the `mautic:campaign:update` command for the community)

Expected result:
- Repeatable campaign: The campaign members will be added again, all the campaign events will be executed twice. The `rotation` in the `campaign_leads` table is 2, `manually_removed` = 0 and `date_last_exited` is null
- Non-repeatable campaign: The campaign members will be added again, all the campaign events will be executed once. The `rotation` in the `campaign_leads` table is 1, `manually_removed` = 1 and `date_last_exited` is current timestamp.

We should also test for repeatable and non-repeatable campaigns:
- Changing campaign membership with a campaign action. Test that one contact is removed correctly from the first campaign and added to the second one.
- Test that by manipulating the source segment filters the campaign members are also added or removed correctly.

#### Other areas of Mautic that may be affected by the change:
1. Just campaign building, adding and removing contacts

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
The functional tests cover the BC break. Meaning it creates a repeatable campaign, add some members to it, deletes the data, build the campaign members again and checks that they were added correctly. Same for a non-repeatable campaign and we are checking for different results.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11001"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

