### PR TITLE
Save plaintext to the Copy entity

### DIFF
--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -47,6 +47,7 @@ class Copy
             ->build();
 
         $builder->addNullableField('body', 'text');
+        $builder->addNullableField('body_text', 'text');
 
         $builder->addNullableField('subject', 'text');
     }

--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -25,10 +25,7 @@ class Copy
      */
     private $body;
 
-    /**
-     * @var string
-     */
-    private $bodyText;
+    private ?string $bodyText;
 
     /**
      * @var string|null
@@ -40,7 +37,7 @@ class Copy
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable('email_copies')
-            ->setCustomRepositoryClass('Mautic\EmailBundle\Entity\CopyRepository');
+            ->setCustomRepositoryClass(CopyRepository::class);
 
         $builder->createField('id', 'string')
             ->isPrimaryKey()
@@ -143,18 +140,12 @@ class Copy
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getBodyText()
+    public function getBodyText(): ?string
     {
         return $this->bodyText;
     }
 
-    /**
-     * @param string $bodyText
-     */
-    public function setBodyText($bodyText)
+    public function setBodyText(?string $bodyText): self
     {
         $bodyText       = EmojiHelper::toShort($bodyText);
         $this->bodyText = $bodyText;

--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -26,6 +26,11 @@ class Copy
     private $body;
 
     /**
+     * @var string
+     */
+    private $bodyText;
+
+    /**
      * @var string|null
      */
     private $subject;
@@ -47,7 +52,7 @@ class Copy
             ->build();
 
         $builder->addNullableField('body', 'text');
-        $builder->addNullableField('body_text', 'text');
+        $builder->addNullableField('bodyText', 'text', 'body_text');
 
         $builder->addNullableField('subject', 'text');
     }
@@ -134,6 +139,25 @@ class Copy
         $subject = EmojiHelper::toShort($subject);
 
         $this->subject = $subject;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodyText()
+    {
+        return $this->bodyText;
+    }
+
+    /**
+     * @param string $bodyText
+     */
+    public function setBodyText($bodyText)
+    {
+        $bodyText       = EmojiHelper::toShort($bodyText);
+        $this->bodyText = $bodyText;
 
         return $this;
     }

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -15,6 +15,7 @@ class CopyRepository extends CommonRepository
      * @param $hash
      * @param $subject
      * @param $body
+     * @param $bodyText
      */
     public function saveCopy($hash, $subject, $body, $bodyText)
     {

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -16,18 +16,20 @@ class CopyRepository extends CommonRepository
      * @param $subject
      * @param $body
      */
-    public function saveCopy($hash, $subject, $body)
+    public function saveCopy($hash, $subject, $body, $bodyText)
     {
         $db = $this->getEntityManager()->getConnection();
 
         try {
-            $body    = EmojiHelper::toShort($body);
-            $subject = EmojiHelper::toShort($subject);
+            $body        = EmojiHelper::toShort($body);
+            $subject     = EmojiHelper::toShort($subject);
+            $bodyText    = EmojiHelper::toShort($bodyText);
             $db->insert(
                 MAUTIC_TABLE_PREFIX.'email_copies',
                 [
                     'id'           => $hash,
                     'body'         => $body,
+                    'body_text'    => $bodyText,
                     'subject'      => $subject,
                     'date_created' => (new \DateTime())->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
                 ]

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -6,16 +6,13 @@ use Doctrine\ORM\NoResultException;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 
-/**
- * Class CopyRepository.
- */
 class CopyRepository extends CommonRepository
 {
     /**
-     * @param $hash
-     * @param $subject
-     * @param $body
-     * @param $bodyText
+     * @param string $hash
+     * @param string $subject
+     * @param string $body
+     * @param string $bodyText
      */
     public function saveCopy($hash, $subject, $body, $bodyText)
     {

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -21,9 +21,9 @@ class CopyRepository extends CommonRepository
         $db = $this->getEntityManager()->getConnection();
 
         try {
-            $body        = EmojiHelper::toShort($body);
-            $subject     = EmojiHelper::toShort($subject);
-            $bodyText    = EmojiHelper::toShort($bodyText);
+            $body     = EmojiHelper::toShort($body);
+            $subject  = EmojiHelper::toShort($subject);
+            $bodyText = EmojiHelper::toShort($bodyText);
             $db->insert(
                 MAUTIC_TABLE_PREFIX.'email_copies',
                 [

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1891,7 +1891,7 @@ class MailHelper
             $copyCreated = false;
             if (null === $copy) {
                 $contentToPersist = strtr($this->body['content'], array_flip($this->embedImagesReplaces));
-                if (!$emailModel->getCopyRepository()->saveCopy($hash, $this->subject, $contentToPersist)) {
+                if (!$emailModel->getCopyRepository()->saveCopy($hash, $this->subject, $contentToPersist), $this->body['plain_text']) {
                     // Try one more time to find the ID in case there was overlap when creating
                     $copy = $emailModel->getCopyRepository()->findByHash($hash);
                 } else {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1891,7 +1891,7 @@ class MailHelper
             $copyCreated = false;
             if (null === $copy) {
                 $contentToPersist = strtr($this->body['content'], array_flip($this->embedImagesReplaces));
-                if (!$emailModel->getCopyRepository()->saveCopy($hash, $this->subject, $contentToPersist), $this->body['plain_text']) {
+                if (!$emailModel->getCopyRepository()->saveCopy($hash, $this->subject, $contentToPersist, $this->plainText)) {
                     // Try one more time to find the ID in case there was overlap when creating
                     $copy = $emailModel->getCopyRepository()->findByHash($hash);
                 } else {

--- a/app/migrations/Version20200513162918.php
+++ b/app/migrations/Version20200513162918.php
@@ -1,12 +1,6 @@
 <?php
-/*
- * @copyright   2020 Mautic, Inc. All rights reserved
- * @author      Mautic, Inc.
- *
- * @link        https://mautic.com
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+
+declare(strict_types=1);
 
 namespace Mautic\Migrations;
 

--- a/app/migrations/Version20200513162918.php
+++ b/app/migrations/Version20200513162918.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * @copyright   2020 Mautic, Inc. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.com
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Migration for removing online status.
+ */
+class Version20200513162918 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigration
+     * @throws SchemaException
+     */
+    public function preUp(Schema $schema): void
+    {
+        if ($schema->getTable("{$this->prefix}email_copies")->hasColumn('body_text')) {
+            throw new SkipMigration("The body_text column has already been added to the {$this->prefix}email_copies table.");
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}email_copies ADD COLUMN `body_text` LONGTEXT NULL DEFAULT NULL AFTER `body`");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}email_copies DROP COLUMN `body_text`");
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We needed for out custom email transport to get also email plain text from the Copy entity. This PR saves this information together with the Subject and HTML version that was there already. It is not used by the core code but I think it is good addition for the future email transport implementations.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure the segment email send is still working.
3. If you know how to do that, check that the email_copies table as new column `bodyText` and it gets populated on segment email send.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11254"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

