### PR TITLE
TPROD-282 - Controller reference syntax updated to Symfony 5

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -11,17 +11,17 @@ return [
             ],
             'fos_oauth_server_authorize' => [
                 'path'       => '/oauth/v2/authorize',
-                'controller' => 'MauticApiBundle:oAuth2/Authorize:authorize',
+                'controller' => 'Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::authorizeAction',
                 'method'     => 'GET|POST',
             ],
             'mautic_oauth2_server_auth_login' => [
                 'path'       => '/oauth/v2/authorize_login',
-                'controller' => 'MauticApiBundle:oAuth2/Security:login',
+                'controller' => 'Mautic\ApiBundle\Controller\oAuth2\SecurityController::loginAction',
                 'method'     => 'GET|POST',
             ],
             'mautic_oauth2_server_auth_login_check' => [
                 'path'       => '/oauth/v2/authorize_login_check',
-                'controller' => 'MauticApiBundle:oAuth2/Security:loginCheck',
+                'controller' => 'Mautic\ApiBundle\Controller\oAuth2\SecurityController::loginCheckAction',
                 'method'     => 'GET|POST',
             ],
         ],
@@ -29,11 +29,11 @@ return [
             // Clients
             'mautic_client_index' => [
                 'path'       => '/credentials/{page}',
-                'controller' => 'MauticApiBundle:Client:index',
+                'controller' => 'Mautic\ApiBundle\Controller\ClientController::indexAction',
             ],
             'mautic_client_action' => [
                 'path'       => '/credentials/{objectAction}/{objectId}',
-                'controller' => 'MauticApiBundle:Client:execute',
+                'controller' => 'Mautic\ApiBundle\Controller\ClientController::executeAction',
             ],
         ],
     ],

--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -57,7 +57,7 @@ class ClientController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticApiBundle:Client:index',
+                    'contentTemplate' => 'Mautic\ApiBundle\Controller\ClientController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_client_index',
                         'mauticContent' => 'client',
