### PR TITLE
Adding missing table prefix

### DIFF
--- a/app/bundles/SmsBundle/Assets/js/sms.js
+++ b/app/bundles/SmsBundle/Assets/js/sms.js
@@ -1,9 +1,13 @@
 /** SmsBundle **/
 Mautic.smsOnLoad = function (container, response) {
-    Mautic.setSmsCharactersCount();
-    mQuery('#sms_message').on("input", () => {
-        Mautic.setSmsCharactersCount();
-    });
+    const smsMessage = mQuery('#sms_message');
+
+    if (smsMessage.length) {
+        Mautic.setSmsCharactersCount(smsMessage);
+        smsMessage.on('input', () => {
+            Mautic.setSmsCharactersCount(smsMessage);
+        });
+    }
 
     if (mQuery(container + ' #list-search').length) {
         Mautic.activateSearchAutocomplete('list-search', 'sms');
@@ -42,8 +46,8 @@ Mautic.smsOnLoad = function (container, response) {
     }
 };
 
-Mautic.setSmsCharactersCount = function () {
-    mQuery('#sms_nb_char').text((mQuery('#sms_message').val().length))
+Mautic.setSmsCharactersCount = function (smsMessage) {
+    mQuery('#sms_nb_char').text((smsMessage.val().length))
 };
 
 Mautic.selectSmsType = function(smsType) {

--- a/app/bundles/SmsBundle/Entity/SmsRepository.php
+++ b/app/bundles/SmsBundle/Entity/SmsRepository.php
@@ -63,7 +63,7 @@ class SmsRepository extends CommonRepository
     {
         // Main query
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $q->from('sms_message_list_xref', 'sml')
+        $q->from(MAUTIC_TABLE_PREFIX.'sms_message_list_xref', 'sml')
             ->join('sml', MAUTIC_TABLE_PREFIX.'lead_lists', 'll', 'll.id = sml.leadlist_id and ll.is_published = 1')
             ->join('ll', MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'lll', 'lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0')
             ->join('lll', MAUTIC_TABLE_PREFIX.'leads', 'l', 'lll.lead_id = l.id')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When testing another PR I went to the Channels > Text Messages and got this error:
```
500 Internal Server Error - An exception occurred while executing 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC' with params [1]: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.sms_message_list_xref' doesn't exist

/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:61 at
/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:182 at Doctrine\DBAL\Driver\AbstractMySQLDriver -> convertException ( 'An exception occurred while executing 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC' with params [1]: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.sms_message_list_xref' doesn't exist', object(Exception) )
/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:159 at Doctrine\DBAL\DBALException :: wrapException ( object(Driver), object(Exception), 'An exception occurred while executing 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC' with params [1]: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.sms_message_list_xref' doesn't exist' )
/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:2226 at Doctrine\DBAL\DBALException :: driverExceptionDuringQuery ( object(Driver), object(Exception), 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC', array('1') )
/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1313 at Doctrine\DBAL\Connection -> handleExceptionDuringQuery ( object(Exception), 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC', array('1'), array('2') )
/vendor/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php:212 at Doctrine\DBAL\Connection -> executeQuery ( 'SELECT COUNT(DISTINCT l.id) FROM sms_message_list_xref sml INNER JOIN mautic_lead_lists ll ON ll.id = sml.leadlist_id and ll.is_published = 1 INNER JOIN mautic_lead_lists_leads lll ON lll.leadlist_id = sml.leadlist_id and lll.manually_removed = 0 INNER JOIN mautic_leads l ON lll.lead_id = l.id WHERE (sml.sms_id = ?) AND (((l.mobile IS NOT NULL) OR (l.mobile <> '')) OR ((l.phone IS NOT NULL) OR (l.phone <> ''))) AND (NOT EXISTS (SELECT null FROM mautic_sms_message_stats stat WHERE (stat.lead_id = l.id) AND (stat.sms_id = 1))) AND (NOT EXISTS (SELECT null FROM mautic_lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'sms'))) AND (NOT EXISTS (SELECT null FROM mautic_message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'sms'))) ORDER BY lll.lead_id ASC', array('1'), array('2') )
/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php:60 at Doctrine\DBAL\Query\QueryBuilder -> execute ( )
/app/bundles/SmsBundle/Controller/AjaxController.php:39 at Mautic\SmsBundle\Broadcast\BroadcastQuery -> getPendingCount ( object(Sms) )
/app/bundles/CoreBundle/Controller/AjaxController.php:131 at Mautic\SmsBundle\Controller\AjaxController -> getSmsCountStatsAction ( object(Request), 'sms' )
/vendor/symfony/http-kernel/HttpKernel.php:158 at Mautic\CoreBundle\Controller\AjaxController -> executeAjaxAction ( 'getSmsCountStats', object(Request), 'sms' )
/vendor/symfony/http-kernel/HttpKernel.php:80 at Symfony\Component\HttpKernel\HttpKernel -> handleRaw ( object(Request), '2' )
/vendor/symfony/framework-bundle/Controller/ControllerTrait.php:96 at Symfony\Component\HttpKernel\HttpKernel -> handle ( object(Request), '2' )
/app/bundles/CoreBundle/Controller/AjaxController.php:109 at Symfony\Bundle\FrameworkBundle\Controller\Controller -> forward ( 'MauticSmsBundle:Ajax:executeAjax', array('action' => 'getSmsCountStats', 'request' => object(Request), 'bundle' => 'sms', '_controller' => 'MauticSmsBundle:Ajax:executeAjax') )
/vendor/symfony/http-kernel/HttpKernel.php:158 at Mautic\CoreBundle\Controller\AjaxController -> delegateAjaxAction ( )
/vendor/symfony/http-kernel/HttpKernel.php:80 at Symfony\Component\HttpKernel\HttpKernel -> handleRaw ( object(Request), '1' )
/vendor/symfony/http-kernel/Kernel.php:201 at Symfony\Component\HttpKernel\HttpKernel -> handle ( object(Request), '1', true )
/app/AppKernel.php:115 at Symfony\Component\HttpKernel\Kernel -> handle ( object(Request), '1', true )
/app/middlewares/CORSMiddleware.php:82 at AppKernel -> handle ( object(Request), '1', true )
/app/middlewares/CatchExceptionMiddleware.php:34 at Mautic\Middleware\CORSMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/Dev/IpRestrictMiddleware.php:52 at Mautic\Middleware\CatchExceptionMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/VersionCheckMiddleware.php:58 at Mautic\Middleware\Dev\IpRestrictMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/TrustMiddleware.php:42 at Mautic\Middleware\VersionCheckMiddleware -> handle ( object(Request), '1', true )
/vendor/stack/builder/src/Stack/StackedHttpKernel.php:23 at Mautic\Middleware\TrustMiddleware -> handle ( object(Request), '1', true )
/vendor/stack/run/src/Stack/run.php:13 at Stack\StackedHttpKernel -> handle ( object(Request) )
/index_dev.php:25 at Stack\run ( object(StackedHttpKernel) )
```
The code generating the error above is there for 3 years. It's not that visible as it affects only instances with a table prefix that use SMS and it only breaks the ajax call for counting sent messages so it "only" breaks the send counts in the sms table.

Then I couldn't replicate it because of this JS error:

```
sms.js?v1651b26d:46 Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at Object.Mautic.setSmsCharactersCount (sms.js?v1651b26d:46:62)
    at Object.Mautic.smsOnLoad (sms.js?v1651b26d:3:12)
    at Object.Mautic.onPageLoad (1a.content.js?v1651b26d:676:47)
    at sms:1206:20
```

This was lastly touched in 4.2.2 so this is a regression.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. The Mautic instance should have some table_prefix to test the SQL error.
3. Go to Channels > Text Messages
4. Create a new message.
5. Test that the character counter works correctly when you type in the SMS content
6. Open dev tools for your browser
7. In the console tab you should see the JS error
8. And the Ajax request should fail with 500 error when you have a table_prefix configured.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11159"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

