### PR TITLE
Add 4.3.x series to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -24,6 +24,7 @@ body:
       label: Mautic Version
       description: What version of Mautic you are using? Please test to reproduce your bug with the [latest stable version of Mautic](https://www.mautic.org/mautic-releases) which might contain new fixes.  If you are able, please also check the latest development release.
       options:
+        - 4.3.x series
         - 4.2.x series
         - 4.1.x series
         - 4.0.x series (not supported)


### PR DESCRIPTION
#### Description:
This adds the 4.3.x series to the dropdown when creating a new issue.

#### Steps to test this PR:
N/A


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11240"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

