### PR TITLE
Do not perform delete queries on the sync tables for anonymous contacts

### DIFF
--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -117,7 +117,11 @@ class LeadSubscriber implements EventSubscriberInterface
 
     public function onLeadPostDelete(Events\LeadEvent $event): void
     {
-        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
+        if ($event->getLead()->isAnonymous()) {
+            return;
+        }
+
+        $this->fieldChangeRepo->deleteEntitiesForObject((int) $event->getLead()->deletedId, Lead::class);
         $this->objectMappingRepository->deleteEntitiesForObject((int) $event->getLead()->deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -277,9 +277,9 @@ class LeadSubscriberTest extends TestCase
         $deletedId       = '5';
         $lead            = new Lead();
         $lead->deletedId = $deletedId;
+        $lead->setEmail('john@doe.email');
 
-        $this->leadEvent->expects($this->exactly(2))
-            ->method('getLead')
+        $this->leadEvent->method('getLead')
             ->willReturn($lead);
 
         $this->fieldChangeRepository->expects($this->once())
@@ -289,6 +289,24 @@ class LeadSubscriberTest extends TestCase
         $this->objectMappingRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
             ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
+
+        $this->subscriber->onLeadPostDelete($this->leadEvent);
+    }
+
+    public function testOnLeadPostDeleteForAnonymousLeads(): void
+    {
+        $deletedId       = '5';
+        $lead            = new Lead();
+        $lead->deletedId = $deletedId;
+
+        $this->leadEvent->method('getLead')
+            ->willReturn($lead);
+
+        $this->fieldChangeRepository->expects($this->never())
+            ->method('deleteEntitiesForObject');
+
+        $this->objectMappingRepository->expects($this->never())
+            ->method('deleteEntitiesForObject');
 
         $this->subscriber->onLeadPostDelete($this->leadEvent);
     }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -274,7 +274,7 @@ class LeadSubscriberTest extends TestCase
 
     public function testOnLeadPostDelete(): void
     {
-        $deletedId       = '5';
+        $deletedId       = 5;
         $lead            = new Lead();
         $lead->deletedId = $deletedId;
         $lead->setEmail('john@doe.email');
@@ -284,7 +284,7 @@ class LeadSubscriberTest extends TestCase
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
+            ->with((int) $deletedId, Lead::class);
 
         $this->objectMappingRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
@@ -295,7 +295,7 @@ class LeadSubscriberTest extends TestCase
 
     public function testOnLeadPostDeleteForAnonymousLeads(): void
     {
-        $deletedId       = '5';
+        $deletedId       = 5;
         $lead            = new Lead();
         $lead->deletedId = $deletedId;
 
@@ -424,7 +424,7 @@ class LeadSubscriberTest extends TestCase
 
     public function testOnCompanyPostDelete(): void
     {
-        $deletedId       = '5';
+        $deletedId       = 5;
         $lead            = new Company();
         $lead->deletedId = $deletedId;
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We are getting errors in the log like this one:
```
"An exception occurred while executing 'DELETE FROM sync_object_mapping WHERE internal_object_name = ? AND internal_object_id = ?' with params ["lead", 3158644]: SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction"
```
The `sync_object_mapping` is overloaded. This PR will run the delete queries only for identified contacts. It will not run the delete queries for anonymous contacts which will not get into those tables anyway.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

It's better to test this on a local instance so you could inspect the database before running the commands. Otherwise you'll have to inspect the SQL logs.

1. Configure your database to show all queries in an interactive log
2. Configure a plugin that is built on top of the IntegrationsBundle
3. Create an anonymous contact
4. There should be no records for this contact in the `sync_object_field_change_report` nor in the `sync_object_mapping` table.
5. Delete the contact

- You should see the DELETE query from the error above.

#### Steps to test this PR:
1. Create another anonymous contact
2. Delete it

- There should be no anonymous query.

3. Also test that if you create a contact with an email for example then it will be listed in the `sync_object_field_change_report` table and once you delete it then the record will be deleted as well.

#### Other areas of Mautic that may be affected by the change:
1. This change affects all integrations built on top of the IntegrationsBundle


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11262"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

