### PR TITLE
rework the seek / fgets combo to be compatible with both PHP 7 and 8

### DIFF
--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -274,7 +274,7 @@ class ImportModel extends FormModel
     public function process(Import $import, Progress $progress, $limit = 0)
     {
         //Auto detect line endings for the file to work around MS DOS vs Unix new line characters
-        ini_set('auto_detect_line_endings', true);
+        ini_set('auto_detect_line_endings', '1');
 
         try {
             $file = new \SplFileObject($import->getFilePath());

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -292,10 +292,7 @@ class ImportModel extends FormModel
         $config           = $import->getParserConfig();
         $counter          = 0;
 
-        if ($lastImportedLine > 0) {
-            // Seek is zero-based line numbering and
-            $file->seek($lastImportedLine - 1);
-        }
+        $file->seek($lastImportedLine);
 
         $lineNumber = $lastImportedLine + 1;
         $this->logDebug('The import is starting on line '.$lineNumber, $import);
@@ -308,7 +305,9 @@ class ImportModel extends FormModel
         });
 
         while ($batchSize && !$file->eof()) {
-            $data = $file->fgetcsv($config['delimiter'], $config['enclosure'], $config['escape']);
+            $string = $file->current();
+            $file->next();
+            $data = str_getcsv($string, $config['delimiter'], $config['enclosure'], $config['escape']);
             $import->setLastLineImported($lineNumber);
 
             // Ignore the header row


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

_this is a needed bugfix for the PHP 8 support, so that's why it's marked as a new feature / enhancement instead of a bugfix._

When testing and working on the PHP 8 support (see https://github.com/mautic/mautic/pull/9969#issuecomment-1020322075), I noticed a test failure for the `ImportModelTest::testLimit` test.

The run with PHP 8 would result in the last row of the first batch to be reimported as first row of the second batch.
This results in an extra imported row, failing the test.

After a long banging my head against the wall session, I found out this is actually a [PHP bugfix / feature](https://bugs.php.net/bug.php?id=81551).

Bottom line is that the default behaviour of [`splfileobject.fgets`](https://www.php.net/manual/en/splfileobject.fgets.php)  (and `splfileobject.fgetscsv`) has changed in PHP 8, without any BC breaking documentation.

This PR reworks the logic to have a consistent outcome in both PHP 7 and 8.
This is done by not relying on `fgets()` moving the line forward (which it doesn't anymore in PHP8 ), but using `current()` and `next()`.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

This PR isn't really testable manually, as it ensures the test outcome in PHPUnit is consistent between PHP 7 and PHP 8.

If you want to test this manually, you could try following steps

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. go to https://example.com/s/contacts/import/new
3. import a CSV file that has +- 3,5 times the number of rows than the configured batch site (this to reproduce the multiple scenrario's like first batch, second batch, last half batch,...)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11060"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

