### PR TITLE
Fixing PHPSTAN issue with PHP8 on 4.4 branch

### DIFF
--- a/app/bundles/MarketplaceBundle/Service/PluginCollector.php
+++ b/app/bundles/MarketplaceBundle/Service/PluginCollector.php
@@ -83,7 +83,7 @@ class PluginCollector
      *
      * @return array<string,mixed>
      */
-    private function getAllowlistedPackages(int $page = 1, int $limit): array
+    private function getAllowlistedPackages(int $page, int $limit): array
     {
         $total   = count($this->allowlistedPackages);
         $results = [];


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Our CI (GithubActions) is failing PHPSTAN checks on PHP8 and 4.4 branch:

https://github.com/mautic/mautic/runs/7808232065?check_suite_focus=true

With error:
```
 ------ ------------------------------------------------------------------- 
  Line   app/bundles/MarketplaceBundle/Service/PluginCollector.php          
 ------ ------------------------------------------------------------------- 
  86     Deprecated in PHP 8.0: Required parameter $limit follows optional  
         parameter $page.                                                   
 ------ ------------------------------------------------------------------- 
```

This PR fixes it. The optional param value is not necessary because the private method is always called with an integer.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the Marketplace list view
3. Notice there are no errors

This change is affecting pagination, but since we have only 4 plugins in the allow list then we cannot test that part.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

Gitpod link: https://gitpod.io/#https://github.com/mautic/mautic/pull/11394