### PR TITLE
Fix property must not be accessed before initialization error

### DIFF
--- a/app/bundles/LeadBundle/Event/ImportValidateEvent.php
+++ b/app/bundles/LeadBundle/Event/ImportValidateEvent.php
@@ -11,8 +11,8 @@ class ImportValidateEvent extends Event
 {
     private string $routeObjectName;
     private Form $form;
-    private ?int $ownerId;
-    private ?int $list;
+    private ?int $ownerId = null;
+    private ?int $list    = null;
 
     /**
      * @var mixed[]


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | ❌ 
| Deprecations?                          | ❌ 
| BC breaks? (use the c.x branch)        | ❌ 
| Automated tests included?              | ❌  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes Custom Objects Imports <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Since PHP 7.4 introduces type-hinting for properties, it is particularly important to provide valid values for all properties, so that all properties have values that match their declared types.

A property that has never been assigned doesn't have a null value, but it is on an uninitialized (undefined) state, which will never match any declared type (undefined !== null).

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create custom object with some fields
3. Now, try to import a CSV with relevant fields for custom objects
4. Observe the "Property must not be accessed before initialization error" message in the logs before the PR is applied
5. After PR, you should be able to import CSV for custom objects 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11388"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

