### PR TITLE
Fix user language preference over system language

### DIFF
--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -130,12 +130,7 @@ class ConfigController extends FormController
                             $this->addFlash('mautic.config.config.error.not.updated', ['%exception%' => $exception->getMessage()], 'error');
                         }
 
-                        $me     = $this->get('security.token_storage')->getToken()->getUser();
-                        $locale = $me->getLocale();
-                        if (empty($locale)) {
-                            $locale = $params['locale'] ?? $this->get('mautic.helper.core_parameters')->get('locale');
-                        }
-                        $this->get('session')->set('_locale', $locale);
+                        $this->setLocale($params);
                     }
                 } elseif (!$isWritabale) {
                     $form->addError(
@@ -288,5 +283,20 @@ class ConfigController extends FormController
                 }
             }
         }
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function setLocale(array $params): void
+    {
+        $me     = $this->get('security.token_storage')->getToken()->getUser();
+        $locale = $me->getLocale();
+
+        if (empty($locale)) {
+            $locale = $params['locale'] ?? $this->get('mautic.helper.core_parameters')->get('locale');
+        }
+
+        $this->get('session')->set('_locale', $locale);
     }
 }

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -129,6 +129,13 @@ class ConfigController extends FormController
                         } catch (\RuntimeException $exception) {
                             $this->addFlash('mautic.config.config.error.not.updated', ['%exception%' => $exception->getMessage()], 'error');
                         }
+
+                        $me     = $this->get('security.token_storage')->getToken()->getUser();
+                        $locale = $me->getLocale();
+                        if (empty($locale)) {
+                            $locale = $params['locale'] ?? $this->get('mautic.helper.core_parameters')->get('locale');
+                        }
+                        $this->get('session')->set('_locale', $locale);
                     }
                 } elseif (!$isWritabale) {
                     $form->addError(

--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -266,12 +266,12 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         $accountForm       = $accountSaveButton->form();
         $accountForm->setValues(
             [
-                'user[locale]' => 'de',
+                'user[locale]' => 'en_US',
             ]
         );
         $this->client->submit($accountForm);
         Assert::assertTrue($this->client->getResponse()->isOk());
-        Assert::assertSame('de', self::$container->get('session')->get('_locale'));
+        Assert::assertSame('en_US', self::$container->get('session')->get('_locale'));
 
         // 2. Change system locale in configuration - should not change _locale session
         $configCrawler    = $this->client->request(Request::METHOD_GET, '/s/config/edit');
@@ -285,7 +285,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         );
         $this->client->submit($configForm);
         Assert::assertTrue($this->client->getResponse()->isOk());
-        Assert::assertSame('de', self::$container->get('session')->get('_locale'));
+        Assert::assertSame('en_US', self::$container->get('session')->get('_locale'));
 
         // 3. Change user locale to system default in account - should change _locale session to system default
         $accountCrawler    = $this->client->request(Request::METHOD_GET, '/s/account');
@@ -293,7 +293,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         $accountForm       = $accountSaveButton->form();
         $accountForm->setValues(
             [
-                'user[locale]' => null,
+                'user[locale]' => '',
             ]
         );
         $this->client->submit($accountForm);

--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -25,6 +25,8 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
             'kernel.project_dir',
         ];
 
+        $this->configParams['locale'] = 'en_US';
+
         parent::setUp();
 
         $this->prefix = MAUTIC_TABLE_PREFIX;
@@ -254,5 +256,62 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertEquals($campaign_notification_email_addresses, $form['config[notification_config][campaign_notification_email_addresses]']->getValue());
         Assert::assertEquals($send_notification_to_author, $form['config[notification_config][webhook_send_notification_to_author]']->getValue());
         Assert::assertEquals($webhook_notification_email_addresses, $form['config[notification_config][webhook_notification_email_addresses]']->getValue());
