### PR TITLE
Add core lib readme and workflow to auto-close PRs

### DIFF
--- a/app/.github/workflows/close_pull_requests.yml
+++ b/app/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the [respective directory](https://github.com/mautic/mautic/blob/head/app/) of the main repository where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://github.com/mautic/mautic/blob/head/.github/CONTRIBUTING.md) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,5 @@
+# Mautic Core-lib repo
+
+## This is a mirror repository of the /app folder of Mautic, and is managed centrally in https://github.com/mautic/mautic/blob/head/app.  This is a read-only mirror repository.
+
+**📣 Please make PRs and issues against Mautic Core, not here!**

--- a/app/README.md
+++ b/app/README.md
@@ -2,4 +2,4 @@
 
 ## This is a mirror repository of the /app folder of Mautic, and is managed centrally in https://github.com/mautic/mautic/blob/head/app.  This is a read-only mirror repository.
 
-**📣 Please make PRs and issues against Mautic Core, not here!**
+**📣 Please make PRs and issues against the [mautic/mautic](https://github.com/mautic/mautic) repository, not here!**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ✅ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

This PR adds the missing GitHub workflow and readme for the core-lib mirror repo which was missed in the [earlier PR](https://github.com/mautic/mautic/pull/11154) to add them to all our mirror repos.

No testing needed - just code review.

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

