### PR TITLE
DDEV updates for 4.x

### DIFF
--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 setup_mautic() {
-    [ -z "${MAUTIC_URL}" ] && MAUTIC_URL="https://${DDEV_HOSTNAME}"
+    [ -z "${MAUTIC_URL}" ] && MAUTIC_URL="https://${DDEV_HOSTNAME}/index_dev.php"
     [ -z "${PHPMYADMIN_URL}" ] && PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
     [ -z "${MAILHOG_URL}" ] && MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ image:
 # when starting a workspace all docker images are ready
 tasks:
   - before: bash .ddev/gitpod-setup-ddev.sh
-    command: gp await-port 8080 && gp preview $(gp url 8080) 
+    command: gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
 
 # VScode xdebug extension
 vscode:


### PR DESCRIPTION
This is a PR which applies the changes from https://github.com/mautic/mautic/pull/10986 on the 4.x branch.

**Description**
As far as I know, DDEV is only used as a tool for spinning up development areas in which to test Mautic PRs etc. As such, we should really be defaulting to setting the URL to enable developer mode by default (e.g. index_dev.php after the hostname. Sometimes folks have problems because assets have not been regenerated, for example, because they are testing in prod mode.

Steps to test this PR:
Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
Check to see if the URL opened is dev mode, and all is well.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11134"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

