### PR TITLE
Clearing risky tests

### DIFF
--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -311,7 +311,9 @@ abstract class AbstractCommonModel
     }
 
     /**
-     * @param $alias
+     * @param string      $alias
+     * @param string|null $categoryAlias
+     * @param string|null $lang
      *
      * @return object|null
      */

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -42,7 +42,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
              */
             public function addViolation($message, array $parameters = [])
             {
-                $this->violationCount++;
+                ++$this->violationCount;
                 ($this->violationResult)($message, $parameters);
             }
         };

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -24,15 +24,15 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
      *
      * @param mixed $value
      */
-    public function testNoEmailsProvided($value, callable $getFieldMocker, callable $violationResult): void
+    public function testNoEmailsProvided($value, int $expectedViolationCount, callable $getFieldMocker, callable $violationResult): void
     {
-        $context = new class($violationResult) extends ExecutionContext {
+        $context = new class() extends ExecutionContext {
             /** @var callable */
-            private $violationResult;
+            public $violationResult;
+            public int $violationCount = 0;
 
-            public function __construct(callable $violationResult)
+            public function __construct()
             {
-                $this->violationResult = $violationResult;
             }
 
             /**
@@ -42,9 +42,12 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
              */
             public function addViolation($message, array $parameters = [])
             {
+                $this->violationCount++;
                 ($this->violationResult)($message, $parameters);
             }
         };
+
+        $context->violationResult = $violationResult;
 
         $translator = new class() extends Translator {
             public function __construct()
@@ -71,25 +74,21 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             }
         };
 
-        $fieldModel = new class($getFieldMocker) extends FieldModel {
+        $fieldModel = new class() extends FieldModel {
             /** @var callable */
-            private $getFieldMocker;
+            public $getFieldMocker;
 
-            public function __construct(callable $getFieldMocker)
+            public function __construct()
             {
-                $this->getFieldMocker = $getFieldMocker;
             }
 
-            /**
-             * @param string      $alias
-             * @param string|null $categoryAlias
-             * @param string|null $lang
-             */
             public function getEntityByAlias($alias, $categoryAlias = null, $lang = null)
             {
                 return ($this->getFieldMocker)($alias);
             }
         };
+
+        $fieldModel->getFieldMocker = $getFieldMocker;
 
         $emaiOrEmailTokenListValidator = new EmailOrEmailTokenListValidator(
             new EmailValidator($translator, $dispatcher),
@@ -97,8 +96,9 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         );
 
         $emaiOrEmailTokenListValidator->initialize($context);
-
         $emaiOrEmailTokenListValidator->validate($value, new EmailOrEmailTokenList());
+
+        Assert::assertSame($expectedViolationCount, $context->violationCount);
     }
 
     /**
@@ -109,6 +109,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test null value.
         yield [
             null,
+            0,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -120,6 +121,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test empty value.
         yield [
             '',
+            0,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -131,6 +133,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test invalid email and invalid token.
         yield [
             'somestring',
+            1,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -149,6 +152,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test that valid email address do not add any violation.
         yield [
             'john@doe.com',
+            0,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -160,6 +164,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test valid email address with invalid token.
         yield [
             'john@doe.com, somestring',
+            1,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -177,6 +182,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
 
         yield [
             'john@doe.com, {contactfield=somefield | invalid-default-email-address}',
+            1,
             function () {
                 $this->fail('Field should not be fetched');
             },
@@ -195,6 +201,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test error when the field is not found in the database.
         yield [
             'john@doe.com, {contactfield=somefield|jane@doe.com}',
+            1,
             function (string $alias) {
                 Assert::assertSame('somefield', $alias);
 
@@ -215,6 +222,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test error when the field is found but is not type of email.
         yield [
             'john@doe.com, {contactfield=somefield}',
+            1,
             function (string $alias) {
                 Assert::assertSame('somefield', $alias);
 
@@ -239,6 +247,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test valid email addresses and valid tokens.
         yield [
             'john@doe.com, {contactfield=somefield|jane@doe.com}, jone@doe.email, {contactfield=somefield}',
+            0,
             function (string $alias) {
                 Assert::assertSame('somefield', $alias);
 
@@ -256,6 +265,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         // Test valid email addresses and valid token but without a comma between.
         yield [
             'jone@doe.email {contactfield=somefield}',
+            1,
             function (string $alias) {
                 Assert::assertSame('somefield', $alias);
 

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -1,19 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Validator\Constraints;
 
-use Mautic\EmailBundle\Helper\EmailValidator;
+use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Form\Validator\Constraints\EmailAddress;
 use Mautic\LeadBundle\Form\Validator\Constraints\EmailAddressValidator;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
-class EmailAddressValidatorTest extends \PHPUnit\Framework\TestCase
+class EmailAddressValidatorTest extends AbstractMauticTestCase
 {
-    public function testValidate(): void
+    /**
+     * @dataProvider provider
+     */
+    public function testValidate(?string $value, int $expectedViolationCount): void
     {
-        $constraint            = new EmailAddress();
-        $emailAddressValidator = $this->createMock(EmailValidator::class);
-        $emailAddressValidator->method('validate')->willReturn(null);
-        $validator  = new EmailAddressValidator($emailAddressValidator);
-        $validator->validate('test@test.com', $constraint);
+        /** @var EmailAddressValidator $emailAddressValidator */
+        $emailAddressValidator = self::$container->get('mautic.validator.emailaddress');
+
+        $context = new ExecutionContext(
+            $this->createMock(ValidatorInterface::class),
+            null,
+            $this->createMock(TranslatorInterface::class)
+        );
+
+        $emailAddressValidator->initialize($context);
+        $emailAddressValidator->validate($value, new EmailAddress());
+
+        Assert::assertSame($expectedViolationCount, $context->getViolations()->count());
+    }
+
+    public function provider(): iterable
+    {
+        yield [null, 0];
+        yield ['', 0];
+        yield ['test@test.com', 0];
+        yield ['testtest.com', 1];
+        yield ['test@testcom', 1];
+        yield ['test@test@.com', 1];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -34,6 +34,9 @@ class EmailAddressValidatorTest extends AbstractMauticTestCase
         Assert::assertSame($expectedViolationCount, $context->getViolations()->count());
     }
 
+    /**
+     * @return iterable<mixed[]>
+     */
     public function provider(): iterable
     {
         yield [null, 0];

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="autoload.php"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    failOnRisky="true"
+    failOnWarning="true"
+  >
   <coverage>
     <include>
       <directory>bundles</directory>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There are 4 risky test warnings on every PHPUNIT run. It's annoying:
```
There were 4 risky tests:

1) Mautic\EmailBundle\Tests\Validator\EmailOrEmailTokenListValidatorTest::testNoEmailsProvided with data set #0 (null, Closure Object (...), Closure Object (...))
This test did not perform any assertions

/home/runner/work/mautic/mautic/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php:27

phpvfscomposer:///home/runner/work/mautic/mautic/vendor/phpunit/phpunit/phpunit:97

2) Mautic\EmailBundle\Tests\Validator\EmailOrEmailTokenListValidatorTest::testNoEmailsProvided with data set #1 ('', Closure Object (...), Closure Object (...))
This test did not perform any assertions

/home/runner/work/mautic/mautic/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php:27

phpvfscomposer:///home/runner/work/mautic/mautic/vendor/phpunit/phpunit/phpunit:97

3) Mautic\EmailBundle\Tests\Validator\EmailOrEmailTokenListValidatorTest::testNoEmailsProvided with data set #3 ('john@doe.com', Closure Object (...), Closure Object (...))
This test did not perform any assertions

/home/runner/work/mautic/mautic/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php:27

phpvfscomposer:///home/runner/work/mautic/mautic/vendor/phpunit/phpunit/phpunit:97

4) Mautic\LeadBundle\Tests\Validator\Constraints\EmailAddressValidatorTest::testValidate
This test did not perform any assertions

/home/runner/work/mautic/mautic/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php:11

phpvfscomposer:///home/runner/work/mautic/mautic/vendor/phpunit/phpunit/phpunit:97

OK, but incomplete, skipped, or risky tests!
Tests: 26[68](https://github.com/mautic/mautic/runs/6225833929?check_suite_focus=true#step:9:68), Assertions: [80](https://github.com/mautic/mautic/runs/6225833929?check_suite_focus=true#step:9:80)59, Skipped: 5, Risky: 4.
```

This PR fixes that and adds configuration so we won't merge PRs adding more.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No need to test Mautic. Just review the changes and check that there are no more risky tests GH Actions.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11132"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

