### PR TITLE
Move release notes to separate file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - chore
+    authors:
+      - github-actions
+  categories:
+    - title: 🛠 Breaking Changes 
+      labels:
+        - bc-break
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: ✨ Features and enhancements
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Bugs
+      labels:
+        - bug
+        - regression

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,25 +258,3 @@ jobs:
         "${{ env.MAUTIC_VERSION }}" \
         4 \
         "${{ github.workspace }}/${{ env.MAUTIC_VERSION }}.zip"
-
-  changelog:
-    exclude:
-      labels:
-        - chore
-      authors:
-        - github-actions
-    categories:
-      - title: 🛠 Breaking Changes 
-        labels:
-          - bc-break
-      - title: 🔒 Security
-        labels:
-          - security
-      - title: ✨ Features and enhancements
-        labels:
-          - feature
-          - enhancement
-      - title: 🐛 Bugs
-        labels:
-          - bug
-          - regression


### PR DESCRIPTION
GitHub Support advised that GitHub release notes need to be in a **separate** file in the root of .github rather than appended to the .github/workflows/release.yml which we are already using.

This PR removes the changelog from the main release workflow and adds a release.yml file in the root of the .github directory for the sole purpose of generating release notes.

I appreciate this may cause some confusion having two files in different locations called release.yml but it seems to be the only way.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11014"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

