### PR TITLE
Track changes for Message entity and Category Entity

### DIFF
--- a/app/bundles/CategoryBundle/Entity/Category.php
+++ b/app/bundles/CategoryBundle/Entity/Category.php
@@ -134,6 +134,7 @@ class Category extends FormEntity
      */
     public function setTitle($title)
     {
+        $this->isChanged('title', $title);
         $this->title = $title;
 
         return $this;
@@ -158,6 +159,7 @@ class Category extends FormEntity
      */
     public function setAlias($alias)
     {
+        $this->isChanged('alias', $alias);
         $this->alias = $alias;
 
         return $this;
@@ -182,6 +184,7 @@ class Category extends FormEntity
      */
     public function setDescription($description)
     {
+        $this->isChanged('description', $description);
         $this->description = $description;
 
         return $this;
@@ -206,6 +209,7 @@ class Category extends FormEntity
      */
     public function setColor($color)
     {
+        $this->isChanged('color', $color);
         $this->color = $color;
     }
 
@@ -228,6 +232,7 @@ class Category extends FormEntity
      */
     public function setBundle($bundle)
     {
+        $this->isChanged('bundle', $bundle);
         $this->bundle = $bundle;
     }
 

--- a/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
+++ b/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
@@ -17,6 +17,8 @@ class CategoryTest extends TestCase
         $category->setTitle('Title Changed of Category');
         $category->setAlias('changed alias of category');
         $category->setBundle('campaigns');
+        $category->setColor('Blue');
+        $category->setDescription('My Description');
 
         $this->assertIsArray($category->getChanges());
         $this->assertNotEmpty($category->getChanges());

--- a/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
+++ b/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Mautic\CategoryBundle\Tests\Entity;
+
+use Mautic\CategoryBundle\Entity\Category;
+use PHPUnit\Framework\TestCase;
+
+class CategoryTest extends TestCase
+{
+    public function testCategoryUpdatesReflectsInChanges()
+    {
+        $category = new Category();
+        $category->setTitle('New Category');
+        $category->setAlias('category');
+        $category->setBundle('bundle');
+
+        $category->setTitle('Title Changed of Category');
+        $category->setAlias('changed alias of category');
+        $category->setBundle('campaigns');
+
+        $this->assertIsArray($category->getChanges());
+        $this->assertNotEmpty($category->getChanges());
+    }
+}

--- a/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
+++ b/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class CategoryTest extends TestCase
 {
-    public function testCategoryUpdatesReflectsInChanges()
+    public function testCategoryUpdatesReflectsInChanges(): void
     {
         $category = new Category();
         $category->setTitle('New Category');

--- a/app/bundles/ChannelBundle/Entity/Message.php
+++ b/app/bundles/ChannelBundle/Entity/Message.php
@@ -137,6 +137,7 @@ class Message extends FormEntity
      */
     public function setName($name)
     {
+        $this->isChanged('name', $name);
         $this->name = $name;
 
         return $this;
@@ -157,6 +158,7 @@ class Message extends FormEntity
      */
     public function setDescription($description)
     {
+        $this->isChanged('description', $description);
         $this->description = $description;
 
         return $this;
@@ -177,6 +179,7 @@ class Message extends FormEntity
      */
     public function setPublishUp($publishUp)
     {
+        $this->isChanged('publishUp', $publishUp);
         $this->publishUp = $publishUp;
 
         return $this;
@@ -197,6 +200,7 @@ class Message extends FormEntity
      */
     public function setPublishDown($publishDown)
     {
+        $this->isChanged('publishDown', $publishDown);
         $this->publishDown = $publishDown;
 
         return $this;
@@ -217,6 +221,7 @@ class Message extends FormEntity
      */
     public function setCategory($category)
     {
+        $this->isChanged('category', $category);
         $this->category = $category;
 
         return $this;
@@ -237,6 +242,7 @@ class Message extends FormEntity
      */
     public function setChannels($channels)
     {
+        $this->isChanged('channels', $channels);
         $this->channels = $channels;
 
         return $this;

--- a/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
+++ b/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class MessageTest extends TestCase
 {
-    public function testMessageUpdatesReflectsInChanges()
+    public function testMessageUpdatesReflectsInChanges(): void
     {
         $category = new Category();
         $category->setTitle('New Category');

--- a/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
+++ b/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
@@ -2,33 +2,18 @@
 
 namespace Mautic\ChannelBundle\Tests\Entity;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\ChannelBundle\Entity\Message;
-use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class MessageTest extends MauticMysqlTestCase
+class MessageTest extends TestCase
 {
-    protected $useCleanupRollback = false;
-
-    /**
-     * @var MockObject|EntityManagerInterface
-     */
-    protected $em;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testMessageUpdatesReflectsInChanges()
     {
         $category = new Category();
         $category->setTitle('New Category');
         $category->setAlias('category');
         $category->setBundle('bundle');
-        $this->em->persist($category);
 
         $message = new Message();
         $message->setName('New Message');
@@ -37,9 +22,7 @@ class MessageTest extends MauticMysqlTestCase
         $message->setPublishDown(new \DateTime());
         $message->setPublishUp(new \DateTime());
 
-        $this->em->persist($message);
         $this->assertIsArray($message->getChanges());
         $this->assertNotEmpty($message->getChanges());
-        $this->em->flush();
     }
 }

--- a/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
+++ b/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Mautic\ChannelBundle\Tests\Entity;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\ChannelBundle\Entity\Message;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MessageTest extends MauticMysqlTestCase
+{
+    protected $useCleanupRollback = false;
+
+    /**
+     * @var MockObject|EntityManagerInterface
+     */
+    protected $em;
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testMessageUpdatesReflectsInChanges()
+    {
+        $category = new Category();
+        $category->setTitle('New Category');
+        $category->setAlias('category');
+        $category->setBundle('bundle');
+        $this->em->persist($category);
+
+        $message = new Message();
+        $message->setName('New Message');
+        $message->setDescription('random text string for description');
+        $message->setCategory($category);
+        $message->setPublishDown(new \DateTime());
+        $message->setPublishUp(new \DateTime());
+
+        $this->em->persist($message);
+        $this->assertIsArray($message->getChanges());
+        $this->assertNotEmpty($message->getChanges());
+        $this->em->flush();
+    }
+}

--- a/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
+++ b/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
@@ -17,7 +17,7 @@ class MessageTest extends MauticMysqlTestCase
      */
     protected $em;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | No
| New feature/enhancement? (use the a.x branch)      | Yes
| Deprecations?                          | -
| BC breaks? (use the c.x branch)        | -
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | - <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR adds `is_changed` to setter functions of Entity/Message, Entity/Category.
Missing is_changed was resulting in Messages or Category being not tracked when checked via isChanged() method.


#### Note:

There are no UI changes and no manual test required. The changes are covered with Unit test.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

