### PR TITLE
Fixing DoctrineEventSubscriber for plugin installations

### DIFF
--- a/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
+++ b/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\InstallBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Mautic\LeadBundle\Field\SchemaDefinition;
 use Mautic\LeadBundle\Model\FieldModel;

--- a/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
+++ b/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
@@ -25,12 +25,12 @@ class DoctrineEventSubscriber implements EventSubscriber
         ];
 
         foreach ($fieldGroups as $tableName => $fields) {
-            try {
-                $table = $args->getSchema()->getTable(MAUTIC_TABLE_PREFIX.$tableName);
-            } catch (SchemaException $e) {
+            $fullTableName = MAUTIC_TABLE_PREFIX.$tableName;
+            if (!$args->getSchema()->hasTable($fullTableName)) {
                 // Ignore during plugin installations as not all tables are present in the schema.
                 continue;
             }
+            $table = $args->getSchema()->getTable($fullTableName);
 
             foreach ($fields as $alias => $field) {
                 if (!$table->hasColumn($alias)) {

--- a/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
+++ b/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 class DoctrineEventSubscriberTest extends TestCase
 {
     /**
-     * @var MockObject&EntityManagerInterface $entityManager
+     * @var MockObject&EntityManagerInterface
      */
     private $entityManager;
 

--- a/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
+++ b/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
@@ -35,13 +35,13 @@ class DoctrineEventSubscriberTest extends TestCase
 
     public function testSubscriberWillAddCorrectIndexes(): void
     {
-        $idColumn       = new Column('id', new BigIntType());
-        $textColumn     = new Column('firstname', new TextType());
-        $textColumn     = new Column('date_added', new DateTimeType());
-        $table          = new Table(MAUTIC_TABLE_PREFIX.'leads', [$idColumn, $textColumn]);
-        $schema         = new Schema([$table]);
-        $args           = new GenerateSchemaEventArgs($this->entityManager, $schema);
-        $subscriber     = new DoctrineEventSubscriber();
+        $idColumn   = new Column('id', new BigIntType());
+        $textColumn = new Column('firstname', new TextType());
+        $dateColumn = new Column('date_added', new DateTimeType());
+        $table      = new Table(MAUTIC_TABLE_PREFIX.'leads', [$idColumn, $textColumn, $dateColumn]);
+        $schema     = new Schema([$table]);
+        $args       = new GenerateSchemaEventArgs($this->entityManager, $schema);
+        $subscriber = new DoctrineEventSubscriber();
         $subscriber->postGenerateSchema($args);
 
         Assert::assertTrue($schema->hasTable(MAUTIC_TABLE_PREFIX.'leads'));

--- a/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
+++ b/app/bundles/InstallBundle/Tests/EventListener/DoctrineEventSubscriberTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\InstallBundle\Tests\EventListener;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\BigIntType;
+use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\TextType;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Mautic\InstallBundle\EventListener\DoctrineEventSubscriber;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineEventSubscriberTest extends TestCase
+{
+    /**
+     * @var MockObject&EntityManagerInterface $entityManager
+     */
+    private $entityManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+
+    public function testSubscriberWillAddCorrectIndexes(): void
+    {
+        $idColumn       = new Column('id', new BigIntType());
+        $textColumn     = new Column('firstname', new TextType());
+        $textColumn     = new Column('date_added', new DateTimeType());
+        $table          = new Table(MAUTIC_TABLE_PREFIX.'leads', [$idColumn, $textColumn]);
+        $schema         = new Schema([$table]);
+        $args           = new GenerateSchemaEventArgs($this->entityManager, $schema);
+        $subscriber     = new DoctrineEventSubscriber();
+        $subscriber->postGenerateSchema($args);
+
+        Assert::assertTrue($schema->hasTable(MAUTIC_TABLE_PREFIX.'leads'));
+        $contactsTable = $schema->getTable(MAUTIC_TABLE_PREFIX.'leads');
+        Assert::assertTrue($contactsTable->hasIndex('contact_attribution'));
+        Assert::assertTrue($contactsTable->hasIndex('date_added_country_index'));
+    }
+
+    public function testSubscriberWillNotFailWithTablesFromAPlugin(): void
+    {
+        $table      = new Table(MAUTIC_TABLE_PREFIX.'some_plugin_table', [new Column('id', new BigIntType())]);
+        $schema     = new Schema([$table]);
+        $args       = new GenerateSchemaEventArgs($this->entityManager, $schema);
+        $subscriber = new DoctrineEventSubscriber();
+        $subscriber->postGenerateSchema($args);
+
+        Assert::assertTrue($schema->hasTable(MAUTIC_TABLE_PREFIX.'some_plugin_table'));
+        Assert::assertFalse($schema->hasTable(MAUTIC_TABLE_PREFIX.'leads'));
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/11186 , https://forum.mautic.org/t/how-to-install-acquias-custom-objects-plugin/24204/21

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The change in https://github.com/mautic/mautic/pull/11059 causes troubles when installing plugins as the Schema contains only tables from the plugin. It does not contain the leads nor the companies tables. This PR is catching the exception if the table is not present and skips the additional logic.

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Install some plugin that has some schema to install. For example https://github.com/acquia/mc-cs-plugin-custom-objects
3. When you run `bin/console mautic:plugins:install` you will get this error:
```
There is no table with name 'db.mautic_leads' in the schema.
```
which is fixed by this PR.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
