### PR TITLE
Do not create session on API request - test added

### DIFF
--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -76,6 +76,16 @@ return [
                     'priority' => 1,
                 ],
             ],
+<<<<<<< HEAD
+=======
+            'mautic.install.configurator.step.email' => [
+                'class'        => \Mautic\InstallBundle\Configurator\Step\EmailStep::class,
+                'tag'          => 'mautic.configurator.step',
+                'tagArguments' => [
+                    'priority' => 3,
+                ],
+            ],
+>>>>>>> b00ec6fd1e (CS fix)
             'mautic.install.configurator.step.user' => [
                 'class'        => \Mautic\InstallBundle\Configurator\Step\UserStep::class,
                 'tag'          => 'mautic.configurator.step',

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -76,16 +76,6 @@ return [
                     'priority' => 1,
                 ],
             ],
-<<<<<<< HEAD
-=======
-            'mautic.install.configurator.step.email' => [
-                'class'        => \Mautic\InstallBundle\Configurator\Step\EmailStep::class,
-                'tag'          => 'mautic.configurator.step',
-                'tagArguments' => [
-                    'priority' => 3,
-                ],
-            ],
->>>>>>> b00ec6fd1e (CS fix)
             'mautic.install.configurator.step.user' => [
                 'class'        => \Mautic\InstallBundle\Configurator\Step\UserStep::class,
                 'tag'          => 'mautic.configurator.step',

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -20,9 +20,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Disable API just for specific test.
         $this->configParams['api_enabled'] = 'testDisabledApi' !== $this->getName();
 
-        $this->useMockServices = false;
-
-        self::$container->set(
+        static::getContainer()->set(
             'session',
             new Session(
                 new class() extends FixedMockFileSessionStorage {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -25,7 +25,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         self::$container->set(
             'session',
             new Session(
-                new class extends FixedMockFileSessionStorage {
+                new class() extends FixedMockFileSessionStorage {
                     public function start()
                     {
                         Assert::fail('Session cannot be started during API call. It must be stateless.');
@@ -328,9 +328,9 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
-        
+
         $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        
+
         $response  = json_decode($clientResponse->getContent(), true);
         $contactId = $response['contact']['id'];
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -1,12 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Test\Session\FixedMockFileSessionStorage;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -14,6 +19,20 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         // Disable API just for specific test.
         $this->configParams['api_enabled'] = 'testDisabledApi' !== $this->getName();
+
+        $this->useMockServices = false;
+
+        self::$container->set(
+            'session',
+            new Session(
+                new class extends FixedMockFileSessionStorage {
+                    public function start()
+                    {
+                        Assert::fail('Session cannot be started during API call. It must be stateless.');
+                    }
+                }
+            )
+        );
 
         parent::setUp();
     }
@@ -74,7 +93,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
@@ -167,7 +186,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload[1]['points'] = 3;
 
         // Update the 3 contacts
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
@@ -307,10 +326,13 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             'owner'            => 1,
         ];
 
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $response       = json_decode($clientResponse->getContent(), true);
-        $contactId      = $response['contact']['id'];
+        
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        
+        $response  = json_decode($clientResponse->getContent(), true);
+        $contactId = $response['contact']['id'];
 
         $this->assertEquals($payload['email'], $response['contact']['fields']['all']['email']);
         $this->assertEquals($payload['firstname'], $response['contact']['fields']['all']['firstname']);
@@ -328,7 +350,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload['lastname'] = '';
 
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -344,7 +366,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload['lastname']           = '';
 
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -371,7 +393,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             'owner'    => 2,
         ];
 
-        $this->client->request('POST', '/api/contacts/new', $updatedValues);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $updatedValues);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -408,8 +430,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $updatedValues['owner'] = 2;
 
         // Test getting a contact
-        $this->client->request(
-            'GET', '/api/contacts/'.$contactId);
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contactId);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -427,8 +448,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($updatedValues['owner'], $response['contact']['owner']['id']);
 
         // Test fetching the batch of contacts
-        $this->client->request(
-            'GET', '/api/contacts');
+        $this->client->request(Request::METHOD_GET, '/api/contacts');
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -503,7 +523,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
                 ],
             ],
         ];
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $contactId      = $response['contact']['id'];
@@ -513,7 +533,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['doNotContact'][0]['reason'], $response['contact']['doNotContact'][0]['reason']);
 
         // Remove contact
-        $this->client->request('DELETE', "/api/contacts/$contactId/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
         $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
@@ -748,7 +768,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             'email' => $emailAddress,
         ];
 
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $contactId      = $response['contact']['id'];
@@ -769,7 +789,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertSame(3, $response['contacts'][0]['doNotContact'][0]['reason']);
@@ -790,14 +810,14 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
         $this->assertEmpty($response['contacts'][0]['doNotContact']);
 
         // Remove contact
-        $this->client->request('DELETE', "/api/contacts/$contactId/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
         $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
@@ -805,11 +825,9 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testAddAndRemoveDncToExistingContact(): void
     {
         // Create contact
-        $payload = [
-            'email' => 'addDncDemo@mautic.org',
-        ];
+        $payload = ['email' => 'addDncDemo@mautic.org'];
 
-        $this->client->request('POST', '/api/contacts/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $contactId      = $response['contact']['id'];
@@ -818,12 +836,10 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame([], $response['contact']['doNotContact']);
 
         // Check with a DNC payload that has an empty reasoncode in it, this should throw a 400 Bad Request error
-        $dncPayload = [
-            'reason' => 0,
-        ];
+        $dncPayload = ['reason' => 0];
         $dncChannel = 'email';
 
-        $this->client->request('POST', "/api/contacts/$contactId/dnc/$dncChannel/add", $dncPayload);
+        $this->client->request(Request::METHOD_POST, "/api/contacts/$contactId/dnc/$dncChannel/add", $dncPayload);
         $clientResponse = $this->client->getResponse();
         $this->assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
 
@@ -831,7 +847,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $dncPayload = [];
 
         // Add DNC to the contact.
-        $this->client->request('POST', "/api/contacts/$contactId/dnc/$dncChannel/add", $dncPayload);
+        $this->client->request(Request::METHOD_POST, "/api/contacts/$contactId/dnc/$dncChannel/add", $dncPayload);
         $clientResponse = $this->client->getResponse();
         $dncResponse    = json_decode($clientResponse->getContent(), true);
 
@@ -851,7 +867,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame('Contact was manually set as do not contact for this channel.', $dncEvents[0]['details']['dnc']['reason']);
 
         // Remove DNC from the contact.
-        $this->client->request('POST', "/api/contacts/$contactId/dnc/$dncChannel/remove");
+        $this->client->request(Request::METHOD_POST, "/api/contacts/$contactId/dnc/$dncChannel/remove");
         $clientResponse    = $this->client->getResponse();
         self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
         $dncRemoveResponse = json_decode($clientResponse->getContent(), true);
@@ -860,7 +876,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame([], $dncRemoveResponse['contact']['doNotContact']);
 
         // Remove the contact.
-        $this->client->request('DELETE', "/api/contacts/$contactId/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
         $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [Done in https://github.com/mautic/mautic/pull/11557] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/11137

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We noticed slowness and even denial of service for one of our clouds. We noticed there is several millions of API calls happening per day and that Redis which we use as the session storage was the bottleneck. It took us a while to connect the dots but the problem was that the [EmailStep](https://github.com/mautic/mautic/blob/4.x/app/bundles/InstallBundle/Configurator/Step/EmailStep.php#L115) from the InstallBundle is accessing session in its constructor ❗ 

So we created a quick patch of setting the `$user` to `null` because we do not use the InstallBundle but we need some more permanent solution.

One option is to use Local Storage or setting the session in a setter by a compiler pass to move the session out of the constructor.

It was a pain to sort this out as there is a lot of magic going on in the install process.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make any API call
3. Check that session was created. You and dump and die at the end of `index.php`. Something like `dd($_SESSION)`.
4. Also test that the installer still works as before and the email and name is pre-filled in step 3.


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11144"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

