### PR TITLE
Segment filter optimization

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterFactory
 {
-    public const CUSTOM_OPERATOR             = 'custom_operator';
+    public const CUSTOM_OPERATOR = 'custom_operator';
 
     /**
      * @var array|string[]
@@ -96,11 +96,11 @@ class ContactSegmentFilterFactory
     }
 
     /**
-     * Merge multiple filters of same field with OR
+     * Merge multiple filters of same field with OR.
      *
-     * @param array<string, mixed> $filters
+     * @param mixed[] $filters
      *
-     * @return array<string, mixed>
+     * @return mixed[]
      */
     private function mergeFilters(array $filters): array
     {
@@ -112,7 +112,7 @@ class ContactSegmentFilterFactory
         foreach ($filters as $filter) {
             // easy to compare
             $key = implode('_', [
-                $filter['object'],
+                $filter['object'] ?? '',
                 $filter['field'],
                 $filter['glue'],
                 $filter['operator'],
@@ -126,7 +126,7 @@ class ContactSegmentFilterFactory
                 array_push($arrStacks[$key], $filter);
             } else { // glue = and
                 // if 'or' followed by 'and', it becomes - or (cond1 and cond2)
-                if (isset($arrStacks[$previousKey]) && count($arrStacks[$previousKey]) > 0) {
+                if (isset($arrStacks[$previousKey]) && count($arrStacks[$previousKey]) > 0) { /** @phpstan-ignore-line `Comparison operation ">" between 0 and 0 is always false.` I don't see anything wrong. Seems to be a PHPSTAN issue https://github.com/phpstan/phpstan/issues/3831 */
                     $previousFilter = array_pop($arrStacks[$previousKey]);
                     array_push($shrinkedFilters, $previousFilter);
                 }
@@ -149,9 +149,9 @@ class ContactSegmentFilterFactory
     }
 
     /**
-     * @param array<string, mixed> $stack
+     * @param mixed[] $stack
      *
-     * @return array<string, mixed>
+     * @return mixed[]
      */
     private function groupFilters(array $stack): array
     {

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -4,31 +4,23 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Command;
 
-use Exception;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\Command\SegmentCountCacheCommand;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
-use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
-class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
+final class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
 {
-    /**
-     * @throws Exception
-     */
     public function testSegmentFilterOnUpdateCommand(): void
     {
         $application = new Application(self::$kernel);
         $application->setAutoExit(false);
         $applicationTester = new ApplicationTester($application);
 
-        $contacts   = $this->saveContacts();
+        $this->saveContacts();
         $segmentA   = $this->saveSegmentA();
         $segmentAId = $segmentA->getId();
 
@@ -45,6 +37,9 @@ class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
         self::assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentBId]));
     }
 
+    /**
+     * @return Lead[]
+     */
     private function saveContacts(): array
     {
         // Add 10 contacts
@@ -66,11 +61,8 @@ class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
 
     private function saveSegmentA(): LeadList
     {
-        // Add 1 segment
-        /** @var LeadListRepository $contactRepo */
-        $segmentRepo = $this->em->getRepository(LeadList::class);
-        $segment     = new LeadList();
-        $filters     = [
+        $segment = new LeadList();
+        $filters = [
             [
                 'object'     => 'lead',
                 'glue'       => 'and',
@@ -130,20 +122,19 @@ class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
         ];
 
         $segment->setName('Segment A')
+            ->setPublicName('Segment A')
             ->setFilters($filters)
             ->setAlias('segment-a');
-        $segmentRepo->saveEntity($segment);
+        $this->em->persist($segment);
+        $this->em->flush();
 
         return $segment;
     }
 
     private function saveSegmentB(int $segmentAId): LeadList
     {
-        // Add 1 segment
-        /** @var LeadListRepository $contactRepo */
-        $segmentRepo = $this->em->getRepository(LeadList::class);
-        $segment     = new LeadList();
-        $filters     = [
+        $segment = new LeadList();
+        $filters = [
             [
                 'object'     => 'lead',
                 'glue'       => 'and',
@@ -187,9 +178,11 @@ class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
         ];
 
         $segment->setName('Segment B')
+            ->setPublicName('Segment B')
             ->setFilters($filters)
             ->setAlias('segment-b');
-        $segmentRepo->saveEntity($segment);
+        $this->em->persist($segment);
+        $this->em->flush();
 
         return $segment;
     }

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Command;
+
+use Exception;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Command\SegmentCountCacheCommand;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testSegmentFilterOnUpdateCommand(): void
+    {
+        $application = new Application(self::$kernel);
+        $application->setAutoExit(false);
+        $applicationTester = new ApplicationTester($application);
+
+        $contacts   = $this->saveContacts();
+        $segmentA   = $this->saveSegmentA();
+        $segmentAId = $segmentA->getId();
+
+        // Run segments update command.
+        $exitCode = $applicationTester->run(['command' => 'mautic:segments:update', '-i' => $segmentAId]);
+        self::assertSame(0, $exitCode, $applicationTester->getDisplay());
+        self::assertCount(5, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentAId]));
+
+        $segmentB   = $this->saveSegmentB($segmentAId);
+        $segmentBId = $segmentB->getId();
+        // Run segments update command.
+        $exitCode = $applicationTester->run(['command' => 'mautic:segments:update', '-i' => $segmentBId]);
+        self::assertSame(0, $exitCode, $applicationTester->getDisplay());
+        self::assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentBId]));
+    }
+
+    private function saveContacts(): array
+    {
+        // Add 10 contacts
+        /** @var LeadRepository $contactRepo */
+        $contactRepo = $this->em->getRepository(Lead::class);
+        $contacts    = [];
+
+        for ($i = 0; $i <= 10; ++$i) {
+            $contact = new Lead();
+            $contact->setFirstname('fn'.$i);
+            $contact->setLastname('ln'.$i);
+            $contacts[] = $contact;
+        }
+
+        $contactRepo->saveEntities($contacts);
+
+        return $contacts;
+    }
+
+    private function saveSegmentA(): LeadList
+    {
+        // Add 1 segment
+        /** @var LeadListRepository $contactRepo */
+        $segmentRepo = $this->em->getRepository(LeadList::class);
+        $segment     = new LeadList();
+        $filters     = [
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn1'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln1'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn2'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn3'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln3'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn4'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln5'],
+            ],
+        ];
+
+        $segment->setName('Segment A')
+            ->setFilters($filters)
+            ->setAlias('segment-a');
+        $segmentRepo->saveEntity($segment);
+
+        return $segment;
+    }
+
+    private function saveSegmentB(int $segmentAId): LeadList
+    {
+        // Add 1 segment
+        /** @var LeadListRepository $contactRepo */
+        $segmentRepo = $this->em->getRepository(LeadList::class);
+        $segment     = new LeadList();
+        $filters     = [
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn6'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn2'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn3'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln3'],
+            ],
+            [
+                'glue'       => 'and',
+                'field'      => 'leadlist',
+                'object'     => 'lead',
+                'type'       => 'leadlist',
+                'operator'   => 'in',
+                'properties' => ['filter' => [$segmentAId]],
+            ],
+        ];
+
+        $segment->setName('Segment B')
+            ->setFilters($filters)
+            ->setAlias('segment-b');
+        $segmentRepo->saveEntity($segment);
+
+        return $segment;
+    }
+}


### PR DESCRIPTION
<!-- ## staging

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ no]
| New feature/enhancement? (use the a.x branch)      | [enhancement ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ yes] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR replaces multiple 'OR' conditions on the same field of any segment's filters with a single 'IN' condition by grouping all the 'OR' conditions' values.

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a large number of contacts
3. Create a segment with large number of filters. 
4. Based on the data given, the query process becomes very slow.


