### PR TITLE
Use proper env variable processor for rememberme_lifetime.

### DIFF
--- a/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional;
+
+use Mautic\CoreBundle\Test\AbstractMauticTestCase;
+use PHPUnit\Framework\Assert;
+
+class ParametersTest extends AbstractMauticTestCase
+{
+    public function testRememberMeParameterUsesIntProcessor(): void
+    {
+        Assert::assertSame(31536000, self::$container->getParameter('mautic.rememberme_lifetime'));
+    }
+}

--- a/app/config/parameters.php
+++ b/app/config/parameters.php
@@ -25,6 +25,13 @@ foreach ($mauticParams as $k => $v) {
             $type = 'bool:';
             break;
         case is_int($v):
+            // some configuration entries require processor to return explicit int, instead of string|int type,
+            // which is returned by \Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor
+            if ('rememberme_lifetime' === $k) {
+                $type = 'int:';
+                break;
+            }
+
             $type = 'intNullable:';
             break;
         case is_array($v):

--- a/app/config/security.php
+++ b/app/config/security.php
@@ -83,7 +83,7 @@ $firewalls = [
         ],
         'remember_me' => [
             'secret'   => '%mautic.rememberme_key%',
-            'lifetime' => (int) $container->getParameter('mautic.rememberme_lifetime'),
+            'lifetime' => '%mautic.rememberme_lifetime%',
             'path'     => '%mautic.rememberme_path%',
             'domain'   => '%mautic.rememberme_domain%',
         ],


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ 4.4 ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Kind of. Have no idea how to test parameter value before the resolver. <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #9011 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Some configuration entries require processor to return explicit `int`, instead of `string|int` type, which is returned by `\Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor`
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Log in with `remember me` checked.
3. Cookie `REMEMBERME` should be created and have expiration time in next year.
3.1 If you are not technical enough - you may open the mautic test page (not in incognito!) in the browser, then log in as described above, close the browser, reopen the browser and you need to be still logged in into mautic.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11363"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

