### PR TITLE
Fixing GH actions for 4.2 branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v6.2
+      uses: tj-actions/changed-files@v18.7
 
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
See https://github.com/mautic/mautic/pull/11074. This is the same commit for 4.2 branch to unblock PRs based on this branch.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11075"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

