### PR TITLE
use a more strict constraint for doctrine-bundle

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -60,7 +60,7 @@
     "symfony/polyfill-php74": "^1.13",
     "symfony/css-selector": "~4.4.0",
     "symfony/http-client": "~4.4.0",
-    "doctrine/doctrine-bundle": "^2.1.1",
+    "doctrine/doctrine-bundle": ">= 2.1.1 < 2.6",
     "doctrine/doctrine-fixtures-bundle": "^3.3.2",
     "doctrine/doctrine-migrations-bundle": "~2.1",
     "doctrine/annotations": "^1.10.3",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes mautic/recommended-project#15 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There was a [recent change](https://github.com/doctrine/DoctrineBundle/pull/1452) in doctrine/DoctrineBundle that is releases since doctrine/DoctrineBundle [2.6.0](https://github.com/doctrine/DoctrineBundle/releases/tag/2.6.0)

That release is used for composer based installs, as [the constraint](https://github.com/mautic/mautic/blob/05020707c20414980ac849fb073201f42a8a7254/app/composer.json#L63) allows to use this version.

Version >= 2.6.0 results in errors on the CLI and in web requests, as [the implementation](https://github.com/mautic/mautic/blob/05020707c20414980ac849fb073201f42a8a7254/app/bundles/CoreBundle/DependencyInjection/Compiler/DbalPass.php#L27) (based on [this comment](https://github.com/doctrine/DoctrineBundle/issues/114#issuecomment-638882114)) is not compatible anymore.

This results in following error:

```
Argument 1 passed to Doctrine\DBAL\Configuration::setResultCacheImpl() must implement interface Doctrine\Common\Cache\Cache, instance of Symfony\Component\Cache\Adapter\ArrayAdapter given, called in /var/www/html/mautic/var/cache/pro_/ContainerHhAx6pL/appAppKernelProdContainer.php on line 2319  
```    

##### Possible solutions

**stricter contraint**

ensure the package is currently locked to < 2.6.0 to prevent this issue

This is implemented in this PR


**make the code compatible**

I would wait for this, as other issues bumped up too since that release:

* https://github.com/doctrine/DoctrineBundle/issues/1501
* https://github.com/doctrine/DoctrineBundle/issues/1485


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

* run `composer create-project mautic/recommended-project:^4 test-mautic --no-interaction`
* 

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11053"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

