### PR TITLE
Code mode fix

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -582,7 +582,7 @@ class ThemeHelper implements ThemeHelperInterface
 
     public function getCurrentTheme(string $template, string $specificFeature): string
     {
-        if (!in_array($template, array_keys($this->getInstalledThemes($specificFeature)))) {
+        if ('mautic_code_mode' !== $template && !in_array($template, array_keys($this->getInstalledThemes($specificFeature)))) {
             return $this->coreParametersHelper->get('theme_email_default');
         }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -579,4 +579,47 @@ class ThemeHelperTest extends TestCase
         Assert::assertArrayHasKey('name', $themes['theme-legacy-all']);
         Assert::assertArrayHasKey('dir', $themes['theme-legacy-all']);
     }
+
+    public function testGetCurrentThemeWillReturnCodeModeIfTheThemeIsCodeMode(): void
+    {
+        $themeHelper = new ThemeHelper(
+            new class() extends PathsHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends TemplatingHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Translator {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends CoreParametersHelper {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Filesystem {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends Finder {
+                public function __construct()
+                {
+                }
+            },
+            new class() extends BuilderIntegrationsHelper {
+                public function __construct()
+                {
+                }
+            }
+        );
+
+        Assert::assertSame('mautic_code_mode', $themeHelper->getCurrentTheme('mautic_code_mode', 'foo'));
+    }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/custom-email-does-not-work-in-4-3-1/24344

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

https://github.com/mautic/mautic/pull/10154 introduced a regression that code mode theme was changed to blank. This PR fixes it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new template email in the legacy builder
3. Set any name and subject.
4. Choose the Code Mode theme.
5. Click on Save
6. Check that the Blank theme is selected instead of Code Mode

With this PR applied the Code Mode will stay selected.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

Gitpod: https://gitpod.io/#https://github.com/mautic/mautic/pull/11221

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11221"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