+    }
+
+    public function testUserAndSystemLocale(): void
+    {
+        // 1. Change user locale in account - should change _locale session
+        $accountCrawler    = $this->client->request(Request::METHOD_GET, '/s/account');
+        $accountSaveButton = $accountCrawler->selectButton('user[buttons][save]');
+        $accountForm       = $accountSaveButton->form();
+        $accountForm->setValues(
+            [
+                'user[locale]' => 'de',
+            ]
+        );
+        $this->client->submit($accountForm);
+        Assert::assertTrue($this->client->getResponse()->isOk());
+        Assert::assertSame('de', self::$container->get('session')->get('_locale'));
+
+        // 2. Change system locale in configuration - should not change _locale session
+        $configCrawler    = $this->client->request(Request::METHOD_GET, '/s/config/edit');
+        $configSaveButton = $configCrawler->selectButton('config[buttons][save]');
+        $configForm       = $configSaveButton->form();
+        $configForm->setValues(
+            [
+                'config[coreconfig][locale]'   => 'en_US',
+                'config[coreconfig][site_url]' => 'https://mautic-cloud.local', // required
+            ]
+        );
+        $this->client->submit($configForm);
+        Assert::assertTrue($this->client->getResponse()->isOk());
+        Assert::assertSame('de', self::$container->get('session')->get('_locale'));
+
+        // 3. Change user locale to system default in account - should change _locale session to system default
+        $accountCrawler    = $this->client->request(Request::METHOD_GET, '/s/account');
+        $accountSaveButton = $accountCrawler->selectButton('user[buttons][save]');
+        $accountForm       = $accountSaveButton->form();
+        $accountForm->setValues(
+            [
+                'user[locale]' => null,
+            ]
+        );
+        $this->client->submit($accountForm);
+        Assert::assertTrue($this->client->getResponse()->isOk());
+        Assert::assertSame('en_US', self::$container->get('session')->get('_locale'));
+
+        // 2. Change system locale in configuration to en_US - should change _locale session
+        $configCrawler    = $this->client->request(Request::METHOD_GET, '/s/config/edit');
+        $configSaveButton = $configCrawler->selectButton('config[buttons][save]');
+        $configForm       = $configSaveButton->form();
+        $configForm->setValues(
+            [
+                'config[coreconfig][locale]'   => 'en_US',
+                'config[coreconfig][site_url]' => 'https://mautic-cloud.local', // required
+            ]
+        );
+        $this->client->submit($configForm);
+        Assert::assertTrue($this->client->getResponse()->isOk());
+        Assert::assertSame('en_US', self::$container->get('session')->get('_locale'));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
@@ -67,7 +67,7 @@ class EnvironmentSubscriberTest extends TestCase
         $requestMock->expects($this->once())
             ->method('hasPreviousSession')
             ->willReturn(true);
-        $requestMock->expects($this->once())
+        $requestMock->expects($this->exactly(2))
             ->method('getSession')
             ->willReturn($sessionInterfaceMock);
         $sessionInterfaceMock->expects($this->once())
@@ -77,6 +77,10 @@ class EnvironmentSubscriberTest extends TestCase
         $requestMock->expects($this->once())
             ->method('setLocale')
             ->with('en_US');
+        $sessionInterfaceMock->expects($this->once())
+            ->method('set')
+            ->with('_locale')
+            ->willReturn('en_US');
         $this->coreParametersHelperMock->expects($this->never())
             ->method('get')
             ->with('locale');

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\EventListener;
+
+use Mautic\CoreBundle\EventListener\EnvironmentSubscriber;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class EnvironmentSubscriberTest extends TestCase
+{
+    private EnvironmentSubscriber $environmentSubscriber;
+
+    /**
+     * @var MockObject|CoreParametersHelper
+     */
+    private $coreParametersHelperMock;
+
+    protected function setUp(): void
+    {
+        $this->coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
+        $this->environmentSubscriber    = new EnvironmentSubscriber($this->coreParametersHelperMock);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        Assert::assertSame(
+            [
+                KernelEvents::REQUEST => [
+                    ['onKernelRequestSetTimezone', 128],
+                    ['onKernelRequestSetLocale', 101],
+                ],
+            ],
+            $this->environmentSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testSetLocaleThatDoesNotHavePreviousSession(): void
+    {
+        $requestEventMock = $this->createMock(RequestEvent::class);
+        $requestMock      = $this->createMock(Request::class);
+        $requestEventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($requestMock);
+        $requestMock->expects($this->once())
+            ->method('hasPreviousSession')
+            ->willReturn(false);
+
+        $this->environmentSubscriber->onKernelRequestSetLocale($requestEventMock);
+    }
+
+    public function testSetLocaleWithUserLanguagePreference(): void
+    {
+        $requestEventMock     = $this->createMock(RequestEvent::class);
+        $requestMock          = $this->createMock(Request::class);
+        $sessionInterfaceMock = $this->createMock(SessionInterface::class);
+        $requestEventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($requestMock);
+        $requestMock->expects($this->once())
+            ->method('hasPreviousSession')
+            ->willReturn(true);
+        $requestMock->expects($this->once())
+            ->method('getSession')
+            ->willReturn($sessionInterfaceMock);
+        $sessionInterfaceMock->expects($this->once())
+            ->method('get')
+            ->with('_locale')
+            ->willReturn('en_US');
+        $requestMock->expects($this->once())
+            ->method('setLocale')
+            ->with('en_US');
+        $this->coreParametersHelperMock->expects($this->never())
+            ->method('get')
+            ->with('locale');
+
+        $this->environmentSubscriber->onKernelRequestSetLocale($requestEventMock);
+    }
+
+    public function testSetLocaleWithSystemLanguage(): void
+    {
+        $requestEventMock     = $this->createMock(RequestEvent::class);
+        $requestMock          = $this->createMock(Request::class);
+        $sessionInterfaceMock = $this->createMock(SessionInterface::class);
+        $requestEventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($requestMock);
+        $requestMock->expects($this->once())
+            ->method('hasPreviousSession')
+            ->willReturn(true);
+        $requestMock->expects($this->exactly(2))
+            ->method('getSession')
+            ->willReturn($sessionInterfaceMock);
+        $sessionInterfaceMock->expects($this->once())
+            ->method('get')
+            ->with('_locale')
+            ->willReturn(null);
+        $this->coreParametersHelperMock->expects($this->once())
+            ->method('get')
+            ->with('locale')
+            ->willReturn('en_GB');
+        $requestMock->expects($this->once())
+            ->method('setLocale')
+            ->with('en_GB');
+        $sessionInterfaceMock->expects($this->once())
+            ->method('set')
+            ->with('_locale')
+            ->willReturn('en_GB');
+
+        $this->environmentSubscriber->onKernelRequestSetLocale($requestEventMock);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | ❌ 
| Deprecations?                          | ❌ 
| BC breaks? (use the c.x branch)        | ❌ 
| Automated tests included?              | ✅  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

The user language preferences should have precedence over system language preference. If you change the user language preference, the system language takes immediate effect. This PR fixes this.

To change the language back to what the system language is, user must select 'System Default Locale' from the account section.

#### Steps to reproduce:
1. Login and change the user language preferences from Account settings
2. Now, go to configuration and change system language - this should not get applied immediately but, only after 'System Default Locale' is applied from Account settings

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Follow steps to reproduce and after PR it should work

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

