### PR TITLE
Segment filter 'Asset Downloads' not showing all assets

### DIFF
--- a/app/bundles/AssetBundle/Entity/AssetRepository.php
+++ b/app/bundles/AssetBundle/Entity/AssetRepository.php
@@ -53,7 +53,7 @@ class AssetRepository extends CommonRepository
 
         if (!empty($search)) {
             $q->andWhere($q->expr()->like('a.title', ':search'))
-                ->setParameter('search', "{$search}%");
+                ->setParameter('search', "%{$search}%");
         }
 
         if (!$viewOther) {

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -51,11 +51,6 @@ class AssetModel extends FormModel
     protected $leadModel;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Request|null
-     */
-    protected $request;
-
-    /**
      * @var IpLookupHelper
      */
     protected $ipLookupHelper;
@@ -90,9 +85,6 @@ class AssetModel extends FormModel
      */
     private $requestStack;
 
-    /**
-     * AssetModel constructor.
-     */
     public function __construct(
         LeadModel $leadModel,
         CategoryModel $categoryModel,
@@ -471,11 +463,13 @@ class AssetModel extends FormModel
         switch ($type) {
             case 'asset':
                 $viewOther = $this->security->isGranted('asset:assets:viewother');
+                $request   = $this->requestStack->getCurrentRequest();
                 $repo      = $this->getRepository();
                 $repo->setCurrentUser($this->userHelper->getUser());
                 // During the form submit & edit, make sure that the data is checked against available assets
-                if ('mautic_segment_action' == $this->request->get('_route') &&
-                    (Request::METHOD_POST == $this->request->getMethod() || 'edit' == $this->request->get('objectAction'))) {
+                if ('mautic_segment_action' === $request->get('_route') &&
+                    (Request::METHOD_POST === $request->getMethod() || 'edit' === $request->get('objectAction'))
+                ) {
                     $limit = 0;
                 }
                 $results = $repo->getAssetList($filter, $limit, 0, $viewOther);

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -34,6 +34,7 @@ use Mautic\LeadBundle\Tracker\Factory\DeviceDetectorFactory\DeviceDetectorFactor
 use Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorServiceInterface;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
@@ -472,6 +473,11 @@ class AssetModel extends FormModel
                 $viewOther = $this->security->isGranted('asset:assets:viewother');
                 $repo      = $this->getRepository();
                 $repo->setCurrentUser($this->userHelper->getUser());
+                // During the form submit & edit, make sure that the data is checked against available assets
+                if ('mautic_segment_action' == $this->request->get('_route') &&
+                    (Request::METHOD_POST == $this->request->getMethod() || 'edit' == $this->request->get('objectAction'))) {
+                    $limit = 0;
+                }
                 $results = $repo->getAssetList($filter, $limit, 0, $viewOther);
                 break;
             case 'category':

--- a/app/bundles/CoreBundle/Translations/en_US/javascript.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/javascript.ini
@@ -4,6 +4,7 @@ mautic.core.builder.section_delete_warning="Are you sure you want to delete the 
 mautic.core.lookup.keep_typing = "Keep typing..."
 mautic.core.lookup.looking_for = "Looking for"
 mautic.core.lookup.search_options = "Search options..."
+mautic.core.lookup.loading_data = "Loading data..."
 mautic.core.dynamicContent="Dynamic Content"
 mautic.core.dynamicContent.new="Dynamic Content %number%"
 mautic.core.dynamicContent.token_name="Name"

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1462,16 +1462,21 @@ Mautic.setAsPrimaryCompany = function (companyId,leadId){
 Mautic.handleAssetDownloadSearch = function(filterNum, fieldObject, fieldAlias, operator, resultHtml, search) {
     var assetDownloadFilter = mQuery('#leadlist_filters_' + filterNum + '_properties_filter');
     var assetDownloadInput = mQuery('#leadlist_filters_' + filterNum + '_properties input');
+    var assetDownloadProperties = mQuery('#leadlist_filters_' + filterNum + '_properties');
     assetDownloadFilter.on('chosen:no_results', function () {
         var search = assetDownloadInput.val();
         mQuery('#leadlist_filters_' + filterNum + '_properties .chosen-drop').remove();
         clearTimeout(mQuery.data(this, 'timer'));
+        var existingOptions = mQuery('#leadlist_filters_' + filterNum + '_properties_filter option');
+        mQuery(assetDownloadProperties).data('existing-options', existingOptions);
         mQuery(this).data('timer', setTimeout(function () {
             assetDownloadInput.width('auto').prop('disabled', true).val(Mautic.translate('mautic.core.lookup.loading_data'));
             Mautic.loadFilterForm(filterNum, fieldObject, fieldAlias, operator, resultHtml, search)
         }, 1000, search))
     });
-
+    var existingOptions = mQuery(assetDownloadProperties).data('existing-options');
+    assetDownloadFilter.append(existingOptions);
+    assetDownloadFilter.trigger('chosen:updated');
     if (mQuery('#leadlist_filters_' + filterNum + '_properties_filter option').length === 0 ) {
         assetDownloadInput.val(mauticLang['chosenNoResults']);
     }

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -177,6 +177,7 @@ class AjaxController extends CommonAjaxController
         $fieldAlias  = InputHelper::clean($request->request->get('fieldAlias'));
         $fieldObject = InputHelper::clean($request->request->get('fieldObject'));
         $operator    = InputHelper::clean($request->request->get('operator'));
+        $search      = InputHelper::clean($request->request->get('search'));
         $filterNum   = (int) $request->request->get('filterNum');
 
         /** @var FormFactoryInterface $formFactory */
@@ -196,7 +197,7 @@ class AjaxController extends CommonAjaxController
                 $fieldAlias,
                 $fieldObject,
                 $operator,
-                $listModel->getChoiceFields()[$fieldObject][$fieldAlias]
+                $listModel->getChoiceFields($search)[$fieldObject][$fieldAlias]
             );
         }
 

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -38,17 +38,20 @@ class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
      */
     protected $translator;
 
+    protected $search;
+
     /**
      * @param mixed[] $choices
      * @param mixed[] $operators
      */
-    public function __construct($choices, $operators, TranslatorInterface $translator, Request $request = null)
+    public function __construct($choices, $operators, TranslatorInterface $translator, Request $request = null, string $search = '')
     {
         parent::__construct($request);
 
         $this->choices    = $choices;
         $this->operators  = $operators;
         $this->translator = $translator;
+        $this->search     = $search;
     }
 
     /**
@@ -73,6 +76,11 @@ class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
     public function getTranslator()
     {
         return $this->translator;
+    }
+
+    public function getSearch(): string
+    {
+        return $this->search;
     }
 
     /**

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -38,7 +38,7 @@ class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
      */
     protected $translator;
 
-    protected $search;
+    private string $search;
 
     /**
      * @param mixed[] $choices

--- a/app/bundles/LeadBundle/Event/ListFieldChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/ListFieldChoicesEvent.php
@@ -21,6 +21,8 @@ final class ListFieldChoicesEvent extends Event
      */
     private array $choicesForAliases = [];
 
+    private string $searchTerm = '';
+
     /**
      * @param mixed[] $choices
      */
@@ -51,5 +53,15 @@ final class ListFieldChoicesEvent extends Event
     public function getChoicesForAllListFieldAliases(): array
     {
         return $this->choicesForAliases;
+    }
+
+    public function setSearchTerm(string $searchTerm): void
+    {
+        $this->searchTerm = $searchTerm;
+    }
+
+    public function getSearchTerm(): string
+    {
+        return $this->searchTerm;
     }
 }

--- a/app/bundles/LeadBundle/EventListener/FilterOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/FilterOperatorSubscriber.php
@@ -148,7 +148,7 @@ final class FilterOperatorSubscriber implements EventSubscriberInterface
                 'label'      => $this->translator->trans('mautic.lead.list.filter.lists'),
                 'properties' => [
                     'type' => 'leadlist',
-                    'list' => $this->fieldChoicesProvider->getChoicesForField('multiselect', 'leadlist'),
+                    'list' => $this->fieldChoicesProvider->getChoicesForField('multiselect', 'leadlist', $event->getSearch()),
                 ],
                 'operators'  => $this->typeOperatorProvider->getOperatorsForFieldType('multiselect'),
                 'object'     => 'lead',
@@ -325,7 +325,7 @@ final class FilterOperatorSubscriber implements EventSubscriberInterface
                 'label'      => $this->translator->trans('mautic.lead.list.filter.lead_asset_download'),
                 'properties' => [
                     'type' => 'assets',
-                    'list' => $this->fieldChoicesProvider->getChoicesForField('select', 'lead_asset_download'),
+                    'list' => $this->fieldChoicesProvider->getChoicesForField('select', 'lead_asset_download', $event->getSearch()),
                 ],
                 'operators'  => $this->typeOperatorProvider->getOperatorsForFieldType('multiselect'),
                 'object'     => 'lead',

--- a/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
@@ -114,7 +114,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
 
         $emails = $this->emailModel->getLookupResults('email', '', 0, 0, ['name_is_key' => true]);
 
-        $event->setChoicesForFieldAlias('lead_asset_download', $this->getAssetChoices());
+        $event->setChoicesForFieldAlias('lead_asset_download', $this->getAssetChoices($event->getSearchTerm()));
         $event->setChoicesForFieldAlias('campaign', $this->getCampaignChoices());
         $event->setChoicesForFieldAlias('leadlist', $this->getSegmentChoices());
         $event->setChoicesForFieldAlias('tags', $this->getTagChoices());
@@ -355,9 +355,9 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
     /**
      * @return mixed[]
      */
-    private function getAssetChoices(): array
+    private function getAssetChoices(string $filter = ''): array
     {
-        return $this->makeChoices($this->assetModel->getLookupResults('asset'), 'title', 'id');
+        return $this->makeChoices($this->assetModel->getLookupResults('asset', $filter), 'title', 'id');
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -277,7 +277,7 @@ class ListModel extends FormModel
      *
      * @return array
      */
-    public function getChoiceFields()
+    public function getChoiceFields(string $search = '')
     {
         if ($this->choiceFieldsCache) {
             return $this->choiceFieldsCache;
@@ -297,7 +297,7 @@ class ListModel extends FormModel
 
         // Add custom choices
         if ($this->dispatcher->hasListeners(LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE)) {
-            $event = new LeadListFiltersChoicesEvent([], $this->getOperatorsForFieldType(), $this->translator, $this->requestStack->getCurrentRequest());
+            $event = new LeadListFiltersChoicesEvent([], $this->getOperatorsForFieldType(), $this->translator, $this->requestStack->getCurrentRequest(), $search);
             $this->dispatcher->dispatch(LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE, $event);
             $choices = $event->getChoices();
         }

--- a/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
+++ b/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
@@ -31,9 +31,9 @@ final class FieldChoicesProvider implements FieldChoicesProviderInterface
     /**
      * @return mixed[]
      */
-    public function getChoicesForField(string $fieldType, string $fieldAlias): array
+    public function getChoicesForField(string $fieldType, string $fieldAlias, string $search = ''): array
     {
-        $aliasChoices = $this->getAllChoicesForListFieldAliases();
+        $aliasChoices = $this->getAllChoicesForListFieldAliases($search);
         $typeChoices  = $this->getAllChoicesForListFieldTypes();
 
         if (isset($aliasChoices[$fieldAlias])) {
@@ -60,18 +60,18 @@ final class FieldChoicesProvider implements FieldChoicesProviderInterface
     /**
      * @return mixed[]
      */
-    private function getAllChoicesForListFieldAliases(): array
+    private function getAllChoicesForListFieldAliases(string $search = ''): array
     {
-        $this->lookForFieldChoices();
+        $this->lookForFieldChoices($search);
 
         return $this->cachedAliasChoices;
     }
 
-    private function lookForFieldChoices(): void
+    private function lookForFieldChoices(string $search = ''): void
     {
         if (empty($this->cachedTypeChoices)) {
             $event = new ListFieldChoicesEvent();
-
+            $event->setSearchTerm($search);
             $this->dispatcher->dispatch(LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE, $event);
 
             $this->cachedTypeChoices  = $event->getChoicesForAllListFieldTypes();

--- a/app/bundles/LeadBundle/Provider/FieldChoicesProviderInterface.php
+++ b/app/bundles/LeadBundle/Provider/FieldChoicesProviderInterface.php
@@ -13,5 +13,5 @@ interface FieldChoicesProviderInterface
      *
      * @return mixed[]
      */
-    public function getChoicesForField(string $fieldType, string $fieldAlias): array;
+    public function getChoicesForField(string $fieldType, string $fieldAlias, string $search = ''): array;
 }

--- a/app/bundles/LeadBundle/Tests/Event/LeadListFiltersChoicesEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadListFiltersChoicesEventTest.php
@@ -1,52 +1,52 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class LeadListFiltersChoicesEventTest extends TestCase
 {
-    /** @var LeadListFiltersChoicesEvent */
-    private $leadListFiltersChoicesEvent;
-
     public function testGetters(): void
     {
         $operators = [
             'text' => [
-                    'equals'      => '=',
-                    'not equal'   => '!=',
-                    'empty'       => 'empty',
-                    'not empty'   => '!empty',
-                    'like'        => 'like',
-                    'not like'    => '!like',
-                    'regexp'      => 'regexp',
-                    'not regexp'  => '!regexp',
-                    'starts with' => 'startsWith',
-                    'ends with'   => 'endsWith',
-                    'contains'    => 'contains',
-                ],
+                'equals'      => '=',
+                'not equal'   => '!=',
+                'empty'       => 'empty',
+                'not empty'   => '!empty',
+                'like'        => 'like',
+                'not like'    => '!like',
+                'regexp'      => 'regexp',
+                'not regexp'  => '!regexp',
+                'starts with' => 'startsWith',
+                'ends with'   => 'endsWith',
+                'contains'    => 'contains',
+            ],
             'select' => [
-                    'equals'     => '=',
-                    'not equal'  => '!=',
-                    'empty'      => 'empty',
-                    'not empty'  => '!empty',
-                    'including'  => 'in',
-                    'excluding'  => '!in',
-                    'regexp'     => 'regexp',
-                    'not regexp' => '!regexp',
-                ],
+                'equals'     => '=',
+                'not equal'  => '!=',
+                'empty'      => 'empty',
+                'not empty'  => '!empty',
+                'including'  => 'in',
+                'excluding'  => '!in',
+                'regexp'     => 'regexp',
+                'not regexp' => '!regexp',
+            ],
             'bool' => [
-                    'equals'    => '=',
-                    'not equal' => '!=',
-                ],
+                'equals'    => '=',
+                'not equal' => '!=',
+            ],
         ];
 
         $choices                     = [0 => 'Choice1', 1 => 'Choice2'];
         $search                      = 'Test Search';
         $translator                  = $this->createMock(TranslatorInterface::class);
-        $leadListFiltersChoicesEvent = new LeadListFiltersChoicesEvent($choices, $operators, $translator, $search);
+        $leadListFiltersChoicesEvent = new LeadListFiltersChoicesEvent($choices, $operators, $translator, new Request(), $search);
         $this->assertSame($operators, $leadListFiltersChoicesEvent->getOperators());
         $this->assertSame($choices, $leadListFiltersChoicesEvent->getChoices());
         $this->assertSame($translator, $leadListFiltersChoicesEvent->getTranslator());

--- a/app/bundles/LeadBundle/Tests/Event/LeadListFiltersChoicesEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadListFiltersChoicesEventTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mautic\LeadBundle\Tests\Event;
+
+use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class LeadListFiltersChoicesEventTest extends TestCase
+{
+    /** @var LeadListFiltersChoicesEvent */
+    private $leadListFiltersChoicesEvent;
+
+    public function testGetters(): void
+    {
+        $operators = [
+            'text' => [
+                    'equals'      => '=',
+                    'not equal'   => '!=',
+                    'empty'       => 'empty',
+                    'not empty'   => '!empty',
+                    'like'        => 'like',
+                    'not like'    => '!like',
+                    'regexp'      => 'regexp',
+                    'not regexp'  => '!regexp',
+                    'starts with' => 'startsWith',
+                    'ends with'   => 'endsWith',
+                    'contains'    => 'contains',
+                ],
+            'select' => [
+                    'equals'     => '=',
+                    'not equal'  => '!=',
+                    'empty'      => 'empty',
+                    'not empty'  => '!empty',
+                    'including'  => 'in',
+                    'excluding'  => '!in',
+                    'regexp'     => 'regexp',
+                    'not regexp' => '!regexp',
+                ],
+            'bool' => [
+                    'equals'    => '=',
+                    'not equal' => '!=',
+                ],
+        ];
+
+        $choices                     = [0 => 'Choice1', 1 => 'Choice2'];
+        $search                      = 'Test Search';
+        $translator                  = $this->createMock(TranslatorInterface::class);
+        $leadListFiltersChoicesEvent = new LeadListFiltersChoicesEvent($choices, $operators, $translator, $search);
+        $this->assertSame($operators, $leadListFiltersChoicesEvent->getOperators());
+        $this->assertSame($choices, $leadListFiltersChoicesEvent->getChoices());
+        $this->assertSame($translator, $leadListFiltersChoicesEvent->getTranslator());
+        $this->assertSame($search, $leadListFiltersChoicesEvent->getSearch());
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Event/ListFieldChoicesEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/ListFieldChoicesEventTest.php
@@ -17,8 +17,10 @@ final class ListFieldChoicesEventTest extends \PHPUnit\Framework\TestCase
 
         $event->setChoicesForFieldType('boolean', ['No' => 0, 'Yes' => 1]);
         $event->setChoicesForFieldAlias('campaign', ['Campaign A' => 1, 'Campaign B' => 2]);
+        $event->setSearchTerm('Test search');
 
         $this->assertSame(['boolean' => ['No' => 0, 'Yes' => 1]], $event->getChoicesForAllListFieldTypes());
         $this->assertSame(['campaign' => ['Campaign A' => 1, 'Campaign B' => 2]], $event->getChoicesForAllListFieldAliases());
+        $this->assertSame('Test search', $event->getSearchTerm());
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | Yes
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | /
| BC breaks? | No
| Deprecations? | No

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go to assets and create more than 10 assets(for easiness, have an asset starting with `w/x/y/z` so that it will be the 11th one if sorted)
2. Click on Segments >> New and chose tab "Filters"
3. Select "Asset Downloads" from the combo box
4. Chose 'including' from the operator dropdown box
5. Observe that the first 10 of your assets are listed in the filter next to it. Also notice that the file we mentioned above which starts with `w/x/y/z` is missing from the list
6. Start typing the missing file's name
7. It should now trigger an ajax request and should find the files starting with the searched text



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11002"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

