### PR TITLE
migration script for dnc filters update

### DIFF
--- a/app/migrations/Version20211209101447.php
+++ b/app/migrations/Version20211209101447.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20211209101447 extends AbstractMauticMigration
+{
+    public function up(Schema $schema): void
+    {
+        $tableName      = $this->prefix.'lead_lists';
+        $sql            = sprintf(
+            "select id, filters from %s where filters like '%s' or filters like '%s'",
+            $tableName,
+            '%dnc_unsubscribed_manually%',
+            '%dnc_unsubscribed_sms_manually%'
+        );
+        $results        = $this->connection->executeQuery($sql)->fetchAll();
+        $updatedRecords = 0;
+        foreach ($results as $row) {
+            $filters = unserialize($row['filters']);
+
+            $serializedFilters = serialize(array_map(function ($filter) {
+                if ('dnc_unsubscribed_manually' === $filter['field']) {
+                    $filter['field'] = 'dnc_manual_email';
+                } elseif ('dnc_unsubscribed_sms_manually' === $filter['field']) {
+                    $filter['field'] = 'dnc_manual_sms';
+                }
+
+                return $filter;
+            }, $filters));
+
+            $sql  = sprintf('UPDATE %s SET filters = :filters where id = :id', $tableName);
+            $stmt = $this->connection->prepare($sql);
+            $stmt->bindParam('filters', $serializedFilters, \PDO::PARAM_STR);
+            $stmt->bindParam('id', $row['id'], \PDO::PARAM_INT);
+            $stmt->execute();
+
+            $updatedRecords += $stmt->rowCount();
+        }
+        $this->write(sprintf('<comment>%s record(s) have been updated successfully.</comment>', $updatedRecords));
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ no]
| New feature/enhancement? (use the a.x branch)      | [yes ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Migration that pulls a segments with dnc_unsubscribed_manually or dnc_unsubscribed_sms_manually in the filters
Unserialize the filters and replace the dnc_unsubscribed_manually key with dnc_manual_email and dnc_unsubscribed_sms_manually with dnc_manual_sms
Serialize and save (without using the entity manager)



#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Connect to DB and query mautic_lead_lists table which has filter like '% dnc_unsubscribed_manually%' or filter like '% dnc_unsubscribed_sms_manually%'
3. After loading this PR, migration script will be run
4. Check the selected rows, filter column should have now updated strings.

#### Other areas of Mautic that may be affected by the change:
Segment filters "MAnually marked on do not contact Email/SMS'
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
