### PR TITLE
Add wordpress to the list of automatic integrations

### DIFF
--- a/app/bundles/FormBundle/Translations/en_US/messages.ini
+++ b/app/bundles/FormBundle/Translations/en_US/messages.ini
@@ -128,6 +128,7 @@ mautic.form.form.help.automaticcopy="With this option, Mautic will automatically
 mautic.form.form.help.automaticcopy.js="Via Javascript (recommended)"
 mautic.form.form.help.automaticcopy.iframe="Via iframe"
 mautic.form.form.help.automaticcopy.iframe.note="Note: Adjust the width and height attribute so the form fits in."
+mautic.form.form.help.automaticcopy.wordpress="WordPress"
 mautic.form.form.help.landingpages="It's really simple to place a form inside a Mautic landing page: just use the editor to select the form! But if you want more flexibility, use one of the other two options below."
 mautic.form.form.help.manualcopy="This option requires you to manually update the HTML if you make any changes to the form from within Mautic. But, it gives you flexibility to edit the code and/or not rely on Mautic to serve up the form."
 mautic.form.form.help.manualcopy.body="Copy and paste the form's content into the document's body."

--- a/app/bundles/FormBundle/Views/Form/details.html.php
+++ b/app/bundles/FormBundle/Views/Form/details.html.php
@@ -333,7 +333,9 @@ $showActions = count($activeFormActions);
                             true
                         ); ?>" width="300" height="300"&gt;&lt;p&gt;Your browser does not support iframes.&lt;/p&gt;&lt;/iframe&gt;</textarea>
                     <i><?php echo $view['translator']->trans('mautic.form.form.help.automaticcopy.iframe.note'); ?></i>
-                </div>
+                    <h3 class="pt-lg"><?php echo $view['translator']->trans('mautic.form.form.help.automaticcopy.wordpress'); ?></h3>
+                    <textarea class="form-control" readonly onclick="this.setSelectionRange(0, this.value.length);">&lsqb;mautic type="form" id="&lcub;&lcub;<?php echo$activeForm->getId(); ?>&rcub;&rcub;"&rsqb;</textarea>
+               </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo $view['translator']->trans(
                             'mautic.core.close'


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [no]
| New feature/enhancement? (use the a.x branch)      | [yes]
| Deprecations?                          | [no]
| BC breaks? (use the c.x branch)        | [no]
| Automated tests included?              | [no] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
As a user I want an easy way to integrate my form with my CMS

Since Wordpress is the most commonly used CMS we should add it to the list of options to automatically integrate Forms.
#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new form or use existing one
3. Open the modal to copy the injection code 
4. Wordpress injection code here

![image](https://user-images.githubusercontent.com/96085911/164650346-8d342353-5e14-4fa2-872f-791a1d1043a6.png)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11096"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

