### PR TITLE
Instances with DB prefix set failed after #11059

### DIFF
--- a/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
+++ b/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
@@ -24,7 +24,7 @@ class DoctrineEventSubscriber implements EventSubscriber
         $fieldGroups['companies'] = FieldModel::$coreCompanyFields;
 
         foreach ($fieldGroups as $tableName => $fields) {
-            $table = $schema->getTable($tableName);
+            $table = $schema->getTable(MAUTIC_TABLE_PREFIX.$tableName);
 
             foreach ($fields as $alias => $field) {
                 if (!$table->hasColumn($alias)) {


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/pull/11059

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I had this error on an instance that have DB prefix configured:
```
www-data@d9710f602dd2:~/html$ bin/console d:s:u --dump-sql -vvv
09:07:07 NOTICE    [mautic] Doctrine\DBAL\Schema\SchemaException: There is no table with name 'db.leads' in the schema. (uncaught exception) at /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/SchemaException.php line 34 while running console command `doctrine:schema:update`
[stack trace]
#0 /var/www/html/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/Schema.php(178): Doctrine\DBAL\Schema\SchemaException::tableDoesNotExist('db.leads')
#1 /var/www/html/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php(27): Doctrine\DBAL\Schema\Schema->getTable('db.leads')
#2 /var/www/html/vendor/symfony/doctrine-bridge/ContainerAwareEventManager.php(64): Mautic\InstallBundle\EventListener\DoctrineEventSubscriber->postGenerateSchema(Object(Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs))
#3 /var/www/html/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/SchemaTool.php(415): Symfony\Bridge\Doctrine\ContainerAwareEventManager->dispatchEvent('postGenerateSch...', Object(Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs))
#4 /var/www/html/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/SchemaTool.php(938): Doctrine\ORM\Tools\SchemaTool->getSchemaFromMetadata(Array)
#5 /var/www/html/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php(95): Doctrine\ORM\Tools\SchemaTool->getUpdateSchemaSql(Array, true)
#6 /var/www/html/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php(61): Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand->executeSchemaCommand(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput), Object(Doctrine\ORM\Tools\SchemaTool), Array, Object(Symfony\Component\Console\Style\SymfonyStyle))
#7 /var/www/html/vendor/doctrine/doctrine-bundle/Command/Proxy/UpdateSchemaDoctrineCommand.php(40): Doctrine\ORM\Tools\Console\Command\SchemaTool\AbstractCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/vendor/symfony/console/Command/Command.php(255): Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/vendor/symfony/console/Application.php(1027): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(97): Symfony\Component\Console\Application->doRunCommand(Object(Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /var/www/html/vendor/symfony/console/Application.php(273): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Doctrine\Bundle\DoctrineBundle\Command\Proxy\UpdateSchemaDoctrineCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(83): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/html/vendor/symfony/console/Application.php(149): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/html/bin/console(43): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 {main}
```
It works on the 4.2 branch so I searched from PRs merged into the 4.3 milestone and found that https://github.com/mautic/mautic/pull/11059 is missing DB prefix.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `bin/console d:s:u --dump-sql -vvv` on the 4.x branch. It will work on this branch.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

