### PR TITLE
Dynamics plugin broken - Pulling - Caps in object

### DIFF
--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -218,7 +218,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    public function populateLeadData($lead, $config = [], $object = 'Contacts')
+    public function populateLeadData($lead, $config = [], $object = 'contacts')
     {
         if ('company' === $object) {
             $object = 'accounts';
@@ -404,7 +404,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
      */
     public function getLeads($params = [], $query = null, &$executed = null, $result = [], $object = 'contacts')
     {
-        if ('Contact' === $object) {
+        if ('Contact' === $object || 'Contacts' === $object) {
             $object = 'contacts';
         }
         $executed    = 0;
@@ -574,7 +574,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
                     $recordId = $entityData['accountid'];
                     // first try to find integration entity
                     $integrationId = $integrationEntityRepo->getIntegrationsEntityId('Dynamics', $object, 'company',
-                        null, null, null, false, 0, 0, "'".$recordId."'");
+                        null, null, null, false, 0, 0, $recordId);
                     if (count($integrationId)) { // company exists, then update local fields
                         /** @var Company $entity */
                         $entity        = $this->companyModel->getEntity($integrationId[0]['internal_entity_id']);
@@ -624,7 +624,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
                     $recordId = $entityData['contactid'];
                     // first try to find integration entity
                     $integrationId = $integrationEntityRepo->getIntegrationsEntityId('Dynamics', $object, 'lead',
-                        null, null, null, false, 0, 0, "'".$recordId."'");
+                        null, null, null, false, 0, 0, $recordId);
                     if (count($integrationId)) { // lead exists, then update
                         /** @var Lead $entity */
                         $entity        = $this->leadModel->getEntity($integrationId[0]['internal_entity_id']);


### PR DESCRIPTION
Pulling from dynamics gets 'Contacts' as $object, which results in not being able to map any data as it is case-sentive (should be 'contacts')

Also retreiving integrationId broken due to added quotes.

Guess nobody is actually using the dynamics 365 integration?

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]
| Issue(s) addressed                     | Fixes: issue not exists

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Enable Dynamics plugin and run task to reproduce errors:
php bin/console mautic:integration:fetchleads -i Dynamics -vvv
