### PR TITLE
Fix prerelease logic in CI, use outputs instead of env in several places

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'mautic/mautic'
 
+    outputs:
+      mautic-version: ${{ steps.get-mautic-version.outputs.version }}
+      is-prerelease: ${{ steps.is-prerelease.outputs.is-prerelease }}
+
     steps:
     - uses: actions/checkout@v2
       # Our build script needs access to all previous tags, so we add fetch-depth: 0
@@ -23,17 +27,18 @@ jobs:
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Get tag name
-      run: echo "MAUTIC_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      id: get-mautic-version
+      run: echo "::set-output name=version::${GITHUB_REF/refs\/tags\//}"
 
     - name: Check if tag name matches version in release_metadata.json
       run: |
         METADATA_VERSION=$(jq -r '.version' app/release_metadata.json)
 
-        if [[ "${{ env.MAUTIC_VERSION }}" != "$METADATA_VERSION" ]]; then
-          echo "❌ ERROR: tag name (${{ env.MAUTIC_VERSION }}) doesn't match version in app/release_metadata.json ($METADATA_VERSION). Please ensure that both versions match!"
+        if [[ "${{ steps.get-mautic-version.outputs.version }}" != "$METADATA_VERSION" ]]; then
+          echo "❌ ERROR: tag name (${{ steps.get-mautic-version.outputs.version }}) doesn't match version in app/release_metadata.json ($METADATA_VERSION). Please ensure that both versions match!"
           exit 1
         else
-          echo "✔ Tag name (${{ env.MAUTIC_VERSION }}) and the version in app/release_metadata.json ($METADATA_VERSION) match. Great!"
+          echo "✔ Tag name (${{ steps.get-mautic-version.outputs.version }}) and the version in app/release_metadata.json ($METADATA_VERSION) match. Great!"
         fi
 
     - name: Install dependencies
@@ -43,12 +48,13 @@ jobs:
 
     - name: Build release files
       run: |
-        php build/package_release.php -b=${{ env.MAUTIC_VERSION }}
+        php build/package_release.php -b=${{ steps.get-mautic-version.outputs.version }}
         echo 'MAUTIC_SHA1_CONTENTS<<EOF' >> $GITHUB_ENV
         cat build/packages/build-sha1-all >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
 
     - name: "Prerelease or not?"
+      id: is-prerelease
       run: |
         STABILITY=$(jq -r '.stability' app/release_metadata.json)
 
@@ -58,7 +64,7 @@ jobs:
           PRERELEASE=true
         fi
 
-        echo "IS_PRERELEASE=${PRERELEASE}" >> $GITHUB_ENV
+        echo "::set-output name=is-prerelease::${PRERELEASE}"
 
     - name: Create Release
       id: create_release
@@ -66,46 +72,46 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ env.MAUTIC_VERSION }}
-        release_name: Mautic Community ${{ env.MAUTIC_VERSION }}
+        tag_name: ${{ steps.get-mautic-version.outputs.version }}
+        release_name: Mautic Community ${{ steps.get-mautic-version.outputs.version }}
         draft: true
-        prerelease: ${{ env.IS_PRERELEASE }}
+        prerelease: ${{ steps.is-prerelease.outputs.is-prerelease }}
         body: |
           ${{ env.MAUTIC_CHANGELOG }}
 
           ${{ env.MAUTIC_SHA1_CONTENTS }}
 
-    - name: Upload full package ${{ env.MAUTIC_VERSION }}.zip
+    - name: Upload full package ${{ steps.get-mautic-version.outputs.version }}.zip
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./build/packages/${{ env.MAUTIC_VERSION }}.zip
-        asset_name: ${{ env.MAUTIC_VERSION }}.zip
+        asset_path: ./build/packages/${{ steps.get-mautic-version.outputs.version }}.zip
+        asset_name: ${{ steps.get-mautic-version.outputs.version }}.zip
         asset_content_type: application/zip
 
-    - name: Upload update package ${{ env.MAUTIC_VERSION }}-update.zip
+    - name: Upload update package ${{ steps.get-mautic-version.outputs.version }}-update.zip
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./build/packages/${{ env.MAUTIC_VERSION }}-update.zip
-        asset_name: ${{ env.MAUTIC_VERSION }}-update.zip
+        asset_path: ./build/packages/${{ steps.get-mautic-version.outputs.version }}-update.zip
+        asset_name: ${{ steps.get-mautic-version.outputs.version }}-update.zip
         asset_content_type: application/zip
 
     - name: Store full package artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ env.MAUTIC_VERSION }}.zip
-        path: ./build/packages/${{ env.MAUTIC_VERSION }}.zip
+        name: ${{ steps.get-mautic-version.outputs.version }}.zip
+        path: ./build/packages/${{ steps.get-mautic-version.outputs.version }}.zip
 
     - name: Store update package artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ env.MAUTIC_VERSION }}-update.zip
