### PR TITLE
Fixing BC change after moving some segment filters to behaviors

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -61,7 +61,8 @@ class FilterType extends AbstractType
             $form        = $event->getForm();
             $fieldAlias  = $data['field'] ?? null;
             $fieldObject = $data['object'] ?? 'behaviors';
-            $field       = $fieldChoices[$fieldObject][$fieldAlias] ?? null;
+            // Looking for behaviors for BC reasons as some filters were moved from 'lead' to 'behaviors'.
+            $field       = $fieldChoices[$fieldObject][$fieldAlias] ?? $fieldChoices['behaviors'][$fieldAlias] ?? null;
             $operators   = $field['operators'] ?? [];
             $operator    = $data['operator'] ?? null;
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x]
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/10990

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

If I create the segment on the 4.1 branch and then open it in the 4.x branch. This is how it is saved on 4.1:
```php
array (
    'glue' => 'and',
    'field' => 'hit_url',
    'object' => 'lead',
    'type' => 'text',
    'filter' => 'unicorn',
    'display' => NULL,
    'operator' => '=',
  ),
```
And this is on 4.x:
```php
array (
    'glue' => 'and',
    'field' => 'hit_url',
    'object' => 'behaviors',
    'type' => 'text',
    'operator' => '=',
    'properties' => 
    array (
      'filter' => 'pako',
    ),
  ),
```
The problem is not with moving the filter to the properties array. That is working nicely. The problem is that the object has changes from `lead` to `behaviors` and the code cannot find the operators for such field anymore.

It was introduced in https://github.com/mautic/mautic/pull/7194 that was merged to the big segment refactoring PR.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Create a segment with Visited URL on an instance prior 4.2 release
2. Upgrade to 4.2+
3. Edit the segment and see that the operator select box is empty and filter value cannot be added. Once you apply this PR you will be able to see the operators and filter field and value.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11003"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

