### PR TITLE
Improve docs on builder events

### DIFF
--- a/app/bundles/CoreBundle/Event/BuilderEvent.php
+++ b/app/bundles/CoreBundle/Event/BuilderEvent.php
@@ -143,20 +143,19 @@ class BuilderEvent extends Event
     /**
      * Adds an A/B test winner criteria option.
      *
-     * @param string $key      - a unique identifier; it is recommended that it be namespaced i.e. lead.points
-     * @param array  $criteria - can contain the following keys:
-     *                         'group'           => (required) translation string to group criteria by in the dropdown select list
-     *                         'label'           => (required) what to display in the list
-     *                         'formType'        => (optional) name of the form type SERVICE for the criteria
-     *                         'formTypeOptions' => (optional) array of options to pass to the formType service
-     *                         'callback'        => (required) callback function that will be passed the parent page or email for winner determination
-     *                         The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
-     *                         array $properties - values saved from the formType as defined here; keyed by page or email id in the case of
-     *                         multiple variants
-     *                         Mautic\CoreBundle\Factory\MauticFactory $factory
-     *                         Mautic\PageBundle\Entity\Page $page | Mautic\EmailBundle\Entity\Email $email (depending on the context)
-     *                         Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email $parent
-     *                         Doctrine\Common\Collections\ArrayCollection $children
+     * @param string $key - a unique identifier; it is recommended that it be namespaced i.e. lead.points
+     * @param array{
+     *   group: string,
+     *   label: string,
+     *   event: string,
+     *   formType?: string,
+     *   formTypeOptions?: string
+     * } $criteria Can contain the following keys:
+     *  - group - (required) translation string to group criteria by in the dropdown select list
+     *  - label - (required) what to display in the list
+     *  - event - (required) event class constant that will receieve the DetermineWinnerEvent for further handling. E.g. `HelloWorldEvents::ON_DETERMINE_PLANET_VISIT_WINNER`
+     *  - formType - (optional) name of the form type SERVICE for the criteria
+     *  - formTypeOptions - (optional) array of options to pass to the formType service
      */
     public function addAbTestWinnerCriteria($key, array $criteria)
     {

--- a/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
+++ b/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
@@ -8,10 +8,10 @@ class DetermineWinnerEvent extends Event
 {
     /**
      * @var array{
-     *             parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
-     *             children?: Doctrine\Common\Collections\ArrayCollection,
-     *             page?: Mautic\PageBundle\Entity\Page,
-     *             email?: Mautic\EmailBundle\Entity\Email
+     *             parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
+     *             children?: \Doctrine\Common\Collections\ArrayCollection,
+     *             page?: \Mautic\PageBundle\Entity\Page,
+     *             email?: \Mautic\EmailBundle\Entity\Email
      *             }
      */
     private $parameters;
@@ -27,10 +27,10 @@ class DetermineWinnerEvent extends Event
 
     /**
      * @param array{
-     *   parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
-     *   children?: Doctrine\Common\Collections\ArrayCollection,
-     *   page?: Mautic\PageBundle\Entity\Page,
-     *   email?: Mautic\EmailBundle\Entity\Email
+     *   parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
+     *   children?: \Doctrine\Common\Collections\ArrayCollection,
+     *   page?: \Mautic\PageBundle\Entity\Page,
+     *   email?: \Mautic\EmailBundle\Entity\Email
      * } $parameters
      */
     public function __construct(array $parameters)
@@ -40,10 +40,10 @@ class DetermineWinnerEvent extends Event
 
     /**
      * @return array{
-     *                parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
-     *                children?: Doctrine\Common\Collections\ArrayCollection,
-     *                page?: Mautic\PageBundle\Entity\Page,
-     *                email?: Mautic\EmailBundle\Entity\Email
+     *                parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
+     *                children?: \Doctrine\Common\Collections\ArrayCollection,
+     *                page?: \Mautic\PageBundle\Entity\Page,
+     *                email?: \Mautic\EmailBundle\Entity\Email
      *                }
      */
     public function getParameters()

--- a/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
+++ b/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
@@ -9,7 +9,7 @@ class DetermineWinnerEvent extends Event
     /**
      * @var array{
      *             parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
-     *             children?: \Doctrine\Common\Collections\ArrayCollection,
+     *             children?: array<mixed>,
      *             page?: \Mautic\PageBundle\Entity\Page,
      *             email?: \Mautic\EmailBundle\Entity\Email
      *             }
@@ -28,7 +28,7 @@ class DetermineWinnerEvent extends Event
     /**
      * @param array{
      *   parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
-     *   children?: \Doctrine\Common\Collections\ArrayCollection,
+     *   children?: array<mixed>,
      *   page?: \Mautic\PageBundle\Entity\Page,
      *   email?: \Mautic\EmailBundle\Entity\Email
      * } $parameters
@@ -41,7 +41,7 @@ class DetermineWinnerEvent extends Event
     /**
      * @return array{
      *                parent?: \Mautic\PageBundle\Entity\Page|\Mautic\EmailBundle\Entity\Email,
-     *                children?: \Doctrine\Common\Collections\ArrayCollection,
+     *                children?: array<mixed>,
      *                page?: \Mautic\PageBundle\Entity\Page,
      *                email?: \Mautic\EmailBundle\Entity\Email
      *                }

--- a/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
+++ b/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
@@ -7,22 +7,44 @@ use Symfony\Component\EventDispatcher\Event;
 class DetermineWinnerEvent extends Event
 {
     /**
-     * @var array
+     * @var array{
+     *             parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
+     *             children?: Doctrine\Common\Collections\ArrayCollection,
+     *             page?: Mautic\PageBundle\Entity\Page,
+     *             email?: Mautic\EmailBundle\Entity\Email
+     *             }
      */
     private $parameters;
 
     /**
-     * @var array
+     * @var array{
+     *             winners: array,
+     *             support?: mixed,
+     *             supportTemplate?: string
+     *             }
      */
     private $abTestResults;
 
+    /**
+     * @param array{
+     *   parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
+     *   children?: Doctrine\Common\Collections\ArrayCollection,
+     *   page?: Mautic\PageBundle\Entity\Page,
+     *   email?: Mautic\EmailBundle\Entity\Email
+     * } $parameters
+     */
     public function __construct(array $parameters)
     {
         $this->parameters = $parameters;
     }
 
     /**
-     * @return array
+     * @return array{
+     *                parent?: Mautic\PageBundle\Entity\Page|Mautic\EmailBundle\Entity\Email,
+     *                children?: Doctrine\Common\Collections\ArrayCollection,
+     *                page?: Mautic\PageBundle\Entity\Page,
+     *                email?: Mautic\EmailBundle\Entity\Email
+     *                }
      */
     public function getParameters()
     {
@@ -30,14 +52,28 @@ class DetermineWinnerEvent extends Event
     }
 
     /**
-     * @return array
+     * @return array{
+     *                winners:array,
+     *                support?:mixed,
+     *                supportTemplate?:string
+     *                }
      */
     public function getAbTestResults()
     {
         return $this->abTestResults;
     }
 
-    public function setAbTestResults(array $abTestResults)
+    /**
+     * @param array{
+     *   winners:array,
+     *   support?:mixed,
+     *   supportTemplate?:string
+     * } $abTestResults The following parameters are available:
+     * - (required) winners - Array of IDs of the winners (empty array in case of a tie)
+     * - (optional) support - Data passed to the view defined by supportTemplate below in order to render visual support for the winners (such as a graph, etc)
+     * - (optional) supportTemplate - View notation to render content for the A/B stats modal. For example, `HelloWorldBundle:SubscribedEvents\AbTest:graph.html.php`
+     */
+    public function setAbTestResults(array $abTestResults): void
     {
         $this->abTestResults = $abTestResults;
     }


### PR DESCRIPTION
Part of https://github.com/mautic/developer-documentation-new/pull/26. This PR only adds and fixes some in-code documentation. It leverages PHPSTAN's [Array shapes](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes) to run static code analysis as well. We should probably switch to proper objects in the future, but this should be a good enough improvement for now, without introducing any BC breaks.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11047"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

