### PR TITLE
Remove uneeded if

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -289,20 +289,18 @@ trait FilterTrait
                 $type                                       = ChoiceType::class;
             break;
             case 'lookup':
-                if ('number' !== $fieldType) {
-                    $attr = array_merge(
-                        $attr,
-                        [
-                            'data-toggle' => 'field-lookup',
-                            'data-target' => isset($data['field']) ? $data['field'] : '',
-                            'data-action' => 'lead:fieldList',
-                            'placeholder' => $translator->trans('mautic.lead.list.form.filtervalue'),
-                        ]
-                    );
+                $attr = array_merge(
+                    $attr,
+                    [
+                        'data-toggle' => 'field-lookup',
+                        'data-target' => isset($data['field']) ? $data['field'] : '',
+                        'data-action' => 'lead:fieldList',
+                        'placeholder' => $translator->trans('mautic.lead.list.form.filtervalue'),
+                    ]
+                );
 
-                    if (isset($field['properties']['list'])) {
-                        $attr['data-options'] = $field['properties']['list'];
-                    }
+                if (isset($field['properties']['list'])) {
+                    $attr['data-options'] = $field['properties']['list'];
                 }
 
                 break;


### PR DESCRIPTION
A while back the default entry of this case was remove (here https://github.com/mautic/mautic/commit/5334db336986f46a8fa7d39f487624cfb56461e1#diff-4ebbff336dd53afb958d9359ab3294e2409a8649b14656236ffb3b986f962b76L291) so the if i remove as no effect

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | No
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | No <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I'm not sure that's the correct way (and the correct branch) to do this, but the if is always true as the switch depend on the same variable)


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

