### PR TITLE
Segment lookup_id field : use the data-action attribute if present

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -583,7 +583,7 @@ Mautic.activateSegmentFilterTypeahead = function(displayId, filterId, fieldOptio
 
     mQuery('#' + displayId).attr('data-lookup-callback', 'updateLookupListFilter');
 
-    Mautic.activateFieldTypeahead(displayId, filterId, [], 'lead:fieldList')
+    Mautic.activateFieldTypeahead(displayId, filterId, [], mQuery('#' + displayId).data('action') || 'lead:fieldList');
 
     mQuery = mQueryBackup;
 };


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #11316  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I tried to add a new choice on my segment filters, using the type "lookup_id", i saw an `data-action` but it has no effect on the ajax request made.

#### How to test

1. Create an EventListener that listen to `LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE`
   ```php
   $event->addChoice('lead', 'lead_transaction_purchase_product', [
       'label' => 'Purchase Product',
       'object' => 'lead',
       'properties' => [
           'type' => 'lookup_id',
           'data-action' => 'plugin:Ecommerce:products'
       ],
       'operators' => $this->typeOperatorProvider->getOperatorsIncluding([
           OperatorOptions::EQUAL_TO,
           OperatorOptions::NOT_EQUAL_TO,
       ]),
    ]);
    ``` 
2. Now the choice must appear inside your segments filter
3. When trying to fill the value field an ajax request is made but the endpoint do not receive the data-action value
    - The controller called is `\Mautic\CoreBundle\Controller\AjaxController::delegateAjaxAction` and it's expecting an `action` parameter which is always `lead:fieldList`
 
With the change i made to the `lead.js` the data-action will be pass to the ajax request and now the controller receive the correct value (and is now looking for an action product inside the AjaxController of my bundle)

See #11316 for more information

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11327"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

