### PR TITLE
TPROD-280 - The scale option was removed from the IntegerType

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -203,7 +203,7 @@ ul.tag-cloud li {
 }
 
 .frequency{
-    width: 45px!important;
+    width: 65px!important;
 }
 
 .contact{
@@ -222,7 +222,7 @@ ul.tag-cloud li {
 }
 
 .frequency-select {
-    width:145px !important;
+    width:125px !important;
     float: right;
     padding-right: 5px;
 }

--- a/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
@@ -77,7 +77,6 @@ class ContactChannelsType extends AbstractType
                     'frequency_number_'.$channel,
                     IntegerType::class,
                     [
-                        'scale'      => 0,
                         'label'      => 'mautic.lead.list.frequency.number',
                         'label_attr' => ['class' => 'text-muted fw-n label1'],
                         'attr'       => array_merge(


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://mautic.atlassian.net/browse/TPROD-280 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

The scale option was removed from the IntegerType. See https://mautic.atlassian.net/browse/TPROD-280
The input box was widened so the digits filled in are better visible.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to any contact detail page.
3. Click the arrow button in the top left corner and select preferences.
4. Make sure there are no issues with the frequency input box.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11034"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

