### PR TITLE
Company merge event

### DIFF
--- a/app/bundles/LeadBundle/Event/CompanyMergeEvent.php
+++ b/app/bundles/LeadBundle/Event/CompanyMergeEvent.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * @copyright   2014 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Event;
 
 use Mautic\LeadBundle\Entity\Company;

--- a/app/bundles/LeadBundle/Event/CompanyMergeEvent.php
+++ b/app/bundles/LeadBundle/Event/CompanyMergeEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Event;
+
+use Mautic\LeadBundle\Entity\Company;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class CompanyMergeEvent.
+ */
+class CompanyMergeEvent extends Event
+{
+    private $victor;
+
+    private $loser;
+
+    public function __construct(Company $victor, Company $loser)
+    {
+        $this->victor = $victor;
+        $this->loser  = $loser;
+    }
+
+    /**
+     * Returns the victor (loser merges into the victor).
+     *
+     * @return Company
+     */
+    public function getVictor()
+    {
+        return $this->victor;
+    }
+
+    /**
+     * Returns the loser (loser merges into the victor).
+     */
+    public function getLoser()
+    {
+        return $this->loser;
+    }
+}

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -581,6 +581,26 @@ final class LeadEvents
     const COMPANY_POST_DELETE = 'mautic.company_post_delete';
 
     /**
+     * The mautic.company_pre_merge event is dispatched before two companies are merged.
+     *
+     * The event listener receives a
+     * Mautic\LeadBundle\Event\CompanyMergeEvent instance.
+     *
+     * @var string
+     */
+    const COMPANY_PRE_MERGE = 'mautic.company_pre_merge';
+
+    /**
+     * The mautic.company_post_merge event is dispatched after two companies are merged.
+     *
+     * The event listener receives a
+     * Mautic\LeadBundle\Event\CompanyMergeEvent instance.
+     *
+     * @var string
+     */
+    const COMPANY_POST_MERGE = 'mautic.company_post_merge';
+
+    /**
      * The mautic.list_filters_choices_on_generate event is dispatched when the choices for list filters are generated.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Event\CompanyEvent;
+use Mautic\LeadBundle\Event\CompanyMergeEvent;
 use Mautic\LeadBundle\Event\LeadChangeCompanyEvent;
 use Mautic\LeadBundle\Exception\UniqueFieldNotFoundException;
 use Mautic\LeadBundle\Form\Type\CompanyType;
@@ -664,6 +665,10 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         $mainCompanyId = $mainCompany->getId();
         $secCompanyId  = $secCompany->getId();
 
+        // Dispatch pre merge event
+        $event = new CompanyMergeEvent($mainCompany, $secCompany);
+        $this->dispatcher->dispatch(LeadEvents::COMPANY_PRE_MERGE, $event);
+
         //if they are the same lead, then just return one
         if ($mainCompanyId === $secCompanyId) {
             return $mainCompany;
@@ -698,6 +703,9 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         }
         //save the updated company
         $this->saveEntity($mainCompany, false);
+
+        // Dispatch post merge event
+        $this->dispatcher->dispatch(LeadEvents::COMPANY_POST_MERGE, $event);
 
         //delete the old company
         $this->deleteEntity($secCompany);

--- a/app/bundles/LeadBundle/Tests/Event/CompanyMergeEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/CompanyMergeEventTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * @copyright   2018 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\Company;

--- a/app/bundles/LeadBundle/Tests/Event/CompanyMergeEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/CompanyMergeEventTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Event;
+
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Event\CompanyMergeEvent;
+use PHPUnit\Framework\TestCase;
+
+class CompanyMergeEventTest extends TestCase
+{
+    public function testConstructGettersSetters()
+    {
+        $victor = new Company();
+        $loser = new Company();
+        $event   = new CompanyMergeEvent($victor, $loser);
+
+        $this->assertEquals($victor, $event->getVictor());
+        $this->assertEquals($loser, $event->getLoser());
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This is a developer-only feature which adds an event (CompanyMergeEvent) which is fired both before and after companies are merged.

It includes a very simple test class for the new class which follows how similar event tests work.

Note: This PR exists because a different PR (https://github.com/mautic/mautic/pull/11229) needs this functionality. That PR is specifically about Pipedrive, however, so this PR adds the event generically. The same 2 commits from this PR are also in that PR since otherwise it would be broken, so this PR should probably be merged first.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

Note: Since this is a developer-only PR, testing this feature without any additional features simply means ensuring Mautic and its existing tests don't break.

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Install/start Mautic
3. Create two companies to be merged
4. Merge the companies from within Mautic and ensure there are no errors related to the event

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11228"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

