### PR TITLE
Fix gitpod for form submissions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ image:
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready
 tasks:
-  - before: bash .ddev/gitpod-setup-ddev.sh
+  - command: bash .ddev/gitpod-setup-ddev.sh
     command: gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
 
 # VScode xdebug extension

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,8 +5,7 @@ image:
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready
 tasks:
-  - command: bash .ddev/gitpod-setup-ddev.sh
-    command: gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
+  - command: bash .ddev/gitpod-setup-ddev.sh gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
 
 # VScode xdebug extension
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,7 @@ tasks:
   - name: Startup 
   - command: |
       bash .ddev/gitpod-setup-ddev.sh 
-      gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
+      gp ports await 8080 && gp preview $(gp url 8080)/index_dev.php 
 
 # VScode xdebug extension
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,10 @@ image:
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready
 tasks:
-  - command: bash .ddev/gitpod-setup-ddev.sh gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
+  - name: Startup 
+  - command: |
+      bash .ddev/gitpod-setup-ddev.sh 
+      gp await-port 8080 && gp preview $(gp url 8080)/index_dev.php 
 
 # VScode xdebug extension
 vscode:


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ✅ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ]
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

#### Description:

When testing form submissions on Gitpod, often (and more likely if a Gitpod prebuild is used) the submission results in a 404 as it is redirecting to a URL from an earlier prebuild.

Thanks to some help from the Gitpod support team, this PR fixes that issue, and also updates the `await-port` command which has been deprecated, to use the new `ports await` command.

#### Steps to test this PR:

1. Open this PR on Gitpod (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new standalone form
3. Add a form action (eg send form results)
4. Make sure that you can submit the form
5. Check with a prebuild as well, using this URL: https://gitpod.io/#prebuild/https://github.com/mautic/mautic/pull/11409 - do all of the tests as above.
6. Try closing your Gitpod environment and then accessing it again after a time and make sure you are still able to submit forms.

Gitpod URL: https://gitpod.io/#https://github.com/mautic/mautic/pull/11409