### PR TITLE
Implementing the RemoveUnusedPrivateMethodParameterRector Rector rule

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
@@ -126,7 +126,7 @@ class LegacyEventDispatcher
 
                 // Dispatch new events for legacy processed logs
                 if ($this->isFailed($result)) {
-                    $this->processFailedLog($result, $log, $pendingEvent);
+                    $this->processFailedLog($log, $pendingEvent);
 
                     $rescheduleFailures->set($log->getId(), $log);
 
@@ -326,10 +326,7 @@ class LegacyEventDispatcher
             || (is_array($result) && isset($result['result']) && false === $result['result']);
     }
 
-    /**
-     * @param $result
-     */
-    private function processFailedLog($result, LeadEventLog $log, PendingEvent $pendingEvent)
+    private function processFailedLog(LeadEventLog $log, PendingEvent $pendingEvent)
     {
         $this->logger->debug(
             'CAMPAIGN: '.ucfirst($log->getEvent()->getEventType()).' ID# '.$log->getEvent()->getId().' for contact ID# '.$log->getLead()->getId()

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -176,23 +176,11 @@ namespace Mautic\CoreBundle\ErrorHandler {
          */
         public function handleException($exception, $returnContent = false, $inTemplate = false)
         {
-            $inline = $inTemplate;
-            if (!$exception instanceof FatalThrowableError && defined('MAUTIC_DELEGATE_VIEW')) {
-                $inline = true;
-            }
-
             if (!$error = self::prepareExceptionForOutput($exception)) {
                 return false;
             }
-            if (isset($error['inline'])) {
-                $inline = $error['inline'];
-            }
 
-            if (!empty($GLOBALS['MAUTIC_AJAX_DIRECT_RENDER'])) {
-                $inline = true;
-            }
-
-            $content = $this->generateResponse($error, $inline, $inTemplate);
+            $content = $this->generateResponse($error, $inTemplate);
 
             $message = isset($error['logMessage']) ? $error['logMessage'] : $error['message'];
             $this->log(LogLevel::ERROR, "$message - in file {$error['file']} - at line {$error['line']}", [], $error['trace']);
@@ -435,12 +423,10 @@ namespace Mautic\CoreBundle\ErrorHandler {
 
         /**
          * @param      $error
-         * @param bool $inline
          * @param bool $inTemplate
-         *
          * @return mixed|string
          */
-        private function generateResponse($error, $inline = true, $inTemplate = false)
+        private function generateResponse($error, $inTemplate = false)
         {
             // Get a trace
             if ('dev' == self::$environment) {

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -42,9 +42,6 @@ namespace Mautic\CoreBundle\ErrorHandler {
          */
         private static $root;
 
-        /**
-         * ErrorHandler constructor.
-         */
         public function __construct()
         {
             self::$root = realpath(__DIR__.'/../../../../');
@@ -422,8 +419,9 @@ namespace Mautic\CoreBundle\ErrorHandler {
         }
 
         /**
-         * @param      $error
-         * @param bool $inTemplate
+         * @param mixed[] $error
+         * @param bool    $inTemplate
+         *
          * @return mixed|string
          */
         private function generateResponse($error, $inTemplate = false)

--- a/app/bundles/LeadBundle/Command/CheckQueryBuildersCommand.php
+++ b/app/bundles/LeadBundle/Command/CheckQueryBuildersCommand.php
@@ -40,7 +40,6 @@ class CheckQueryBuildersCommand extends ModeratedCommand
         $listModel = $container->get('mautic.lead.model.list');
 
         $id            = $input->getOption('segment-id');
-        $verbose       = $input->getOption('verbose');
         $this->skipOld = $input->getOption('skip-old');
 
         $failed = $ok = 0;
@@ -53,7 +52,7 @@ class CheckQueryBuildersCommand extends ModeratedCommand
 
                 return 1;
             }
-            $response = $this->runSegment($output, $verbose, $list, $listModel);
+            $response = $this->runSegment($output, $list, $listModel);
             if ($response) {
                 ++$ok;
             } else {
@@ -74,7 +73,7 @@ class CheckQueryBuildersCommand extends ModeratedCommand
                 if ('+' == substr($id, strlen($id) - 1, 1) and $l->getId() < intval(trim($id, '+'))) {
                     continue;
                 }
-                $response = $this->runSegment($output, $verbose, $l, $listModel);
+                $response = $this->runSegment($output, $l, $listModel);
                 if (!$response) {
                     ++$failed;
                 } else {
@@ -111,7 +110,7 @@ class CheckQueryBuildersCommand extends ModeratedCommand
         return $now->format('H:i:s.u');
     }
 
-    private function runSegment(OutputInterface $output, $verbose, LeadList $l, ListModel $listModel)
+    private function runSegment(OutputInterface $output, LeadList $l, ListModel $listModel)
     {
         if (!$l->isPublished()) {
             $msg = sprintf('Segment #%d is not published', $l->getId());

--- a/app/bundles/MarketplaceBundle/Service/PluginCollector.php
+++ b/app/bundles/MarketplaceBundle/Service/PluginCollector.php
@@ -33,7 +33,7 @@ class PluginCollector
 
         if (!empty($allowlist)) {
             $this->allowlistedPackages = $this->filterAllowlistedPackagesForCurrentMauticVersion($allowlist->entries);
-            $payload                   = $this->getAllowlistedPackages($page, $limit, $query);
+            $payload                   = $this->getAllowlistedPackages($page, $limit);
         } else {
             $payload = $this->connection->getPlugins($page, $limit, $query);
         }
@@ -83,7 +83,7 @@ class PluginCollector
      *
      * @return array<string,mixed>
      */
-    private function getAllowlistedPackages(int $page, int $limit, string $query = ''): array
+    private function getAllowlistedPackages(int $page = 1, int $limit): array
     {
         $total   = count($this->allowlistedPackages);
         $results = [];

--- a/app/bundles/ReportBundle/Controller/ScheduleController.php
+++ b/app/bundles/ReportBundle/Controller/ScheduleController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\ReportBundle\Scheduler\Date\DateBuilder;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 
 class ScheduleController extends CommonAjaxController
 {
@@ -51,19 +50,19 @@ class ScheduleController extends CommonAjaxController
         if (empty($report)) {
             $this->addFlash('mautic.report.notfound', ['%id%' => $reportId], FlashBag::LEVEL_ERROR, 'messages');
 
-            return $this->flushFlash(Response::HTTP_NOT_FOUND);
+            return $this->flushFlash();
         }
 
         if (!$security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $report->getCreatedBy())) {
             $this->addFlash('mautic.core.error.accessdenied', [], FlashBag::LEVEL_ERROR);
 
-            return $this->flushFlash(Response::HTTP_FORBIDDEN);
+            return $this->flushFlash();
         }
 
         if ($report->isScheduled()) {
             $this->addFlash('mautic.report.scheduled.already', ['%id%' => $reportId], FlashBag::LEVEL_ERROR);
 
-            return $this->flushFlash(Response::HTTP_PROCESSING);
+            return $this->flushFlash();
         }
 
         $report->setAsScheduledNow($this->user->getEmail());
@@ -74,15 +73,13 @@ class ScheduleController extends CommonAjaxController
             ['%id%' => $reportId, '%email%' => $this->user->getEmail()]
         );
 
-        return $this->flushFlash(Response::HTTP_OK);
+        return $this->flushFlash();
     }
 
     /**
-     * @param string $status
-     *
      * @return JsonResponse
      */
-    private function flushFlash($status)
+    private function flushFlash()
     {
         return new JsonResponse(['flashes' => $this->getFlashContent()]);
     }

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,7 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
     $rectorConfig->rule(\Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector::class);
     $rectorConfig->rule(\Rector\DeadCode\Rector\Stmt\RemoveUnreachableStatementRector::class);
     $rectorConfig->rule(\Rector\DeadCode\Rector\ClassConst\RemoveUnusedPrivateClassConstantRector::class);
-    // $rectorConfig->rule(\Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector::class); // @todo enable this in a separate PR. A few files changed.
+    $rectorConfig->rule(\Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector::class);
 
     // temp workaround to prevent rector to fail due to an undefined const.
     // This doesn't make much sense, and is probably fixed in a more recent version of Rector.


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

As we have Rector set up in our CI we may as well put it in use. This PR is adding this rule:

https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#removeunusedprivatemethodparameterrector

It automatically modified the code for me and I removed some other rows that my editor pointed out like unused properties and use statements. I see no harm merging this without testing because it's obvious from the code review that the code that was removed is not used (dead code).

The changes are not breaking backward compatibility as it affects only private methods.

As the rule was added to the CI config then all future code changes will be checked for this dead code rule.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. As the automatic refactoring tool (Rector) did changes in 5 files each in different bundle and I don't know how to trigger the changed code then I suggest to just get 2 code reviews from developers and get this merged.



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11232"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

