### PR TITLE
Fix segments update when database tables are prefixed

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -278,7 +278,7 @@ class LeadListRepository extends CommonRepository
         $countListIds = count($listIds);
 
         if (1 === $countListIds) {
-            $q          = $this->forceUseIndex($q, MAUTIC_TABLE_PREFIX.'manually_removed');
+            $q          = $this->forceUseIndex($q, 'manually_removed');
             $expression = $q->expr()->eq('l.leadlist_id', $listIds[0]);
         } else {
             $expression = $q->expr()->in('l.leadlist_id', $listIds);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | y
| New feature/enhancement? (use the a.x branch)      | n
| Deprecations?                          | n
| BC breaks? (use the c.x branch)        | n
| Automated tests included?              | n <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
There is a problem with index name in lead_lists_leads when using prefixed tables after updating to 4.3.0 

```
php bin/console m:s:u
Rebuilding contacts for segment 13
0 total contact(s) to be added in batches of 300
0 total contact(s) to be removed in batches of 300

In AbstractMySQLDriver.php line 128:

  An exception occurred while executing 'SELECT count(l.lead_id) as thecount, l.leadlist_id FROM mc_lead_lists_leads l USE INDEX (mc_manually_removed) WHERE (l.leadlist_id = 13) AND (l.manually_removed = ?) GROUP BY l.leadlist_id' with params [0]:  

  SQLSTATE[42000]: Syntax error or access violation: 1176 Key 'mc_manually_removed' doesn't exist in table 'l'
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Install Mautic with table prefix
2. Add segment with filters
3. Run segment update `php bin/console m:s:u`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
