### PR TITLE
Dynamics plugin broken - pushing - ContentType headers return array

### DIFF
--- a/plugins/MauticCrmBundle/Api/DynamicsApi.php
+++ b/plugins/MauticCrmBundle/Api/DynamicsApi.php
@@ -222,7 +222,7 @@ class DynamicsApi extends CrmApi
     {
         $a_data      = [];
         $input       = $response->getBody();
-        $contentType = $response->getHeaders()['Content-Type'];
+        $contentType = $response->getHeaders()['Content-Type'][0];
         // grab multipart boundary from content type header
         preg_match('/boundary=(.*)$/', $contentType, $matches);
         $boundary = $matches[1];


### PR DESCRIPTION
Dynamics response getHeaders()['Content-Type'] returns an array. Select first element.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]
| Issue(s) addressed                     | Fixes non existent issue

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When pushing new leads to Dynamics the response parsing is unable to process it.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11083"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