-        path: ./build/packages/${{ env.MAUTIC_VERSION }}-update.zip
+        name: ${{ steps.get-mautic-version.outputs.version }}-update.zip
+        path: ./build/packages/${{ steps.get-mautic-version.outputs.version }}-update.zip
 
   test-fresh-install:
     name: Test a fresh installation
@@ -126,9 +132,6 @@ jobs:
     # We need this so we can get the local.php override file
     - uses: actions/checkout@v2
 
-    - name: Get tag name
-      run: echo "MAUTIC_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
@@ -138,13 +141,13 @@ jobs:
     - name: Download full installation package from previous step
       uses: actions/download-artifact@v2
       with:
-        name: ${{ env.MAUTIC_VERSION }}.zip
+        name: ${{ needs.release.outputs.mautic-version }}.zip
 
     - name: Install Mautic
       env:
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
       run: |
-        unzip -q ${{ env.MAUTIC_VERSION }}.zip -d ./mautic-testing
+        unzip -q ${{ needs.release.outputs.mautic-version }}.zip -d ./mautic-testing
         mkdir -p ./mautic-testing/var/logs
         cp ./.github/ci-files/local.php ./mautic-testing/app/config/local.php
         cd ./mautic-testing
@@ -178,7 +181,6 @@ jobs:
 
     - name: Get tag name and minimum Mautic version
       run: |
-        echo "MAUTIC_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
         echo "MAUTIC_MINIMUM_VERSION=$(jq -r '.minimum_mautic_version' app/release_metadata.json)" >> $GITHUB_ENV
         echo "MAUTIC_PHP_MINIMUM_VERSION=$(jq -r '.minimum_php_version' app/release_metadata.json)" >> $GITHUB_ENV
 
@@ -199,18 +201,18 @@ jobs:
         cd ./mautic-testing
         php bin/console mautic:install --force http://localhost
     
-    - name: "Download update package artifact ${{ env.MAUTIC_VERSION }}-update.zip"
+    - name: "Download update package artifact ${{ needs.release.outputs.mautic-version }}-update.zip"
       uses: actions/download-artifact@v2
       with:
-        name: ${{ env.MAUTIC_VERSION }}-update.zip
+        name: ${{ needs.release.outputs.mautic-version }}-update.zip
         path: ./mautic-testing
 
-    - name: "Attempt update from ${{ env.MAUTIC_MINIMUM_VERSION }} to ${{ env.MAUTIC_VERSION }}"
+    - name: "Attempt update from ${{ env.MAUTIC_MINIMUM_VERSION }} to ${{ needs.release.outputs.mautic-version }}"
       env:
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
       working-directory: ./mautic-testing
       run: |
-        php bin/console mautic:update:apply --force --update-package=${{ env.MAUTIC_VERSION }}-update.zip
+        php bin/console mautic:update:apply --force --update-package=${{ needs.release.outputs.mautic-version }}-update.zip
         php bin/console mautic:update:apply --finish
 
     - name: Store log artifacts
@@ -224,14 +226,11 @@ jobs:
     name: Upload release asset to m.mautic.org
     needs: [release, test-fresh-install, test-update-install]
     # We only want this job to run in Mautic's repo, not in forks
-    if: github.repository_owner == 'mautic' && env.IS_PRERELEASE != true
+    if: github.repository_owner == 'mautic' && needs.release.outputs.is-prerelease
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Get tag name
-      run: echo "MAUTIC_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
@@ -246,7 +245,7 @@ jobs:
     - name: Download full installation package from previous step
       uses: actions/download-artifact@v2
       with:
-        name: ${{ env.MAUTIC_VERSION }}.zip
+        name: ${{ needs.release.outputs.mautic-version }}.zip
 
     # Category ID is 2 for Mautic release assets on m.mautic.org, that's why you're seeing "2" in the command below
     - name: Upload release asset ZIP to m.mautic.org
@@ -255,6 +254,6 @@ jobs:
         https://m.mautic.org \
         "${{ secrets.MAUTIC_INSTANCE_USER }}" \
         "${{ secrets.MAUTIC_INSTANCE_PASSWORD }}" \
-        "${{ env.MAUTIC_VERSION }}" \
+        "${{ needs.release.outputs.mautic-version }}" \
         4 \
-        "${{ github.workspace }}/${{ env.MAUTIC_VERSION }}.zip"
+        "${{ github.workspace }}/${{ needs.release.outputs.mautic-version }}.zip"


### PR DESCRIPTION
Should fix the release pipeline.

`jobs.<job_id>.if` doesn't support using the `env` context, it only supports `github, needs, inputs`: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

We currently have three jobs in the release pipeline:
- release
- test-fresh-install (needs `release`)
- test-update-install (needs `release`)
- upload-release-asset (needs `release, test-fresh-install, test-update-install`)

The good thing about `needs` is that we can use it to access output variables from the `release` job, e.g. `if: needs.release.outputs.is-prerelease`.

Also took the opportunity to get rid of some duplicate set parts where we set `env.MAUTIC_VERISON`. Replaced it with `needs.release.outputs.mautic-version` instead.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11165"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

