### PR TITLE
split up of lead column structure and field data fixtures

### DIFF
--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -130,6 +130,11 @@ return [
                     'security.password_encoder',
                 ],
             ],
+            'mautic.install.leadcolumns' => [
+                'class'     => \Mautic\InstallBundle\EventListener\DoctrineEventSubscriber::class,
+                'tag'       => 'doctrine.event_subscriber',
+                'arguments' => [],
+            ],
         ],
     ],
 ];

--- a/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
+++ b/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Mautic\InstallBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Mautic\LeadBundle\Field\SchemaDefinition;
+use Mautic\LeadBundle\Model\FieldModel;
+
+class DoctrineEventSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return [
+            'postGenerateSchema',
+        ];
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $args): void
+    {
+        $schema = $args->getSchema();
+
+        $fieldGroups['leads']     = FieldModel::$coreFields;
+        $fieldGroups['companies'] = FieldModel::$coreCompanyFields;
+
+        foreach ($fieldGroups as $tableName => $fields) {
+            $table = $schema->getTable($tableName);
+
+            foreach ($fields as $alias => $field) {
+                if (!$table->hasColumn($alias)) {
+                    $type       = $field['type'] ?? 'text';
+                    $definition = SchemaDefinition::getSchemaDefinition($alias, $type, !empty($field['unique']));
+                    $table->addColumn($definition['name'], $definition['type'], $definition['options']);
+
+                    if ('textarea' !== $type) {
+                        $table->addIndex([$definition['name']], $definition['name'].'_search');
+                    }
+                }
+            }
+
+            if ('leads' === $tableName) {
+                // Add an attribution index
+                $table->addIndex(['attribution', 'attribution_date'], 'contact_attribution');
+                //Add date added and country index
+                $table->addIndex(['date_added', 'country'], 'date_added_country_index');
+            } else {
+                $table->addIndex(['companyname', 'companyemail'], 'company_filter');
+                $table->addIndex(['companyname', 'companycity', 'companycountry', 'companystate'], 'company_match');
+            }
+        }
+    }
+}

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -6,9 +6,6 @@ use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
-use Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper;
-use Mautic\CoreBundle\Exception\SchemaException;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -17,19 +14,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface, FixtureGroupInterface
 {
     /**
-     * @var bool
-     */
-    private $addIndexes;
-
-    /**
      * @var ContainerInterface
      */
     private $container;
-
-    public function __construct(bool $addIndexes = true)
-    {
-        $this->addIndexes = $addIndexes;
-    }
 
     /**
      * {@inheritdoc}
@@ -56,16 +43,7 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
         $fieldGroups['company'] = FieldModel::$coreCompanyFields;
 
         $translator   = $this->container->get('translator');
-        $indexesToAdd = [];
-        foreach ($fieldGroups as $object => $fields) {
-            if ('company' === $object) {
-                /** @var ColumnSchemaHelper $schema */
-                $schema = $this->container->get('mautic.schema.helper.column')->setName('companies', true);
-            } else {
-                /** @var ColumnSchemaHelper $schema */
-                $schema = $this->container->get('mautic.schema.helper.column')->setName('leads', true);
-            }
-
+        foreach ($fieldGroups as $fields) {
             $order = 1;
             foreach ($fields as $alias => $field) {
                 $type = isset($field['type']) ? $field['type'] : 'text';
@@ -91,53 +69,11 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
                 $manager->persist($entity);
                 $manager->flush();
 
-                try {
-                    $schema->addColumn(
-                        FieldModel::getSchemaDefinition($alias, $type, $entity->getIsUniqueIdentifier())
-                    );
-                } catch (SchemaException $e) {
-                    // Schema already has this custom field; likely defined as a property in the entity class itself
-                }
-
-                if ($this->addIndexes) {
-                    $indexesToAdd[$object][$alias] = $field;
-                }
-
                 if (!$this->hasReference('leadfield-'.$alias)) {
                     $this->addReference('leadfield-'.$alias, $entity);
                 }
                 ++$order;
             }
-
-            $schema->executeChanges();
-        }
-
-        foreach ($indexesToAdd as $object => $indexes) {
-            if ('company' === $object) {
-                /** @var IndexSchemaHelper $indexHelper */
-                $indexHelper = $this->container->get('mautic.schema.helper.index')->setName('companies');
-            } else {
-                /** @var IndexSchemaHelper $indexHelper */
-                $indexHelper = $this->container->get('mautic.schema.helper.index')->setName('leads');
-            }
-
-            foreach ($indexes as $name => $field) {
-                $type = (isset($field['type'])) ? $field['type'] : 'text';
-                if ('textarea' !== $type) {
-                    $indexHelper->addIndex([$name], $name.'_search');
-                }
-            }
-            if ('lead' === $object) {
-                // Add an attribution index
-                $indexHelper->addIndex(['attribution', 'attribution_date'], 'contact_attribution');
-                //Add date added and country index
-                $indexHelper->addIndex(['date_added', 'country'], 'date_added_country_index');
-            } else {
-                $indexHelper->addIndex(['companyname', 'companyemail'], 'company_filter');
-                $indexHelper->addIndex(['companyname', 'companycity', 'companycountry', 'companystate'], 'company_match');
-            }
-
-            $indexHelper->executeChanges();
         }
     }
 

--- a/app/bundles/LeadBundle/Field/SchemaDefinition.php
+++ b/app/bundles/LeadBundle/Field/SchemaDefinition.php
@@ -43,6 +43,7 @@ class SchemaDefinition
             case 'multiselect':
             case 'region':
             case 'tel':
+            case 'url':
                 $schemaType = 'string';
                 break;
             case 'text':


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When testing and working on the PHP 8 support (see https://github.com/mautic/mautic/pull/9969#issuecomment-1020322075), I noticed there are some fixtures that contain [DDL queries](https://www.geeksforgeeks.org/sql-ddl-dql-dml-dcl-tcl-commands/).

As Doctrine processes fixtures as 1 transaction that can be rolled back, and DDL queries force a commit when executed,
this results in an error when Doctrine tries to commit the transaction again.

in PHP < 8, this error was silently ignored, but in PHP >= 8 this error results in a ` There is no active transaction` PDOException.

One of the fixtures adds the optional field data to the lead_fields table (OK), and creates the columns for the optional leads and company fields (NOT OK)

This PR splits up those 2 tasks.
The column creation is moved to an eventlistener (`postGenerateSchema`)

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. check if all the expected optional contact fields (e.g. facebook, fax, ... ) are present, both on a contact and on the admin page where you can disable them

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11059"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

