### PR TITLE
Integration sync flag

### DIFF
--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -281,7 +281,9 @@ class ConfigController extends AbstractFormController
     }
 
     /**
-     * @return array $syncDirections
+     * @param mixed[] $fieldMappings
+     *
+     * @return mixed[]
      */
     private function setObjectSyncDirection(array $fieldMappings): array
     {

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -144,17 +144,8 @@ class ConfigController extends AbstractFormController
             }
 
             $settings['sync']['fieldMappings'] = $fieldMerger->getFieldMappings();
-            // add new flag for each integration object based on the each fields sync direction
-            $settings['sync']['directions'] = [];
-            foreach ($settings['sync']['fieldMappings'] as $integrationObject => $objectFieldMappings) {
-                $settings['sync']['directions'][$integrationObject] = ObjectMappingDAO::SYNC_TO_MAUTIC;
-                foreach ($objectFieldMappings as $eachFieldMapping) {
-                    if (ObjectMappingDAO::SYNC_TO_MAUTIC != $eachFieldMapping['syncDirection']) {
-                        $settings['sync']['directions'][$integrationObject] = $eachFieldMapping['syncDirection'];
-                        break;
-                    }
-                }
-            }
+            // add new flag for each integration object based on each field's sync direction
+            $settings['sync']['directions'] = $this->setObjectSyncDirection($settings['sync']['fieldMappings']);
 
             /** @var FieldValidationHelper $fieldValidator */
             $fieldValidator = $this->get('mautic.integrations.helper.field_validator');
@@ -287,5 +278,25 @@ class ConfigController extends AbstractFormController
         /** @var Session $session */
         $session = $this->get('session');
         $session->remove("{$this->integrationObject->getName()}-fields");
+    }
+
+    /**
+     * @return array $syncDirections
+     */
+    private function setObjectSyncDirection(array $fieldMappings): array
+    {
+        $syncDirections = [];
+
+        foreach ($fieldMappings as $integrationObject => $objectFieldMappings) {
+            $syncDirections[$integrationObject] = ObjectMappingDAO::SYNC_TO_MAUTIC;
+            foreach ($objectFieldMappings as $eachFieldMapping) {
+                if (ObjectMappingDAO::SYNC_TO_MAUTIC != $eachFieldMapping['syncDirection']) {
+                    $syncDirections[$integrationObject] = $eachFieldMapping['syncDirection'];
+                    break;
+                }
+            }
+        }
+
+        return $syncDirections;
     }
 }

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -30,6 +30,7 @@ use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormFeaturesInterface
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface;
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface;
 use Mautic\IntegrationsBundle\IntegrationEvents;
+use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use Mautic\PluginBundle\Entity\Integration;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
@@ -143,6 +144,17 @@ class ConfigController extends AbstractFormController
             }
 
             $settings['sync']['fieldMappings'] = $fieldMerger->getFieldMappings();
+            // add new flag for each integration object based on the each fields sync direction
+            $settings['sync']['directions'] = [];
+            foreach ($settings['sync']['fieldMappings'] as $integrationObject => $objectFieldMappings) {
+                $settings['sync']['directions'][$integrationObject] = ObjectMappingDAO::SYNC_TO_MAUTIC;
+                foreach ($objectFieldMappings as $eachFieldMapping) {
+                    if (ObjectMappingDAO::SYNC_TO_MAUTIC != $eachFieldMapping['syncDirection']) {
+                        $settings['sync']['directions'][$integrationObject] = $eachFieldMapping['syncDirection'];
+                        break;
+                    }
+                }
+            }
 
             /** @var FieldValidationHelper $fieldValidator */
             $fieldValidator = $this->get('mautic.integrations.helper.field_validator');

