### PR TITLE
Reverting PR 11353 that used wrong branch

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -69,7 +69,7 @@
     "knplabs/gaufrette": "~0.9.0",
     "aws/aws-sdk-php": "~3.0",
     "friendsofsymfony/rest-bundle": "^3.0.2",
-    "friendsofsymfony/oauth-server-bundle": "dev-master",
+    "friendsofsymfony/oauth-server-bundle": "dev-doctrine-fix",
     "jms/serializer-bundle": "^4.0",
     "joomla/filter": "~1.4.4",
     "oneup/uploader-bundle": "^3.1.0",


### PR DESCRIPTION


| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is reverting https://github.com/mautic/mautic/pull/11353

I made a mistake when evaluating [this issue](https://github.com/mautic/mautic/issues/10651) as a bug. Instead the error mentioned there is a result of [wrong process](https://github.com/mautic/mautic/issues/10651#issuecomment-1202635801).

I also did not notice that we are not actually using the package but [our own fork](https://github.com/mautic/mautic/blob/5.x/composer.json#L95-L98).

The problem became visible when I was [preparing a PR merging 4.4.1 into the 5.x branch](https://github.com/mautic/mautic/pull/11372) and while resolving conflicts I had to rebuild composer.lock which resulted in [PHPSTAN errors](https://github.com/mautic/mautic/runs/7628411178?check_suite_focus=true) that discovered that the dependencies have changed the way we cannot support with Mautic 4 without a BC break. 

I did not notice this problem before the release because I haven't tried to actually update that dependency.

This won't be a problem for zip package installs because we are shielded from the problem by our composer.lock in this repository. But Composer-based installations use https://github.com/mautic/recommended-project which does not have composer.lock so it will use wrong branch and it will result in API authentication not working.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. There is no way how to test it before it is released. But since it's just reverting 1 line that I changed in 4.4.1 release to it's previous state then I think it's safe to say it works.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11373"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

