### PR TITLE
Disable default values

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -633,7 +633,12 @@ return [
             ],
             'mautic.form.type.leadfield' => [
                 'class'     => \Mautic\LeadBundle\Form\Type\FieldType::class,
-                'arguments' => ['translator', 'mautic.lead.repository.field'],
+                'arguments' => [
+                    'doctrine.orm.default_entity_manager',
+                    'translator',
+                    'mautic.lead.field.identifier_fields',
+                ],
+                'alias'     => 'leadfield',
             ],
             'mautic.form.type.lead.submitaction.pointschange' => [
                 'class'     => \Mautic\LeadBundle\Form\Type\FormSubmitActionPointsChangeType::class,
@@ -1477,6 +1482,13 @@ return [
                 'arguments' => [
                     'mautic.lead.repository.field',
                     'translator',
+                ],
+            ],
+            'mautic.lead.field.identifier_fields' => [
+                'class'     => \Mautic\LeadBundle\Field\IdentifierFields::class,
+                'arguments' => [
+                    'mautic.lead.field.fields_with_unique_identifier',
+                    'mautic.lead.field.field_list',
                 ],
             ],
             'mautic.lead.field.lead_field_saver' => [

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -9,9 +9,6 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\UserBundle\Entity\User;
 
-/**
- * Class Company.
- */
 class Company extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface
 {
     use CustomFieldEntityTrait;
@@ -29,12 +26,12 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     private $score = 0;
 
     /**
-     * @var \Mautic\UserBundle\Entity\User
+     * @var User
      */
     private $owner;
 
     /**
-     * @var array
+     * @var mixed[]
      */
     private $socialCache = [];
 
@@ -70,9 +67,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Get social cache.
-     *
-     * @return mixed
+     * @return mixed[]
      */
     public function getSocialCache()
     {
@@ -80,9 +75,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Set social cache.
-     *
-     * @param $cache
+     * @param mixed[] $cache
      */
     public function setSocialCache($cache)
     {
@@ -93,7 +86,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     {
         $builder = new ClassMetadataBuilder($metadata);
         $builder->setTable('companies')
-            ->setCustomRepositoryClass('Mautic\LeadBundle\Entity\CompanyRepository');
+            ->setCustomRepositoryClass(CompanyRepository::class);
 
         $builder->createField('id', 'integer')
             ->isPrimaryKey()
@@ -171,10 +164,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
             ->build();
     }
 
-    /**
-     * @return array
-     */
-    public static function getDefaultIdentifierFields()
+    public static function getDefaultIdentifierFields(): array
     {
         return [
             'companyname',
@@ -211,8 +201,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Get id.
-     *
      * @return int
      */
     public function getId()
@@ -235,8 +223,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Set owner.
-     *
      * @param User $owner
      *
      * @return Company
@@ -250,8 +236,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Get owner.
-     *
      * @return User
      */
     public function getOwner()
@@ -270,8 +254,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Set score.
-     *
      * @param User $score
      *
      * @return Company
@@ -287,8 +269,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * Get score.
-     *
      * @return int
      */
     public function getScore()

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -12,7 +12,7 @@ use Mautic\UserBundle\Entity\User;
 /**
  * Class Company.
  */
-class Company extends FormEntity implements CustomFieldEntityInterface
+class Company extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface
 {
     use CustomFieldEntityTrait;
 
@@ -169,6 +169,21 @@ class Company extends FormEntity implements CustomFieldEntityInterface
                 ]
             )
             ->build();
+    }
+
+    /**
+     * @return array
+     */
+    public static function getDefaultIdentifierFields()
+    {
+        return [
+            'companyname',
+            'companyemail',
+            'companywebsite',
+            'city',
+            'state',
+            'country',
+        ];
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/IdentifierFieldEntityInterface.php
+++ b/app/bundles/LeadBundle/Entity/IdentifierFieldEntityInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Entity;
+
+interface IdentifierFieldEntityInterface
+{
+    /**
+     * @return array
+     */
+    public static function getDefaultIdentifierFields();
+}

--- a/app/bundles/LeadBundle/Entity/IdentifierFieldEntityInterface.php
+++ b/app/bundles/LeadBundle/Entity/IdentifierFieldEntityInterface.php
@@ -1,20 +1,13 @@
 <?php
 
-/*
- * @copyright   2018 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Entity;
 
 interface IdentifierFieldEntityInterface
 {
     /**
-     * @return array
+     * @return string[]
      */
-    public static function getDefaultIdentifierFields();
+    public static function getDefaultIdentifierFields(): array;
 }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -454,10 +454,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
             ->build();
     }
 
-    /**
-     * @return array
-     */
-    public static function getDefaultIdentifierFields()
+    public static function getDefaultIdentifierFields(): array
     {
         return [
             'firstname',

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -14,7 +14,7 @@ use Mautic\NotificationBundle\Entity\PushID;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\UserBundle\Entity\User;
 
-class Lead extends FormEntity implements CustomFieldEntityInterface
+class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface
 {
     use CustomFieldEntityTrait;
 
@@ -452,6 +452,19 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
                 ]
             )
             ->build();
+    }
+
+    /**
+     * @return array
+     */
+    public static function getDefaultIdentifierFields()
+    {
+        return [
+            'firstname',
+            'lastname',
+            'company',
+            'email',
+        ];
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -25,6 +25,9 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     const POINTS_DIVIDE   = 'divide';
     const DEFAULT_ALIAS   = 'l';
 
+    public const IDENTIFIER_FIELDS = [
+    ];
+
     /**
      * Used to determine social identity.
      *

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -25,9 +25,6 @@ class Lead extends FormEntity implements CustomFieldEntityInterface
     const POINTS_DIVIDE   = 'divide';
     const DEFAULT_ALIAS   = 'l';
 
-    public const IDENTIFIER_FIELDS = [
-    ];
-
     /**
      * Used to determine social identity.
      *

--- a/app/bundles/LeadBundle/Field/FieldsWithUniqueIdentifier.php
+++ b/app/bundles/LeadBundle/Field/FieldsWithUniqueIdentifier.php
@@ -22,7 +22,7 @@ class FieldsWithUniqueIdentifier
     }
 
     /**
-     * Retrieves a list of published fields that are unique identifers.
+     * Retrieves a list of published fields that are unique identifiers.
      *
      * @return mixed
      */

--- a/app/bundles/LeadBundle/Field/IdentifierFields.php
+++ b/app/bundles/LeadBundle/Field/IdentifierFields.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Field;
+
+class IdentifierFields
+{
+    /**
+     * @var FieldsWithUniqueIdentifier
+     */
+    private $fieldsWithUniqueIdentifier;
+
+    /**
+     * @var FieldList
+     */
+    private $fieldList;
+
+    /**
+     * @var string
+     */
+    private $object;
+
+    /**
+     * Fields that are used to identify as not anonymous or unique identifiers (company).
+     *
+     * @var array
+     */
+    private $defaultFields = [
+        'lead' => [
+            'firstname',
+            'lastname',
+            'company',
+            'email',
+        ],
+        'company' => [
+            'companyname',
+            'companyemail',
+            'companywebsite',
+            'city',
+            'state',
+            'country',
+        ],
+    ];
+
+    /**
+     * IdentifierFields constructor.
+     *
+     * @param FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier
+     * @param FieldList                  $fieldList
+     */
+    public function __construct(FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier, FieldList $fieldList)
+    {
+        $this->fieldsWithUniqueIdentifier = $fieldsWithUniqueIdentifier;
+        $this->fieldList                  = $fieldList;
+    }
+
+    /**
+     * @param $object
+     *
+     * @return array
+     */
+    public function getFieldList($object)
+    {
+        $this->object = $object;
+
+        return array_merge(
+            isset($this->defaultFields[$object]) ? $this->defaultFields[$object] : [],
+            $this->getUniqueIdentifierFields(),
+            $this->getSocialFields()
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function getUniqueIdentifierFields()
+    {
+        $fields = $this->fieldsWithUniqueIdentifier->getFieldsWithUniqueIdentifier(
+            [
+                'object' => $this->object,
+            ]
+        );
+
+        return array_keys($fields);
+    }
+
+    /**
+     * @return array
+     */
+    private function getSocialFields()
+    {
+        $fields = $this->fieldList->getFieldList(
+            true,
+            false,
+            [
+                'isPublished' => true,
+                'object'      => $this->object,
+            ]
+        );
+
+        if (!isset($fields['Social'])) {
+            return [];
+        }
+
+        return array_keys($fields['Social']);
+    }
+}

--- a/app/bundles/LeadBundle/Field/IdentifierFields.php
+++ b/app/bundles/LeadBundle/Field/IdentifierFields.php
@@ -1,13 +1,6 @@
 <?php
 
-/*
- * @copyright   2018 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field;
 
@@ -17,27 +10,9 @@ use Mautic\LeadBundle\Entity\Lead;
 
 class IdentifierFields
 {
-    /**
-     * @var FieldsWithUniqueIdentifier
-     */
-    private $fieldsWithUniqueIdentifier;
+    private FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier;
+    private FieldList $fieldList;
 
-    /**
-     * @var FieldList
-     */
-    private $fieldList;
-
-    /**
-     * @var string
-     */
-    private $object;
-
-    /**
-     * IdentifierFields constructor.
-     *
-     * @param FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier
-     * @param FieldList                  $fieldList
-     */
     public function __construct(FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier, FieldList $fieldList)
     {
         $this->fieldsWithUniqueIdentifier = $fieldsWithUniqueIdentifier;
@@ -45,31 +20,24 @@ class IdentifierFields
     }
 
     /**
-     * @param $object
-     * @param $entityClass
-     *
-     * @return array
+     * @return string[]
      */
-    public function getFieldList($object, $entityClass = null)
+    public function getFieldList(string $object, ?object $entityClass = null): array
     {
-        $this->object = $object;
-
         return array_merge(
-            $this->getDefaultFields($entityClass),
-            $this->getUniqueIdentifierFields(),
-            $this->getSocialFields()
+            $this->getDefaultFields($object, $entityClass),
+            $this->getUniqueIdentifierFields($object),
+            $this->getSocialFields($object)
         );
     }
 
     /**
-     * @param $entityClass
-     *
-     * @return array
+     * @return string[]
      */
-    public function getDefaultFields($entityClass)
+    private function getDefaultFields(string $object, ?object $entityClass): array
     {
         if (null === $entityClass) {
-            switch ($this->object) {
+            switch ($object) {
                 case 'lead':
                     $entityClass = Lead::class;
                     break;
@@ -90,13 +58,13 @@ class IdentifierFields
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    private function getUniqueIdentifierFields()
+    private function getUniqueIdentifierFields(string $object): array
     {
         $fields = $this->fieldsWithUniqueIdentifier->getFieldsWithUniqueIdentifier(
             [
-                'object' => $this->object,
+                'object' => $object,
             ]
         );
 
@@ -104,16 +72,16 @@ class IdentifierFields
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    private function getSocialFields()
+    private function getSocialFields(string $object): array
     {
         $fields = $this->fieldList->getFieldList(
             true,
             false,
             [
                 'isPublished' => true,
-                'object'      => $this->object,
+                'object'      => $object,
             ]
         );
 

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -449,6 +449,10 @@ class FieldType extends AbstractType
                     $data['defaultValue'] = null;
                 }
 
+                if (isset($data['type']) && !in_array($data['type'], $this->indexableFieldsWithLimits)) {
+                    $data['charLengthLimit'] = null;
+                }
+
                 $event->setData($data);
             }
         );

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -437,14 +437,14 @@ class FieldType extends AbstractType
 
         $builder->addEventListener(
             FormEvents::PRE_SUBMIT,
-            function (FormEvent $event) use ($formModifier) {
+            function (FormEvent $event) use ($formModifier, $disableDefaultValue) {
                 $data          = $event->getData();
                 $cleaningRules = $formModifier($event);
                 $masks         = !empty($cleaningRules) ? $cleaningRules : 'clean';
                 // clean the data
                 $data = InputHelper::_($data, $masks);
 
-                if ('social' === $data['group'] || !empty($data['isUniqueIdentifer'])) {
+                if ('social' === $data['group'] || !empty($data['isUniqueIdentifer']) || $disableDefaultValue) {
                     // Don't allow a default for social or unique identifiers
                     $data['defaultValue'] = null;
                 }

--- a/app/bundles/LeadBundle/Tests/Field/IdentifierFieldsTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/IdentifierFieldsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * @copyright   2018 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Tests\Field;
+
+use Mautic\LeadBundle\Field\FieldList;
+use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
+use Mautic\LeadBundle\Field\IdentifierFields;
+
+class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FieldsWithUniqueIdentifier|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldsWithUniqueIdentifiers;
+
+    /**
+     * @var FieldList|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldList;
+
+    protected function setUp()
+    {
+        $this->fieldsWithUniqueIdentifiers = $this->createMock(FieldsWithUniqueIdentifier::class);
+        $this->fieldList                   = $this->createMock(FieldList::class);
+    }
+
+    public function testLeadObjectReturnsDefaultFields()
+    {
+        $this->fieldsWithUniqueIdentifiers->expects($this->once())
+            ->method('getFieldsWithUniqueIdentifier')
+            ->with(['object' => 'lead'])
+            ->willReturn([]);
+
+        $this->fieldList->expects($this->once())
+            ->method('getFieldList')
+            ->with(true, false, ['isPublished' => true, 'object' => 'lead'])
+            ->willReturn([]);
+
+        $fields = $this->getIdentifierFields()->getFieldList('lead');
+
+        $this->assertEquals(
+            [
+                'firstname',
+                'lastname',
+                'company',
+                'email',
+            ],
+            $fields
+        );
+    }
+
+    public function testCompanyObjectReturnsDefaultFields()
+    {
+        $this->fieldsWithUniqueIdentifiers->expects($this->once())
+            ->method('getFieldsWithUniqueIdentifier')
+            ->with(['object' => 'company'])
+            ->willReturn([]);
+
+        $this->fieldList->expects($this->once())
+            ->method('getFieldList')
+            ->with(true, false, ['isPublished' => true, 'object' => 'company'])
+            ->willReturn([]);
+
+        $fields = $this->getIdentifierFields()->getFieldList('company');
+
+        $this->assertEquals(
+            [
+                'companyname',
+                'companyemail',
+                'companywebsite',
+                'city',
+                'state',
+                'country',
+            ],
+            $fields
+        );
+    }
+
+    public function testUniqueIdentifiersAreIncluded()
+    {
+        $this->fieldsWithUniqueIdentifiers->expects($this->once())
+            ->method('getFieldsWithUniqueIdentifier')
+            ->with(['object' => 'lead'])
+            ->willReturn(
+                [
+                    'unique_id' => 'Unique ID',
+                ]
+            );
+
+        $this->fieldList->expects($this->once())
+            ->method('getFieldList')
+            ->with(true, false, ['isPublished' => true, 'object' => 'lead'])
+            ->willReturn([]);
+
+        $fields = $this->getIdentifierFields()->getFieldList('lead');
+
+        $this->assertEquals(
+            [
+                'firstname',
+                'lastname',
+                'company',
+                'email',
+                'unique_id',
+            ],
+            $fields
+        );
+    }
+
+    public function testSocialFieldsAreIncluded()
+    {
+        $this->fieldsWithUniqueIdentifiers->expects($this->once())
+            ->method('getFieldsWithUniqueIdentifier')
+            ->with(['object' => 'lead'])
+            ->willReturn(
+                [
+                    'unique_id' => 'Unique ID',
+                ]
+            );
+
+        $this->fieldList->expects($this->once())
+            ->method('getFieldList')
+            ->with(true, false, ['isPublished' => true, 'object' => 'lead'])
+            ->willReturn(
+                [
+                    'Social' => [
+                        'twitter' => [
+                            'alias' => 'twitter',
+                            'label' => 'Twitter',
+                            'type'  => 'text',
+                        ],
+                    ],
+                    'Core' => [
+                        'foo' => [
+                            'alias' => 'foo',
+                            'label' => 'Foo',
+                            'type'  => 'text',
+                        ],
+                    ],
+                ]
+            );
+
+        $fields = $this->getIdentifierFields()->getFieldList('lead');
+
+        $this->assertEquals(
+            [
+                'firstname',
+                'lastname',
+                'company',
+                'email',
+                'unique_id',
+                'twitter',
+            ],
+            $fields
+        );
+    }
+
+    /**
+     * @return IdentifierFields
+     */
+    private function getIdentifierFields()
+    {
+        return new IdentifierFields($this->fieldsWithUniqueIdentifiers, $this->fieldList);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Field/IdentifierFieldsTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/IdentifierFieldsTest.php
@@ -1,39 +1,40 @@
 <?php
 
-/*
- * @copyright   2018 Mautic Inc. All rights reserved
- * @author      Mautic, Inc.
- *
- * @link        https://www.mautic.com
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Field;
 
 use Mautic\LeadBundle\Field\FieldList;
 use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Field\IdentifierFields;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
+class IdentifierFieldsTest extends TestCase
 {
     /**
-     * @var FieldsWithUniqueIdentifier|\PHPUnit_Framework_MockObject_MockObject
+     * @var FieldsWithUniqueIdentifier&MockObject
      */
     private $fieldsWithUniqueIdentifiers;
 
     /**
-     * @var FieldList|\PHPUnit_Framework_MockObject_MockObject
+     * @var FieldList&MockObject
      */
     private $fieldList;
 
-    protected function setUp()
+    /**
+     * @var IdentifierFields
+     */
+    private $identifierFields;
+
+    protected function setUp(): void
     {
         $this->fieldsWithUniqueIdentifiers = $this->createMock(FieldsWithUniqueIdentifier::class);
         $this->fieldList                   = $this->createMock(FieldList::class);
+        $this->identifierFields            = new IdentifierFields($this->fieldsWithUniqueIdentifiers, $this->fieldList);
     }
 
-    public function testLeadObjectReturnsDefaultFields()
+    public function testLeadObjectReturnsDefaultFields(): void
     {
         $this->fieldsWithUniqueIdentifiers->expects($this->once())
             ->method('getFieldsWithUniqueIdentifier')
@@ -45,7 +46,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
             ->with(true, false, ['isPublished' => true, 'object' => 'lead'])
             ->willReturn([]);
 
-        $fields = $this->getIdentifierFields()->getFieldList('lead');
+        $fields = $this->identifierFields->getFieldList('lead');
 
         $this->assertEquals(
             [
@@ -58,7 +59,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCompanyObjectReturnsDefaultFields()
+    public function testCompanyObjectReturnsDefaultFields(): void
     {
         $this->fieldsWithUniqueIdentifiers->expects($this->once())
             ->method('getFieldsWithUniqueIdentifier')
@@ -70,7 +71,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
             ->with(true, false, ['isPublished' => true, 'object' => 'company'])
             ->willReturn([]);
 
-        $fields = $this->getIdentifierFields()->getFieldList('company');
+        $fields = $this->identifierFields->getFieldList('company');
 
         $this->assertEquals(
             [
@@ -85,7 +86,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testUniqueIdentifiersAreIncluded()
+    public function testUniqueIdentifiersAreIncluded(): void
     {
         $this->fieldsWithUniqueIdentifiers->expects($this->once())
             ->method('getFieldsWithUniqueIdentifier')
@@ -101,7 +102,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
             ->with(true, false, ['isPublished' => true, 'object' => 'lead'])
             ->willReturn([]);
 
-        $fields = $this->getIdentifierFields()->getFieldList('lead');
+        $fields = $this->identifierFields->getFieldList('lead');
 
         $this->assertEquals(
             [
@@ -115,7 +116,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testSocialFieldsAreIncluded()
+    public function testSocialFieldsAreIncluded(): void
     {
         $this->fieldsWithUniqueIdentifiers->expects($this->once())
             ->method('getFieldsWithUniqueIdentifier')
@@ -148,7 +149,7 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
                 ]
             );
 
-        $fields = $this->getIdentifierFields()->getFieldList('lead');
+        $fields = $this->identifierFields->getFieldList('lead');
 
         $this->assertEquals(
             [
@@ -161,13 +162,5 @@ class IdentifierFieldsTest extends \PHPUnit_Framework_TestCase
             ],
             $fields
         );
-    }
-
-    /**
-     * @return IdentifierFields
-     */
-    private function getIdentifierFields()
-    {
-        return new IdentifierFields($this->fieldsWithUniqueIdentifiers, $this->fieldList);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -5615,7 +5615,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "9b05a66b449980154fb2fb1416b8342a6aea74ba"
+                "reference": "e05007453398ca880a68dd9a4b7fe776b6d6db2f"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "173d73534de293e80cb03695c4c29c1a",
+    "content-hash": "18c810239b16e7a63b7514bf61b0539f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5615,7 +5615,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "e05007453398ca880a68dd9a4b7fe776b6d6db2f"
+                "reference": "3e7a938c18f6adbf4dec4f29e0f9be362c55f40a"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18c810239b16e7a63b7514bf61b0539f",
+    "content-hash": "173d73534de293e80cb03695c4c29c1a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5615,7 +5615,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "3e7a938c18f6adbf4dec4f29e0f9be362c55f40a"
+                "reference": "9b05a66b449980154fb2fb1416b8342a6aea74ba"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | https://github.com/mautic/mautic-documentation/pull/321
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This disables the default value for fields that Mautic uses to set someone as identified. This prevents the case where all visitors can be marked as identified if they have a default value set for first name. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Set a default value for first name
2. Visit a landing page or Mautic tracked page
3. Look for the contact in Mautic and notice they are not anonymous

#### Steps to test this PR:
1. Edit the custom field for first name and notice default value is disabled
2. Save and edit again and the default value should be empty
3. Edit email, company, first name, last name, any unique identifier field, or any social field and default value should be disabled. For company, companyname, companyemail, companywebsite, state, country and city should have default value disabled (all used to identify a company). 


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11250"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

