### PR TITLE
Update guzzlehttp/oauth-subscriber to 0.6.*

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -91,7 +91,7 @@
     "sendgrid/sendgrid": "~6.0",
     "noxlogic/ratelimit-bundle": "^1.11",
     "knplabs/knp-menu-bundle": "^3.0",
-    "guzzlehttp/oauth-subscriber": "^0.5.0",
+    "guzzlehttp/oauth-subscriber": "^0.6.0",
     "helios-ag/fm-elfinder-bundle": "^10.1",
     "leezy/pheanstalk-bundle": "^4.0",
     "tightenco/collect": "^8.16.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #11175

#### Description:

When installing a new mautic, the last version of `guzzlehttp/psr7` was installed, but it was not supported by `guzzlehttp/oauth-subscriber:0.5.0` (it used deprecated code)

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.Create an HttpClient as follow (i put mine inside the index_dev.php of the project to test it)

```
$stack = \GuzzleHttp\HandlerStack::create();

$middleware = new \GuzzleHttp\Subscriber\Oauth\Oauth1([
    'consumer_key'    => 'consumer-key',
    'consumer_secret' => 'consumer-secret',
]);
$stack->push($middleware);

$httpClient = new \GuzzleHttp\Client([
    'base_uri' => 'http://localhost/',
    'handler' => $stack,
    'auth' => 'oauth',
]);

$httpClient->get('/');
```

3. With `guzzlehttp/oauth-subscriber` version 0.5 it will break as the function `parse_query` was remove from `guzzlehttp/psr7` v2. but with guzzlehttp/oauth-subscriber version 0.6 it will work