### PR TITLE
Set correct stability channel

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "4.3.0-beta",
-  "stability": "stable",
+  "stability": "beta",
   "minimum_php_version": "7.4.0",
   "maximum_php_version": "8.0.99",
   "minimum_mysql_version": "5.7.14",


### PR DESCRIPTION
We had several reports that 4.3.0-beta was showing as available on production systems which it shouldn't do, as it's a pre-release for use with the stability setting at beta.

This PR fixes the issue - we will need to re-release 4.3.0-beta (as beta-2) once this PR is merged.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11172"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

