### PR TITLE
Updating GitHub templates for issues and PRs with new verions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -25,8 +25,10 @@ body:
       description: What version of Mautic you are using? Please test to reproduce your bug with the [latest stable version of Mautic](https://www.mautic.org/mautic-releases) which might contain new fixes.  If you are able, please also check the latest development release.
       options:
         - 5.0.x series
-        - 4.2.x series
-        - 4.1.x series
+        - 4.4.x series
+        - 4.3.x series
+        - 4.2.x series (not supported)
+        - 4.1.x series (not supported)
         - 4.0.x series (not supported)
         - 3.3.x series (not supported)
     validations:
@@ -36,7 +38,7 @@ body:
     attributes:
       label: PHP version
       description: What PHP version are you using in your environment?
-      placeholder: ex. 7.3.27
+      placeholder: ex. 8.0.20
     validations:
       required: true
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@ a = current major release
 b = current minor release
 c = future major release
 
-* a.x for any features and enhancements (e.g. 4.x)
-* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
+* a.x for any features and enhancements (e.g. 5.x)
+* a.b for any bug fixes (e.g. 4.4, 5.1)
 * c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->
 
 | Q                                      | A
@@ -41,7 +41,7 @@ Please write a short README for your feature/bugfix. This will help people under
 This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
 -->
 1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
-2.
+2. 
 
 <!--
 If you have any deprecations, list them here along with the new alternative.


### PR DESCRIPTION
Check the changes in the GitHub templates. We are in the place where there will be no more Mautic 4 feature releases. Just a couple of bug fix releases. The focus should aim to Mautic 5.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11307"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