@@ -154,7 +154,7 @@ class ClientController extends FormController
         return $this->postActionRedirect(
             [
                 'returnUrl'       => $this->generateUrl('mautic_user_account'),
-                'contentTemplate' => 'MauticUserBundle:Profile:index',
+                'contentTemplate' => 'Mautic\UserBundle\Controller\ProfileController::indexAction',
                 'passthroughVars' => [
                     'success' => $success,
                 ],
@@ -232,7 +232,7 @@ class ClientController extends FormController
                 return $this->postActionRedirect(
                     [
                         'returnUrl'       => $returnUrl,
-                        'contentTemplate' => 'MauticApiBundle:Client:index',
+                        'contentTemplate' => 'Mautic\ApiBundle\Controller\ClientController::indexAction',
                         'passthroughVars' => [
                             'activeLink'    => '#mautic_client_index',
                             'mauticContent' => 'client',
@@ -281,7 +281,7 @@ class ClientController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticApiBundle:Client:index',
+            'contentTemplate' => 'Mautic\ApiBundle\Controller\ClientController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_client_index',
                 'mauticContent' => 'client',
@@ -386,7 +386,7 @@ class ClientController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticApiBundle:Client:index',
+            'contentTemplate' => 'Mautic\ApiBundle\Controller\ClientController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_client_index',
                 'success'       => $success,

--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -5,15 +5,15 @@ return [
         'main' => [
             'mautic_asset_index' => [
                 'path'       => '/assets/{page}',
-                'controller' => 'MauticAssetBundle:Asset:index',
+                'controller' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
             ],
             'mautic_asset_remote' => [
                 'path'       => '/assets/remote',
-                'controller' => 'MauticAssetBundle:Asset:remote',
+                'controller' => 'Mautic\AssetBundle\Controller\AssetController::remoteAction',
             ],
             'mautic_asset_action' => [
                 'path'       => '/assets/{objectAction}/{objectId}',
-                'controller' => 'MauticAssetBundle:Asset:execute',
+                'controller' => 'Mautic\AssetBundle\Controller\AssetController::executeAction',
             ],
         ],
         'api' => [
@@ -21,13 +21,13 @@ return [
                 'standard_entity' => true,
                 'name'            => 'assets',
                 'path'            => '/assets',
-                'controller'      => 'MauticAssetBundle:Api\AssetApi',
+                'controller'      => 'Mautic\AssetBundle\Controller\Api\AssetApiController',
             ],
         ],
         'public' => [
             'mautic_asset_download' => [
                 'path'       => '/asset/{slug}',
-                'controller' => 'MauticAssetBundle:Public:download',
+                'controller' => 'Mautic\AssetBundle\Controller\PublicController::downloadAction',
                 'defaults'   => [
                     'slug' => '',
                 ],

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -82,7 +82,7 @@ class AssetController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['asset' => $lastPage],
-                'contentTemplate' => 'MauticAssetBundle:Asset:index',
+                'contentTemplate' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_asset_index',
                     'mauticContent' => 'asset',
@@ -149,7 +149,7 @@ class AssetController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticAssetBundle:Asset:index',
+                'contentTemplate' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_asset_index',
                     'mauticContent' => 'asset',
@@ -348,12 +348,12 @@ class AssetController extends FormController
                         'objectId'     => $entity->getId(),
                     ];
                     $returnUrl = $this->generateUrl('mautic_asset_action', $viewParameters);
-                    $template  = 'MauticAssetBundle:Asset:view';
+                    $template  = 'Mautic\AssetBundle\Controller\AssetController::viewAction';
                 }
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_asset_index', $viewParameters);
-                $template       = 'MauticAssetBundle:Asset:index';
+                $template       = 'Mautic\AssetBundle\Controller\AssetController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -440,7 +440,7 @@ class AssetController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticAssetBundle:Asset:index',
+            'contentTemplate' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_asset_index',
                 'mauticContent' => 'asset',
@@ -508,7 +508,7 @@ class AssetController extends FormController
                         'objectId'     => $entity->getId(),
                     ]);
                     $viewParams = ['objectId' => $entity->getId()];
-                    $template   = 'MauticAssetBundle:Asset:view';
+                    $template   = 'Mautic\AssetBundle\Controller\AssetController::viewAction';
                 }
             } else {
                 //clear any modified content
@@ -518,7 +518,7 @@ class AssetController extends FormController
 
                 $returnUrl  = $this->generateUrl('mautic_asset_index', ['page' => $page]);
                 $viewParams = ['page' => $page];
-                $template   = 'MauticAssetBundle:Asset:index';
+                $template   = 'Mautic\AssetBundle\Controller\AssetController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -614,7 +614,7 @@ class AssetController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticAssetBundle:Asset:index',
+            'contentTemplate' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_asset_index',
                 'mauticContent' => 'asset',
@@ -677,7 +677,7 @@ class AssetController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticAssetBundle:Asset:index',
+            'contentTemplate' => 'Mautic\AssetBundle\Controller\AssetController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_asset_index',
                 'mauticContent' => 'asset',

--- a/app/bundles/CalendarBundle/Config/config.php
+++ b/app/bundles/CalendarBundle/Config/config.php
@@ -5,11 +5,11 @@ return [
         'main' => [
             'mautic_calendar_index' => [
                 'path'       => '/calendar',
-                'controller' => 'MauticCalendarBundle:Default:index',
+                'controller' => 'Mautic\CalendarBundle\Controller\DefaultController::indexAction',
             ],
             'mautic_calendar_action' => [
                 'path'       => '/calendar/{objectAction}',
-                'controller' => 'MauticCalendarBundle:Default:execute',
+                'controller' => 'Mautic\CalendarBundle\Controller\DefaultController::executeAction',
             ],
         ],
     ],

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -5,27 +5,27 @@ return [
         'main' => [
             'mautic_campaignevent_action'  => [
                 'path'       => '/campaigns/events/{objectAction}/{objectId}',
-                'controller' => 'MauticCampaignBundle:Event:execute',
+                'controller' => 'Mautic\CampaignBundle\Controller\EventController::executeAction',
             ],
             'mautic_campaignsource_action' => [
                 'path'       => '/campaigns/sources/{objectAction}/{objectId}',
-                'controller' => 'MauticCampaignBundle:Source:execute',
+                'controller' => 'Mautic\CampaignBundle\Controller\SourceController::executeAction',
             ],
             'mautic_campaign_index'        => [
                 'path'       => '/campaigns/{page}',
-                'controller' => 'MauticCampaignBundle:Campaign:index',
+                'controller' => 'Mautic\CampaignBundle\Controller\CampaignController::indexAction',
             ],
             'mautic_campaign_action'       => [
                 'path'       => '/campaigns/{objectAction}/{objectId}',
-                'controller' => 'MauticCampaignBundle:Campaign:execute',
+                'controller' => 'Mautic\CampaignBundle\Controller\CampaignController::executeAction',
             ],
             'mautic_campaign_contacts'     => [
                 'path'       => '/campaigns/view/{objectId}/contact/{page}',
-                'controller' => 'MauticCampaignBundle:Campaign:contacts',
+                'controller' => 'Mautic\CampaignBundle\Controller\CampaignController::contactsAction',
             ],
             'mautic_campaign_preview'      => [
                 'path'       => '/campaign/preview/{objectId}',
-                'controller' => 'MauticEmailBundle:Public:preview',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::previewAction',
             ],
         ],
         'api'  => [
@@ -33,7 +33,7 @@ return [
                 'standard_entity' => true,
                 'name'            => 'campaigns',
                 'path'            => '/campaigns',
-                'controller'      => 'MauticCampaignBundle:Api\CampaignApi',
+                'controller'      => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController',
             ],
             'mautic_api_campaigneventsstandard'       => [
                 'standard_entity'     => true,
@@ -43,45 +43,45 @@ return [
                 ],
                 'name'                => 'events',
                 'path'                => '/campaigns/events',
-                'controller'          => 'MauticCampaignBundle:Api\EventApi',
+                'controller'          => 'Mautic\CampaignBundle\Controller\Api\EventApiController',
             ],
             'mautic_api_campaigns_events_contact'     => [
                 'path'       => '/campaigns/events/contact/{contactId}',
-                'controller' => 'MauticCampaignBundle:Api\EventLogApi:getContactEvents',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::getContactEventsAction',
                 'method'     => 'GET',
             ],
             'mautic_api_campaigns_edit_contact_event' => [
                 'path'       => '/campaigns/events/{eventId}/contact/{contactId}/edit',
-                'controller' => 'MauticCampaignBundle:Api\EventLogApi:editContactEvent',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::editContactEventAction',
                 'method'     => 'PUT',
             ],
             'mautic_api_campaigns_batchedit_events'   => [
                 'path'       => '/campaigns/events/batch/edit',
-                'controller' => 'MauticCampaignBundle:Api\EventLogApi:editEvents',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::editEventsAction',
                 'method'     => 'PUT',
             ],
             'mautic_api_campaign_contact_events'      => [
                 'path'       => '/campaigns/{campaignId}/events/contact/{contactId}',
-                'controller' => 'MauticCampaignBundle:Api\EventLogApi:getContactEvents',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::getContactEventsAction',
                 'method'     => 'GET',
             ],
             'mautic_api_campaigngetcontacts'          => [
                 'path'       => '/campaigns/{id}/contacts',
-                'controller' => 'MauticCampaignBundle:Api\CampaignApi:getContacts',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::getContactsAction',
             ],
             'mautic_api_campaignaddcontact'           => [
                 'path'       => '/campaigns/{id}/contact/{leadId}/add',
-                'controller' => 'MauticCampaignBundle:Api\CampaignApi:addLead',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::addLeadAction',
                 'method'     => 'POST',
             ],
             'mautic_api_campaignremovecontact'        => [
                 'path'       => '/campaigns/{id}/contact/{leadId}/remove',
-                'controller' => 'MauticCampaignBundle:Api\CampaignApi:removeLead',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::removeLeadAction',
                 'method'     => 'POST',
             ],
             'mautic_api_contact_clone_campaign' => [
                 'path'       => '/campaigns/clone/{campaignId}',
-                'controller' => 'MauticCampaignBundle:Api\CampaignApi:cloneCampaign',
+                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::cloneCampaignAction',
                 'method'     => 'POST',
             ],
         ],

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -255,7 +255,7 @@ class CampaignApiController extends CommonApiController
         ];
 
         return $this->forward(
-            'MauticCoreBundle:Api\StatsApi:list',
+            'Mautic\CoreBundle\Controller\Api\StatsApiController::listAction',
             [
                 'table'     => 'campaign_leads',
                 'itemsName' => 'contacts',

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -688,10 +688,7 @@ class CampaignController extends AbstractStandardFormController
         return $sessionId;
     }
 
-    /**
-     * @return string
-     */
-    protected function getControllerBase()
+    protected function getTemplateBase(): string
     {
         return 'MauticCampaignBundle:Campaign';
     }

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -246,7 +246,7 @@ class CampaignController extends AbstractStandardFormController
                     [
                         'returnUrl'       => $returnUrl,
                         'viewParameters'  => ['page' => $lastPage],
-                        'contentTemplate' => 'MauticCampaignBundle:Campaign:index',
+                        'contentTemplate' => 'Mautic\CampaignBundle\Controller\CampaignController::indexAction',
                         'passthroughVars' => [
                             'mauticContent' => 'campaign',
                         ],
@@ -330,11 +330,11 @@ class CampaignController extends AbstractStandardFormController
                         if (method_exists($this, 'viewAction')) {
                             $viewParameters = ['objectId' => $campaign->getId(), 'objectAction' => 'view'];
                             $returnUrl      = $this->generateUrl('mautic_campaign_action', $viewParameters);
-                            $template       = 'MauticCampaignBundle:Campaign:view';
+                            $template       = 'Mautic\CampaignBundle\Controller\CampaignController::viewAction';
                         } else {
                             $viewParameters = ['page' => $page];
                             $returnUrl      = $this->generateUrl('mautic_campaign_index', $viewParameters);
-                            $template       = 'MauticCampaignBundle:Campaign:index';
+                            $template       = 'Mautic\CampaignBundle\Controller\CampaignController::indexAction';
                         }
                     }
                 }
@@ -343,7 +343,7 @@ class CampaignController extends AbstractStandardFormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('c', $viewParameters);
-                $template       = 'MauticCampaignBundle:Campaign:index';
+                $template       = 'Mautic\CampaignBundle\Controller\CampaignController::indexAction';
             }
 
             $passthrough = [

--- a/app/bundles/CategoryBundle/Config/config.php
+++ b/app/bundles/CategoryBundle/Config/config.php
@@ -5,22 +5,22 @@ return [
         'main' => [
             'mautic_category_batch_contact_set' => [
                 'path'       => '/categories/batch/contact/set',
-                'controller' => 'MauticCategoryBundle:BatchContact:exec',
+                'controller' => 'Mautic\CategoryBundle\Controller\BatchContactController::execAction',
             ],
             'mautic_category_batch_contact_view' => [
                 'path'       => '/categories/batch/contact/view',
-                'controller' => 'MauticCategoryBundle:BatchContact:index',
+                'controller' => 'Mautic\CategoryBundle\Controller\BatchContactController::indexAction',
             ],
             'mautic_category_index' => [
                 'path'       => '/categories/{bundle}/{page}',
-                'controller' => 'MauticCategoryBundle:Category:index',
+                'controller' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
                 'defaults'   => [
                     'bundle' => 'category',
                 ],
             ],
             'mautic_category_action' => [
                 'path'       => '/categories/{bundle}/{objectAction}/{objectId}',
-                'controller' => 'MauticCategoryBundle:Category:executeCategory',
+                'controller' => 'Mautic\CategoryBundle\Controller\CategoryController::executeCategoryAction',
                 'defaults'   => [
                     'bundle' => 'category',
                 ],
@@ -31,7 +31,7 @@ return [
                 'standard_entity' => true,
                 'name'            => 'categories',
                 'path'            => '/categories',
-                'controller'      => 'MauticCategoryBundle:Api\CategoryApi',
+                'controller'      => 'Mautic\CategoryBundle\Controller\Api\CategoryApiController',
             ],
         ],
     ],

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -123,7 +123,7 @@ class CategoryController extends AbstractFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticCategoryBundle:Category:index',
+                    'contentTemplate' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_'.$bundle.'category_index',
                         'mauticContent' => 'category',
@@ -237,7 +237,7 @@ class CategoryController extends AbstractFormController
             return $this->postActionRedirect([
                 'returnUrl'       => $this->generateUrl('mautic_category_index', $viewParameters),
                 'viewParameters'  => $viewParameters,
-                'contentTemplate' => 'MauticCategoryBundle:Category:index',
+                'contentTemplate' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_'.$bundle.'category_index',
                     'mauticContent' => 'category',
@@ -365,7 +365,7 @@ class CategoryController extends AbstractFormController
                 [
                     'returnUrl'       => $this->generateUrl('mautic_category_index', $viewParameters),
                     'viewParameters'  => $viewParameters,
-                    'contentTemplate' => 'MauticCategoryBundle:Category:index',
+                    'contentTemplate' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_'.$bundle.'category_index',
                         'mauticContent' => 'category',
@@ -413,7 +413,7 @@ class CategoryController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => $viewParams,
-            'contentTemplate' => 'MauticCategoryBundle:Category:index',
+            'contentTemplate' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_'.$bundle.'category_index',
                 'mauticContent' => 'category',
@@ -476,7 +476,7 @@ class CategoryController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => $viewParams,
-            'contentTemplate' => 'MauticCategoryBundle:Category:index',
+            'contentTemplate' => 'Mautic\CategoryBundle\Controller\CategoryController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_'.$bundle.'category_index',
                 'mauticContent' => 'category',

--- a/app/bundles/ChannelBundle/Config/config.php
+++ b/app/bundles/ChannelBundle/Config/config.php
@@ -5,23 +5,23 @@ return [
         'main' => [
             'mautic_message_index' => [
                 'path'       => '/messages/{page}',
-                'controller' => 'MauticChannelBundle:Message:index',
+                'controller' => 'Mautic\ChannelBundle\Controller\MessageController::indexAction',
             ],
             'mautic_message_contacts' => [
                 'path'       => '/messages/contacts/{objectId}/{channel}/{page}',
-                'controller' => 'MauticChannelBundle:Message:contacts',
+                'controller' => 'Mautic\ChannelBundle\Controller\MessageController::contactsAction',
             ],
             'mautic_message_action' => [
                 'path'       => '/messages/{objectAction}/{objectId}',
-                'controller' => 'MauticChannelBundle:Message:execute',
+                'controller' => 'Mautic\ChannelBundle\Controller\MessageController::executeAction',
             ],
             'mautic_channel_batch_contact_set' => [
                 'path'       => '/channels/batch/contact/set',
-                'controller' => 'MauticChannelBundle:BatchContact:set',
+                'controller' => 'Mautic\ChannelBundle\Controller\BatchContactController::setAction',
             ],
             'mautic_channel_batch_contact_view' => [
                 'path'       => '/channels/batch/contact/view',
-                'controller' => 'MauticChannelBundle:BatchContact:index',
+                'controller' => 'Mautic\ChannelBundle\Controller\BatchContactController::indexAction',
             ],
         ],
         'api' => [
@@ -29,7 +29,7 @@ return [
                 'standard_entity' => true,
                 'name'            => 'messages',
                 'path'            => '/messages',
-                'controller'      => 'MauticChannelBundle:Api\MessageApi',
+                'controller'      => 'Mautic\ChannelBundle\Controller\Api\MessageApiController',
             ],
         ],
         'public' => [

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -124,7 +124,7 @@ class MessageController extends AbstractStandardFormController
 
                 $messagedLeads = [
                     'all' => $this->forward(
-                        'MauticChannelBundle:Message:contacts',
+                        'Mautic\ChannelBundle\Controller\MessageController::contactsAction',
                         [
                             'objectId'   => $message->getId(),
                             'page'       => $this->get('session')->get('mautic.'.$this->getSessionBase('all').'.contact.page', 1),
@@ -142,7 +142,7 @@ class MessageController extends AbstractStandardFormController
                         );
 
                         $messagedLeads[$channel->getChannel()] = $this->forward(
-                            'MauticChannelBundle:Message:contacts',
+                            'Mautic\ChannelBundle\Controller\MessageController::contactsAction',
                             [
                                 'objectId' => $message->getId(),
                                 'page'     => $this->get('session')->get(

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -188,10 +188,7 @@ class MessageController extends AbstractStandardFormController
         return $this->deleteStandard($objectId);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getControllerBase()
+    protected function getTemplateBase(): string
     {
         return 'MauticChannelBundle:Message';
     }

--- a/app/bundles/ConfigBundle/Config/config.php
+++ b/app/bundles/ConfigBundle/Config/config.php
@@ -5,11 +5,11 @@ return [
         'main' => [
             'mautic_config_action' => [
                 'path'       => '/config/{objectAction}/{objectId}',
-                'controller' => 'MauticConfigBundle:Config:execute',
+                'controller' => 'Mautic\ConfigBundle\Controller\ConfigController::executeAction',
             ],
             'mautic_sysinfo_index' => [
                 'path'       => '/sysinfo',
-                'controller' => 'MauticConfigBundle:Sysinfo:index',
+                'controller' => 'Mautic\ConfigBundle\Controller\SysinfoController::indexAction',
             ],
         ],
     ],

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -783,7 +783,7 @@ return [
                 'class'     => 'Mautic\CoreBundle\EventListener\ExceptionListener',
                 'arguments' => [
                     'router',
-                    '"MauticCoreBundle:Exception:show"',
+                    'Mautic\CoreBundle\Controller\ExceptionController::showAction',
                     'monolog.logger.mautic',
                 ],
                 'tag'          => 'kernel.event_listener',

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -5,56 +5,56 @@ return [
         'main' => [
             'mautic_core_ajax' => [
                 'path'       => '/ajax',
-                'controller' => 'MauticCoreBundle:Ajax:delegateAjax',
+                'controller' => 'Mautic\CoreBundle\Controller\AjaxController::delegateAjaxAction',
             ],
             'mautic_core_update' => [
                 'path'       => '/update',
-                'controller' => 'MauticCoreBundle:Update:index',
+                'controller' => 'Mautic\CoreBundle\Controller\UpdateController::indexAction',
             ],
             'mautic_core_update_schema' => [
                 'path'       => '/update/schema',
-                'controller' => 'MauticCoreBundle:Update:schema',
+                'controller' => 'Mautic\CoreBundle\Controller\UpdateController::schemaAction',
             ],
             'mautic_core_form_action' => [
                 'path'       => '/action/{objectAction}/{objectModel}/{objectId}',
-                'controller' => 'MauticCoreBundle:Form:execute',
+                'controller' => 'Mautic\CoreBundle\Controller\FormController::executeAction',
                 'defaults'   => [
                     'objectModel' => '',
                 ],
             ],
             'mautic_core_file_action' => [
                 'path'       => '/file/{objectAction}/{objectId}',
-                'controller' => 'MauticCoreBundle:File:execute',
+                'controller' => 'Mautic\CoreBundle\Controller\FileController::executeAction',
             ],
             'mautic_themes_index' => [
                 'path'       => '/themes',
-                'controller' => 'MauticCoreBundle:Theme:index',
+                'controller' => 'Mautic\CoreBundle\Controller\ThemeController::indexAction',
             ],
             'mautic_themes_action' => [
                 'path'       => '/themes/{objectAction}/{objectId}',
-                'controller' => 'MauticCoreBundle:Theme:execute',
+                'controller' => 'Mautic\CoreBundle\Controller\ThemeController::executeAction',
             ],
         ],
         'public' => [
             'mautic_js' => [
                 'path'       => '/mtc.js',
-                'controller' => 'MauticCoreBundle:Js:index',
+                'controller' => 'Mautic\CoreBundle\Controller\JsController::indexAction',
             ],
             'mautic_base_index' => [
                 'path'       => '/',
-                'controller' => 'MauticCoreBundle:Default:index',
+                'controller' => 'Mautic\CoreBundle\Controller\DefaultController::indexAction',
             ],
             'mautic_secure_root' => [
                 'path'       => '/s',
-                'controller' => 'MauticCoreBundle:Default:redirectSecureRoot',
+                'controller' => 'Mautic\CoreBundle\Controller\DefaultController::redirectSecureRootAction',
             ],
             'mautic_secure_root_slash' => [
                 'path'       => '/s/',
-                'controller' => 'MauticCoreBundle:Default:redirectSecureRoot',
+                'controller' => 'Mautic\CoreBundle\Controller\DefaultController::redirectSecureRootAction',
             ],
             'mautic_remove_trailing_slash' => [
                 'path'         => '/{url}',
-                'controller'   => 'MauticCoreBundle:Common:removeTrailingSlash',
+                'controller'   => 'Mautic\CoreBundle\Controller\CommonController::removeTrailingSlashAction',
                 'method'       => 'GET',
                 'requirements' => [
                     'url' => '.*/$',
@@ -64,39 +64,39 @@ return [
         'api' => [
             'mautic_core_api_file_list' => [
                 'path'       => '/files/{dir}',
-                'controller' => 'MauticCoreBundle:Api\FileApi:list',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::listAction',
             ],
             'mautic_core_api_file_create' => [
                 'path'       => '/files/{dir}/new',
-                'controller' => 'MauticCoreBundle:Api\FileApi:create',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::createAction',
                 'method'     => 'POST',
             ],
             'mautic_core_api_file_delete' => [
                 'path'       => '/files/{dir}/{file}/delete',
-                'controller' => 'MauticCoreBundle:Api\FileApi:delete',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::deleteAction',
                 'method'     => 'DELETE',
             ],
             'mautic_core_api_theme_list' => [
                 'path'       => '/themes',
-                'controller' => 'MauticCoreBundle:Api\ThemeApi:list',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::listAction',
             ],
             'mautic_core_api_theme_get' => [
                 'path'       => '/themes/{theme}',
-                'controller' => 'MauticCoreBundle:Api\ThemeApi:get',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::getAction',
             ],
             'mautic_core_api_theme_create' => [
                 'path'       => '/themes/new',
-                'controller' => 'MauticCoreBundle:Api\ThemeApi:new',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::newAction',
                 'method'     => 'POST',
             ],
             'mautic_core_api_theme_delete' => [
                 'path'       => '/themes/{theme}/delete',
-                'controller' => 'MauticCoreBundle:Api\ThemeApi:delete',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::deleteAction',
                 'method'     => 'DELETE',
             ],
             'mautic_core_api_stats' => [
                 'path'       => '/stats/{table}',
-                'controller' => 'MauticCoreBundle:Api\StatsApi:list',
+                'controller' => 'Mautic\CoreBundle\Controller\Api\StatsApiController::listAction',
                 'defaults'   => [
                     'table' => '',
                 ],

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -82,7 +82,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => $this->getControllerBase().':'.$this->getPostActionControllerAction('batchDelete'),
+            'contentTemplate' => $this->getControllerBase().'::'.$this->getPostActionControllerAction('batchDelete').'Action',
             'passthroughVars' => [
                 'mauticContent' => $this->getJsLoadMethodPrefix(),
             ],
@@ -288,7 +288,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => $this->getControllerBase().':'.$this->getPostActionControllerAction('delete'),
+            'contentTemplate' => $this->getControllerBase().'::'.$this->getPostActionControllerAction('delete').'Action',
             'passthroughVars' => [
                 'mauticContent' => $this->getJsLoadMethodPrefix(),
             ],
@@ -357,7 +357,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $page           = $this->get('session')->get('mautic.'.$this->getSessionBase().'.page', 1);
         $viewParameters = ['page' => $page];
 
-        $template = $this->getControllerBase().':'.$this->getPostActionControllerAction('edit');
+        $template = $this->getControllerBase().'::'.$this->getPostActionControllerAction('edit').'Action';
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
@@ -436,7 +436,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                         if (!$this->isFormApplied($form) && method_exists($this, 'viewAction')) {
                             $viewParameters                    = ['objectId' => $objectId, 'objectAction' => 'view'];
                             $returnUrl                         = $this->generateUrl($this->getActionRoute(), $viewParameters);
-                            $postActionVars['contentTemplate'] = $this->getControllerBase().':view';
+                            $postActionVars['contentTemplate'] = $this->getControllerBase().'::viewAction';
                         }
                     }
 
@@ -525,7 +525,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
      */
     protected function getControllerBase()
     {
-        return 'MauticCoreBundle:Standard';
+        return static::class;
     }
 
     /**
@@ -718,9 +718,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
      */
     protected function getTemplateName($file)
     {
-        if ($this->get('templating')->exists($this->getControllerBase().':'.$file)) {
-            return $this->getControllerBase().':'.$file;
-        } elseif ($this->get('templating')->exists($this->getTemplateBase().':'.$file)) {
+        if ($this->get('templating')->exists($this->getTemplateBase().':'.$file)) {
             return $this->getTemplateBase().':'.$file;
         } else {
             return 'MauticCoreBundle:Standard:'.$file;
@@ -904,7 +902,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                     [
                         'returnUrl'       => $returnUrl,
                         'viewParameters'  => ['page' => $lastPage],
-                        'contentTemplate' => $this->getControllerBase().':'.$this->getPostActionControllerAction('index'),
+                        'contentTemplate' => $this->getControllerBase().'::'.$this->getPostActionControllerAction('index').'Action',
                         'passthroughVars' => [
                             'mauticContent' => $this->getJsLoadMethodPrefix(),
                         ],
@@ -990,11 +988,11 @@ abstract class AbstractStandardFormController extends AbstractFormController
                         if (method_exists($this, 'viewAction')) {
                             $viewParameters = ['objectId' => $entity->getId(), 'objectAction' => 'view'];
                             $returnUrl      = $this->generateUrl($this->getActionRoute(), $viewParameters);
-                            $template       = $this->getControllerBase().':view';
+                            $template       = $this->getControllerBase().'::viewAction';
                         } else {
                             $viewParameters = ['page' => $page];
                             $returnUrl      = $this->generateUrl($this->getIndexRoute(), $viewParameters);
-                            $template       = $this->getControllerBase().':'.$this->getPostActionControllerAction('new');
+                            $template       = $this->getControllerBase().'::'.$this->getPostActionControllerAction('new').'Action';
                         }
                     }
                 }
@@ -1003,7 +1001,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl($this->getIndexRoute(), $viewParameters);
-                $template       = $this->getControllerBase().':'.$this->getPostActionControllerAction('new');
+                $template       = $this->getControllerBase().'::'.$this->getPostActionControllerAction('new').'Action';
             }
 
             $passthrough = [
@@ -1105,7 +1103,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                     [
                         'returnUrl'       => $this->generateUrl($this->getIndexRoute(), ['page' => $page]),
                         'viewParameters'  => ['page' => $page],
-                        'contentTemplate' => $this->getControllerBase().':'.$this->getPostActionControllerAction('view'),
+                        'contentTemplate' => $this->getControllerBase().'::'.$this->getPostActionControllerAction('view').'Action',
                         'passthroughVars' => [
                             'mauticContent' => $this->getJsLoadMethodPrefix(),
                         ],

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -78,12 +78,10 @@ class AjaxController extends CommonController
                 //call the specified bundle's ajax action
                 $parts     = explode(':', $action);
                 $namespace = 'Mautic';
-                $isPlugin  = false;
 
                 if (3 == count($parts) && 'plugin' == $parts['0']) {
                     $namespace = 'MauticPlugin';
                     array_shift($parts);
-                    $isPlugin = true;
                 }
 
                 if (2 == count($parts)) {
@@ -95,13 +93,11 @@ class AjaxController extends CommonController
                         // Check if a plugin is prefixed with Mautic
                         $bundle      = 'Mautic'.$bundle;
                         $classExists = class_exists($namespace.'\\'.$bundle.'Bundle\\Controller\\AjaxController');
-                    } elseif (!$isPlugin && 'Marketplace' !== $bundle) {
-                        $bundle = 'Mautic'.$bundle;
                     }
 
                     if ($classExists) {
                         return $this->forward(
-                            "{$bundle}Bundle:Ajax:executeAjax",
+                            $namespace.'\\'.$bundle.'Bundle\\Controller\\AjaxController::executeAjaxAction',
                             [
                                 'action' => $action,
                                 //forward the request as well as Symfony creates a subrequest without GET/POST

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -428,7 +428,7 @@ class CommonController extends Controller implements MauticController
         $parameters = ['request' => $this->request, 'exception' => $exception];
         $query      = ['ignoreAjax' => true, 'request' => $this->request, 'subrequest' => true];
 
-        return $this->forward('MauticCoreBundle:Exception:show', $parameters, $query);
+        return $this->forward('Mautic\CoreBundle\Controller\ExceptionController::showAction', $parameters, $query);
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/DefaultController.php
+++ b/app/bundles/CoreBundle/Controller/DefaultController.php
@@ -35,7 +35,7 @@ class DefaultController extends CommonController
 
             $request->attributes->set('ignore_mismatch', true);
 
-            return $this->forward('MauticPageBundle:Public:index', ['slug' => $slug]);
+            return $this->forward('Mautic\PageBundle\Controller\PublicController::indexAction', ['slug' => $slug]);
         }
     }
 

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -121,14 +121,6 @@ class FormController extends AbstractStandardFormController
     /**
      * @return mixed
      */
-    protected function getControllerBase()
-    {
-        return $this->deprecatedTemplateBase;
-    }
-
-    /**
-     * @return mixed
-     */
     protected function getTranslationBase()
     {
         return $this->deprecatedTranslationBase;

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -279,7 +279,7 @@ class ThemeController extends FormController
     {
         return [
             'returnUrl'       => $this->generateUrl('mautic_themes_index'),
-            'contentTemplate' => 'MauticCoreBundle:theme:index',
+            'contentTemplate' => 'Mautic\CoreBundle\Controller\themeController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_themes_index',
                 'mauticContent' => 'theme',

--- a/app/bundles/CoreBundle/Controller/UpdateController.php
+++ b/app/bundles/CoreBundle/Controller/UpdateController.php
@@ -92,7 +92,7 @@ class UpdateController extends CommonController
             $failed = true;
         } elseif ($this->request->get('update', 0)) {
             // This was a retry from the update so call up the finalizeAction to finish the process
-            $this->forward('MauticCoreBundle:Ajax:updateFinalization',
+            $this->forward('Mautic\CoreBundle\Controller\AjaxController::updateFinalizationAction',
                 [
                     'request' => $this->request,
                 ]

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -347,7 +347,7 @@ class CoreSubscriber implements EventSubscriberInterface
                                 $standardDetails,
                                 [
                                     'path'       => $pathBase.$standardDetails['path'],
-                                    'controller' => $controller.':'.$standardDetails['action'],
+                                    'controller' => $controller.':'.$standardDetails['action'].'Action',
                                     'method'     => $standardDetails['method'],
                                 ]
                             );

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/resource/GoodConfig/Config/config.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/resource/GoodConfig/Config/config.php
@@ -5,7 +5,7 @@ return [
         'main' => [
             'mautic_core_ajax' => [
                 'path'       => '/ajax',
-                'controller' => 'MauticCoreBundle:Ajax:delegateAjax',
+                'controller' => 'Mautic\CoreBundle\Controller\AjaxController::delegateAjaxAction',
             ],
         ],
     ],

--- a/app/bundles/CoreBundle/Views/Default/navbar.html.php
+++ b/app/bundles/CoreBundle/Views/Default/navbar.html.php
@@ -27,8 +27,8 @@
                 <i class="fa fa-navicon fs-16"></i>
             </a>
         </li>
-        <?php echo $view['actions']->render(new \Symfony\Component\HttpKernel\Controller\ControllerReference('MauticCoreBundle:Default:notifications')); ?>
-        <?php echo $view['actions']->render(new \Symfony\Component\HttpKernel\Controller\ControllerReference('MauticCoreBundle:Default:globalSearch')); ?>
+        <?php echo $view['actions']->render(new \Symfony\Component\HttpKernel\Controller\ControllerReference('Mautic\CoreBundle\Controller\DefaultController::notificationsAction')); ?>
+        <?php echo $view['actions']->render(new \Symfony\Component\HttpKernel\Controller\ControllerReference('Mautic\CoreBundle\Controller\DefaultController::globalSearchAction')); ?>
     </ul>
     <!--/ end: left nav -->
 

--- a/app/bundles/DashboardBundle/Config/config.php
+++ b/app/bundles/DashboardBundle/Config/config.php
@@ -5,25 +5,25 @@ return [
         'main' => [
             'mautic_dashboard_index' => [
                 'path'       => '/dashboard',
-                'controller' => 'MauticDashboardBundle:Dashboard:index',
+                'controller' => 'Mautic\DashboardBundle\Controller\DashboardController::indexAction',
             ],
             'mautic_dashboard_widget' => [
                 'path'       => '/dashboard/widget/{widgetId}',
-                'controller' => 'MauticDashboardBundle:Dashboard:widget',
+                'controller' => 'Mautic\DashboardBundle\Controller\DashboardController::widgetAction',
             ],
             'mautic_dashboard_action' => [
                 'path'       => '/dashboard/{objectAction}/{objectId}',
-                'controller' => 'MauticDashboardBundle:Dashboard:execute',
+                'controller' => 'Mautic\DashboardBundle\Controller\DashboardController::executeAction',
             ],
         ],
         'api' => [
             'mautic_widget_types' => [
                 'path'       => '/data',
-                'controller' => 'MauticDashboardBundle:Api\WidgetApi:getTypes',
+                'controller' => 'Mautic\DashboardBundle\Controller\Api\WidgetApiController::getTypesAction',
             ],
             'mautic_widget_data' => [
                 'path'       => '/data/{type}',
-                'controller' => 'MauticDashboardBundle:Api\WidgetApi:getData',
+                'controller' => 'Mautic\DashboardBundle\Controller\Api\WidgetApiController::getDataAction',
             ],
         ],
     ],

--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -17,21 +17,21 @@ return [
         'main' => [
             'mautic_dynamicContent_index' => [
                 'path'       => '/dwc/{page}',
-                'controller' => 'MauticDynamicContentBundle:DynamicContent:index',
+                'controller' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction',
             ],
             'mautic_dynamicContent_action' => [
                 'path'       => '/dwc/{objectAction}/{objectId}',
-                'controller' => 'MauticDynamicContentBundle:DynamicContent:execute',
+                'controller' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::executeAction',
             ],
         ],
         'public' => [
             'mautic_api_dynamicContent_index' => [
                 'path'       => '/dwc',
-                'controller' => 'MauticDynamicContentBundle:DynamicContentApi:getEntities',
+                'controller' => 'Mautic\DynamicContentBundle\Controller\DynamicContentApiController::getEntitiesAction',
             ],
             'mautic_api_dynamicContent_action' => [
                 'path'       => '/dwc/{objectAlias}',
-                'controller' => 'MauticDynamicContentBundle:DynamicContentApi:process',
+                'controller' => 'Mautic\DynamicContentBundle\Controller\DynamicContentApiController::processAction',
             ],
         ],
         'api' => [
@@ -39,7 +39,7 @@ return [
                 'standard_entity' => true,
                 'name'            => 'dynamicContents',
                 'path'            => '/dynamiccontents',
-                'controller'      => 'MauticDynamicContentBundle:Api\DynamicContentApi',
+                'controller'      => 'Mautic\DynamicContentBundle\Controller\Api\DynamicContentApiController',
             ],
         ],
     ],

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -161,7 +161,7 @@ class DynamicContentController extends FormController
                             'objectId'     => $entity->getId(),
                         ];
                         $retUrl   = $this->generateUrl('mautic_dynamicContent_action', $viewParameters);
-                        $template = 'MauticDynamicContentBundle:DynamicContent:view';
+                        $template = 'Mautic\DynamicContentBundle\Controller\DynamicContentController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -170,7 +170,7 @@ class DynamicContentController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $retUrl         = $this->generateUrl('mautic_dynamicContent_index', $viewParameters);
-                $template       = 'MauticDynamicContentBundle:DynamicContent:index';
+                $template       = 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction';
             }
 
             $passthrough = [
@@ -238,7 +238,7 @@ class DynamicContentController extends FormController
         $postActionVars = [
             'returnUrl'       => $retUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticDynamicContentBundle:DynamicContent:index',
+            'contentTemplate' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_dynamicContent_index',
                 'mauticContent' => 'dynamicContent',
@@ -354,7 +354,7 @@ class DynamicContentController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticDynamicContentBundle:DynamicContent:index',
+                    'contentTemplate' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_dynamicContent_index',
                         'mauticContent' => 'dynamicContent',
@@ -468,7 +468,7 @@ class DynamicContentController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticDynamicContentBundle:DynamicContent:index',
+            'contentTemplate' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_dynamicContent_index',
                 'mauticContent' => 'dynamicContent',
@@ -525,7 +525,7 @@ class DynamicContentController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticDynamicContentBundle:DynamicContent:index',
+            'contentTemplate' => 'Mautic\DynamicContentBundle\Controller\DynamicContentController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_dynamicContent_index',
                 'mauticContent' => 'dynamicContent',

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -5,19 +5,19 @@ return [
         'main' => [
             'mautic_email_index' => [
                 'path'       => '/emails/{page}',
-                'controller' => 'MauticEmailBundle:Email:index',
+                'controller' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             ],
             'mautic_email_graph_stats' => [
                 'path'       => '/emails-graph-stats/{objectId}/{isVariant}/{dateFrom}/{dateTo}',
-                'controller' => 'MauticEmailBundle:EmailGraphStats:view',
+                'controller' => 'Mautic\EmailBundle\Controller\EmailGraphStatsController::viewAction',
             ],
             'mautic_email_action' => [
                 'path'       => '/emails/{objectAction}/{objectId}',
-                'controller' => 'MauticEmailBundle:Email:execute',
+                'controller' => 'Mautic\EmailBundle\Controller\EmailController::executeAction',
             ],
             'mautic_email_contacts' => [
                 'path'       => '/emails/view/{objectId}/contact/{page}',
-                'controller' => 'MauticEmailBundle:Email:contacts',
+                'controller' => 'Mautic\EmailBundle\Controller\EmailController::contactsAction',
             ],
         ],
         'api' => [
@@ -25,56 +25,56 @@ return [
                 'standard_entity' => true,
                 'name'            => 'emails',
                 'path'            => '/emails',
-                'controller'      => 'MauticEmailBundle:Api\EmailApi',
+                'controller'      => 'Mautic\EmailBundle\Controller\Api\EmailApiController',
             ],
             'mautic_api_sendemail' => [
                 'path'       => '/emails/{id}/send',
-                'controller' => 'MauticEmailBundle:Api\EmailApi:send',
+                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::sendAction',
                 'method'     => 'POST',
             ],
             'mautic_api_sendcontactemail' => [
                 'path'       => '/emails/{id}/contact/{leadId}/send',
-                'controller' => 'MauticEmailBundle:Api\EmailApi:sendLead',
+                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::sendLeadAction',
                 'method'     => 'POST',
             ],
             'mautic_api_reply' => [
                 'path'       => '/emails/reply/{trackingHash}',
-                'controller' => 'MauticEmailBundle:Api\EmailApi:reply',
+                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::replyAction',
                 'method'     => 'POST',
             ],
         ],
         'public' => [
             'mautic_plugin_tracker' => [
                 'path'         => '/plugin/{integration}/tracking.gif',
-                'controller'   => 'MauticEmailBundle:Public:pluginTrackingGif',
+                'controller'   => 'Mautic\EmailBundle\Controller\PublicController::pluginTrackingGifAction',
                 'requirements' => [
                     'integration' => '.+',
                 ],
             ],
             'mautic_email_tracker' => [
                 'path'       => '/email/{idHash}.gif',
-                'controller' => 'MauticEmailBundle:Public:trackingImage',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::trackingImageAction',
             ],
             'mautic_email_webview' => [
                 'path'       => '/email/view/{idHash}',
-                'controller' => 'MauticEmailBundle:Public:index',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::indexAction',
             ],
             'mautic_email_unsubscribe' => [
                 'path'       => '/email/unsubscribe/{idHash}',
-                'controller' => 'MauticEmailBundle:Public:unsubscribe',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::unsubscribeAction',
             ],
             'mautic_email_resubscribe' => [
                 'path'       => '/email/resubscribe/{idHash}',
-                'controller' => 'MauticEmailBundle:Public:resubscribe',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::resubscribeAction',
             ],
             'mautic_mailer_transport_callback' => [
                 'path'       => '/mailer/{transport}/callback',
-                'controller' => 'MauticEmailBundle:Public:mailerCallback',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::mailerCallbackAction',
                 'method'     => ['GET', 'POST'],
             ],
             'mautic_email_preview' => [
                 'path'       => '/email/preview/{objectId}',
-                'controller' => 'MauticEmailBundle:Public:preview',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::previewAction',
             ],
         ],
     ],

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -216,7 +216,7 @@ class EmailController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticEmailBundle:Email:index',
+                    'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_email_index',
                         'mauticContent' => 'email',
@@ -280,7 +280,7 @@ class EmailController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticEmailBundle:Email:index',
+                    'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_email_index',
                         'mauticContent' => 'email',
@@ -507,7 +507,7 @@ class EmailController extends FormController
                             'objectId'     => $entity->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_email_action', $viewParameters);
-                        $template  = 'MauticEmailBundle:Email:view';
+                        $template  = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -516,7 +516,7 @@ class EmailController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_email_index', $viewParameters);
-                $template       = 'MauticEmailBundle:Email:index';
+                $template       = 'Mautic\EmailBundle\Controller\EmailController::indexAction';
                 //clear any modified content
                 $session->remove('mautic.emailbuilder.'.$entity->getSessionId().'.content');
             }
@@ -621,7 +621,7 @@ class EmailController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticEmailBundle:Email:index',
+            'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_email_index',
                 'mauticContent' => 'email',
@@ -705,7 +705,7 @@ class EmailController extends FormController
                 $model->unlockEntity($entity);
             }
 
-            $template    = 'MauticEmailBundle:Email:view';
+            $template    = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
             $passthrough = [
                 'activeLink'    => 'mautic_email_index',
                 'mauticContent' => 'email',
@@ -867,7 +867,7 @@ class EmailController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticEmailBundle:Email:index',
+            'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_email_index',
                 'mauticContent' => 'email',
@@ -1042,7 +1042,7 @@ class EmailController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticEmailBundle:Page:index',
+            'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_email_index',
                 'mauticContent' => 'page',
@@ -1086,7 +1086,7 @@ class EmailController extends FormController
                 'objectId'     => $objectId,
             ];
             $postActionVars['returnUrl']       = $this->generateUrl('mautic_page_action', $postActionVars['viewParameters']);
-            $postActionVars['contentTemplate'] = 'MauticEmailBundle:Email:view';
+            $postActionVars['contentTemplate'] = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
         } //else don't do anything
 
         return $this->postActionRedirect(
@@ -1120,7 +1120,7 @@ class EmailController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticEmailBundle:Email:index',
+            'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_email_index',
                 'mauticContent' => 'email',
@@ -1262,7 +1262,7 @@ class EmailController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticEmailBundle:Email:index',
+            'contentTemplate' => 'Mautic\EmailBundle\Controller\EmailController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_email_index',
                 'mauticContent' => 'email',

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -415,7 +415,7 @@ class EmailController extends FormController
                         UrlGeneratorInterface::ABSOLUTE_URL
                     ),
                     'contacts' => $this->forward(
-                        'MauticEmailBundle:Email:contacts',
+                        'Mautic\EmailBundle\Controller\EmailController::contactsAction',
                         [
                             'objectId'   => $email->getId(),
                             'page'       => $this->get('session')->get('mautic.email.contact.page', 1),

--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -38,37 +38,37 @@ return [
         'main' => [
             'mautic_formaction_action' => [
                 'path'       => '/forms/action/{objectAction}/{objectId}',
-                'controller' => 'MauticFormBundle:Action:execute',
+                'controller' => 'Mautic\FormBundle\Controller\ActionController::executeAction',
             ],
             'mautic_formfield_action' => [
                 'path'       => '/forms/field/{objectAction}/{objectId}',
-                'controller' => 'MauticFormBundle:Field:execute',
+                'controller' => 'Mautic\FormBundle\Controller\FieldController::executeAction',
             ],
             'mautic_form_index' => [
                 'path'       => '/forms/{page}',
-                'controller' => 'MauticFormBundle:Form:index',
+                'controller' => 'Mautic\FormBundle\Controller\FormController::indexAction',
             ],
             'mautic_form_results' => [
                 'path'       => '/forms/results/{objectId}/{page}',
-                'controller' => 'MauticFormBundle:Result:index',
+                'controller' => 'Mautic\FormBundle\Controller\ResultController::indexAction',
             ],
             'mautic_form_export' => [
                 'path'       => '/forms/results/{objectId}/export/{format}',
-                'controller' => 'MauticFormBundle:Result:export',
+                'controller' => 'Mautic\FormBundle\Controller\ResultController::exportAction',
                 'defaults'   => [
                     'format' => 'csv',
                 ],
             ],
             'mautic_form_results_action' => [
                 'path'       => '/forms/results/{formId}/{objectAction}/{objectId}',
-                'controller' => 'MauticFormBundle:Result:execute',
+                'controller' => 'Mautic\FormBundle\Controller\ResultController::executeAction',
                 'defaults'   => [
                     'objectId' => 0,
                 ],
             ],
             'mautic_form_action' => [
                 'path'       => '/forms/{objectAction}/{objectId}',
-                'controller' => 'MauticFormBundle:Form:execute',
+                'controller' => 'Mautic\FormBundle\Controller\FormController::executeAction',
             ],
         ],
         'api' => [
@@ -76,62 +76,62 @@ return [
                 'standard_entity' => true,
                 'name'            => 'forms',
                 'path'            => '/forms',
-                'controller'      => 'MauticFormBundle:Api\FormApi',
+                'controller'      => 'Mautic\FormBundle\Controller\Api\FormApiController',
             ],
             'mautic_api_formresults' => [
                 'path'       => '/forms/{formId}/submissions',
-                'controller' => 'MauticFormBundle:Api\SubmissionApi:getEntities',
+                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntitiesAction',
             ],
             'mautic_api_formresult' => [
                 'path'       => '/forms/{formId}/submissions/{submissionId}',
-                'controller' => 'MauticFormBundle:Api\SubmissionApi:getEntity',
+                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntityAction',
             ],
             'mautic_api_contactformresults' => [
                 'path'       => '/forms/{formId}/submissions/contact/{contactId}',
-                'controller' => 'MauticFormBundle:Api\SubmissionApi:getEntitiesForContact',
+                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntitiesForContactAction',
             ],
             'mautic_api_formdeletefields' => [
                 'path'       => '/forms/{formId}/fields/delete',
-                'controller' => 'MauticFormBundle:Api\FormApi:deleteFields',
+                'controller' => 'Mautic\FormBundle\Controller\Api\FormApiController::deleteFieldsAction',
                 'method'     => 'DELETE',
             ],
             'mautic_api_formdeleteactions' => [
                 'path'       => '/forms/{formId}/actions/delete',
-                'controller' => 'MauticFormBundle:Api\FormApi:deleteActions',
+                'controller' => 'Mautic\FormBundle\Controller\Api\FormApiController::deleteActionsAction',
                 'method'     => 'DELETE',
             ],
         ],
         'public' => [
             'mautic_form_file_download' => [
                 'path'       => '/forms/results/file/{submissionId}/{field}',
-                'controller' => 'MauticFormBundle:Result:downloadFile',
+                'controller' => 'Mautic\FormBundle\Controller\ResultController::downloadFileAction',
             ],
             'mautic_form_postresults' => [
                 'path'       => '/form/submit',
-                'controller' => 'MauticFormBundle:Public:submit',
+                'controller' => 'Mautic\FormBundle\Controller\PublicController::submitAction',
             ],
             'mautic_form_generateform' => [
                 'path'       => '/form/generate.js',
-                'controller' => 'MauticFormBundle:Public:generate',
+                'controller' => 'Mautic\FormBundle\Controller\PublicController::generateAction',
             ],
             'mautic_form_postmessage' => [
                 'path'       => '/form/message',
-                'controller' => 'MauticFormBundle:Public:message',
+                'controller' => 'Mautic\FormBundle\Controller\PublicController::messageAction',
             ],
             'mautic_form_preview' => [
                 'path'       => '/form/{id}',
-                'controller' => 'MauticFormBundle:Public:preview',
+                'controller' => 'Mautic\FormBundle\Controller\PublicController::previewAction',
                 'defaults'   => [
                     'id' => '0',
                 ],
             ],
             'mautic_form_embed' => [
                 'path'       => '/form/embed/{id}',
-                'controller' => 'MauticFormBundle:Public:embed',
+                'controller' => 'Mautic\FormBundle\Controller\PublicController::embedAction',
             ],
             'mautic_form_postresults_ajax' => [
                 'path'       => '/form/submit/ajax',
-                'controller' => 'MauticFormBundle:Ajax:submit',
+                'controller' => 'Mautic\FormBundle\Controller\AjaxController::submitAction',
             ],
         ],
     ],

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -108,7 +108,7 @@ class AjaxController extends CommonAjaxController
      */
     public function submitAction()
     {
-        $response     = $this->forwardWithPost('MauticFormBundle:Public:submit', $this->request->request->all(), [], ['ajax' => true]);
+        $response     = $this->forwardWithPost('Mautic\FormBundle\Controller\PublicController::submitAction', $this->request->request->all(), [], ['ajax' => true]);
         $responseData = json_decode($response->getContent(), true);
         $success      = (!in_array($response->getStatusCode(), [404, 500]) && empty($responseData['errorMessage'])
             && empty($responseData['validationErrors']));

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -83,7 +83,7 @@ class FormController extends CommonFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticFormBundle:Form:index',
+                    'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_form_index',
                         'mauticContent' => 'form',
@@ -140,7 +140,7 @@ class FormController extends CommonFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticFormBundle:Form:index',
+                    'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_form_index',
                         'mauticContent' => 'form',
@@ -344,7 +344,7 @@ class FormController extends CommonFormController
                                     'objectId'     => $entity->getId(),
                                 ];
                                 $returnUrl = $this->generateUrl('mautic_form_action', $viewParameters);
-                                $template  = 'MauticFormBundle:Form:view';
+                                $template  = 'Mautic\FormBundle\Controller\FormController::viewAction';
                             } else {
                                 //return edit view so that all the session stuff is loaded
                                 return $this->editAction($entity->getId(), true);
@@ -371,7 +371,7 @@ class FormController extends CommonFormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_form_index', $viewParameters);
-                $template       = 'MauticFormBundle:Form:index';
+                $template       = 'Mautic\FormBundle\Controller\FormController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -494,7 +494,7 @@ class FormController extends CommonFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticFormBundle:Form:index',
+            'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_form_index',
                 'mauticContent' => 'form',
@@ -622,7 +622,7 @@ class FormController extends CommonFormController
                                     'objectId'     => $entity->getId(),
                                 ];
                                 $returnUrl = $this->generateUrl('mautic_form_action', $viewParameters);
-                                $template  = 'MauticFormBundle:Form:view';
+                                $template  = 'Mautic\FormBundle\Controller\FormController::viewAction';
                             }
                         } catch (ValidationException $ex) {
                             $form->addError(
@@ -640,7 +640,7 @@ class FormController extends CommonFormController
 
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_form_index', $viewParameters);
-                $template       = 'MauticFormBundle:Form:index';
+                $template       = 'Mautic\FormBundle\Controller\FormController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -979,7 +979,7 @@ class FormController extends CommonFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticFormBundle:Form:index',
+            'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_form_index',
                 'mauticContent' => 'form',
@@ -1044,7 +1044,7 @@ class FormController extends CommonFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticFormBundle:Form:index',
+            'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_form_index',
                 'mauticContent' => 'form',
@@ -1128,7 +1128,7 @@ class FormController extends CommonFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticFormBundle:Form:index',
+            'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_form_index',
                 'mauticContent' => 'form',

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -50,7 +50,7 @@ class ResultController extends CommonFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $formPage],
-                    'contentTemplate' => 'MauticFormBundle:Form:index',
+                    'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_form_index',
                         'mauticContent' => 'form',
@@ -130,7 +130,7 @@ class ResultController extends CommonFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticFormBundle:Result:index',
+                    'contentTemplate' => 'Mautic\FormBundle\Controller\ResultController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_form_index',
                         'mauticContent' => 'formresult',
@@ -249,7 +249,7 @@ class ResultController extends CommonFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $formPage],
-                    'contentTemplate' => 'MauticFormBundle:Form:index',
+                    'contentTemplate' => 'Mautic\FormBundle\Controller\FormController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_form_index',
                         'mauticContent' => 'form',
@@ -340,7 +340,7 @@ class ResultController extends CommonFormController
             [
                 'returnUrl'       => $this->generateUrl('mautic_form_results', $viewParameters),
                 'viewParameters'  => $viewParameters,
-                'contentTemplate' => 'MauticFormBundle:Result:index',
+                'contentTemplate' => 'Mautic\FormBundle\Controller\ResultController::indexAction',
                 'passthroughVars' => [
                     'mauticContent' => 'formresult',
                 ],

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -5,23 +5,23 @@ return [
         'public' => [
             'mautic_installer_home' => [
                 'path'       => '/installer',
-                'controller' => 'MauticInstallBundle:Install:step',
+                'controller' => 'Mautic\InstallBundle\Controller\InstallController::stepAction',
             ],
             'mautic_installer_remove_slash' => [
                 'path'       => '/installer/',
-                'controller' => 'MauticCoreBundle:Common:removeTrailingSlash',
+                'controller' => 'Mautic\CoreBundle\Controller\CommonController::removeTrailingSlashAction',
             ],
             'mautic_installer_step' => [
                 'path'       => '/installer/step/{index}',
-                'controller' => 'MauticInstallBundle:Install:step',
+                'controller' => 'Mautic\InstallBundle\Controller\InstallController::stepAction',
             ],
             'mautic_installer_final' => [
                 'path'       => '/installer/final',
-                'controller' => 'MauticInstallBundle:Install:final',
+                'controller' => 'Mautic\InstallBundle\Controller\InstallController::finalAction',
             ],
             'mautic_installer_catchcall' => [
                 'path'         => '/installer/{noerror}',
-                'controller'   => 'MauticInstallBundle:Install:step',
+                'controller'   => 'Mautic\InstallBundle\Controller\InstallController::stepAction',
                 'requirements' => [
                     'noerror' => '^(?).+',
                 ],

--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -10,24 +10,24 @@ return [
         'main' => [
             'mautic_integration_config' => [
                 'path'       => '/integration/{integration}/config',
-                'controller' => 'IntegrationsBundle:Config:edit',
+                'controller' => 'Mautic\IntegrationsBundle\Controller\ConfigController::editAction',
             ],
             'mautic_integration_config_field_pagination' => [
                 'path'       => '/integration/{integration}/config/{object}/{page}',
-                'controller' => 'IntegrationsBundle:FieldPagination:paginate',
+                'controller' => 'Mautic\IntegrationsBundle\Controller\FieldPaginationController::paginateAction',
                 'defaults'   => [
                     'page' => 1,
                 ],
             ],
             'mautic_integration_config_field_update' => [
                 'path'       => '/integration/{integration}/config/{object}/field/{field}',
-                'controller' => 'IntegrationsBundle:UpdateField:update',
+                'controller' => 'Mautic\IntegrationsBundle\Controller\UpdateFieldController::updateAction',
             ],
         ],
         'public' => [
             'mautic_integration_public_callback' => [
                 'path'       => '/integration/{integration}/callback',
-                'controller' => 'IntegrationsBundle:Auth:callback',
+                'controller' => 'Mautic\IntegrationsBundle\Controller\AuthController::callbackAction',
             ],
         ],
     ],

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -5,14 +5,14 @@ return [
         'main' => [
             'mautic_plugin_timeline_index' => [
                 'path'         => '/plugin/{integration}/timeline/{page}',
-                'controller'   => 'MauticLeadBundle:Timeline:pluginIndex',
+                'controller'   => 'Mautic\LeadBundle\Controller\TimelineController::pluginIndexAction',
                 'requirements' => [
                     'integration' => '.+',
                 ],
             ],
             'mautic_plugin_timeline_view' => [
                 'path'         => '/plugin/{integration}/timeline/view/{leadId}/{page}',
-                'controller'   => 'MauticLeadBundle:Timeline:pluginView',
+                'controller'   => 'Mautic\LeadBundle\Controller\TimelineController::pluginViewAction',
                 'requirements' => [
                     'integration' => '.+',
                     'leadId'      => '\d+',
@@ -20,35 +20,35 @@ return [
             ],
             'mautic_segment_batch_contact_set' => [
                 'path'       => '/segments/batch/contact/set',
-                'controller' => 'MauticLeadBundle:BatchSegment:set',
+                'controller' => 'Mautic\LeadBundle\Controller\BatchSegmentController::setAction',
             ],
             'mautic_segment_batch_contact_view' => [
                 'path'       => '/segments/batch/contact/view',
-                'controller' => 'MauticLeadBundle:BatchSegment:index',
+                'controller' => 'Mautic\LeadBundle\Controller\BatchSegmentController::indexAction',
             ],
             'mautic_segment_index' => [
                 'path'       => '/segments/{page}',
-                'controller' => 'MauticLeadBundle:List:index',
+                'controller' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
             ],
             'mautic_segment_action' => [
                 'path'       => '/segments/{objectAction}/{objectId}',
-                'controller' => 'MauticLeadBundle:List:execute',
+                'controller' => 'Mautic\LeadBundle\Controller\ListController::executeAction',
             ],
             'mautic_contactfield_index' => [
                 'path'       => '/contacts/fields/{page}',
-                'controller' => 'MauticLeadBundle:Field:index',
+                'controller' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
             ],
             'mautic_contactfield_action' => [
                 'path'       => '/contacts/fields/{objectAction}/{objectId}',
-                'controller' => 'MauticLeadBundle:Field:execute',
+                'controller' => 'Mautic\LeadBundle\Controller\FieldController::executeAction',
             ],
             'mautic_contact_index' => [
                 'path'       => '/contacts/{page}',
-                'controller' => 'MauticLeadBundle:Lead:index',
+                'controller' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             ],
             'mautic_contactnote_index' => [
                 'path'       => '/contacts/notes/{leadId}/{page}',
-                'controller' => 'MauticLeadBundle:Note:index',
+                'controller' => 'Mautic\LeadBundle\Controller\NoteController::indexAction',
                 'defaults'   => [
                     'leadId' => 0,
                 ],
@@ -58,83 +58,83 @@ return [
             ],
             'mautic_contactnote_action' => [
                 'path'         => '/contacts/notes/{leadId}/{objectAction}/{objectId}',
-                'controller'   => 'MauticLeadBundle:Note:executeNote',
+                'controller'   => 'Mautic\LeadBundle\Controller\NoteController::executeNoteAction',
                 'requirements' => [
                     'leadId' => '\d+',
                 ],
             ],
             'mautic_contacttimeline_action' => [
                 'path'         => '/contacts/timeline/{leadId}/{page}',
-                'controller'   => 'MauticLeadBundle:Timeline:index',
+                'controller'   => 'Mautic\LeadBundle\Controller\TimelineController::indexAction',
                 'requirements' => [
                     'leadId' => '\d+',
                 ],
             ],
             'mautic_contact_timeline_export_action' => [
                 'path'         => '/contacts/timeline/batchExport/{leadId}',
-                'controller'   => 'MauticLeadBundle:Timeline:batchExport',
+                'controller'   => 'Mautic\LeadBundle\Controller\TimelineController::batchExportAction',
                 'requirements' => [
                     'leadId' => '\d+',
                 ],
             ],
             'mautic_contact_auditlog_action' => [
                 'path'         => '/contacts/auditlog/{leadId}/{page}',
-                'controller'   => 'MauticLeadBundle:Auditlog:index',
+                'controller'   => 'Mautic\LeadBundle\Controller\AuditlogController::indexAction',
                 'requirements' => [
                     'leadId' => '\d+',
                 ],
             ],
             'mautic_contact_auditlog_export_action' => [
                 'path'         => '/contacts/auditlog/batchExport/{leadId}',
-                'controller'   => 'MauticLeadBundle:Auditlog:batchExport',
+                'controller'   => 'Mautic\LeadBundle\Controller\AuditlogController::batchExportAction',
                 'requirements' => [
                     'leadId' => '\d+',
                 ],
             ],
             'mautic_contact_export_action' => [
                 'path'         => '/contacts/contact/export/{contactId}',
-                'controller'   => 'MauticLeadBundle:Lead:contactExport',
+                'controller'   => 'Mautic\LeadBundle\Controller\LeadController::contactExportAction',
                 'requirements' => [
                     'contactId' => '\d+',
                 ],
             ],
             'mautic_import_index' => [
                 'path'       => '/{object}/import/{page}',
-                'controller' => 'MauticLeadBundle:Import:index',
+                'controller' => 'Mautic\LeadBundle\Controller\ImportController::indexAction',
             ],
             'mautic_import_action' => [
                 'path'       => '/{object}/import/{objectAction}/{objectId}',
-                'controller' => 'MauticLeadBundle:Import:execute',
+                'controller' => 'Mautic\LeadBundle\Controller\ImportController::executeAction',
             ],
             'mautic_contact_action' => [
                 'path'       => '/contacts/{objectAction}/{objectId}',
-                'controller' => 'MauticLeadBundle:Lead:execute',
+                'controller' => 'Mautic\LeadBundle\Controller\LeadController::executeAction',
             ],
             'mautic_company_index' => [
                 'path'       => '/companies/{page}',
-                'controller' => 'MauticLeadBundle:Company:index',
+                'controller' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             ],
             'mautic_company_contacts_list' => [
                 'path'         => '/company/{objectId}/contacts/{page}',
-                'controller'   => 'MauticLeadBundle:Company:contactsList',
+                'controller'   => 'Mautic\LeadBundle\Controller\CompanyController::contactsListAction',
                 'requirements' => [
                     'objectId' => '\d+',
                 ],
             ],
             'mautic_company_action' => [
                 'path'       => '/companies/{objectAction}/{objectId}',
-                'controller' => 'MauticLeadBundle:Company:execute',
+                'controller' => 'Mautic\LeadBundle\Controller\CompanyController::executeAction',
             ],
             'mautic_company_export_action' => [
                 'path'         => '/companies/company/export/{companyId}',
-                'controller'   => 'MauticLeadBundle:Company:companyExport',
+                'controller'   => 'Mautic\LeadBundle\Controller\CompanyController::companyExportAction',
                 'requirements' => [
                     'companyId' => '\d+',
                 ],
             ],
             'mautic_segment_contacts' => [
                 'path'       => '/segment/view/{objectId}/contact/{page}',
-                'controller' => 'MauticLeadBundle:List:contacts',
+                'controller' => 'Mautic\LeadBundle\Controller\ListController::contactsAction',
             ],
         ],
         'api' => [
@@ -142,11 +142,11 @@ return [
                 'standard_entity' => true,
                 'name'            => 'contacts',
                 'path'            => '/contacts',
-                'controller'      => 'MauticLeadBundle:Api\LeadApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\LeadApiController',
             ],
             'mautic_api_dncaddcontact' => [
                 'path'       => '/contacts/{id}/dnc/{channel}/add',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:addDnc',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::addDncAction',
                 'method'     => 'POST',
                 'defaults'   => [
                     'channel' => 'email',
@@ -154,101 +154,101 @@ return [
             ],
             'mautic_api_dncremovecontact' => [
                 'path'       => '/contacts/{id}/dnc/{channel}/remove',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:removeDnc',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::removeDncAction',
                 'method'     => 'POST',
             ],
             'mautic_api_getcontactevents' => [
                 'path'       => '/contacts/{id}/activity',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getActivity',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getActivityAction',
             ],
             'mautic_api_getcontactsevents' => [
                 'path'       => '/contacts/activity',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getAllActivity',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getAllActivityAction',
             ],
             'mautic_api_getcontactnotes' => [
                 'path'       => '/contacts/{id}/notes',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getNotes',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getNotesAction',
             ],
             'mautic_api_getcontactdevices' => [
                 'path'       => '/contacts/{id}/devices',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getDevices',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getDevicesAction',
             ],
             'mautic_api_getcontactcampaigns' => [
                 'path'       => '/contacts/{id}/campaigns',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getCampaigns',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getCampaignsAction',
             ],
             'mautic_api_getcontactssegments' => [
                 'path'       => '/contacts/{id}/segments',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getLists',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getListsAction',
             ],
             'mautic_api_getcontactscompanies' => [
                 'path'       => '/contacts/{id}/companies',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getCompanies',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getCompaniesAction',
             ],
             'mautic_api_utmcreateevent' => [
                 'path'       => '/contacts/{id}/utm/add',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:addUtmTags',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::addUtmTagsAction',
                 'method'     => 'POST',
             ],
             'mautic_api_utmremoveevent' => [
                 'path'       => '/contacts/{id}/utm/{utmid}/remove',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:removeUtmTags',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::removeUtmTagsAction',
                 'method'     => 'POST',
             ],
             'mautic_api_getcontactowners' => [
                 'path'       => '/contacts/list/owners',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getOwners',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getOwnersAction',
             ],
             'mautic_api_getcontactfields' => [
                 'path'       => '/contacts/list/fields',
-                'controller' => 'MauticLeadBundle:Api\LeadApi:getFields',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getFieldsAction',
             ],
             'mautic_api_getcontactsegments' => [
                 'path'       => '/contacts/list/segments',
-                'controller' => 'MauticLeadBundle:Api\ListApi:getLists',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::getListsAction',
             ],
             'mautic_api_segmentsstandard' => [
                 'standard_entity' => true,
                 'name'            => 'lists',
                 'path'            => '/segments',
-                'controller'      => 'MauticLeadBundle:Api\ListApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\ListApiController',
             ],
             'mautic_api_segmentaddcontact' => [
                 'path'       => '/segments/{id}/contact/{leadId}/add',
-                'controller' => 'MauticLeadBundle:Api\ListApi:addLead',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::addLeadAction',
                 'method'     => 'POST',
             ],
             'mautic_api_segmentaddcontacts' => [
                 'path'       => '/segments/{id}/contacts/add',
-                'controller' => 'MauticLeadBundle:Api\ListApi:addLeads',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::addLeadsAction',
                 'method'     => 'POST',
             ],
             'mautic_api_segmentremovecontact' => [
                 'path'       => '/segments/{id}/contact/{leadId}/remove',
-                'controller' => 'MauticLeadBundle:Api\ListApi:removeLead',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::removeLeadAction',
                 'method'     => 'POST',
             ],
             'mautic_api_companiesstandard' => [
                 'standard_entity' => true,
                 'name'            => 'companies',
                 'path'            => '/companies',
-                'controller'      => 'MauticLeadBundle:Api\CompanyApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\CompanyApiController',
             ],
             'mautic_api_companyaddcontact' => [
                 'path'       => '/companies/{companyId}/contact/{contactId}/add',
-                'controller' => 'MauticLeadBundle:Api\CompanyApi:addContact',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::addContactAction',
                 'method'     => 'POST',
             ],
             'mautic_api_companyremovecontact' => [
                 'path'       => '/companies/{companyId}/contact/{contactId}/remove',
-                'controller' => 'MauticLeadBundle:Api\CompanyApi:removeContact',
+                'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::removeContactAction',
                 'method'     => 'POST',
             ],
             'mautic_api_fieldsstandard' => [
                 'standard_entity' => true,
                 'name'            => 'fields',
                 'path'            => '/fields/{object}',
-                'controller'      => 'MauticLeadBundle:Api\FieldApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\FieldApiController',
                 'defaults'        => [
                     'object' => 'contact',
                 ],
@@ -257,19 +257,19 @@ return [
                 'standard_entity' => true,
                 'name'            => 'notes',
                 'path'            => '/notes',
-                'controller'      => 'MauticLeadBundle:Api\NoteApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\NoteApiController',
             ],
             'mautic_api_devicesstandard' => [
                 'standard_entity' => true,
                 'name'            => 'devices',
                 'path'            => '/devices',
-                'controller'      => 'MauticLeadBundle:Api\DeviceApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\DeviceApiController',
             ],
             'mautic_api_tagsstandard' => [
                 'standard_entity' => true,
                 'name'            => 'tags',
                 'path'            => '/tags',
-                'controller'      => 'MauticLeadBundle:Api\TagApi',
+                'controller'      => 'Mautic\LeadBundle\Controller\Api\TagApiController',
             ],
         ],
     ],

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -78,7 +78,7 @@ class CompanyController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticLeadBundle:Company:index',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_company_index',
                         'mauticContent' => 'company',
@@ -213,7 +213,7 @@ class CompanyController extends FormController
 
         $viewParameters = ['page' => $page];
         $returnUrl      = $this->generateUrl('mautic_company_index', $viewParameters);
-        $template       = 'MauticLeadBundle:Company:index';
+        $template       = 'Mautic\LeadBundle\Controller\CompanyController::indexAction';
 
         ///Check for a submitted form and process it
         if ('POST' == $this->request->getMethod()) {
@@ -248,7 +248,7 @@ class CompanyController extends FormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_company_index', $viewParameters);
-                        $template  = 'MauticLeadBundle:Company:index';
+                        $template  = 'Mautic\LeadBundle\Controller\CompanyController::indexAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -341,7 +341,7 @@ class CompanyController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => $viewParameters,
-            'contentTemplate' => 'MauticLeadBundle:Company:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_company_index',
                 'mauticContent' => 'company',
@@ -423,7 +423,7 @@ class CompanyController extends FormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_company_index', $viewParameters);
-                        $template  = 'MauticLeadBundle:Company:index';
+                        $template  = 'Mautic\LeadBundle\Controller\CompanyController::indexAction';
                     }
                 }
             } else {
@@ -431,7 +431,7 @@ class CompanyController extends FormController
                 $model->unlockEntity($entity);
 
                 $returnUrl = $this->generateUrl('mautic_company_index', $viewParameters);
-                $template  = 'MauticLeadBundle:Company:index';
+                $template  = 'Mautic\LeadBundle\Controller\CompanyController::indexAction';
             }
 
             $passthrough = [
@@ -540,7 +540,7 @@ class CompanyController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticLeadBundle:Company:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_company_index',
                 'mauticContent' => 'company',
@@ -694,7 +694,7 @@ class CompanyController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Company:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_company_index',
                 'mauticContent' => 'company',
@@ -753,7 +753,7 @@ class CompanyController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Company:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_company_index',
                 'mauticContent' => 'company',
@@ -838,7 +838,7 @@ class CompanyController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Company:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_company_index',
                 'mauticContent' => 'company',
@@ -927,7 +927,7 @@ class CompanyController extends FormController
                 [
                     'returnUrl'       => $this->generateUrl('mautic_company_action', $viewParameters),
                     'viewParameters'  => $viewParameters,
-                    'contentTemplate' => 'MauticLeadBundle:Company:edit',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\CompanyController::editAction',
                     'passthroughVars' => [
                         'closeModal' => 1,
                     ],

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -72,7 +72,7 @@ class FieldController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $lastPage],
-                'contentTemplate' => 'MauticLeadBundle:Field:index',
+                'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_contactfield_index',
                     'mauticContent' => 'leadfield',
@@ -187,7 +187,7 @@ class FieldController extends FormController
                 return $this->postActionRedirect(
                     [
                         'returnUrl'       => $returnUrl,
-                        'contentTemplate' => 'MauticLeadBundle:Field:index',
+                        'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
                         'passthroughVars' => [
                             'activeLink'    => '#mautic_contactfield_index',
                             'mauticContent' => 'leadfield',
@@ -243,7 +243,7 @@ class FieldController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticLeadBundle:Field:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contactfield_index',
                 'mauticContent' => 'leadfield',
@@ -310,7 +310,7 @@ class FieldController extends FormController
                 return $this->postActionRedirect(
                     array_merge($postActionVars, [
                             'viewParameters'  => ['objectId' => $field->getId()],
-                            'contentTemplate' => 'MauticLeadBundle:Field:index',
+                            'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
                         ]
                     )
                 );
@@ -389,7 +389,7 @@ class FieldController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticLeadBundle:Field:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contactfield_index',
                 'mauticContent' => 'lead',
@@ -467,7 +467,7 @@ class FieldController extends FormController
 
         $postActionVars = [
             'returnUrl'       => $returnUrl,
-            'contentTemplate' => 'MauticLeadBundle:Field:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\FieldController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contactfield_index',
                 'mauticContent' => 'lead',

--- a/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
@@ -40,7 +40,7 @@ trait LeadAccessTrait
                     [
                         'returnUrl'       => $returnUrl,
                         'viewParameters'  => ['page' => $page],
-                        'contentTemplate' => $isPlugin ? 'MauticLeadBundle:Lead:pluginIndex' : 'MauticLeadBundle:Lead:index',
+                        'contentTemplate' => $isPlugin ? 'Mautic\LeadBundle\Controller\LeadController::pluginIndexAction' : 'Mautic\LeadBundle\Controller\LeadController::indexAction',
                         'passthroughVars' => [
                             'activeLink'    => $isPlugin ? '#mautic_plugin_timeline_index' : '#mautic_contact_index',
                             'mauticContent' => 'leadTimeline',

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1470,7 +1470,7 @@ class LeadController extends FormController
                 [
                     'returnUrl'       => $this->generateUrl($route, $viewParameters),
                     'viewParameters'  => $viewParameters,
-                    'contentTemplate' => 'MauticLeadBundle:Lead:'.$func,
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::'.$func.'Action',
                     'passthroughVars' => [
                         'mauticContent' => 'lead',
                         'closeModal'    => 1,

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -388,7 +388,7 @@ class LeadController extends FormController
                     'doNotContact'      => end($dnc),
                     'doNotContactSms'   => end($dncSms),
                     'leadNotes'         => $this->forward(
-                        'MauticLeadBundle:Note:index',
+                        'Mautic\LeadBundle\Controller\NoteController::indexAction',
                         [
                             'leadId'     => $lead->getId(),
                             'ignoreAjax' => 1,

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -129,7 +129,7 @@ class LeadController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticLeadBundle:Lead:index',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_contact_index',
                         'mauticContent' => 'lead',
@@ -304,7 +304,7 @@ class LeadController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticLeadBundle:Lead:index',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_contact_index',
                         'mauticContent' => 'contact',
@@ -507,14 +507,14 @@ class LeadController extends FormController
                     if ($inQuickForm) {
                         $viewParameters = ['page' => $page];
                         $returnUrl      = $this->generateUrl('mautic_contact_index', $viewParameters);
-                        $template       = 'MauticLeadBundle:Lead:index';
+                        $template       = 'Mautic\LeadBundle\Controller\LeadController::indexAction';
                     } elseif ($form->get('buttons')->get('save')->isClicked()) {
                         $viewParameters = [
                             'objectAction' => 'view',
                             'objectId'     => $lead->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_contact_action', $viewParameters);
-                        $template  = 'MauticLeadBundle:Lead:view';
+                        $template  = 'Mautic\LeadBundle\Controller\LeadController::viewAction';
                     } else {
                         return $this->editAction($lead->getId(), true);
                     }
@@ -529,7 +529,7 @@ class LeadController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_contact_index', $viewParameters);
-                $template       = 'MauticLeadBundle:Lead:index';
+                $template       = 'Mautic\LeadBundle\Controller\LeadController::indexAction';
             }
 
             if ($cancelled || $valid) { //cancelled or success
@@ -597,7 +597,7 @@ class LeadController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Lead:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contact_index',
                 'mauticContent' => 'lead',
@@ -720,7 +720,7 @@ class LeadController extends FormController
                         [
                             'returnUrl'       => $this->generateUrl('mautic_contact_action', $viewParameters),
                             'viewParameters'  => $viewParameters,
-                            'contentTemplate' => 'MauticLeadBundle:Lead:view',
+                            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::viewAction',
                         ]
                     )
                 );
@@ -796,7 +796,7 @@ class LeadController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Lead:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contact_index',
                 'mauticContent' => 'lead',
@@ -926,7 +926,7 @@ class LeadController extends FormController
                     [
                         'returnUrl'       => $this->generateUrl('mautic_contact_action', $viewParameters),
                         'viewParameters'  => $viewParameters,
-                        'contentTemplate' => 'MauticLeadBundle:Lead:view',
+                        'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::viewAction',
                         'passthroughVars' => [
                             'closeModal' => 1,
                         ],
@@ -1006,7 +1006,7 @@ class LeadController extends FormController
                         'objectAction' => 'view',
                     ]),
                     'viewParameters'  => $viewParameters,
-                    'contentTemplate' => 'MauticLeadBundle:Lead:view',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::viewAction',
                     'passthroughVars' => [
                         'closeModal' => 1,
                     ],
@@ -1058,7 +1058,7 @@ class LeadController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Lead:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contact_index',
                 'mauticContent' => 'lead',
@@ -1123,7 +1123,7 @@ class LeadController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Lead:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contact_index',
                 'mauticContent' => 'lead',

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -103,7 +103,7 @@ class ListController extends FormController
                     'page' => $lastPage,
                     'tmpl' => $tmpl,
                 ],
-                'contentTemplate' => 'MauticLeadBundle:List:index',
+                'contentTemplate' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_segment_index',
                     'mauticContent' => 'leadlist',
@@ -193,7 +193,7 @@ class ListController extends FormController
                 return $this->postActionRedirect([
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticLeadBundle:List:index',
+                    'contentTemplate' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_segment_index',
                         'mauticContent' => 'leadlist',
@@ -422,13 +422,13 @@ class ListController extends FormController
         if ($objectId) {
             $returnUrl       = $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId'=> $objectId]);
             $viewParameters  = ['objectAction' => 'view', 'objectId'=> $objectId];
-            $contentTemplate = 'MauticLeadBundle:List:view';
+            $contentTemplate = 'Mautic\LeadBundle\Controller\ListController::viewAction';
         } else {
             //set the page we came from
             $page            = $this->get('session')->get('mautic.segment.page', 1);
             $returnUrl       = $this->generateUrl('mautic_segment_index', ['page' => $page]);
             $viewParameters  = ['page' => $page];
-            $contentTemplate = 'MauticLeadBundle:List:index';
+            $contentTemplate = 'Mautic\LeadBundle\Controller\ListController::indexAction';
         }
 
         return [
@@ -460,7 +460,7 @@ class ListController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:List:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_segment_index',
                 'mauticContent' => 'lead',
@@ -536,7 +536,7 @@ class ListController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:List:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_segment_index',
                 'mauticContent' => 'lead',
@@ -637,7 +637,7 @@ class ListController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticLeadBundle:Lead:index',
+            'contentTemplate' => 'Mautic\LeadBundle\Controller\LeadController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_contact_index',
                 'mauticContent' => 'lead',
@@ -739,7 +739,7 @@ class ListController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticLeadBundle:List:index',
+                'contentTemplate' => 'Mautic\LeadBundle\Controller\ListController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_segment_index',
                     'mauticContent' => 'list',

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -806,7 +806,7 @@ class ListController extends FormController
                     ],
                 ],
                 'contacts' => $this->forward(
-                    'MauticLeadBundle:List:contacts',
+                    'Mautic\LeadBundle\Controller\ListController::contactsAction',
                     [
                         'objectId'   => $list->getId(),
                         'page'       => $this->get('session')->get('mautic.segment.contact.page', 1),

--- a/app/bundles/MarketplaceBundle/Config/config.php
+++ b/app/bundles/MarketplaceBundle/Config/config.php
@@ -10,23 +10,23 @@ return [
         'main' => [
             RouteProvider::ROUTE_LIST => [
                 'path'       => '/marketplace/{page}',
-                'controller' => 'MarketplaceBundle:Package\List:list',
+                'controller' => 'Mautic\MarketplaceBundle\Controller\Package\ListController::listAction',
                 'method'     => 'GET|POST',
                 'defaults'   => ['page' => 1],
             ],
             RouteProvider::ROUTE_DETAIL => [
                 'path'       => '/marketplace/detail/{vendor}/{package}',
-                'controller' => 'MarketplaceBundle:Package\Detail:view',
+                'controller' => 'Mautic\MarketplaceBundle\Controller\Package\DetailController::viewAction',
                 'method'     => 'GET',
             ],
             RouteProvider::ROUTE_INSTALL => [
                 'path'       => '/marketplace/install/{vendor}/{package}',
-                'controller' => 'MarketplaceBundle:Package\Install:view',
+                'controller' => 'Mautic\MarketplaceBundle\Controller\Package\InstallController::viewAction',
                 'method'     => 'GET|POST',
             ],
             RouteProvider::ROUTE_REMOVE => [
                 'path'       => '/marketplace/remove/{vendor}/{package}',
-                'controller' => 'MarketplaceBundle:Package\Remove:view',
+                'controller' => 'Mautic\MarketplaceBundle\Controller\Package\RemoveController::viewAction',
                 'method'     => 'GET|POST',
             ],
         ],

--- a/app/bundles/NotificationBundle/Config/config.php
+++ b/app/bundles/NotificationBundle/Config/config.php
@@ -170,59 +170,59 @@ return [
         'main' => [
             'mautic_notification_index' => [
                 'path'       => '/notifications/{page}',
-                'controller' => 'MauticNotificationBundle:Notification:index',
+                'controller' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
             ],
             'mautic_notification_action' => [
                 'path'       => '/notifications/{objectAction}/{objectId}',
-                'controller' => 'MauticNotificationBundle:Notification:execute',
+                'controller' => 'Mautic\NotificationBundle\Controller\NotificationController::executeAction',
             ],
             'mautic_notification_contacts' => [
                 'path'       => '/notifications/view/{objectId}/contact/{page}',
-                'controller' => 'MauticNotificationBundle:Notification:contacts',
+                'controller' => 'Mautic\NotificationBundle\Controller\NotificationController::contactsAction',
             ],
             'mautic_mobile_notification_index' => [
                 'path'       => '/mobile_notifications/{page}',
-                'controller' => 'MauticNotificationBundle:MobileNotification:index',
+                'controller' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
             ],
             'mautic_mobile_notification_action' => [
                 'path'       => '/mobile_notifications/{objectAction}/{objectId}',
-                'controller' => 'MauticNotificationBundle:MobileNotification:execute',
+                'controller' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::executeAction',
             ],
             'mautic_mobile_notification_contacts' => [
                 'path'       => '/mobile_notifications/view/{objectId}/contact/{page}',
-                'controller' => 'MauticNotificationBundle:MobileNotification:contacts',
+                'controller' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::contactsAction',
             ],
         ],
         'public' => [
             'mautic_receive_notification' => [
                 'path'       => '/notification/receive',
-                'controller' => 'MauticNotificationBundle:Api\NotificationApi:receive',
+                'controller' => 'Mautic\NotificationBundle\Controller\Api\NotificationApiController::receiveAction',
             ],
             'mautic_subscribe_notification' => [
                 'path'       => '/notification/subscribe',
-                'controller' => 'MauticNotificationBundle:Api\NotificationApi:subscribe',
+                'controller' => 'Mautic\NotificationBundle\Controller\Api\NotificationApiController::subscribeAction',
             ],
             'mautic_notification_popup' => [
                 'path'       => '/notification',
-                'controller' => 'MauticNotificationBundle:Popup:index',
+                'controller' => 'Mautic\NotificationBundle\Controller\PopupController::indexAction',
             ],
 
             // JS / Manifest URL's
             'mautic_onesignal_worker' => [
                 'path'       => '/OneSignalSDKWorker.js',
-                'controller' => 'MauticNotificationBundle:Js:worker',
+                'controller' => 'Mautic\NotificationBundle\Controller\JsController::workerAction',
             ],
             'mautic_onesignal_updater' => [
                 'path'       => '/OneSignalSDKUpdaterWorker.js',
-                'controller' => 'MauticNotificationBundle:Js:updater',
+                'controller' => 'Mautic\NotificationBundle\Controller\JsController::updaterAction',
             ],
             'mautic_onesignal_manifest' => [
                 'path'       => '/manifest.json',
-                'controller' => 'MauticNotificationBundle:Js:manifest',
+                'controller' => 'Mautic\NotificationBundle\Controller\JsController::manifestAction',
             ],
             'mautic_app_notification' => [
                 'path'       => '/notification/appcallback',
-                'controller' => 'MauticNotificationBundle:AppCallback:index',
+                'controller' => 'Mautic\NotificationBundle\Controller\AppCallbackController::indexAction',
             ],
         ],
         'api' => [
@@ -230,7 +230,7 @@ return [
                 'standard_entity' => true,
                 'name'            => 'notifications',
                 'path'            => '/notifications',
-                'controller'      => 'MauticNotificationBundle:Api\NotificationApi',
+                'controller'      => 'Mautic\NotificationBundle\Controller\Api\NotificationApiController',
             ],
         ],
     ],

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -221,7 +221,7 @@ class MobileNotificationController extends FormController
                 'security'    => $security,
                 'entityViews' => $entityViews,
                 'contacts'    => $this->forward(
-                    'MauticNotificationBundle:MobileNotification:contacts',
+                    'Mautic\NotificationBundle\Controller\MobileNotificationController::contactsAction',
                     [
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.mobile_notification.contact.page', 1),

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -101,7 +101,7 @@ class MobileNotificationController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticNotificationBundle:MobileNotification:index',
+                    'contentTemplate' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_mobile_notification_index',
                         'mauticContent' => 'mobile_notification',
@@ -160,7 +160,7 @@ class MobileNotificationController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticNotificationBundle:MobileNotification:index',
+                    'contentTemplate' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_mobile_notification_index',
                         'mauticContent' => 'mobile_notification',
@@ -306,7 +306,7 @@ class MobileNotificationController extends FormController
                             'objectId'     => $entity->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_mobile_notification_action', $viewParameters);
-                        $template  = 'MauticNotificationBundle:MobileNotification:view';
+                        $template  = 'Mautic\NotificationBundle\Controller\MobileNotificationController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -315,7 +315,7 @@ class MobileNotificationController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_mobile_notification_index', $viewParameters);
-                $template       = 'MauticNotificationBundle:MobileNotification:index';
+                $template       = 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction';
                 //clear any modified content
                 $session->remove('mautic.mobile_notification.'.$entity->getId().'.content');
             }
@@ -398,7 +398,7 @@ class MobileNotificationController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:MobileNotification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_mobile_notification_index',
                 'mauticContent' => 'mobile_notification',
@@ -473,7 +473,7 @@ class MobileNotificationController extends FormController
                 $model->unlockEntity($entity);
             }
 
-            $template    = 'MauticNotificationBundle:MobileNotification:view';
+            $template    = 'Mautic\NotificationBundle\Controller\MobileNotificationController::viewAction';
             $passthrough = [
                 'activeLink'    => 'mautic_mobile_notification_index',
                 'mauticContent' => 'mobile_notification',
@@ -592,7 +592,7 @@ class MobileNotificationController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:MobileNotification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_mobile_notification_index',
                 'mauticContent' => 'mobile_notification',
@@ -656,7 +656,7 @@ class MobileNotificationController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:MobileNotification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\MobileNotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_mobile_notification_index',
                 'mauticContent' => 'mobile_notification',

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -105,7 +105,7 @@ class NotificationController extends AbstractFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticNotificationBundle:Notification:index',
+                    'contentTemplate' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_notification_index',
                         'mauticContent' => 'notification',
@@ -164,7 +164,7 @@ class NotificationController extends AbstractFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticNotificationBundle:Notification:index',
+                    'contentTemplate' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_notification_index',
                         'mauticContent' => 'notification',
@@ -310,7 +310,7 @@ class NotificationController extends AbstractFormController
                             'objectId'     => $entity->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_notification_action', $viewParameters);
-                        $template  = 'MauticNotificationBundle:Notification:view';
+                        $template  = 'Mautic\NotificationBundle\Controller\NotificationController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -319,7 +319,7 @@ class NotificationController extends AbstractFormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_notification_index', $viewParameters);
-                $template       = 'MauticNotificationBundle:Notification:index';
+                $template       = 'Mautic\NotificationBundle\Controller\NotificationController::indexAction';
                 //clear any modified content
                 $session->remove('mautic.notification.'.$entity->getId().'.content');
             }
@@ -399,7 +399,7 @@ class NotificationController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:Notification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_notification_index',
                 'mauticContent' => 'notification',
@@ -475,7 +475,7 @@ class NotificationController extends AbstractFormController
                 $model->unlockEntity($entity);
             }
 
-            $template    = 'MauticNotificationBundle:Notification:view';
+            $template    = 'Mautic\NotificationBundle\Controller\NotificationController::viewAction';
             $passthrough = [
                 'activeLink'    => 'mautic_notification_index',
                 'mauticContent' => 'notification',
@@ -591,7 +591,7 @@ class NotificationController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:Notification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_notification_index',
                 'mauticContent' => 'notification',
@@ -655,7 +655,7 @@ class NotificationController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticNotificationBundle:Notification:index',
+            'contentTemplate' => 'Mautic\NotificationBundle\Controller\NotificationController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_notification_index',
                 'mauticContent' => 'notification',

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -225,7 +225,7 @@ class NotificationController extends AbstractFormController
                 'security'    => $security,
                 'entityViews' => $entityViews,
                 'contacts'    => $this->forward(
-                    'MauticNotificationBundle:Notification:contacts',
+                    'Mautic\NotificationBundle\Controller\NotificationController::contactsAction',
                     [
                         'objectId'   => $notification->getId(),
                         'page'       => $this->get('session')->get('mautic.notification.contact.page', 1),

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -5,19 +5,19 @@ return [
         'main' => [
             'mautic_page_index' => [
                 'path'       => '/pages/{page}',
-                'controller' => 'MauticPageBundle:Page:index',
+                'controller' => 'Mautic\PageBundle\Controller\PageController::indexAction',
             ],
             'mautic_page_action' => [
                 'path'       => '/pages/{objectAction}/{objectId}',
-                'controller' => 'MauticPageBundle:Page:execute',
+                'controller' => 'Mautic\PageBundle\Controller\PageController::executeAction',
             ],
             'mautic_page_results' => [
                 'path'       => '/pages/results/{objectId}/{page}',
-                'controller' => 'MauticPageBundle:Page:results',
+                'controller' => 'Mautic\PageBundle\Controller\PageController::resultsAction',
             ],
             'mautic_page_export' => [
                 'path'       => '/pages/results/{objectId}/export/{format}',
-                'controller' => 'MauticPageBundle:Page:export',
+                'controller' => 'Mautic\PageBundle\Controller\PageController::exportAction',
                 'defaults'   => [
                     'format' => 'csv',
                 ],
@@ -26,31 +26,31 @@ return [
         'public' => [
             'mautic_page_tracker' => [
                 'path'       => '/mtracking.gif',
-                'controller' => 'MauticPageBundle:Public:trackingImage',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::trackingImageAction',
             ],
             'mautic_page_tracker_cors' => [
                 'path'       => '/mtc/event',
-                'controller' => 'MauticPageBundle:Public:tracking',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::trackingAction',
             ],
             'mautic_page_tracker_getcontact' => [
                 'path'       => '/mtc',
-                'controller' => 'MauticPageBundle:Public:getContactId',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::getContactIdAction',
             ],
             'mautic_url_redirect' => [
                 'path'       => '/r/{redirectId}',
-                'controller' => 'MauticPageBundle:Public:redirect',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::redirectAction',
             ],
             'mautic_page_redirect' => [
                 'path'       => '/redirect/{redirectId}',
-                'controller' => 'MauticPageBundle:Public:redirect',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::redirectAction',
             ],
             'mautic_page_preview' => [
                 'path'       => '/page/preview/{id}',
-                'controller' => 'MauticPageBundle:Public:preview',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::previewAction',
             ],
             'mautic_gated_video_hit' => [
                 'path'       => '/video/hit',
-                'controller' => 'MauticPageBundle:Public:hitVideo',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::hitVideoAction',
             ],
         ],
         'api' => [
@@ -58,13 +58,13 @@ return [
                 'standard_entity' => true,
                 'name'            => 'pages',
                 'path'            => '/pages',
-                'controller'      => 'MauticPageBundle:Api\PageApi',
+                'controller'      => 'Mautic\PageBundle\Controller\Api\PageApiController',
             ],
         ],
         'catchall' => [
             'mautic_page_public' => [
                 'path'         => '/{slug}',
-                'controller'   => 'MauticPageBundle:Public:index',
+                'controller'   => 'Mautic\PageBundle\Controller\PublicController::indexAction',
                 'requirements' => [
                     'slug' => '^(?!(_(profiler|wdt)|css|images|js|favicon.ico|apps/bundles/|plugins/)).+',
                 ],

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -133,7 +133,7 @@ class PageController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $lastPage],
-                'contentTemplate' => 'MauticPageBundle:Page:index',
+                'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_page_index',
                     'mauticContent' => 'page',
@@ -188,7 +188,7 @@ class PageController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticPageBundle:Page:index',
+                'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_page_index',
                     'mauticContent' => 'page',
@@ -397,7 +397,7 @@ class PageController extends FormController
                             'objectId'     => $entity->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_page_action', $viewParameters);
-                        $template  = 'MauticPageBundle:Page:view';
+                        $template  = 'Mautic\PageBundle\Controller\PageController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -406,7 +406,7 @@ class PageController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_page_index', $viewParameters);
-                $template       = 'MauticPageBundle:Page:index';
+                $template       = 'Mautic\PageBundle\Controller\PageController::indexAction';
                 //clear any modified content
                 $session->remove('mautic.pagebuilder.'.$entity->getSessionId().'.content');
             }
@@ -485,7 +485,7 @@ class PageController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPageBundle:Page:index',
+            'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_page_index',
                 'mauticContent' => 'page',
@@ -558,7 +558,7 @@ class PageController extends FormController
                     array_merge($postActionVars, [
                         'returnUrl'       => $this->generateUrl('mautic_page_action', $viewParameters),
                         'viewParameters'  => $viewParameters,
-                        'contentTemplate' => 'MauticPageBundle:Page:view',
+                        'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::viewAction',
                     ])
                 );
             }
@@ -676,7 +676,7 @@ class PageController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPageBundle:Page:index',
+            'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_page_index',
                 'mauticContent' => 'page',
@@ -737,7 +737,7 @@ class PageController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPageBundle:Page:index',
+            'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_page_index',
                 'mauticContent' => 'page',
@@ -909,7 +909,7 @@ class PageController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPageBundle:Page:index',
+            'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_page_index',
                 'mauticContent' => 'page',
@@ -953,7 +953,7 @@ class PageController extends FormController
                 'objectId'     => $objectId,
             ];
             $postActionVars['returnUrl']       = $this->generateUrl('mautic_page_action', $postActionVars['viewParameters']);
-            $postActionVars['contentTemplate'] = 'MauticPageBundle:Page:view';
+            $postActionVars['contentTemplate'] = 'Mautic\PageBundle\Controller\PageController::viewAction';
         } //else don't do anything
 
         return $this->postActionRedirect(
@@ -1032,7 +1032,7 @@ class PageController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $pageListPage],
-                    'contentTemplate' => 'MauticPageBundle:Page:index',
+                    'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_page_index',
                         'mauticContent' => 'page',
@@ -1110,7 +1110,7 @@ class PageController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticPageBundle:Page:results',
+                    'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::resultsAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_page_index',
                         'mauticContent' => 'pageresult',
@@ -1175,7 +1175,7 @@ class PageController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $pageListPage],
-                    'contentTemplate' => 'MauticPageBundle:Page:index',
+                    'contentTemplate' => 'Mautic\PageBundle\Controller\PageController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => 'mautic_page_index',
                         'mauticContent' => 'page',

--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -5,41 +5,41 @@ return [
         'main' => [
             'mautic_integration_auth_callback_secure' => [
                 'path'       => '/plugins/integrations/authcallback/{integration}',
-                'controller' => 'MauticPluginBundle:Auth:authCallback',
+                'controller' => 'Mautic\PluginBundle\Controller\AuthController::authCallbackAction',
             ],
             'mautic_integration_auth_postauth_secure' => [
                 'path'       => '/plugins/integrations/authstatus/{integration}',
-                'controller' => 'MauticPluginBundle:Auth:authStatus',
+                'controller' => 'Mautic\PluginBundle\Controller\AuthController::authStatusAction',
             ],
             'mautic_plugin_index' => [
                 'path'       => '/plugins',
-                'controller' => 'MauticPluginBundle:Plugin:index',
+                'controller' => 'Mautic\PluginBundle\Controller\PluginController::indexAction',
             ],
             'mautic_plugin_config' => [
                 'path'       => '/plugins/config/{name}/{page}',
-                'controller' => 'MauticPluginBundle:Plugin:config',
+                'controller' => 'Mautic\PluginBundle\Controller\PluginController::configAction',
             ],
             'mautic_plugin_info' => [
                 'path'       => '/plugins/info/{name}',
-                'controller' => 'MauticPluginBundle:Plugin:info',
+                'controller' => 'Mautic\PluginBundle\Controller\PluginController::infoAction',
             ],
             'mautic_plugin_reload' => [
                 'path'       => '/plugins/reload',
-                'controller' => 'MauticPluginBundle:Plugin:reload',
+                'controller' => 'Mautic\PluginBundle\Controller\PluginController::reloadAction',
             ],
         ],
         'public' => [
             'mautic_integration_auth_user' => [
                 'path'       => '/plugins/integrations/authuser/{integration}',
-                'controller' => 'MauticPluginBundle:Auth:authUser',
+                'controller' => 'Mautic\PluginBundle\Controller\AuthController::authUserAction',
             ],
             'mautic_integration_auth_callback' => [
                 'path'       => '/plugins/integrations/authcallback/{integration}',
-                'controller' => 'MauticPluginBundle:Auth:authCallback',
+                'controller' => 'Mautic\PluginBundle\Controller\AuthController::authCallbackAction',
             ],
             'mautic_integration_auth_postauth' => [
                 'path'       => '/plugins/integrations/authstatus/{integration}',
-                'controller' => 'MauticPluginBundle:Auth:authStatus',
+                'controller' => 'Mautic\PluginBundle\Controller\AuthController::authStatusAction',
             ],
         ],
     ],

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -425,7 +425,7 @@ class PluginController extends FormController
             [
                 'returnUrl'       => $this->generateUrl('mautic_plugin_index', $viewParameters),
                 'viewParameters'  => $viewParameters,
-                'contentTemplate' => 'MauticPluginBundle:Plugin:index',
+                'contentTemplate' => 'Mautic\PluginBundle\Controller\PluginController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_plugin_index',
                     'mauticContent' => 'plugin',

--- a/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
@@ -101,7 +101,7 @@ class ReloadHelperTest extends \PHPUnit\Framework\TestCase
                         'public' => [
                             'mautic_citrix_proxy' => [
                                 'path'       => '/citrix/proxy',
-                                'controller' => 'MauticCitrixBundle:Public:proxy',
+                                'controller' => 'MauticPlugin\MauticCitrixBundle\Controller\PublicController::proxyAction',
                             ],
                         ],
                     ],

--- a/app/bundles/PointBundle/Config/config.php
+++ b/app/bundles/PointBundle/Config/config.php
@@ -5,23 +5,23 @@ return [
         'main' => [
             'mautic_pointtriggerevent_action' => [
                 'path'       => '/points/triggers/events/{objectAction}/{objectId}',
-                'controller' => 'MauticPointBundle:TriggerEvent:execute',
+                'controller' => 'Mautic\PointBundle\Controller\TriggerEventController::executeAction',
             ],
             'mautic_pointtrigger_index' => [
                 'path'       => '/points/triggers/{page}',
-                'controller' => 'MauticPointBundle:Trigger:index',
+                'controller' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
             ],
             'mautic_pointtrigger_action' => [
                 'path'       => '/points/triggers/{objectAction}/{objectId}',
-                'controller' => 'MauticPointBundle:Trigger:execute',
+                'controller' => 'Mautic\PointBundle\Controller\TriggerController::executeAction',
             ],
             'mautic_point_index' => [
                 'path'       => '/points/{page}',
-                'controller' => 'MauticPointBundle:Point:index',
+                'controller' => 'Mautic\PointBundle\Controller\PointController::indexAction',
             ],
             'mautic_point_action' => [
                 'path'       => '/points/{objectAction}/{objectId}',
-                'controller' => 'MauticPointBundle:Point:execute',
+                'controller' => 'Mautic\PointBundle\Controller\PointController::executeAction',
             ],
         ],
         'api' => [
@@ -29,30 +29,30 @@ return [
                 'standard_entity' => true,
                 'name'            => 'points',
                 'path'            => '/points',
-                'controller'      => 'MauticPointBundle:Api\PointApi',
+                'controller'      => 'Mautic\PointBundle\Controller\Api\PointApiController',
             ],
             'mautic_api_getpointactiontypes' => [
                 'path'       => '/points/actions/types',
-                'controller' => 'MauticPointBundle:Api\PointApi:getPointActionTypes',
+                'controller' => 'Mautic\PointBundle\Controller\Api\PointApiController::getPointActionTypesAction',
             ],
             'mautic_api_pointtriggersstandard' => [
                 'standard_entity' => true,
                 'name'            => 'triggers',
                 'path'            => '/points/triggers',
-                'controller'      => 'MauticPointBundle:Api\TriggerApi',
+                'controller'      => 'Mautic\PointBundle\Controller\Api\TriggerApiController',
             ],
             'mautic_api_getpointtriggereventtypes' => [
                 'path'       => '/points/triggers/events/types',
-                'controller' => 'MauticPointBundle:Api\TriggerApi:getPointTriggerEventTypes',
+                'controller' => 'Mautic\PointBundle\Controller\Api\TriggerApiController::getPointTriggerEventTypesAction',
             ],
             'mautic_api_pointtriggerdeleteevents' => [
                 'path'       => '/points/triggers/{triggerId}/events/delete',
-                'controller' => 'MauticPointBundle:Api\TriggerApi:deletePointTriggerEvents',
+                'controller' => 'Mautic\PointBundle\Controller\Api\TriggerApiController::deletePointTriggerEventsAction',
                 'method'     => 'DELETE',
             ],
             'mautic_api_adjustcontactpoints' => [
                 'path'       => '/contacts/{leadId}/points/{operator}/{delta}',
-                'controller' => 'MauticPointBundle:Api\PointApi:adjustPoints',
+                'controller' => 'Mautic\PointBundle\Controller\Api\PointApiController::adjustPointsAction',
                 'method'     => 'POST',
             ],
         ],

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -61,7 +61,7 @@ class PointController extends AbstractFormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $lastPage],
-                'contentTemplate' => 'MauticPointBundle:Point:index',
+                'contentTemplate' => 'Mautic\PointBundle\Controller\PointController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_point_index',
                     'mauticContent' => 'point',
@@ -146,7 +146,7 @@ class PointController extends AbstractFormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_point_index', $viewParameters);
-                        $template  = 'MauticPointBundle:Point:index';
+                        $template  = 'Mautic\PointBundle\Controller\PointController::indexAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -154,7 +154,7 @@ class PointController extends AbstractFormController
                 }
             } else {
                 $returnUrl = $this->generateUrl('mautic_point_index', $viewParameters);
-                $template  = 'MauticPointBundle:Point:index';
+                $template  = 'Mautic\PointBundle\Controller\PointController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -219,7 +219,7 @@ class PointController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => $viewParameters,
-            'contentTemplate' => 'MauticPointBundle:Point:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\PointController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_point_index',
                 'mauticContent' => 'point',
@@ -277,7 +277,7 @@ class PointController extends AbstractFormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_point_index', $viewParameters);
-                        $template  = 'MauticPointBundle:Point:index';
+                        $template  = 'Mautic\PointBundle\Controller\PointController::indexAction';
                     }
                 }
             } else {
@@ -285,7 +285,7 @@ class PointController extends AbstractFormController
                 $model->unlockEntity($entity);
 
                 $returnUrl = $this->generateUrl('mautic_point_index', $viewParameters);
-                $template  = 'MauticPointBundle:Point:index';
+                $template  = 'Mautic\PointBundle\Controller\PointController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -367,7 +367,7 @@ class PointController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPointBundle:Point:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\PointController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_point_index',
                 'mauticContent' => 'point',
@@ -424,7 +424,7 @@ class PointController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPointBundle:Point:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\PointController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_point_index',
                 'mauticContent' => 'point',

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -64,7 +64,7 @@ class TriggerController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $lastPage],
-                'contentTemplate' => 'MauticPointBundle:Trigger:index',
+                'contentTemplate' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_pointtrigger_index',
                     'mauticContent' => 'pointTrigger',
@@ -121,7 +121,7 @@ class TriggerController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticPointBundle:Trigger:index',
+                'contentTemplate' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_pointtrigger_index',
                     'mauticContent' => 'pointTrigger',
@@ -232,7 +232,7 @@ class TriggerController extends FormController
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_pointtrigger_index', $viewParameters);
-                $template       = 'MauticPointBundle:Trigger:index';
+                $template       = 'Mautic\PointBundle\Controller\TriggerController::indexAction';
 
                 //clear temporary fields
                 $this->clearSessionComponents($sessionId);
@@ -300,7 +300,7 @@ class TriggerController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPointBundle:Trigger:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_pointtrigger_index',
                 'mauticContent' => 'pointTrigger',
@@ -377,7 +377,7 @@ class TriggerController extends FormController
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_pointtrigger_index', $viewParameters);
-                $template       = 'MauticPointBundle:Trigger:index';
+                $template       = 'Mautic\PointBundle\Controller\TriggerController::indexAction';
 
                 //remove fields from session
                 $this->clearSessionComponents($objectId);
@@ -479,7 +479,7 @@ class TriggerController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPointBundle:Trigger:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_pointtrigger_index',
                 'mauticContent' => 'pointTrigger',
@@ -536,7 +536,7 @@ class TriggerController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticPointBundle:Trigger:index',
+            'contentTemplate' => 'Mautic\PointBundle\Controller\TriggerController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_pointtrigger_index',
                 'mauticContent' => 'pointTrigger',

--- a/app/bundles/ReportBundle/Config/config.php
+++ b/app/bundles/ReportBundle/Config/config.php
@@ -5,25 +5,25 @@ return [
         'main' => [
             'mautic_report_index' => [
                 'path'       => '/reports/{page}',
-                'controller' => 'MauticReportBundle:Report:index',
+                'controller' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
             ],
             'mautic_report_export' => [
                 'path'       => '/reports/view/{objectId}/export/{format}',
-                'controller' => 'MauticReportBundle:Report:export',
+                'controller' => 'Mautic\ReportBundle\Controller\ReportController::exportAction',
                 'defaults'   => [
                     'format' => 'csv',
                 ],
             ],
             'mautic_report_download' => [
                 'path'       => '/reports/download/{reportId}/{format}',
-                'controller' => 'MauticReportBundle:Report:download',
+                'controller' => 'Mautic\ReportBundle\Controller\ReportController::downloadAction',
                 'defaults'   => [
                     'format' => 'csv',
                 ],
             ],
             'mautic_report_view' => [
                 'path'       => '/reports/view/{objectId}/{reportPage}',
-                'controller' => 'MauticReportBundle:Report:view',
+                'controller' => 'Mautic\ReportBundle\Controller\ReportController::viewAction',
                 'defaults'   => [
                     'reportPage' => 1,
                 ],
@@ -33,7 +33,7 @@ return [
             ],
             'mautic_report_schedule_preview' => [
                 'path'       => '/reports/schedule/preview/{isScheduled}/{scheduleUnit}/{scheduleDay}/{scheduleMonthFrequency}',
-                'controller' => 'MauticReportBundle:Schedule:index',
+                'controller' => 'Mautic\ReportBundle\Controller\ScheduleController::indexAction',
                 'defaults'   => [
                     'isScheduled'            => 0,
                     'scheduleUnit'           => '',
@@ -43,21 +43,21 @@ return [
             ],
             'mautic_report_schedule' => [
                 'path'       => '/reports/schedule/{reportId}/now',
-                'controller' => 'MauticReportBundle:Schedule:now',
+                'controller' => 'Mautic\ReportBundle\Controller\ScheduleController::nowAction',
             ],
             'mautic_report_action' => [
                 'path'       => '/reports/{objectAction}/{objectId}',
-                'controller' => 'MauticReportBundle:Report:execute',
+                'controller' => 'Mautic\ReportBundle\Controller\ReportController::executeAction',
             ],
         ],
         'api' => [
             'mautic_api_getreports' => [
                 'path'       => '/reports',
-                'controller' => 'MauticReportBundle:Api\ReportApi:getEntities',
+                'controller' => 'Mautic\ReportBundle\Controller\Api\ReportApiController::getEntitiesAction',
             ],
             'mautic_api_getreport' => [
                 'path'       => '/reports/{id}',
-                'controller' => 'MauticReportBundle:Api\ReportApi:getReport',
+                'controller' => 'Mautic\ReportBundle\Controller\Api\ReportApiController::getReportAction',
             ],
         ],
     ],

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -84,7 +84,7 @@ class ReportController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticReportBundle:Report:index',
+                    'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_report_index',
                         'mauticContent' => 'report',
@@ -166,7 +166,7 @@ class ReportController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticReportBundle:Report:index',
+            'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_report_index',
                 'mauticContent' => 'report',
@@ -227,7 +227,7 @@ class ReportController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticReportBundle:Report:index',
+            'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_report_index',
                 'mauticContent' => 'report',
@@ -309,7 +309,7 @@ class ReportController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticReportBundle:Report:index',
+            'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_report_index',
                 'mauticContent' => 'report',
@@ -369,7 +369,7 @@ class ReportController extends FormController
                         ]
                     );
                     $viewParams = ['objectId' => $entity->getId()];
-                    $template   = 'MauticReportBundle:Report:view';
+                    $template   = 'Mautic\ReportBundle\Controller\ReportController::viewAction';
                 } else {
                     //reset old columns
                     $entity->setColumns($oldColumns);
@@ -381,7 +381,7 @@ class ReportController extends FormController
 
                 $returnUrl  = $this->generateUrl('mautic_report_index', ['page' => $page]);
                 $viewParams = ['report' => $page];
-                $template   = 'MauticReportBundle:Report:index';
+                $template   = 'Mautic\ReportBundle\Controller\ReportController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -489,12 +489,12 @@ class ReportController extends FormController
                         'objectId' => $entity->getId(),
                     ];
                     $returnUrl = $this->generateUrl('mautic_report_view', $viewParameters);
-                    $template  = 'MauticReportBundle:Report:view';
+                    $template  = 'Mautic\ReportBundle\Controller\ReportController::viewAction';
                 }
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_report_index', $viewParameters);
-                $template       = 'MauticReportBundle:Report:index';
+                $template       = 'Mautic\ReportBundle\Controller\ReportController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -555,7 +555,7 @@ class ReportController extends FormController
                 [
                     'returnUrl'       => $this->generateUrl('mautic_report_index', ['page' => $page]),
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticReportBundle:Report:index',
+                    'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_report_index',
                         'mauticContent' => 'report',
@@ -756,7 +756,7 @@ class ReportController extends FormController
                 [
                     'returnUrl'       => $this->generateUrl('mautic_report_index', ['page' => $page]),
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticReportBundle:Report:index',
+                    'contentTemplate' => 'Mautic\ReportBundle\Controller\ReportController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_report_index',
                         'mauticContent' => 'report',

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -275,26 +275,26 @@ return [
         'main' => [
             'mautic_sms_index' => [
                 'path'       => '/sms/{page}',
-                'controller' => 'MauticSmsBundle:Sms:index',
+                'controller' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
             ],
             'mautic_sms_action' => [
                 'path'       => '/sms/{objectAction}/{objectId}',
-                'controller' => 'MauticSmsBundle:Sms:execute',
+                'controller' => 'Mautic\SmsBundle\Controller\SmsController::executeAction',
             ],
             'mautic_sms_contacts' => [
                 'path'       => '/sms/view/{objectId}/contact/{page}',
-                'controller' => 'MauticSmsBundle:Sms:contacts',
+                'controller' => 'Mautic\SmsBundle\Controller\SmsController::contactsAction',
             ],
         ],
         'public' => [
             'mautic_sms_callback' => [
                 'path'       => '/sms/{transport}/callback',
-                'controller' => 'MauticSmsBundle:Reply:callback',
+                'controller' => 'Mautic\SmsBundle\Controller\ReplyController::callbackAction',
             ],
             /* @deprecated as this was Twilio specific */
             'mautic_receive_sms' => [
                 'path'       => '/sms/receive',
-                'controller' => 'MauticSmsBundle:Reply:callback',
+                'controller' => 'Mautic\SmsBundle\Controller\ReplyController::callbackAction',
                 'defaults'   => [
                     'transport' => 'twilio',
                 ],
@@ -305,11 +305,11 @@ return [
                 'standard_entity' => true,
                 'name'            => 'smses',
                 'path'            => '/smses',
-                'controller'      => 'MauticSmsBundle:Api\SmsApi',
+                'controller'      => 'Mautic\SmsBundle\Controller\Api\SmsApiController',
             ],
             'mautic_api_smses_send' => [
                 'path'       => '/smses/{id}/contact/{contactId}/send',
-                'controller' => 'MauticSmsBundle:Api\SmsApi:send',
+                'controller' => 'Mautic\SmsBundle\Controller\Api\SmsApiController::sendAction',
             ],
         ],
     ],

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -95,7 +95,7 @@ class SmsController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $lastPage],
-                'contentTemplate' => 'MauticSmsBundle:Sms:index',
+                'contentTemplate' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_sms_index',
                     'mauticContent' => 'sms',
@@ -151,7 +151,7 @@ class SmsController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticSmsBundle:Sms:index',
+                'contentTemplate' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_sms_index',
                     'mauticContent' => 'sms',
@@ -297,7 +297,7 @@ class SmsController extends FormController
                             'objectId'     => $entity->getId(),
                         ];
                         $returnUrl = $this->generateUrl('mautic_sms_action', $viewParameters);
-                        $template  = 'MauticSmsBundle:Sms:view';
+                        $template  = 'Mautic\SmsBundle\Controller\SmsController::viewAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -306,7 +306,7 @@ class SmsController extends FormController
             } else {
                 $viewParameters = ['page' => $page];
                 $returnUrl      = $this->generateUrl('mautic_sms_index', $viewParameters);
-                $template       = 'MauticSmsBundle:Sms:index';
+                $template       = 'Mautic\SmsBundle\Controller\SmsController::indexAction';
                 //clear any modified content
                 $session->remove('mautic.sms.'.$entity->getId().'.content');
             }
@@ -386,7 +386,7 @@ class SmsController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticSmsBundle:Sms:index',
+            'contentTemplate' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_sms_index',
                 'mauticContent' => 'sms',
@@ -466,7 +466,7 @@ class SmsController extends FormController
                 'mauticContent' => 'sms',
             ];
 
-            $template = 'MauticSmsBundle:Sms:view';
+            $template = 'Mautic\SmsBundle\Controller\SmsController::viewAction';
 
             // Check to see if this is a popup
             if (isset($form['updateSelect'])) {
@@ -574,7 +574,7 @@ class SmsController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticSmsBundle:Sms:index',
+            'contentTemplate' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_sms_index',
                 'mauticContent' => 'sms',
@@ -636,7 +636,7 @@ class SmsController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticSmsBundle:Sms:index',
+            'contentTemplate' => 'Mautic\SmsBundle\Controller\SmsController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_sms_index',
                 'mauticContent' => 'sms',

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -212,7 +212,7 @@ class SmsController extends FormController
                 'security'    => $security,
                 'entityViews' => $entityViews,
                 'contacts'    => $this->forward(
-                    'MauticSmsBundle:Sms:contacts',
+                    'Mautic\SmsBundle\Controller\SmsController::contactsAction',
                     [
                         'objectId'   => $sms->getId(),
                         'page'       => $this->get('session')->get('mautic.sms.contact.page', 1),

--- a/app/bundles/StageBundle/Config/config.php
+++ b/app/bundles/StageBundle/Config/config.php
@@ -5,11 +5,11 @@ return [
         'main' => [
             'mautic_stage_index' => [
                 'path'       => '/stages/{page}',
-                'controller' => 'MauticStageBundle:Stage:index',
+                'controller' => 'Mautic\StageBundle\Controller\StageController::indexAction',
             ],
             'mautic_stage_action' => [
                 'path'       => '/stages/{objectAction}/{objectId}',
-                'controller' => 'MauticStageBundle:Stage:execute',
+                'controller' => 'Mautic\StageBundle\Controller\StageController::executeAction',
             ],
         ],
         'api' => [
@@ -17,16 +17,16 @@ return [
                 'standard_entity' => true,
                 'name'            => 'stages',
                 'path'            => '/stages',
-                'controller'      => 'MauticStageBundle:Api\StageApi',
+                'controller'      => 'Mautic\StageBundle\Controller\Api\StageApiController',
             ],
             'mautic_api_stageddcontact' => [
                 'path'       => '/stages/{id}/contact/{contactId}/add',
-                'controller' => 'MauticStageBundle:Api\StageApi:addContact',
+                'controller' => 'Mautic\StageBundle\Controller\Api\StageApiController::addContactAction',
                 'method'     => 'POST',
             ],
             'mautic_api_stageremovecontact' => [
                 'path'       => '/stages/{id}/contact/{contactId}/remove',
-                'controller' => 'MauticStageBundle:Api\StageApi:removeContact',
+                'controller' => 'Mautic\StageBundle\Controller\Api\StageApiController::removeContactAction',
                 'method'     => 'POST',
             ],
         ],

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -67,7 +67,7 @@ class StageController extends AbstractFormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticStageBundle:Stage:index',
+                    'contentTemplate' => 'Mautic\StageBundle\Controller\StageController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_stage_index',
                         'mauticContent' => 'stage',
@@ -166,7 +166,7 @@ class StageController extends AbstractFormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_stage_index', $viewParameters);
-                        $template  = 'MauticStageBundle:Stage:index';
+                        $template  = 'Mautic\StageBundle\Controller\StageController::indexAction';
                     } else {
                         //return edit view so that all the session stuff is loaded
                         return $this->editAction($entity->getId(), true);
@@ -174,7 +174,7 @@ class StageController extends AbstractFormController
                 }
             } else {
                 $returnUrl = $this->generateUrl('mautic_stage_index', $viewParameters);
-                $template  = 'MauticStageBundle:Stage:index';
+                $template  = 'Mautic\StageBundle\Controller\StageController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -245,7 +245,7 @@ class StageController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => $viewParameters,
-            'contentTemplate' => 'MauticStageBundle:Stage:index',
+            'contentTemplate' => 'Mautic\StageBundle\Controller\StageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_stage_index',
                 'mauticContent' => 'stage',
@@ -314,7 +314,7 @@ class StageController extends AbstractFormController
 
                     if ($form->get('buttons')->get('save')->isClicked()) {
                         $returnUrl = $this->generateUrl('mautic_stage_index', $viewParameters);
-                        $template  = 'MauticStageBundle:Stage:index';
+                        $template  = 'Mautic\StageBundle\Controller\StageController::indexAction';
                     }
                 }
             } else {
@@ -322,7 +322,7 @@ class StageController extends AbstractFormController
                 $model->unlockEntity($entity);
 
                 $returnUrl = $this->generateUrl('mautic_stage_index', $viewParameters);
-                $template  = 'MauticStageBundle:Stage:index';
+                $template  = 'Mautic\StageBundle\Controller\StageController::indexAction';
             }
 
             if ($cancelled || ($valid && $form->get('buttons')->get('save')->isClicked())) {
@@ -411,7 +411,7 @@ class StageController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticStageBundle:Stage:index',
+            'contentTemplate' => 'Mautic\StageBundle\Controller\StageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_stage_index',
                 'mauticContent' => 'stage',
@@ -471,7 +471,7 @@ class StageController extends AbstractFormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticStageBundle:Stage:index',
+            'contentTemplate' => 'Mautic\StageBundle\Controller\StageController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_stage_index',
                 'mauticContent' => 'stage',

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -20,49 +20,49 @@ return [
         'main' => [
             'login' => [
                 'path'       => '/login',
-                'controller' => 'MauticUserBundle:Security:login',
+                'controller' => 'Mautic\UserBundle\Controller\SecurityController::loginAction',
             ],
             'mautic_user_logincheck' => [
                 'path'       => '/login_check',
-                'controller' => 'MauticUserBundle:Security:loginCheck',
+                'controller' => 'Mautic\UserBundle\Controller\SecurityController::loginCheckAction',
             ],
             'mautic_user_logout' => [
                 'path' => '/logout',
             ],
             'mautic_sso_login' => [
                 'path'       => '/sso_login/{integration}',
-                'controller' => 'MauticUserBundle:Security:ssoLogin',
+                'controller' => 'Mautic\UserBundle\Controller\SecurityController::ssoLoginAction',
             ],
             'mautic_sso_login_check' => [
                 'path'       => '/sso_login_check/{integration}',
-                'controller' => 'MauticUserBundle:Security:ssoLoginCheck',
+                'controller' => 'Mautic\UserBundle\Controller\SecurityController::ssoLoginCheckAction',
             ],
             'lightsaml_sp.login' => [
                 'path'       => '/saml/login',
-                'controller' => 'LightSamlSpBundle:Default:login',
+                'controller' => 'LightSaml\SpBundle\Controller\DefaultController::loginAction',
             ],
             'lightsaml_sp.login_check' => [
                 'path' => '/saml/login_check',
             ],
             'mautic_user_index' => [
                 'path'       => '/users/{page}',
-                'controller' => 'MauticUserBundle:User:index',
+                'controller' => 'Mautic\UserBundle\Controller\UserController::indexAction',
             ],
             'mautic_user_action' => [
                 'path'       => '/users/{objectAction}/{objectId}',
-                'controller' => 'MauticUserBundle:User:execute',
+                'controller' => 'Mautic\UserBundle\Controller\UserController::executeAction',
             ],
             'mautic_role_index' => [
                 'path'       => '/roles/{page}',
-                'controller' => 'MauticUserBundle:Role:index',
+                'controller' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
             ],
             'mautic_role_action' => [
                 'path'       => '/roles/{objectAction}/{objectId}',
-                'controller' => 'MauticUserBundle:Role:execute',
+                'controller' => 'Mautic\UserBundle\Controller\RoleController::executeAction',
             ],
             'mautic_user_account' => [
                 'path'       => '/account',
-                'controller' => 'MauticUserBundle:Profile:index',
+                'controller' => 'Mautic\UserBundle\Controller\ProfileController::indexAction',
             ],
         ],
 
@@ -71,44 +71,44 @@ return [
                 'standard_entity' => true,
                 'name'            => 'users',
                 'path'            => '/users',
-                'controller'      => 'MauticUserBundle:Api\UserApi',
+                'controller'      => 'Mautic\UserBundle\Controller\Api\UserApiController',
             ],
             'mautic_api_getself' => [
                 'path'       => '/users/self',
-                'controller' => 'MauticUserBundle:Api\UserApi:getSelf',
+                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::getSelfAction',
             ],
             'mautic_api_checkpermission' => [
                 'path'       => '/users/{id}/permissioncheck',
-                'controller' => 'MauticUserBundle:Api\UserApi:isGranted',
+                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::isGrantedAction',
                 'method'     => 'POST',
             ],
             'mautic_api_getuserroles' => [
                 'path'       => '/users/list/roles',
-                'controller' => 'MauticUserBundle:Api\UserApi:getRoles',
+                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::getRolesAction',
             ],
             'mautic_api_rolesstandard' => [
                 'standard_entity' => true,
                 'name'            => 'roles',
                 'path'            => '/roles',
-                'controller'      => 'MauticUserBundle:Api\RoleApi',
+                'controller'      => 'Mautic\UserBundle\Controller\Api\RoleApiController',
             ],
         ],
         'public' => [
             'mautic_user_passwordreset' => [
                 'path'       => '/passwordreset',
-                'controller' => 'MauticUserBundle:Public:passwordReset',
+                'controller' => 'Mautic\UserBundle\Controller\PublicController::passwordResetAction',
             ],
             'mautic_user_passwordresetconfirm' => [
                 'path'       => '/passwordresetconfirm',
-                'controller' => 'MauticUserBundle:Public:passwordResetConfirm',
+                'controller' => 'Mautic\UserBundle\Controller\PublicController::passwordResetConfirmAction',
             ],
             'lightsaml_sp.metadata' => [
                 'path'       => '/saml/metadata.xml',
-                'controller' => 'LightSamlSpBundle:Default:metadata',
+                'controller' => 'LightSaml\SpBundle\Controller\DefaultController::metadataAction',
             ],
             'lightsaml_sp.discovery' => [
                 'path'       => '/saml/discovery',
-                'controller' => 'LightSamlSpBundle:Default:discovery',
+                'controller' => 'LightSaml\SpBundle\Controller\DefaultController::discoveryAction',
             ],
         ],
     ],

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -201,7 +201,7 @@ class ProfileController extends FormController
                     return $this->postActionRedirect(
                         [
                             'returnUrl'       => $returnUrl,
-                            'contentTemplate' => 'MauticUserBundle:Profile:index',
+                            'contentTemplate' => 'Mautic\UserBundle\Controller\ProfileController::indexAction',
                             'passthroughVars' => [
                                 'mauticContent' => 'user',
                             ],

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -224,7 +224,7 @@ class ProfileController extends FormController
             'permissions'       => $permissions,
             'me'                => $me,
             'userForm'          => $form->createView(),
-            'authorizedClients' => $this->forward('MauticApiBundle:Client:authorizedClients')->getContent(),
+            'authorizedClients' => $this->forward('Mautic\ApiBundle\Controller\ClientController::authorizedClientsAction')->getContent(),
         ];
 
         return $this->delegateView(

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -59,7 +59,7 @@ class RoleController extends FormController
                     'page' => $lastPage,
                     'tmpl' => $tmpl,
                 ],
-                'contentTemplate' => 'MauticUserBundle:Role:index',
+                'contentTemplate' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_role_index',
                     'mauticContent' => 'role',
@@ -151,7 +151,7 @@ class RoleController extends FormController
                 return $this->postActionRedirect([
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticUserBundle:Role:index',
+                    'contentTemplate' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_role_index',
                         'mauticContent' => 'role',
@@ -204,7 +204,7 @@ class RoleController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:Role:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_role_index',
                 'mauticContent' => 'role',
@@ -362,7 +362,7 @@ class RoleController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:Role:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_role_index',
                 'success'       => $success,
@@ -424,7 +424,7 @@ class RoleController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:Role:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\RoleController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_role_index',
                 'mauticContent' => 'role',

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -47,14 +47,14 @@ class SecurityController extends CommonController
                 // Run migrations
                 $this->request->query->set('finalize', 1);
 
-                return $this->forward('MauticCoreBundle:Ajax:updateDatabaseMigration',
+                return $this->forward('Mautic\CoreBundle\Controller\AjaxController::updateDatabaseMigrationAction',
                     [
                         'request' => $this->request,
                     ]
                 );
             } elseif ('schemaMigration' == $step) {
                 // Done so finalize
-                return $this->forward('MauticCoreBundle:Ajax:updateFinalization',
+                return $this->forward('Mautic\CoreBundle\Controller\AjaxController::updateFinalizationAction',
                     [
                         'request' => $this->request,
                     ]

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -63,7 +63,7 @@ class UserController extends FormController
                     'page' => $lastPage,
                     'tmpl' => $tmpl,
                 ],
-                'contentTemplate' => 'MauticUserBundle:User:index',
+                'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_user_index',
                     'mauticContent' => 'user',
@@ -178,7 +178,7 @@ class UserController extends FormController
                 return $this->postActionRedirect([
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticUserBundle:User:index',
+                    'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_user_index',
                         'mauticContent' => 'user',
@@ -225,7 +225,7 @@ class UserController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:User:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_user_index',
                 'mauticContent' => 'user',
@@ -349,7 +349,7 @@ class UserController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:User:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_user_index',
                 'route'         => $returnUrl,
@@ -414,7 +414,7 @@ class UserController extends FormController
         if (null === $user) {
             return $this->postActionRedirect([
                 'returnUrl'       => $this->generateUrl('mautic_dashboard_index'),
-                'contentTemplate' => 'MauticUserBundle:User:contact',
+                'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::contactAction',
                 'flashes'         => [
                     [
                         'type'    => 'error',
@@ -531,7 +531,7 @@ class UserController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticUserBundle:User:index',
+            'contentTemplate' => 'Mautic\UserBundle\Controller\UserController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_user_index',
                 'mauticContent' => 'user',

--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -5,11 +5,11 @@ return [
         'main' => [
             'mautic_webhook_index' => [
                 'path'       => '/webhooks/{page}',
-                'controller' => 'MauticWebhookBundle:Webhook:index',
+                'controller' => 'Mautic\WebhookBundle\Controller\WebhookController::indexAction',
             ],
             'mautic_webhook_action' => [
                 'path'       => '/webhooks/{objectAction}/{objectId}',
-                'controller' => 'MauticWebhookBundle:Webhook:execute',
+                'controller' => 'Mautic\WebhookBundle\Controller\WebhookController::executeAction',
             ],
         ],
         'api' => [
@@ -17,11 +17,11 @@ return [
                 'standard_entity' => true,
                 'name'            => 'hooks',
                 'path'            => '/hooks',
-                'controller'      => 'MauticWebhookBundle:Api\WebhookApi',
+                'controller'      => 'Mautic\WebhookBundle\Controller\Api\WebhookApiController',
             ],
             'mautic_api_webhookevents' => [
                 'path'       => '/hooks/triggers',
-                'controller' => 'MauticWebhookBundle:Api\WebhookApi:getTriggers',
+                'controller' => 'Mautic\WebhookBundle\Controller\Api\WebhookApiController::getTriggersAction',
             ],
         ],
     ],

--- a/plugins/GrapesJsBuilderBundle/Config/config.php
+++ b/plugins/GrapesJsBuilderBundle/Config/config.php
@@ -11,15 +11,15 @@ return [
         'main'   => [
             'grapesjsbuilder_upload' => [
                 'path'       => '/grapesjsbuilder/upload',
-                'controller' => 'GrapesJsBuilderBundle:FileManager:upload',
+                'controller' => 'MauticPlugin\GrapesJsBuilderBundle\Controller\FileManagerController::uploadAction',
             ],
             'grapesjsbuilder_delete' => [
                 'path'       => '/grapesjsbuilder/delete',
-                'controller' => 'GrapesJsBuilderBundle:FileManager:delete',
+                'controller' => 'MauticPlugin\GrapesJsBuilderBundle\Controller\FileManagerController::deleteAction',
             ],
             'grapesjsbuilder_builder' => [
                 'path'       => '/grapesjsbuilder/{objectType}/{objectId}',
-                'controller' => 'GrapesJsBuilderBundle:GrapesJs:builder',
+                'controller' => 'MauticPlugin\GrapesJsBuilderBundle\Controller\GrapesJsController::builderAction',
             ],
         ],
         'public' => [],

--- a/plugins/MauticCitrixBundle/Config/config.php
+++ b/plugins/MauticCitrixBundle/Config/config.php
@@ -9,11 +9,11 @@ return [
         'public' => [
             'mautic_citrix_proxy' => [
                 'path'       => '/citrix/proxy',
-                'controller' => 'MauticCitrixBundle:Public:proxy',
+                'controller' => 'MauticPlugin\MauticCitrixBundle\Controller\PublicController::proxyAction',
             ],
             'mautic_citrix_sessionchanged' => [
                 'path'       => '/citrix/sessionChanged',
-                'controller' => 'MauticCitrixBundle:Public:sessionChanged',
+                'controller' => 'MauticPlugin\MauticCitrixBundle\Controller\PublicController::sessionChangedAction',
             ],
         ],
     ],

--- a/plugins/MauticClearbitBundle/Config/config.php
+++ b/plugins/MauticClearbitBundle/Config/config.php
@@ -10,13 +10,13 @@ return [
         'public' => [
             'mautic_plugin_clearbit_index' => [
                 'path'       => '/clearbit/callback',
-                'controller' => 'MauticClearbitBundle:Public:callback',
+                'controller' => 'MauticPlugin\MauticClearbitBundle\Controller\PublicController::callbackAction',
             ],
         ],
         'main' => [
             'mautic_plugin_clearbit_action' => [
                 'path'       => '/clearbit/{objectAction}/{objectId}',
-                'controller' => 'MauticClearbitBundle:Clearbit:execute',
+                'controller' => 'MauticPlugin\MauticClearbitBundle\Controller\ClearbitController::executeAction',
             ],
         ],
     ],

--- a/plugins/MauticCrmBundle/Config/config.php
+++ b/plugins/MauticCrmBundle/Config/config.php
@@ -9,21 +9,21 @@ return [
         'public' => [
             'mautic_integration_contacts' => [
                 'path'         => '/plugin/{integration}/contact_data',
-                'controller'   => 'MauticCrmBundle:Public:contactData',
+                'controller'   => 'MauticPlugin\MauticCrmBundle\Controller\PublicController::contactDataAction',
                 'requirements' => [
                     'integration' => '.+',
                 ],
             ],
             'mautic_integration_companies' => [
                 'path'         => '/plugin/{integration}/company_data',
-                'controller'   => 'MauticCrmBundle:Public:companyData',
+                'controller'   => 'MauticPlugin\MauticCrmBundle\Controller\PublicController::companyDataAction',
                 'requirements' => [
                     'integration' => '.+',
                 ],
             ],
             'mautic_integration.pipedrive.webhook' => [
                 'path'       => '/plugin/pipedrive/webhook',
-                'controller' => 'MauticCrmBundle:Pipedrive:webhook',
+                'controller' => 'MauticPlugin\MauticCrmBundle\Controller\PipedriveController::webhookAction',
                 'method'     => 'POST',
             ],
         ],

--- a/plugins/MauticFocusBundle/Config/config.php
+++ b/plugins/MauticFocusBundle/Config/config.php
@@ -10,21 +10,21 @@ return [
         'main' => [
             'mautic_focus_index' => [
                 'path'       => '/focus/{page}',
-                'controller' => 'MauticFocusBundle:Focus:index',
+                'controller' => 'MauticPlugin\MauticFocusBundle\Controller\FocusController::indexAction',
             ],
             'mautic_focus_action' => [
                 'path'       => '/focus/{objectAction}/{objectId}',
-                'controller' => 'MauticFocusBundle:Focus:execute',
+                'controller' => 'MauticPlugin\MauticFocusBundle\Controller\FocusController::executeAction',
             ],
         ],
         'public' => [
             'mautic_focus_generate' => [
                 'path'       => '/focus/{id}.js',
-                'controller' => 'MauticFocusBundle:Public:generate',
+                'controller' => 'MauticPlugin\MauticFocusBundle\Controller\PublicController::generateAction',
             ],
             'mautic_focus_pixel' => [
                 'path'       => '/focus/{id}/viewpixel.gif',
-                'controller' => 'MauticFocusBundle:Public:viewPixel',
+                'controller' => 'MauticPlugin\MauticFocusBundle\Controller\PublicController::viewPixelAction',
             ],
         ],
         'api' => [
@@ -32,11 +32,11 @@ return [
                 'standard_entity' => true,
                 'name'            => 'focus',
                 'path'            => '/focus',
-                'controller'      => 'MauticFocusBundle:Api\FocusApi',
+                'controller'      => 'MauticPlugin\MauticFocusBundle\Controller\Api\FocusApiController',
             ],
             'mautic_api_focusjs' => [
                 'path'       => '/focus/{id}/js',
-                'controller' => 'MauticFocusBundle:Api\FocusApi:generateJs',
+                'controller' => 'MauticPlugin\MauticFocusBundle\Controller\Api\FocusApiController::generateJsAction',
                 'method'     => 'POST',
             ],
         ],

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -15,10 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class FocusController extends AbstractStandardFormController
 {
-    /**
-     * @return string
-     */
-    protected function getControllerBase()
+    protected function getTemplateBase(): string
     {
         return 'MauticFocusBundle:Focus';
     }

--- a/plugins/MauticFullContactBundle/Config/config.php
+++ b/plugins/MauticFullContactBundle/Config/config.php
@@ -10,13 +10,13 @@ return [
         'public' => [
             'mautic_plugin_fullcontact_index' => [
                 'path'       => '/fullcontact/callback',
-                'controller' => 'MauticFullContactBundle:Public:callback',
+                'controller' => 'MauticPlugin\MauticFullContactBundle\Controller\PublicController::callbackAction',
             ],
         ],
         'main' => [
             'mautic_plugin_fullcontact_action' => [
                 'path'       => '/fullcontact/{objectAction}/{objectId}',
-                'controller' => 'MauticFullContactBundle:FullContact:execute',
+                'controller' => 'MauticPlugin\MauticFullContactBundle\Controller\FullContactController::executeAction',
             ],
         ],
     ],

--- a/plugins/MauticSocialBundle/Config/config.php
+++ b/plugins/MauticSocialBundle/Config/config.php
@@ -10,23 +10,23 @@ return [
         'main' => [
             'mautic_social_index' => [
                 'path'       => '/monitoring/{page}',
-                'controller' => 'MauticSocialBundle:Monitoring:index',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction',
             ],
             'mautic_social_action' => [
                 'path'       => '/monitoring/{objectAction}/{objectId}',
-                'controller' => 'MauticSocialBundle:Monitoring:execute',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::executeAction',
             ],
             'mautic_social_contacts' => [
                 'path'       => '/monitoring/view/{objectId}/contacts/{page}',
-                'controller' => 'MauticSocialBundle:Monitoring:contacts',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::contactsAction',
             ],
             'mautic_tweet_index' => [
                 'path'       => '/tweets/{page}',
-                'controller' => 'MauticSocialBundle:Tweet:index',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\TweetController::indexAction',
             ],
             'mautic_tweet_action' => [
                 'path'       => '/tweets/{objectAction}/{objectId}',
-                'controller' => 'MauticSocialBundle:Tweet:execute',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\TweetController::executeAction',
             ],
         ],
         'api' => [
@@ -34,13 +34,13 @@ return [
                 'standard_entity' => true,
                 'name'            => 'tweets',
                 'path'            => '/tweets',
-                'controller'      => 'MauticSocialBundle:Api\TweetApi',
+                'controller'      => 'MauticPlugin\MauticSocialBundle\Controller\Api\TweetApiController',
             ],
         ],
         'public' => [
             'mautic_social_js_generate' => [
                 'path'       => '/social/generate/{formName}.js',
-                'controller' => 'MauticSocialBundle:Js:generate',
+                'controller' => 'MauticPlugin\MauticSocialBundle\Controller\JsController::generateAction',
             ],
         ],
     ],

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -460,7 +460,7 @@ class MonitoringController extends FormController
                     'security'         => $security,
                     'leadStats'        => $chart->render(),
                     'monitorLeads'     => $this->forward(
-                        'MauticSocialBundle:Monitoring:contacts',
+                        'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::contactsAction',
                         [
                             'objectId'   => $monitoringEntity->getId(),
                             'page'       => $page,

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -64,7 +64,7 @@ class MonitoringController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $lastPage],
-                    'contentTemplate' => 'MauticSocialBundle:Monitoring:index',
+                    'contentTemplate' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_social_index',
                         'mauticContent' => 'monitoring',
@@ -143,7 +143,7 @@ class MonitoringController extends FormController
         ///Check for a submitted form and process it
         if ('POST' == $method) {
             $viewParameters = ['page' => $page];
-            $template       = 'MauticSocialBundle:Monitoring:index';
+            $template       = 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction';
             $valid          = false;
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($valid = $this->isFormValid($form)) {
@@ -177,7 +177,7 @@ class MonitoringController extends FormController
                         'objectAction' => 'view',
                         'objectId'     => $entity->getId(),
                     ];
-                    $template = 'MauticSocialBundle:Monitoring:view';
+                    $template = 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::viewAction';
                 }
             }
             $returnUrl = $this->generateUrl('mautic_social_index', $viewParameters);
@@ -338,7 +338,7 @@ class MonitoringController extends FormController
                         [
                             'returnUrl'       => $this->generateUrl('mautic_social_action', $viewParameters),
                             'viewParameters'  => $viewParameters,
-                            'contentTemplate' => 'MauticSocialBundle:Monitoring:view',
+                            'contentTemplate' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::viewAction',
                         ]
                     )
                 );
@@ -408,7 +408,7 @@ class MonitoringController extends FormController
                 [
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticSocialMonitoringBundle:Monitoring:index',
+                    'contentTemplate' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_social_index',
                         'mauticContent' => 'monitoring',
@@ -499,7 +499,7 @@ class MonitoringController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticSocialBundle:Monitoring:index',
+            'contentTemplate' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => 'mautic_social_index',
                 'mauticContent' => 'monitoring',
@@ -566,7 +566,7 @@ class MonitoringController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticSocialBundle:Monitoring:index',
+            'contentTemplate' => 'MauticPlugin\MauticSocialBundle\Controller\MonitoringController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_social_index',
                 'mauticContent' => 'monitoring',

--- a/plugins/MauticSocialBundle/Controller/TweetController.php
+++ b/plugins/MauticSocialBundle/Controller/TweetController.php
@@ -55,14 +55,6 @@ class TweetController extends FormController
     /**
      * @return mixed
      */
-    protected function getControllerBase()
-    {
-        return 'MauticSocialBundle:Tweet';
-    }
-
-    /**
-     * @return mixed
-     */
     protected function getTranslationBase()
     {
         return 'mautic.integration.Twitter';

--- a/plugins/MauticTagManagerBundle/Config/config.php
+++ b/plugins/MauticTagManagerBundle/Config/config.php
@@ -9,11 +9,11 @@ return [
         'main' => [
             'mautic_tagmanager_index' => [
                 'path'       => '/tags/{page}',
-                'controller' => 'MauticTagManagerBundle:Tag:index',
+                'controller' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
             ],
             'mautic_tagmanager_action' => [
                 'path'       => '/tags/{objectAction}/{objectId}',
-                'controller' => 'MauticTagManagerBundle:Tag:execute',
+                'controller' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::executeAction',
             ],
         ],
     ],

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -100,7 +100,7 @@ class TagController extends FormController
                     'page' => $lastPage,
                     'tmpl' => $tmpl,
                 ],
-                'contentTemplate' => 'MauticTagManagerBundle:Tag:index',
+                'contentTemplate' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_tagmanager_index',
                     'mauticContent' => 'tagmanager',
@@ -196,7 +196,7 @@ class TagController extends FormController
                 return $this->postActionRedirect([
                     'returnUrl'       => $returnUrl,
                     'viewParameters'  => ['page' => $page],
-                    'contentTemplate' => 'MauticTagManagerBundle:Tag:index',
+                    'contentTemplate' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
                     'passthroughVars' => [
                         'activeLink'    => '#mautic_tagmanager_index',
                         'mauticContent' => 'tagmanager',
@@ -396,13 +396,13 @@ class TagController extends FormController
         if ($objectId) {
             $returnUrl       = $this->generateUrl('mautic_tagmanager_action', ['objectAction' => 'view', 'objectId'=> $objectId]);
             $viewParameters  = ['objectAction' => 'view', 'objectId'=> $objectId];
-            $contentTemplate = 'MauticTagManagerBundle:Tag:view';
+            $contentTemplate = 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::viewAction';
         } else {
             //set the page we came from
             $page            = $this->get('session')->get('mautic.tagmanager.page', 1);
             $returnUrl       = $this->generateUrl('mautic_tagmanager_index', ['page' => $page]);
             $viewParameters  = ['page' => $page];
-            $contentTemplate = 'MauticTagManagerBundle:Tag:index';
+            $contentTemplate = 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction';
         }
 
         return [
@@ -441,7 +441,7 @@ class TagController extends FormController
             return $this->postActionRedirect([
                 'returnUrl'       => $returnUrl,
                 'viewParameters'  => ['page' => $page],
-                'contentTemplate' => 'MauticTagManagerBundle:Tag:index',
+                'contentTemplate' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
                 'passthroughVars' => [
                     'activeLink'    => '#mautic_tagmanager_index',
                     'mauticContent' => 'tagmanager',
@@ -489,7 +489,7 @@ class TagController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticTagManagerBundle:Tag:index',
+            'contentTemplate' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_tagmanager_index',
                 'mauticContent' => 'tagmanager',
@@ -558,7 +558,7 @@ class TagController extends FormController
         $postActionVars = [
             'returnUrl'       => $returnUrl,
             'viewParameters'  => ['page' => $page],
-            'contentTemplate' => 'MauticTagManagerBundle:Tag:index',
+            'contentTemplate' => 'MauticPlugin\MauticTagManagerBundle\Controller\TagController::indexAction',
             'passthroughVars' => [
                 'activeLink'    => '#mautic_tagmanager_index',
                 'mauticContent' => 'tagmanager',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [x]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://mautic.atlassian.net/browse/TPROD-282 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR rewrites all controller references from `bundle:controller:action` syntax to new `serviceOrFqcn::method` syntax. The `bundle:controller:action` syntax will be no longer supported in Symfony 5.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure everything is working as all controller references have been rewritten.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11055"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

