### PR TITLE
Fix issue 11267 - Sending emails via API should respect useOwnerAsMailer

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -131,6 +131,10 @@ class EmailApiController extends CommonApiController
             }
 
             $leadFields = array_merge(['id' => $leadId], $lead->getProfileFields());
+            // Set owner_id to support the "Owner is mailer" feature
+            if ($lead->getOwner()) {
+                $leadFields['owner_id'] = $lead->getOwner()->getId();
+            }
 
             $result = $this->model->sendEmail(
                 $entity,

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -345,6 +345,7 @@ class MailHelper
                     if (!empty($owner)) {
                         $this->setFrom($owner['email'], $owner['first_name'].' '.$owner['last_name']);
                         $ownerSignature = $this->getContactOwnerSignature($owner);
+                        $this->setReplyTo($owner['email']);
                     } else {
                         $this->setFrom($this->systemFrom, null);
                     }

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -3,17 +3,48 @@
 namespace Mautic\EmailBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\UserBundle\Entity\Role;
+use Mautic\UserBundle\Entity\User;
+use Swift_Mailer;
 use Symfony\Component\HttpFoundation\Response;
 
 class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 {
+    private SmtpTransport $transport;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->loadFixtures([LoadCategoryData::class]);
+        $this->setUpMailer();
+    }
+
+    private function setUpMailer(): void
+    {
+        $mailHelper = self::$container->get('mautic.helper.mailer');
+        $transport  = new SmtpTransport();
+        $mailer     = new Swift_Mailer($transport);
+        $this->setPrivateProperty($mailHelper, 'mailer', $mailer);
+        $this->setPrivateProperty($mailHelper, 'transport', $transport);
+
+        $this->transport  = $transport;
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear owners cache (to leave a clean environment for future tests):
+        $mailHelper = self::$container->get('mautic.helper.mailer');
+        $this->setPrivateProperty($mailHelper, 'leadOwners', []);
+
+        parent::tearDown();
     }
 
     protected function beforeBeginTransaction(): void
@@ -202,5 +233,154 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame($stat->getId(), $fetchedStatData['stats'][0]['id']);
         $this->assertSame('1', $fetchedStatData['stats'][0]['is_read']);
         $this->assertMatchesRegularExpression('/\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}/', $fetchedStatData['stats'][0]['date_read']);
+    }
+
+    public function testSendAction(): void
+    {
+        // Create a user (to test use onwer as mailer):
+        $role = new Role();
+        $role->setName('Role');
+        $this->em->persist($role);
+
+        $user = new User();
+        $user->setUserName('apitest');
+        $user->setFirstName('John');
+        $user->setLastName('Doe');
+        $user->setEmail('john@api.test');
+        $user->setRole($role);
+        $encoder = self::$container->get('security.encoder_factory')->getEncoder($user);
+        $user->setPassword($encoder->encodePassword('password', null));
+        $this->em->persist($user);
+
+        // Create a contact:
+        $contact = new Lead();
+        $contact->setFirstName('Jane');
+        $contact->setLastName('Doe');
+        $contact->setEmail('jane@api.test');
+        $contact->setOwner($user);
+        $this->em->persist($contact);
+
+        // Create a segment:
+        $segment = new LeadList();
+        $segment->setName('API segment');
+        $segment->setPublicName('API segment');
+        $segment->setAlias('API segment');
+        $segment->setDescription('Segment created via API test');
+        $segment->setIsPublished(true);
+        $this->em->persist($segment);
+
+        // Add contact to segment:
+        $segmentContact = new ListLead();
+        $segmentContact->setLead($contact);
+        $segmentContact->setList($segment);
+        $segmentContact->setDateAdded(new \DateTime());
+        $this->em->persist($segmentContact);
+
+        // Commit
+        $this->em->flush();
+
+        $contactId = $contact->getId();
+        $segmentId = $segment->getId();
+
+        // Create an email:
+        $createEmail = function () use ($segment) {
+            $email = new Email();
+            $email->setName('API email');
+            $email->setSubject('Email created via API test');
+            $email->setEmailType('list');
+            $email->addList($segment);
+            $email->setCustomHtml('<h1>Email content created by an API test</h1>');
+            $email->setIsPublished(true);
+            $email->setFromAddress('from@api.test');
+            $email->setFromName('API Test');
+            $email->setReplyToAddress('reply@api.test');
+            $email->setBccAddress('bcc@api.test');
+
+            return $email;
+        };
+
+        $email = $createEmail();
+        $this->em->persist($email);
+        $this->em->flush();
+        $emailId = $email->getId();
+
+        // Send to segment:
+        $this->client->request('POST', "/api/emails/${emailId}/send");
+        $clientResponse = $this->client->getResponse();
+        $sendResponse   = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertEquals($sendResponse, ['success' => true, 'sentCount' => 1, 'failedRecipients' => 0], $clientResponse->getContent());
+
+        $testEmail = function (): void {
+            $message = $this->transport->sentMessage;
+            $this->assertSame($message->getSubject(), 'Email created via API test');
+            $bodyRegExp = '#<h1>Email content created by an API test</h1><img height="1" width="1" src="[^"]+" alt="" />#';
+            $this->assertMatchesRegularExpression($bodyRegExp, $message->getBody());
+            $this->assertSame($message->getTo(), ['jane@api.test' => 'Jane Doe']);
+            $this->assertSame($message->getFrom(), ['from@api.test' => 'API Test']);
+            $this->assertSame($message->getReplyTo(), ['reply@api.test' => null]);
+            $this->assertSame($message->getBcc(), ['bcc@api.test' => null]);
+        };
+        $testEmail();
+
+        // Send to contact:
+        $this->client->request('POST', "/api/emails/${emailId}/contact/${contactId}/send");
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $sendResponse   = json_decode($clientResponse->getContent(), true);
+
+        $this->assertEquals($sendResponse, ['success' => true], $clientResponse->getContent());
+        $testEmail();
+
+        // Test use owner as mailer:
+        $email = $createEmail();
+        $email->setUseOwnerAsMailer(true);
+        $this->em->persist($email);
+        $this->em->flush();
+        $emailId = $email->getId();
+
+        // Send to segment:
+        $this->client->request('POST', "/api/emails/${emailId}/send");
+        $clientResponse = $this->client->getResponse();
+        $sendResponse   = json_decode($clientResponse->getContent(), true);
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertEquals($sendResponse, ['success' => true, 'sentCount' => 1, 'failedRecipients' => 0], $clientResponse->getContent());
+
+        $testEmailOwnerAsMailer = function (): void {
+            $message = $this->transport->sentMessage;
+            $this->assertSame($message->getSubject(), 'Email created via API test');
+            $bodyRegExp = '#<h1>Email content created by an API test</h1><img height="1" width="1" src="[^"]+" alt="" />#';
+            $this->assertMatchesRegularExpression($bodyRegExp, $message->getBody());
+            $this->assertSame($message->getTo(), ['jane@api.test' => 'Jane Doe']);
+            $this->assertSame($message->getFrom(), ['john@api.test' => 'John Doe']);
+            $this->assertSame($message->getReplyTo(), ['john@api.test' => null]);
+            $this->assertSame($message->getBcc(), ['bcc@api.test' => null]);
+        };
+        $testEmailOwnerAsMailer();
+
+        // Send to contact:
+        $this->client->request('POST', "/api/emails/${emailId}/contact/${contactId}/send");
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $sendResponse   = json_decode($clientResponse->getContent(), true);
+
+        $this->assertEquals($sendResponse, ['success' => true], $clientResponse->getContent());
+        $testEmailOwnerAsMailer();
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function setPrivateProperty(object $object, string $property, $value): void
+    {
+        $reflector = new \ReflectionProperty(get_class($object), $property);
+        $reflector->setAccessible(true);
+        $reflector->setValue($object, $value);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -247,6 +247,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $user->setFirstName('John');
         $user->setLastName('Doe');
         $user->setEmail('john@api.test');
+        $user->setSignature('Best regards, |FROM_NAME|');
         $user->setRole($role);
         $encoder = self::$container->get('security.encoder_factory')->getEncoder($user);
         $user->setPassword($encoder->encodePassword('password', null));
@@ -289,7 +290,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             $email->setSubject('Email created via API test');
             $email->setEmailType('list');
             $email->addList($segment);
-            $email->setCustomHtml('<h1>Email content created by an API test</h1>');
+            $email->setCustomHtml('<h1>Email content created by an API test</h1><br>{signature}');
             $email->setIsPublished(true);
             $email->setFromAddress('from@api.test');
             $email->setFromName('API Test');
@@ -315,7 +316,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $testEmail = function (): void {
             $message = $this->transport->sentMessage;
             $this->assertSame($message->getSubject(), 'Email created via API test');
-            $bodyRegExp = '#<h1>Email content created by an API test</h1><img height="1" width="1" src="[^"]+" alt="" />#';
+            $bodyRegExp = '#<h1>Email content created by an API test</h1><br><img height="1" width="1" src="[^"]+" alt="" />#';
             $this->assertMatchesRegularExpression($bodyRegExp, $message->getBody());
             $this->assertSame($message->getTo(), ['jane@api.test' => 'Jane Doe']);
             $this->assertSame($message->getFrom(), ['from@api.test' => 'API Test']);
@@ -353,7 +354,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $testEmailOwnerAsMailer = function (): void {
             $message = $this->transport->sentMessage;
             $this->assertSame($message->getSubject(), 'Email created via API test');
-            $bodyRegExp = '#<h1>Email content created by an API test</h1><img height="1" width="1" src="[^"]+" alt="" />#';
+            $bodyRegExp = '#<h1>Email content created by an API test</h1><br>Best regards, John Doe<img height="1" width="1" src="[^"]+" alt="" />#';
             $this->assertMatchesRegularExpression($bodyRegExp, $message->getBody());
             $this->assertSame($message->getTo(), ['jane@api.test' => 'Jane Doe']);
             $this->assertSame($message->getFrom(), ['john@api.test' => 'John Doe']);

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/SmtpTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/SmtpTransport.php
@@ -6,8 +6,11 @@ use Swift_Mime_SimpleMessage;
 
 class SmtpTransport implements \Swift_Transport
 {
+    public Swift_Mime_SimpleMessage $sentMessage;
+
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {
+        $this->sentMessage = clone $message;
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔
| New feature/enhancement? (use the a.x branch)      | 🟥
| Deprecations?                          | 🟥
| BC breaks? (use the c.x branch)        | 🟥
| Automated tests included?              | ✔ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #11267 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When sending an email using the API endpoint [`POST /emails/ID/contact/CONTACT_ID/send`](https://developer.mautic.org/#send-email-to-contact), the email option `Use owner as mailer` is not respected.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a contact.
3. Set the owner to a Mautic user.
4. Create an email.
5. Enable `Use owner as mailer` for the email.
6. Send the email using the API endpoint `POST /emails/ID/contact/CONTACT_ID/send`.

The expected result is that the contact would receive and email in which the sender's address is the  email address of the owner. The bug that this PR fixes is that the system default sender email is used instead.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

#### Explanation of the Bug:

The owner of the contact is not passed down to the mailer.

The mailer which is [`MailHelper`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/EmailBundle/Helper/MailHelper.php#L24) checks if the email has enabled the option `useOwnerAsMailer`. If enabled, then it overrides the sender's name and address with those of the `owner` of the recipient contact. The `owner` is fetched using the [`getContactOwner()`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/EmailBundle/Helper/MailHelper.php#L2065-L2086) function which expects the contact information passed in as an array to contain the key `owner_id` with a value greater than `0`. The `owner_id` *is* actually present in the database, however only a subset of contact information is passed to the mailer and this subset does not include the `owner_id`. This subset of information is passed to the mailer through the email model's [`sendEmail`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/EmailBundle/Model/EmailModel.php#L1344) function by the [Email API controller](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/EmailBundle/Controller/Api/EmailApiController.php#L133-L144) which makes this subset of contact information by calling the method [`getProfileFields()`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php#L235-L259) which is a member of the `CustomFieldEntityTrait` trait which inserted into the [`Lead`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/LeadBundle/Entity/Lead.php#L17-L19) ORM Entity (Note: Lead in the database represents a contact in Mautic's user interface).

#### The Fix:
Sets the `owner_id` field in the contact information passed to the mailer.

Some similar existing code:
- [CampaignExecutionEvent.php:107](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php#L106-L107)
- [CampaignSubscriber.php:290](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php#L289-L291)
- [LeadController.php:1347](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/bundles/LeadBundle/Controller/LeadController.php#L1347)

#### The unit testing strategy:
Test cases were written for two API endpoints: [`POST /emails/ID/send`](https://developer.mautic.org/#send-email-to-segment) and [`POST /emails/ID/contact/CONTACT_ID/send`](https://developer.mautic.org/#send-email-to-contact) covering cases of sending an email with the option `useOwnerAsMailer` enabled and disabled.

Tests are made with mockup HTTP queries using the `request()` method of
a symfony's [`KernelBrowser`](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php) which delegates requests to the [`AppKernel`](https://github.com/mautic/mautic/blob/9636c5c98fa7ae760b34547b89eaa5510ff49d64/app/AppKernel.php#L25).

Emails that would otherwise be sent to recipients are caught in a mockup [SmtpTransport](https://github.com/abcpro1/mautic/blob/249c6f4c141e7652b5673d17e8c9301f2a832f22/app/bundles/EmailBundle/Tests/Helper/Transport/SmtpTransport.php#L7-L14) which doesn't actually send any emails,
but rather it stores a copy of the last attempted email. The unit testing functions then read the last would be sent email from the `SmtpTransport` object to verify its attributes and content.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11347"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

