### PR TITLE
Fixing Composer install/require

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -69,7 +69,7 @@
     "knplabs/gaufrette": "~0.9.0",
     "aws/aws-sdk-php": "~3.0",
     "friendsofsymfony/rest-bundle": "^3.0.2",
-    "friendsofsymfony/oauth-server-bundle": "dev-doctrine-fix",
+    "friendsofsymfony/oauth-server-bundle": "dev-master",
     "jms/serializer-bundle": "^4.0",
     "joomla/filter": "~1.4.4",
     "oneup/uploader-bundle": "^3.1.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/10651

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

It looks like the repository https://github.com/FriendsOfSymfony/FOSOAuthServerBundle which is one of the Mautic dependencies deleted the `doctrine-fix` branch that Mautic depend on. This branch dependency was added in https://github.com/mautic/mautic/commit/ad81f3d7bb965be6d63f91287153adc87441a9d9#diff-5fd35cf0f24edf28811f71444391a8225d3119b288b7e24d472a55b5257cd582R72 by @nickveenhof and I can't tell why. What I hope is that the changes needed were merged to the `master` branch. There were no releases since 2019 so we cannot use the latest version.

So I pushed this change to `mautic/core-lib` repository:

https://github.com/mautic/core-lib/commit/966487ba57b653f2d1f2220bb1beef7f86e651b8

And released the 4.4.1-alpha tag because Composer did not want to work just with the branch for some reason:

https://github.com/mautic/core-lib/releases/tag/4.4.1-alpha

The master branch of the `FriendsOfSymfony/FOSOAuthServerBundle` repo also contains PHP 8 support, so we should be good on that front:

https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/pull/675

#### Steps to test this PR:
1. `mkdir core-lib-test`
2. `cd core-lib-test`
3. Create new composer.json file in this directory with this content:
```json
{
    "name": "root/core-lib-test",
    "authors": [
        {
            "name": "han"
        }
    ],
    "minimum-stability": "dev",
    "require": {
        "mautic/core-lib": "4.4.1-alpha"
    },
    "config": {
        "allow-plugins": {
            "symfony/flex": true
        }
    }
}
```
Notice that we require the new tag I created. If you use other tag or branch then it will fail.
4. Run `composer install`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11353"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

