### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-grapesjs-assets.yml
+++ b/.github/workflows/build-grapesjs-assets.yml
@@ -11,8 +11,14 @@ defaults:
   run:
     working-directory: plugins/GrapesJsBuilderBundle
 
+permissions:
+  contents: read
+
 jobs:
   build-js:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     if: github.repository == 'mautic/mautic'
 

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -7,6 +7,9 @@ on:
         required: true
         default: 'none'
 
+permissions:
+  contents: read
+
 jobs:
   release-notes:
     name: Create draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,13 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create draft release
     runs-on: ubuntu-latest
     if: github.repository == 'mautic/mautic'


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11295"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

