### PR TITLE
Disable activity push

### DIFF
--- a/app/bundles/IntegrationsBundle/Command/SyncCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/SyncCommand.php
@@ -29,9 +29,6 @@ class SyncCommand extends ContainerAwareCommand
         $this->syncService = $syncService;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configure(): void
     {
         $this->setName(self::NAME)
@@ -100,9 +97,6 @@ class SyncCommand extends ContainerAwareCommand
         parent::configure();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);

--- a/app/bundles/IntegrationsBundle/Command/SyncCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/SyncCommand.php
@@ -89,6 +89,12 @@ class SyncCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Provide option pass to InputOptions Example: --option="type:1" --option="channel_id:1"'
+            )
+            ->addOption(
+                '--disable-activity-push',
+                null,
+                InputOption::VALUE_NONE,
+                'Notate if the sync should disable the activities sync if the integration supports it'
             );
 
         parent::configure();

--- a/app/bundles/IntegrationsBundle/Event/SyncEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/SyncEvent.php
@@ -10,24 +10,18 @@ use Symfony\Component\EventDispatcher\Event;
 class SyncEvent extends Event
 {
     /**
-     * @var string
-     */
-    private $integrationName;
-
-    /**
      * @var InputOptionsDAO
      */
     private $inputOptionsDAO;
 
-    public function __construct(string $integrationName, InputOptionsDAO $inputOptionsDAO)
+    public function __construct(InputOptionsDAO $inputOptionsDAO)
     {
-        $this->integrationName = $integrationName;
         $this->inputOptionsDAO = $inputOptionsDAO;
     }
 
     public function getIntegrationName(): string
     {
-        return $this->integrationName;
+        return $this->inputOptionsDAO->getIntegration();
     }
 
     public function isIntegration(string $integrationName): bool

--- a/app/bundles/IntegrationsBundle/Event/SyncEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/SyncEvent.php
@@ -4,26 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Event;
 
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use Symfony\Component\EventDispatcher\Event;
 
 class SyncEvent extends Event
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     private $integrationName;
-    /**
-     * @var \DateTimeInterface|null
-     */
-    private $fromDateTime;
-    /**
-     * @var \DateTimeInterface|null
-     */
-    private $toDateTime;
 
-    public function __construct(string $integrationName, ?\DateTimeInterface $fromDateTime = null, ?\DateTimeInterface $toDateTime = null)
+    /**
+     * @var InputOptionsDAO
+     */
+    private $inputOptionsDAO;
+
+    public function __construct(string $integrationName, InputOptionsDAO $inputOptionsDAO)
     {
         $this->integrationName = $integrationName;
-        $this->fromDateTime    = $fromDateTime;
-        $this->toDateTime      = $toDateTime;
+        $this->inputOptionsDAO = $inputOptionsDAO;
     }
 
     public function getIntegrationName(): string
@@ -38,11 +37,16 @@ class SyncEvent extends Event
 
     public function getFromDateTime(): ?\DateTimeInterface
     {
-        return $this->fromDateTime;
+        return $this->inputOptionsDAO->getStartDateTime();
     }
 
     public function getToDateTime(): ?\DateTimeInterface
     {
-        return $this->toDateTime;
+        return $this->inputOptionsDAO->getEndDateTime();
+    }
+
+    public function getInputOptions(): InputOptionsDAO
+    {
+        return $this->inputOptionsDAO;
     }
 }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/InputOptionsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/InputOptionsDAO.php
@@ -33,6 +33,11 @@ class InputOptionsDAO
     private $disablePull;
 
     /**
+     * @var bool
+     */
+    private $disableActivityPush;
+
+    /**
      * @var ObjectIdsDAO|null
      */
     private $mauticObjectIds;

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/InputOptionsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/InputOptionsDAO.php
@@ -61,6 +61,7 @@ class InputOptionsDAO
      *      'first-time-sync' => true,
      *      'disable-push' => false,
      *      'disable-pull' => false,
+     *      'disable-activity-push' => false,
      *      'mautic-object-id' => ['contact:12', 'contact:13'] or a ObjectIdsDAO object,
      *      'integration-object-id' => ['Lead:hfskjdhf', 'Lead:hfskjdhr'] or a ObjectIdsDAO object,
      *      'start-datetime' => '2019-09-12T12:01:20' or a DateTimeInterface object, Expecting UTC timezone
@@ -79,6 +80,7 @@ class InputOptionsDAO
         $this->firstTimeSync        = (bool) ($input['first-time-sync'] ?? false);
         $this->disablePush          = (bool) ($input['disable-push'] ?? false);
         $this->disablePull          = (bool) ($input['disable-pull'] ?? false);
+        $this->disableActivityPush  = (bool) ($input['disable-activity-push'] ?? false);
         $this->startDateTime        = $this->validateDateTime($input, 'start-datetime');
         $this->endDateTime          = $this->validateDateTime($input, 'end-datetime');
         $this->mauticObjectIds      = $this->validateObjectIds($input, 'mautic-object-id');
