### PR TITLE
Fix network issues when running composer in ddev

### DIFF
--- a/.ddev/docker-compose.network-mtu.yaml
+++ b/.ddev/docker-compose.network-mtu.yaml
@@ -1,0 +1,18 @@
+# Temporary fix for network issues when running composer inside ddev container (in Gitpod)
+#
+# Since Gitpod removed slirp4netns as part of performance improvements,
+# MTU value should be aligned to the one in gitpod.io
+#
+# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
+# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
+#
+# ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses
+# its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
+# ddev issue [WIP] - https://github.com/drud/ddev/issues/3766
+#
+# Align the MTU value to the one that is set in Gitpod (1440)
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1440


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Summary -
Temporary fix for network issues when running composer inside ddev container (in Gitpod)

Details -
Since Gitpod removed slirp4netns as part of performance improvements,
MTU value should be aligned to the one in gitpod.io

Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4

ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses 
its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
ddev issue [WIP] - https://github.com/drud/ddev/issues/3766

Align the MTU value to the one that is set in Gitpod (1440) 

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. In terminal, run - `ddev ssh`
3. Run `curl https://www.drupal.org`
4. Repeat the last step 10 times, confirm it never halts


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11084"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

