### PR TITLE
Fix set boolean properties on form field

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1119,7 +1119,7 @@ class FormModel extends CommonFormModel
                 $list = $contactFieldProps['list'] ?? [];
                 break;
             case 'boolean':
-                $list = [$contactFieldProps['no'], $contactFieldProps['yes']];
+                $list =     [['label'=> $contactFieldProps['no'], 'value' => 0], ['label'=>  $contactFieldProps['yes'], 'value' => 1]];
                 break;
             case 'country':
                 $list = ContactFieldHelper::getCountryChoices();

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1119,7 +1119,7 @@ class FormModel extends CommonFormModel
                 $list = $contactFieldProps['list'] ?? [];
                 break;
             case 'boolean':
-                $list =     [['label'=> $contactFieldProps['no'], 'value' => 0], ['label'=>  $contactFieldProps['yes'], 'value' => 1]];
+                $list = [['label'=> $contactFieldProps['no'], 'value' => 0], ['label'=>  $contactFieldProps['yes'], 'value' => 1]];
                 break;
             case 'country':
                 $list = ContactFieldHelper::getCountryChoices();

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -188,7 +188,7 @@ class FormModelTest extends FormTestAbstract
 
         $formModel->getEntity(5);
 
-        $this->assertSame(['lunch?', 'dinner?'], $formField->getProperties()['list']['list']);
+        $this->assertSame([['label' => 'lunch?', 'value' => 0], ['label' => 'dinner?', 'value' => 1]], $formField->getProperties()['list']['list']);
     }
 
     public function testGetEntityForSyncedCountryField()


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Properties for bolean fields are set as `yes => Yes` to properties. It make issue for some cases. This PR fixed it.

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create form with email and boolean and checkbox group with boolean contact field mapping and enabled **Use assigned contact/company field's list choices.**
![image](https://user-images.githubusercontent.com/462477/174253835-efb36637-f1d5-46cd-82b7-2e90be7c5b9b.png)
3. Submit form with Yes option
4. Go to campaign and create campaign with `form field condition` for checkboxgroup field  with preselected option Yes
5. Run campaign. 
6. See like condition go to false path, even we expect true
7. Condition compare `'yes' === true`, after PR should go to true


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