@@ -99,6 +101,11 @@ class InputOptionsDAO
     public function pullIsEnabled(): bool
     {
         return !$this->disablePull;
+    }
+
+    public function activityPushIsEnabled(): bool
+    {
+        return !$this->disableActivityPush;
     }
 
     public function pushIsEnabled(): bool

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
@@ -143,7 +143,7 @@ class SyncProcess
         // Tell listeners sync is done
         $this->eventDispatcher->dispatch(
             IntegrationEvents::INTEGRATION_POST_EXECUTE,
-            new SyncEvent($this->mappingManualDAO->getIntegration(), $this->inputOptionsDAO)
+            new SyncEvent($this->inputOptionsDAO)
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
@@ -143,7 +143,7 @@ class SyncProcess
         // Tell listeners sync is done
         $this->eventDispatcher->dispatch(
             IntegrationEvents::INTEGRATION_POST_EXECUTE,
-            new SyncEvent($this->mappingManualDAO->getIntegration(), $this->inputOptionsDAO->getStartDateTime(), $this->inputOptionsDAO->getEndDateTime())
+            new SyncEvent($this->mappingManualDAO->getIntegration(), $this->inputOptionsDAO)
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/InputOptionsDAOTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/InputOptionsDAOTest.php
@@ -23,6 +23,7 @@ class InputOptionsDAOTest extends TestCase
                 'first-time-sync'       => true,
                 'disable-push'          => false,
                 'disable-pull'          => true,
+                'disable-activity-push' => true,
                 'mautic-object-id'      => ['contact:12', 'contact:13', 'company:45'],
                 'integration-object-id' => ['Lead:hfskjdhf', 'Lead:hfskjdhr'],
                 'start-datetime'        => '2019-09-12T12:01:20',
@@ -35,6 +36,7 @@ class InputOptionsDAOTest extends TestCase
         $this->assertTrue($inputOptionsDAO->isFirstTimeSync());
         $this->assertFalse($inputOptionsDAO->pullIsEnabled());
         $this->assertTrue($inputOptionsDAO->pushIsEnabled());
+        $this->assertFalse($inputOptionsDAO->activityPushIsEnabled());
         $this->assertSame(['12', '13'], $inputOptionsDAO->getMauticObjectIds()->getObjectIdsFor(Contact::NAME));
         $this->assertSame(['45'], $inputOptionsDAO->getMauticObjectIds()->getObjectIdsFor(MauticSyncDataExchange::OBJECT_COMPANY));
         $this->assertSame(['hfskjdhf', 'hfskjdhr'], $inputOptionsDAO->getIntegrationObjectIds()->getObjectIdsFor('Lead'));
@@ -56,6 +58,7 @@ class InputOptionsDAOTest extends TestCase
         $this->assertFalse($inputOptionsDAO->isFirstTimeSync());
         $this->assertTrue($inputOptionsDAO->pullIsEnabled());
         $this->assertTrue($inputOptionsDAO->pushIsEnabled());
+        $this->assertTrue($inputOptionsDAO->activityPushIsEnabled());
         $this->assertNull($inputOptionsDAO->getMauticObjectIds());
         $this->assertNull($inputOptionsDAO->getIntegrationObjectIds());
         $this->assertNull($inputOptionsDAO->getStartDateTime());
@@ -76,6 +79,7 @@ class InputOptionsDAOTest extends TestCase
                 'first-time-sync'       => true,
                 'disable-push'          => false,
                 'disable-pull'          => true,
+                'disable-activity-push' => false,
                 'mautic-object-id'      => $mauticObjectIds,
                 'integration-object-id' => $integrationObjectIds,
                 'start-datetime'        => $start,
@@ -88,6 +92,7 @@ class InputOptionsDAOTest extends TestCase
         $this->assertTrue($inputOptionsDAO->isFirstTimeSync());
         $this->assertFalse($inputOptionsDAO->pullIsEnabled());
         $this->assertTrue($inputOptionsDAO->pushIsEnabled());
+        $this->assertTrue($inputOptionsDAO->activityPushIsEnabled());
         $this->assertSame($mauticObjectIds, $inputOptionsDAO->getMauticObjectIds());
         $this->assertSame($integrationObjectIds, $inputOptionsDAO->getIntegrationObjectIds());
         $this->assertSame($start, $inputOptionsDAO->getStartDateTime());


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [n]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR adds new sync command parameter `--disable-activity-push` for CRM integrations built on top of the IntegrationsBundle. If the integration have a feature to push contact activities then this param can be used to disable it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. There is no way to test this as you'd need a plugin using the IntegrationsBundle and can push activities. This change is made for the future plugins. Code review is sufficient. It is tested by PHPUNIT.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11255"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

