### PR TITLE
Skip one way fields

### DIFF
--- a/app/bundles/IntegrationsBundle/Sync/Logger/DebugLogger.php
+++ b/app/bundles/IntegrationsBundle/Sync/Logger/DebugLogger.php
@@ -9,7 +9,7 @@ use Psr\Log\LogLevel;
 
 class DebugLogger
 {
-    private static \Psr\Log\LoggerInterface $logger;
+    private static ?LoggerInterface $logger = null;
 
     public function __construct(LoggerInterface $logger)
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
@@ -138,6 +138,9 @@ class FieldHelper
         return $this->syncFields[$objectName];
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getRequiredFields(string $object): array
     {
         if (isset($this->requiredFieldList[$object])) {

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
@@ -46,13 +46,8 @@ class ObjectChangeGenerator
         ReportObjectDAO $internalObject,
         ReportObjectDAO $integrationObject
     ) {
-        $this->syncReport        = $syncReport;
-        $this->mappingManual     = $mappingManual;
-        $this->internalObject    = $internalObject;
-        $this->integrationObject = $integrationObject;
-
-        $this->objectChange = new ObjectChangeDAO(
-            $this->mappingManual->getIntegration(),
+        $objectChange = new ObjectChangeDAO(
+            $mappingManual->getIntegration(),
             $integrationObject->getObject(),
             $integrationObject->getObjectId(),
             $internalObject->getObject(),
@@ -61,7 +56,7 @@ class ObjectChangeGenerator
 
         if ($integrationObject->getObjectId()) {
             DebugLogger::log(
-                $this->mappingManual->getIntegration(),
+                $mappingManual->getIntegration(),
                 sprintf(
                     "Mautic to integration; found a match between the integration %s:%s object and Mautic's %s:%s object",
                     $integrationObject->getObject(),
@@ -73,7 +68,7 @@ class ObjectChangeGenerator
             );
         } else {
             DebugLogger::log(
-                $this->mappingManual->getIntegration(),
+                $mappingManual->getIntegration(),
                 sprintf(
                     'Mautic to integration: no match found for %s:%s',
                     $internalObject->getObject(),
@@ -86,26 +81,47 @@ class ObjectChangeGenerator
         /** @var FieldMappingDAO[] $fieldMappings */
         $fieldMappings = $objectMapping->getFieldMappings();
         foreach ($fieldMappings as $fieldMappingDAO) {
-            $this->addFieldToObjectChange($fieldMappingDAO);
+            $this->addFieldToObjectChange($fieldMappingDAO, $syncReport, $mappingManual, $internalObject, $integrationObject, $objectChange);
         }
 
         // Set the change date/time from the object so that we can update last sync date based on this
-        $this->objectChange->setChangeDateTime($internalObject->getChangeDateTime());
+        $objectChange->setChangeDateTime($internalObject->getChangeDateTime());
 
-        return $this->objectChange;
+        return $objectChange;
     }
 
     /**
      * @throws ObjectNotFoundException
      */
-    private function addFieldToObjectChange(FieldMappingDAO $fieldMappingDAO): void
-    {
-        try {
-            $fieldState = $this->internalObject->getField($fieldMappingDAO->getInternalField())->getState();
+    private function addFieldToObjectChange(
+        FieldMappingDAO $fieldMappingDAO,
+        ReportDAO $syncReport,
+        MappingManualDAO $mappingManual,
+        ReportObjectDAO $internalObject,
+        ReportObjectDAO $integrationObject,
+        ObjectChangeDAO $objectChange
+    ): void {
+        // Skip adding fields for the push process that should sync to Mautic only.
+        if (ObjectMappingDAO::SYNC_TO_MAUTIC === $fieldMappingDAO->getSyncDirection()) {
+            DebugLogger::log(
+                $mappingManual->getIntegration(),
+                sprintf(
+                    "Mautic to integration; the %s object's field %s was skipped because it's configured to sync to Mautic",
+                    $integrationObject->getObject(),
+                    $fieldMappingDAO->getIntegrationField()
+                ),
+                __CLASS__.':'.__FUNCTION__
+            );
 
-            $internalInformationChangeRequest = $this->syncReport->getInformationChangeRequest(
-                $this->internalObject->getObject(),
-                $this->internalObject->getObjectId(),
+            return;
+        }
+
+        try {
+            $fieldState = $internalObject->getField($fieldMappingDAO->getInternalField())->getState();
+
+            $internalInformationChangeRequest = $syncReport->getInformationChangeRequest(
+                $internalObject->getObject(),
+                $internalObject->getObjectId(),
                 $fieldMappingDAO->getInternalField()
             );
         } catch (FieldNotFoundException) {
@@ -123,39 +139,18 @@ class ObjectChangeGenerator
         }
 
         // Note: bidirectional conflicts were handled by Internal\ObjectChangeGenerator
-        $this->objectChange->addField(
+        $objectChange->addField(
             new FieldDAO($fieldMappingDAO->getIntegrationField(), $newValue),
             $fieldState
         );
 
-        /*
-         * Below here is just debug logging
-         */
-
-        // ObjectMappingDAO::SYNC_TO_MAUTIC
-        if (ObjectMappingDAO::SYNC_TO_MAUTIC === $fieldMappingDAO->getSyncDirection()) {
-            DebugLogger::log(
-                $this->mappingManual->getIntegration(),
-                sprintf(
-                    "Mautic to integration; the %s object's %s field %s was added to the list of %s fields",
-                    $this->integrationObject->getObject(),
-                    $fieldState,
-                    $fieldMappingDAO->getIntegrationField(),
-                    $fieldState
-                ),
-                self::class.':'.__FUNCTION__
-            );
-
-            return;
-        }
-
         // ObjectMappingDAO::SYNC_TO_INTEGRATION
         // ObjectMappingDAO::SYNC_BIDIRECTIONALLY
         DebugLogger::log(
-            $this->mappingManual->getIntegration(),
+            $mappingManual->getIntegration(),
             sprintf(
                 "Mautic to integration; syncing %s object's %s field %s with a value of %s",
-                $this->integrationObject->getObject(),
+                $integrationObject->getObject(),
                 $fieldState,
                 $fieldMappingDAO->getIntegrationField(),
                 var_export($newValue->getNormalizedValue(), true)

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
@@ -19,16 +19,6 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 
 class ObjectChangeGenerator
 {
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO $syncReport = null;
-
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO $mappingManual = null;
-
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO $internalObject = null;
-
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO $integrationObject = null;
-
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO $objectChange = null;
-
     public function __construct(
         private ValueHelper $valueHelper
     ) {

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -114,6 +114,21 @@ class ObjectChangeGenerator
      */
     private function addFieldToObjectChange(FieldMappingDAO $fieldMappingDAO): void
     {
+        // Skip adding fields for the pull process that should sync to integration only.
+        if (ObjectMappingDAO::SYNC_TO_INTEGRATION === $fieldMappingDAO->getSyncDirection()) {
+            DebugLogger::log(
+                $this->mappingManual->getIntegration(),
+                sprintf(
+                    "Integration to Mautic; the %s object's field %s was skipped because it's configured to sync to the integration",
+                    $this->internalObject->getObject(),
+                    $fieldMappingDAO->getInternalField()
+                ),
+                __CLASS__.':'.__FUNCTION__
+            );
+
+            return;
+        }
+
         try {
             $integrationFieldState = $this->integrationObject->getField($fieldMappingDAO->getIntegrationField())->getState();
             $internalFieldState    = $this->getFieldState(
@@ -154,34 +169,14 @@ class ObjectChangeGenerator
             $internalFieldState
         );
 
-        /*
-         * Below here is just debug logging
-         */
-
         // ObjectMappingDAO::SYNC_TO_MAUTIC
-        if (ObjectMappingDAO::SYNC_TO_MAUTIC === $fieldMappingDAO->getSyncDirection()) {
-            DebugLogger::log(
-                $this->mappingManual->getIntegration(),
-                sprintf(
-                    'Integration to Mautic; syncing %s %s with a value of %s',
-                    $internalFieldState,
-                    $fieldMappingDAO->getInternalField(),
-                    var_export($newValue->getNormalizedValue(), true)
-                ),
-                self::class.':'.__FUNCTION__
-            );
-
-            return;
-        }
-
-        // ObjectMappingDAO::SYNC_TO_INTEGRATION:
         DebugLogger::log(
             $this->mappingManual->getIntegration(),
             sprintf(
-                "Integration to Mautic; the %s object's %s field %s was added to the list of required fields because it's configured to sync to the integration",
-                $this->internalObject->getObject(),
+                'Integration to Mautic; syncing %s %s with a value of %s',
                 $internalFieldState,
-                $fieldMappingDAO->getInternalField()
+                $fieldMappingDAO->getInternalField(),
+                var_export($newValue->getNormalizedValue(), true)
             ),
             self::class.':'.__FUNCTION__
         );

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -25,8 +25,6 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 
 class ObjectChangeGenerator
 {
-    private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO $internalObject = null;
-
     private array $judgementModes = [
         SyncJudgeInterface::HARD_EVIDENCE_MODE,
         SyncJudgeInterface::BEST_EVIDENCE_MODE,
@@ -184,7 +182,7 @@ class ObjectChangeGenerator
         string $fieldState
     ): void {
         try {
-            $internalField = $this->internalObject->getField($fieldMappingDAO->getInternalField());
+            $internalField = $internalObject->getField($fieldMappingDAO->getInternalField());
         } catch (FieldNotFoundException) {
             $internalField = null;
         }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -6,15 +6,12 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncProcess\Direction\Integr
 
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
-use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO as ReportFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
-use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
-use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Integration\ObjectChangeGenerator;
 use PHPUnit\Framework\Assert;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -6,14 +6,18 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncProcess\Direction\Integr
 
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO as ReportFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
+use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Integration\ObjectChangeGenerator;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class ObjectChangeGeneratorTest extends TestCase
@@ -120,6 +124,43 @@ class ObjectChangeGeneratorTest extends TestCase
         // First name should not be included because it wasn't found in the internal object
         $fields = $objectChangeDAO->getFields();
         $this->assertFalse(isset($fields['first_name']));
+    }
+
+    public function testFieldsWithDirectionToIntegrationAreSkipped(): void
+    {
+        $objectChangeGenerator = new ObjectChangeGenerator(
+            new class() extends ValueHelper {
+            }
+        );
+
+        $integrationName   = 'Integration A';
+        $reportDAO         = new ReportDAO($integrationName);
+        $mappingManualDAO  = new MappingManualDAO($integrationName);
+        $objectMappingDAO  = new ObjectMappingDAO(Contact::NAME, 'Lead');
+        $internalObject    = new ReportObjectDAO(Contact::NAME, 123);
+        $integrationObject = new ReportObjectDAO('Lead', 'integration-id-1');
+
+        $objectMappingDAO->addFieldMapping('email', 'Email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $objectMappingDAO->addFieldMapping('firstname', 'FirstName', ObjectMappingDAO::SYNC_TO_INTEGRATION);
+        $objectMappingDAO->addFieldMapping('points', 'Score', ObjectMappingDAO::SYNC_TO_MAUTIC);
+
+        $internalObject->addField(new ReportFieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'john@doe.email')));
+        $internalObject->addField(new ReportFieldDAO('firstname', new NormalizedValueDAO(NormalizedValueDAO::TEXT_TYPE, 'John')));
+        $internalObject->addField(new ReportFieldDAO('points', new NormalizedValueDAO(NormalizedValueDAO::INT_TYPE, 40)));
+
+        $reportDAO->addObject($internalObject);
+
+        $objectChange = $objectChangeGenerator->getSyncObjectChange($reportDAO, $mappingManualDAO, $objectMappingDAO, $internalObject, $integrationObject);
+
+        // The points/Score field should not be recorded as a change because it has direction to Mautic.
+        Assert::assertCount(2, $objectChange->getFields());
+        Assert::assertSame('john@doe.email', $objectChange->getField('Email')->getValue()->getNormalizedValue());
+        Assert::assertSame('John', $objectChange->getField('FirstName')->getValue()->getNormalizedValue());
+        Assert::assertSame(Contact::NAME, $objectChange->getMappedObject());
+        Assert::assertSame(123, $objectChange->getMappedObjectId());
+        Assert::assertSame('integration-id-1', $objectChange->getObjectId());
+        Assert::assertSame('Lead', $objectChange->getObject());
+        Assert::assertSame($integrationName, $objectChange->getIntegration());
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -7,15 +7,12 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncProcess\Direction\Intern
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
-use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO as ReportFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
-use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
-use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudge;
 use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\ObjectChangeGenerator;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -7,31 +7,36 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncProcess\Direction\Intern
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO as ReportFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
+use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudge;
 use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\ObjectChangeGenerator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ObjectChangeGeneratorTest extends TestCase
 {
     /**
-     * @var SyncJudgeInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var SyncJudgeInterface|MockObject
      */
     private \PHPUnit\Framework\MockObject\MockObject $syncJudge;
 
     /**
-     * @var ValueHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var ValueHelper|MockObject
      */
     private \PHPUnit\Framework\MockObject\MockObject $valueHelper;
 
     /**
-     * @var FieldHelper|\PHPUnit\Framework\MockObject\MockObject
+     * @var FieldHelper|MockObject
      */
     private \PHPUnit\Framework\MockObject\MockObject $fieldHelper;
 
@@ -154,6 +159,64 @@ class ObjectChangeGeneratorTest extends TestCase
 
         // First name should have changed to Robert because the sync judge returned the integration's information change request
         $this->assertEquals('Bob', $changedFields['firstname']->getValue()->getNormalizedValue());
+    }
+
+    public function testFieldsWithDirectionToIntegrationAreSkipped(): void
+    {
+        $objectChangeGenerator = new ObjectChangeGenerator(
+            new class() implements SyncJudgeInterface {
+                public function adjudicate(
+                    $mode,
+                    InformationChangeRequestDAO $leftChangeRequest,
+                    InformationChangeRequestDAO $rightChangeRequest
+                ) {
+                    return $leftChangeRequest;
+                }
+            },
+            new class() extends ValueHelper {
+            },
+            new class() extends FieldHelper {
+                public function __construct()
+                {
+                }
+
+                public function getRequiredFields(string $object): array
+                {
+                    Assert::assertSame(Contact::NAME, $object);
+
+                    return ['email' => []];
+                }
+            }
+        );
+
+        $integrationName   = 'Integration A';
+        $reportDAO         = new ReportDAO($integrationName);
+        $mappingManualDAO  = new MappingManualDAO($integrationName);
+        $objectMappingDAO  = new ObjectMappingDAO(Contact::NAME, 'Lead');
+        $internalObject    = new ReportObjectDAO(Contact::NAME, 123);
+        $integrationObject = new ReportObjectDAO('Lead', 'integration-id-1');
+
+        $objectMappingDAO->addFieldMapping('email', 'Email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $objectMappingDAO->addFieldMapping('firstname', 'FirstName', ObjectMappingDAO::SYNC_TO_MAUTIC);
+        $objectMappingDAO->addFieldMapping('points', 'Score', ObjectMappingDAO::SYNC_TO_INTEGRATION);
+
+        $integrationObject->addField(new ReportFieldDAO('Email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'john@doe.email')));
+        $integrationObject->addField(new ReportFieldDAO('FirstName', new NormalizedValueDAO(NormalizedValueDAO::TEXT_TYPE, 'John')));
+        $integrationObject->addField(new ReportFieldDAO('Score', new NormalizedValueDAO(NormalizedValueDAO::INT_TYPE, 40)));
+
+        $reportDAO->addObject($integrationObject);
+
+        $objectChange = $objectChangeGenerator->getSyncObjectChange($reportDAO, $mappingManualDAO, $objectMappingDAO, $internalObject, $integrationObject);
+
+        // The points/Score field should not be recorded as a change because it has direction to integration.
+        Assert::assertCount(2, $objectChange->getFields());
+        Assert::assertSame('john@doe.email', $objectChange->getField('email')->getValue()->getNormalizedValue());
+        Assert::assertSame('John', $objectChange->getField('firstname')->getValue()->getNormalizedValue());
+        Assert::assertSame('Lead', $objectChange->getMappedObject());
+        Assert::assertSame('integration-id-1', $objectChange->getMappedObjectId());
+        Assert::assertSame(Contact::NAME, $objectChange->getObject());
+        Assert::assertSame(123, $objectChange->getObjectId());
+        Assert::assertSame($integrationName, $objectChange->getIntegration());
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -41,6 +41,12 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__.'/app/bundles/CoreBundle/Entity/TranslationEntityTrait.php',
         ],
 
+        // Avoiding breaking BC breaks with forced return types in public methods
+        ReturnTypeFromReturnNewRector::class => [
+            __DIR__.'/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php',
+            __DIR__.'/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php',
+        ],
+
         // lets handle later, once we have more type declaratoins
         RecastingRemovalRector::class,
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

The Integrations bundle has a bug that it clear value of a field that is mapped to be synced only from ACS to the integration (SF). I was able to replicate on my local and I could see this debug note during the sync:

`SYNC: Integration to Mautic; the lead object's changed field points was added to the list of required fields because it's configured to sync to the integration`
The points field has nothing to do with required fields in either of the 2 systems.

#### Steps to test:
1. Map a field for example Points in the Salesforce v2 plugin with direction "To Integration".
2. Create a new contact in either of the systems. Set some points to the contact.
3. Run the sync.
4. Update the points field for that contact in SF.
5. Run the sync.

#### Expected result:
The points field value in ACS should stay as before as the direction is from ACS to SF only.

#### Actual result:
The points field gets cleared out in ACS.

#### Other areas of Mautic that may be affected by the change:
1. Any integration built on the IntegrationsBundle


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

