### PR TITLE
Do not retry all objects if one of them should be retried. Retry only the right one(s)

### DIFF
--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
@@ -276,10 +276,6 @@ class OrderDAO
         foreach ($this->changedObjects as $objectChanges) {
             /** @var ObjectChangeDAO $objectChange */
             foreach ($objectChanges as $objectChange) {
-                if (isset($this->retryTheseLater[$objectChange->getMappedObject()])) {
-                    continue;
-                }
-
                 if (isset($this->retryTheseLater[$objectChange->getMappedObject()][$objectChange->getMappedObjectId()])) {
                     continue;
                 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/OrderDAOTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/OrderDAOTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic Inc. All rights reserved
- * @author      Mautic, Inc.
- *
- * @link        https://www.mautic.com
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\DAO\Sync\Order;
 
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
@@ -23,9 +14,9 @@ final class OrderDAOTest extends TestCase
     /**
      * Test that the retry object is removed from the synced objects and the success object is present.
      */
-    public function testGetSuccessfullySyncedObjects()
+    public function testGetSuccessfullySyncedObjects(): void
     {
-        $orderDAO      = new OrderDAO(new \DateTimeImmutable(), false, 0);
+        $orderDAO      = new OrderDAO(new \DateTimeImmutable(), false, 'IntegrationA');
         $successObject = new ObjectChangeDAO('IntegrationA', 'Contact', 'integration-id-1', 'lead', 123);
         $retryObject   = new ObjectChangeDAO('IntegrationA', 'Contact', 'integration-id-2', 'lead', 456);
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/OrderDAOTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/OrderDAOTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://www.mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\DAO\Sync\Order;
+
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\OrderDAO;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class OrderDAOTest extends TestCase
+{
+    /**
+     * Test that the retry object is removed from the synced objects and the success object is present.
+     */
+    public function testGetSuccessfullySyncedObjects()
+    {
+        $orderDAO      = new OrderDAO(new \DateTimeImmutable(), false, 0);
+        $successObject = new ObjectChangeDAO('IntegrationA', 'Contact', 'integration-id-1', 'lead', 123);
+        $retryObject   = new ObjectChangeDAO('IntegrationA', 'Contact', 'integration-id-2', 'lead', 456);
+
+        $orderDAO->addObjectChange($successObject);
+        $orderDAO->addObjectChange($retryObject);
+        $orderDAO->retrySyncLater($retryObject);
+
+        Assert::assertSame(
+            [$successObject],
+            $orderDAO->getSuccessfullySyncedObjects()
+        );
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Imagine that we sync 200 contacts. One of them is marked as retry later. With the removed condition it retried all 200 of them even though 199 of them were synced successfully. Let's retry only the specific contacts that need it.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. This is hard to test and even hard to see.

#### Steps to test this PR:
1. Just test that the sync is working and devs can check the sync_objects_field_change_table is empty after the sync.

#### Other areas of Mautic that may be affected by the change:
1. Any plugin built on the Integrations Bundle

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11252"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