--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -169,6 +169,11 @@ class LeadSubscriber implements EventSubscriberInterface
 
     public function onLeadCompanyChange(Events\LeadChangeCompanyEvent $event): void
     {
+        if (!$this->syncIntegrationsHelper->hasObjectSyncEnabled(Contact::NAME)) {
+            // Only track if an integration is syncing with contacts
+            return;
+        }
+
         $lead = $event->getLead();
 
         // This mechanism is not able to record multiple company changes.

--- a/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
@@ -17,6 +17,7 @@ use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormFeaturesInterface;
 use Mautic\IntegrationsBundle\Integration\Interfaces\SyncInterface;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\SyncDataExchangeInterface;
@@ -128,7 +129,14 @@ class SyncIntegrationsHelper
                 $mappedObjectNames = $mappingManual->getMappedIntegrationObjectsNames($mauticObject);
                 foreach ($mappedObjectNames as $mappedObjectName) {
                     if (in_array($mappedObjectName, $featureSettings['sync']['objects'])) {
-                        return true;
+                        // check the syncDirection (consolidated flag) of the object
+                        if (isset($featureSettings['sync']['directions'])
+                            && isset($featureSettings['sync']['directions'][$mappedObjectName])
+                            && ObjectMappingDAO::SYNC_TO_MAUTIC != $featureSettings['sync']['directions'][$mappedObjectName]) {
+                            return true;
+                        } else {
+                            return false;
+                        }
                     }
                 }
             } catch (ObjectNotFoundException $exception) {

--- a/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
@@ -129,13 +129,12 @@ class SyncIntegrationsHelper
                 $mappedObjectNames = $mappingManual->getMappedIntegrationObjectsNames($mauticObject);
                 foreach ($mappedObjectNames as $mappedObjectName) {
                     if (in_array($mappedObjectName, $featureSettings['sync']['objects'])) {
-                        // check the syncDirection (consolidated flag) of the object
                         if (isset($featureSettings['sync']['directions'])
-                            && isset($featureSettings['sync']['directions'][$mappedObjectName])
-                            && ObjectMappingDAO::SYNC_TO_MAUTIC != $featureSettings['sync']['directions'][$mappedObjectName]) {
-                            return true;
+                            && isset($featureSettings['sync']['directions'][$mappedObjectName])) { // fallback condition
+                            // check the syncDirection (consolidated flag) of the object
+                            return ObjectMappingDAO::SYNC_TO_MAUTIC != $featureSettings['sync']['directions'][$mappedObjectName];
                         } else {
-                            return false;
+                            return true;
                         }
                     }
                 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Helper;
+
+use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
+use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
+use Mautic\IntegrationsBundle\Integration\Interfaces\SyncInterface;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
+use Mautic\PluginBundle\Entity\Integration;
+use PHPUnit\Framework\TestCase;
+
+class SyncIntegrationsHelperTest extends TestCase
+{
+    public function testHasObjectSyncEnabled(): void
+    {
+        $mauticObject           = 'some_integration';
+        $integrationsHelperMock = $this->createMock(IntegrationsHelper::class);
+        $objectProviderMock     = $this->createMock(ObjectProvider::class);
+        $syncIntegrationsHelper = new SyncIntegrationsHelper($integrationsHelperMock, $objectProviderMock);
+        $syncInterfaceMock      = $this->createMock(SyncInterface::class);
+        $syncInterfaceMock->method('getName')->willReturn($mauticObject);
+        $syncIntegrationsHelper->addIntegration($syncInterfaceMock);
+
+        $integrationMock = $this->createMock(Integration::class);
+        $integrationMock->method('getIsPublished')->willReturn(true);
+        $supportedFeatures = [
+            'integration' => [
+                'syncDateFrom'       => '2021-09-01',
+                'syncStrategies'     => [
+                    'Lead' => [
+                        'operator' => null,
+                        'field'    => 'IsUnreadByOwner',
+                    ],
+                ],
+                'syncStrategiesPush' => [
+                    'lead' => [
+                            'operator' => null,
+                            'field'    => null,
+                        ],
+                ],
+                'activitySync'       => null,
+                'activityEvents'     => [
+                    'point.gained',
+                    'form.submitted',
+                    'email.read',
+                ],
+                'sandbox'            => [],
+                'namespace'          => null,
+            ],
+            'sync'        => [
+                'objects'       => [
+                    'Lead',
+                ],
+                'fieldMappings' => [
+                    'Lead' => [
+                        'Company'  => [
+                            'mappedField'   => 'company',
+                            'syncDirection' => 'integration',
+                        ],
+                        'Email'    => [
+                            'mappedField'   => 'email',
+                            'syncDirection' => 'bidirectional',
+                        ],
+                        'LastName' => [
+                            'mappedField'   => 'lastname',
+                            'syncDirection' => 'mautic',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $integrationMock->method('getSupportedFeatures')->willReturn($supportedFeatures);
+        $integrationsHelperMock->method('getIntegrationConfiguration')
+            ->with($syncInterfaceMock)
+            ->willReturn($integrationMock);
+
+        $syncIntegrationsHelper->hasObjectSyncEnabled($mauticObject);
+    }
+}

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
@@ -10,6 +10,7 @@ use Mautic\IntegrationsBundle\Integration\Interfaces\SyncInterface;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
 use Mautic\PluginBundle\Entity\Integration;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class SyncIntegrationsHelperTest extends TestCase
@@ -73,6 +74,9 @@ class SyncIntegrationsHelperTest extends TestCase
                         ],
                     ],
                 ],
+                'directions' => [
+                    'Lead' => 'mautic',
+                ],
             ],
         ];
         $integrationMock->method('getFeatureSettings')->willReturn($featureSettings);
@@ -80,14 +84,17 @@ class SyncIntegrationsHelperTest extends TestCase
         $syncInterfaceMock->method('getIntegrationConfiguration')->willReturn($integrationMock);
 
         $mappingManualDAOMock          = $this->createMock(MappingManualDAO::class);
-        $mappedIntegrationObjectsNames = ['this', 'that'];
-        $mappingManualDAOMock->method('getMappedIntegrationObjectsNames')->with($mauticObject)->willReturn($mappedIntegrationObjectsNames);
+        $mappedIntegrationObjectsNames = ['Lead'];
+        $mappingManualDAOMock->method('getMappedIntegrationObjectsNames')->with($mauticObject)
+            ->willReturn($mappedIntegrationObjectsNames);
         $syncInterfaceMock->method('getMappingManual')->willReturn($mappingManualDAOMock);
 
         $objectProviderMock = $this->createMock(ObjectProvider::class);
 
         $syncIntegrationsHelper = new SyncIntegrationsHelper($integrationsHelperMock, $objectProviderMock);
         $syncIntegrationsHelper->addIntegration($syncInterfaceMock);
-        $syncIntegrationsHelper->hasObjectSyncEnabled($mauticObject);
+        $hasObject = $syncIntegrationsHelper->hasObjectSyncEnabled($mauticObject);
+
+        Assert::assertFalse($hasObject);
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
@@ -7,6 +7,7 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Helper;
 use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
 use Mautic\IntegrationsBundle\Integration\Interfaces\SyncInterface;
+use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
 use Mautic\PluginBundle\Entity\Integration;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,9 @@ class SyncIntegrationsHelperTest extends TestCase
             ->with($syncInterfaceMock)
             ->willReturn($integrationMock);
         $integrationMock->method('getIsPublished')->willReturn(true);
-        $supportedFeatures = [
+        $supportedFeatures = ['sync'];
+        $integrationMock->method('getSupportedFeatures')->willReturn($supportedFeatures);
+        $featureSettings = [
             'integration' => [
                 'syncDateFrom'       => '2021-09-01',
                 'syncStrategies'     => [
@@ -72,9 +75,14 @@ class SyncIntegrationsHelperTest extends TestCase
                 ],
             ],
         ];
-        $integrationMock->method('getSupportedFeatures')->willReturn($supportedFeatures);
+        $integrationMock->method('getFeatureSettings')->willReturn($featureSettings);
 
         $syncInterfaceMock->method('getIntegrationConfiguration')->willReturn($integrationMock);
+
+        $mappingManualDAOMock          = $this->createMock(MappingManualDAO::class);
+        $mappedIntegrationObjectsNames = ['this', 'that'];
+        $mappingManualDAOMock->method('getMappedIntegrationObjectsNames')->with($mauticObject)->willReturn($mappedIntegrationObjectsNames);
+        $syncInterfaceMock->method('getMappingManual')->willReturn($mappingManualDAOMock);
 
         $objectProviderMock = $this->createMock(ObjectProvider::class);
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/SyncIntegrationsHelperTest.php
@@ -17,13 +17,14 @@ class SyncIntegrationsHelperTest extends TestCase
     {
         $mauticObject           = 'some_integration';
         $integrationsHelperMock = $this->createMock(IntegrationsHelper::class);
-        $objectProviderMock     = $this->createMock(ObjectProvider::class);
-        $syncIntegrationsHelper = new SyncIntegrationsHelper($integrationsHelperMock, $objectProviderMock);
-        $syncInterfaceMock      = $this->createMock(SyncInterface::class);
+
+        $syncInterfaceMock = $this->createMock(SyncInterface::class);
         $syncInterfaceMock->method('getName')->willReturn($mauticObject);
-        $syncIntegrationsHelper->addIntegration($syncInterfaceMock);
 
         $integrationMock = $this->createMock(Integration::class);
+        $integrationsHelperMock->method('getIntegrationConfiguration')
+            ->with($syncInterfaceMock)
+            ->willReturn($integrationMock);
         $integrationMock->method('getIsPublished')->willReturn(true);
         $supportedFeatures = [
             'integration' => [
@@ -36,9 +37,9 @@ class SyncIntegrationsHelperTest extends TestCase
                 ],
                 'syncStrategiesPush' => [
                     'lead' => [
-                            'operator' => null,
-                            'field'    => null,
-                        ],
+                        'operator' => null,
+                        'field'    => null,
+                    ],
                 ],
                 'activitySync'       => null,
                 'activityEvents'     => [
@@ -72,10 +73,13 @@ class SyncIntegrationsHelperTest extends TestCase
             ],
         ];
         $integrationMock->method('getSupportedFeatures')->willReturn($supportedFeatures);
-        $integrationsHelperMock->method('getIntegrationConfiguration')
-            ->with($syncInterfaceMock)
-            ->willReturn($integrationMock);
 
+        $syncInterfaceMock->method('getIntegrationConfiguration')->willReturn($integrationMock);
+
+        $objectProviderMock = $this->createMock(ObjectProvider::class);
+
+        $syncIntegrationsHelper = new SyncIntegrationsHelper($integrationsHelperMock, $objectProviderMock);
+        $syncIntegrationsHelper->addIntegration($syncInterfaceMock);
         $syncIntegrationsHelper->hasObjectSyncEnabled($mauticObject);
     }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -88,9 +88,6 @@ class ContactSegmentFilterFactory
         return $this->container->get($qbServiceId);
     }
 
-    /**
-     * @param $filters
-     */
     private function mergeFilters(array $filters): array
     {
         $shrinkedFilters = [];
@@ -137,9 +134,6 @@ class ContactSegmentFilterFactory
         return array_values($shrinkedFilters);
     }
 
-    /**
-     * @param $filters
-     */
     private function groupFilters(array $stack): array
     {
         if (empty($stack)) {

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -109,7 +109,7 @@ class ContactSegmentFilterFactory
                 $filter['operator'],
             ]);
 
-            if ('or' === strtolower($filter['glue'])) {
+            if ('or' === strtolower($filter['glue']) && '=' === $filter['operator']) {
                 if (!isset($arrStacks[$key])) {
                     $arrStacks[$key] = [];
                 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -101,11 +101,6 @@ class ContactSegmentFilterFactory
         $previousKey = ''; // preserve the key from previous iteration
         // replace filters with glue OR and operator = , with IN operator
         foreach ($filters as $filter) {
-            // treat the first filter glue as 'or'
-            if (empty($previousKey)) {
-                $filter['glue'] = 'or';
-            }
-
             // easy to compare
             $key = implode('_', [
                 $filter['object'],

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -90,10 +90,8 @@ class ContactSegmentFilterFactory
 
     /**
      * @param $filters
-     *
-     * @return array
      */
-    private function mergeFilters($filters)
+    private function mergeFilters(array $filters): array
     {
         $shrinkedFilters = [];
         $arrStacks       = []; // Put the same filters from array into Stacks
@@ -139,7 +137,10 @@ class ContactSegmentFilterFactory
         return array_values($shrinkedFilters);
     }
 
-    private function groupFilters($stack)
+    /**
+     * @param $filters
+     */
+    private function groupFilters(array $stack): array
     {
         if (empty($stack)) {
             return [];

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -101,6 +101,11 @@ class ContactSegmentFilterFactory
         $previousKey = ''; // preserve the key from previous iteration
         // replace filters with glue OR and operator = , with IN operator
         foreach ($filters as $filter) {
+            // treat the first filter glue as 'or'
+            if (empty($previousKey)) {
+                $filter['glue'] = 'or';
+            }
+
             // easy to compare
             $key = implode('_', [
                 $filter['object'],

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterCommandFunctionalTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Command;
+
+use Exception;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Command\SegmentCountCacheCommand;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SegmentFilterCommandFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testSegmentFilterOnUpdateCommand(): void
+    {
+        $application = new Application(self::$kernel);
+        $application->setAutoExit(false);
+        $applicationTester = new ApplicationTester($application);
+
+        $contacts  = $this->saveContacts();
+        $segment   = $this->saveSegment();
+        $segmentId = $segment->getId();
+
+        // Run segments update command.
+        $exitCode = $applicationTester->run(['command' => 'mautic:segments:update', '-i' => $segmentId]);
+        self::assertSame(0, $exitCode, $applicationTester->getDisplay());
+
+        self::assertSame(5, $this->em->getRepository(LeadList::class)->find(['leadlist_id' => $segmentId]));
+    }
+
+    private function saveContacts(): array
+    {
+        // Add 10 contacts
+        /** @var LeadRepository $contactRepo */
+        $contactRepo = $this->em->getRepository(Lead::class);
+        $contacts    = [];
+
+        for ($i = 'a'; $i <= 10; ++$i) {
+            $contact = new Lead();
+            $contact->setFirstname('fn'.$i);
+            $contact->setLastname('ln'.$i);
+            $contacts[] = $contact;
+        }
+
+        $contactRepo->saveEntities($contacts);
+
+        return $contacts;
+    }
+
+    private function saveSegment(): LeadList
+    {
+        // Add 1 segment
+        /** @var LeadListRepository $contactRepo */
+        $segmentRepo = $this->em->getRepository(LeadList::class);
+        $segment     = new LeadList();
+        $filters     = [
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn1'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln1'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn2'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn3'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln3'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'firstname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'fn4'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'lastname',
+                'type'       => 'text',
+                'operator'   => '=',
+                'properties' => ['filter' => 'ln5'],
+            ],
+        ];
+
+        $segment->setName('Segment A')
+            ->setFilters($filters)
+            ->setAlias('segment-a');
+        $segmentRepo->saveEntity($segment);
+
+        return $segment;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterCommandFunctionalTest.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,7 +36,7 @@ class SegmentFilterCommandFunctionalTest extends MauticMysqlTestCase
         $exitCode = $applicationTester->run(['command' => 'mautic:segments:update', '-i' => $segmentId]);
         self::assertSame(0, $exitCode, $applicationTester->getDisplay());
 
-        self::assertSame(5, $this->em->getRepository(LeadList::class)->find(['leadlist_id' => $segmentId]));
+        self::assertCount(5, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentId]));
     }
 
     private function saveContacts(): array
@@ -45,7 +46,7 @@ class SegmentFilterCommandFunctionalTest extends MauticMysqlTestCase
         $contactRepo = $this->em->getRepository(Lead::class);
         $contacts    = [];
 
-        for ($i = 'a'; $i <= 10; ++$i) {
+        for ($i = 0; $i <= 10; ++$i) {
             $contact = new Lead();
             $contact->setFirstname('fn'.$i);
             $contact->setLastname('ln'.$i);

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -177,12 +177,12 @@ class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
                 'properties' => ['filter' => 'ln3'],
             ],
             [
-                    'glue'       => 'and',
-                    'field'      => 'leadlist',
-                    'object'     => 'lead',
-                    'type'       => 'leadlist',
-                    'operator'   => 'in',
-                    'properties' => ['filter' => [$segmentAId]],
+                'glue'       => 'and',
+                'field'      => 'leadlist',
+                'object'     => 'lead',
+                'type'       => 'leadlist',
+                'operator'   => 'in',
+                'properties' => ['filter' => [$segmentAId]],
             ],
         ];
 

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SegmentFilterCommandFunctionalTest extends MauticMysqlTestCase
+class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
 {
     /**
      * @throws Exception


### PR DESCRIPTION
<!-- ## 4.x

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ yes]
| New feature/enhancement? (use the a.x branch)      | [4.x ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ yes ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This solution is only effective for new enabled plugins, or you have edit and save the plugin settings.

There are plugins that only pull from the service through the integration sync framework but doesn't push. This has exposed a missed design flaw that assumes all integrations will sync both ways.

The result is that the integration framework tracks a field change per field per contact for these integrations that never gets purged causing the mautic_sync_object_field_change_report table to fill up with useless data that could impact performance of other integrations that sync both ways.

#### Steps to reproduce
Enable a integration plugin and save mapped fields with only mautic (one way(import)) sync.
Try to change the synced contact/company
you will see an entry in DB table 'mautic_sync_object_field_change_report', Ideally this entry would be cleared once it syncs back to integration. Since it is only mautic sync, the entry is being ignored.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Load up [this PR]
3. Enable plugin (Salesforce)
4. Add mapping fields with only mautic integration
5. Once the contacts/company details are synced.
6. Try to edit the contact/company
7. There shouldn't be any entry to 'mautic_sync_object_field_change_report'

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
