### PR TITLE
Changing Rector config to the new format

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,46 +2,27 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $containerConfigurator): void {
-    // here we can define, what sets of rules will be applied
-    $parameters = $containerConfigurator->parameters();
-
-    // Define what rule sets will be applied
-    // $containerConfigurator->import(SetList::DEAD_CODE);
-
-    $parameters->set(
-        Option::PATHS,
-        [
-            __DIR__.'/app/bundles',
-            __DIR__.'/plugins',
-        ]
-    );
-
-    $parameters->set(
-        Option::SKIP,
+return static function (\Rector\Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([__DIR__.'/app/bundles', __DIR__.'/plugins']);
+    $rectorConfig->skip(
         [
             __DIR__.'/*/test/*',
             __DIR__.'/*/tests/*',
             __DIR__.'/*/Test/*',
             __DIR__.'/*/Tests/*',
-            __DIR__.'/*/InstallFixtures/*',
-            __DIR__.'/*/Fixtures/*',
             __DIR__.'/*.html.php',
             __DIR__.'/*.less.php',
             __DIR__.'/*.inc.php',
             __DIR__.'/*.js.php',
-            __DIR__.'/app/bundles/LeadBundle/Entity/LeadField.php',
-            __DIR__.'/app/bundles/WebhookBundle/Entity/Webhook.php',
-            __DIR__.'/app/bundles/UserBundle/Entity/UserToken.php',
-            __DIR__.'/app/bundles/EmailBundle/Entity/EmailReplyRepository.php',
         ]
     );
 
-    $services = $containerConfigurator->services();
-    $services->set(RemoveAndTrueRector::class);
-    // $services->set(RemoveAlwaysTrueIfConditionRector::class); // 41 files would have changed (we should have a separate PR to enable this)
+    // Define what rule sets will be applied
+    // $rectorConfig->sets([\Rector\Set\ValueObject\SetList::DEAD_CODE]); // @todo implement the whole set. Start rule by rule bellow.
+
+    // Define what signle rules will be applied
+    $rectorConfig->rule(\Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector::class);
+    $rectorConfig->rule(\Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector::class);
+    $rectorConfig->rule(\Rector\DeadCode\Rector\ClassConst\RemoveUnusedPrivateClassConstantRector::class);
+    // $rectorConfig->rule(\Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector::class); // @todo enable this in a separate PR. A few files changed.
 };

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-return static function (\Rector\Config\RectorConfig $rectorConfig): void {
+return static function (Rector\Config\RectorConfig $rectorConfig): void {
     $rectorConfig->paths([__DIR__.'/app/bundles', __DIR__.'/plugins']);
     $rectorConfig->skip(
         [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [yes and no] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

#### Description:

The Rector CI reports this warning:
```
Warning: ] Your "/home/runner/work/mautic/mautic/rector.php" config is using old
           syntax with "ContainerConfigurator".                                 
           Please upgrade to "RectorConfig" that allows better autocomplete and 
           future standard.
```

This PR refactors the config file to the new format.

I also removed some files from the **skip** section as it does not break anything anymore. Probably fixed in new Rector version. I added some more rules that do not result in any changes. It's good to get them in for future code changes. I have one more rule commented out that I want to enable in a future PR.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Just make sure that the Rector CI step is running and the warning is gone.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

