### PR TITLE
Hubspot - Fix errors when the API returns a 401 code

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -829,8 +829,13 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
                     ]);
                     break;
             }
-        } catch (\Exception $exception) {
-            return ['error' => ['message' => $exception->getMessage(), 'code' => $exception->getCode()]];
+        } catch (\GuzzleHttp\Exception\RequestException $exception) {
+            return [
+                'error' => [
+                    'message' => $exception->getResponse()->getBody()->getContents(),
+                    'code'    => $exception->getCode(),
+                ],
+            ];
         }
         if (empty($settings['ignore_event_dispatch'])) {
             $event->setResponse($result);

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -30,13 +30,12 @@ class HubspotApi extends CrmApi
         }
 
         if (isset($request['error']) && 401 == $request['error']['code']) {
-            $message = $request['error']['message'];
+            $response = json_decode($request['error']['message'] ?? null, true);
 
-            if (isset($message)) {
-                $cleanMessage = substr(stristr($message, '"message":"'), strlen('"message":"')) ?? $message;
-                throw new ApiErrorException($cleanMessage);
+            if (isset($response)) {
+                throw new ApiErrorException($response['message'], $request['error']['code']);
             } else {
-                throw new ApiErrorException($message);
+                throw new ApiErrorException('401 Unauthorized - Error with Hubspot API', $request['error']['code']);
             }
         }
 

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -29,6 +29,17 @@ class HubspotApi extends CrmApi
             }
         }
 
+        if (isset($request['error']) && 401 == $request['error']['code']) {
+            $message = $request['error']['message'];
+
+            if (isset($message)) {
+                $cleanMessage = substr(stristr($message, '"message":"'), strlen('"message":"')) ?? $message;
+                throw new ApiErrorException($cleanMessage);
+            } else {
+                throw new ApiErrorException($message);
+            }
+        }
+
         return $request;
     }
 

--- a/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticCrmBundle\Tests\Api;
+
+use Mautic\PluginBundle\Exception\ApiErrorException;
+use MauticPlugin\MauticCrmBundle\Api\HubspotApi;
+use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
+
+class HubspotApiTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @testdox Test Hubspot api when the api-key is invalid
+     */
+    public function testHubspotWhenKeyIsInvalid(): void
+    {
+        $integration = $this->createMock(HubspotIntegration::class);
+        $message     = 'The API key provided is invalid. View or manage your API key here: https://app-eu1.hubspot.com/l/api-key/';
+        $code        = 401;
+        $response    = [
+            'status'        => 'error',
+            'message'       => $message,
+            'correlationId' => '00000000-0000-0000-0000-000000000000',
+            'category'      => 'INVALID_AUTHENTICATION',
+            'links'         => [
+                'api key' => 'https://app-eu1.hubspot.com/l/api-key/',
+            ],
+        ];
+
+        $integration->expects($this->exactly(1))
+            ->method('makeRequest')
+            ->willReturn(
+                [
+                    'error' => [
+                        'code'    => $code,
+                        'message' => json_encode($response),
+                    ],
+                ]
+            )
+        ;
+
+        $api = new HubspotApi($integration);
+        try {
+            $api->getLeadFields();
+
+            $this->fail('ApiErrorException not thrown');
+        } catch (ApiErrorException $exception) {
+            $this->assertEquals($message, $exception->getMessage());
+            $this->assertEquals($code, $exception->getCode());
+        }
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #11064
<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR fixes the infinite loading bug of the Hubspot plugin when it return a 401 error or other unmanaged code.
![Hubspot-error-loading](https://image.noelshack.com/fichiers/2022/34/7/1661705694-hubspot.png).

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Setup Hubspot plugin with a valid api key
3. Disable your hubspot api key
4. Return to the plugin, an error message indicates the error encountered with the api



<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11416"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

PR funded by @PierreAmmeloot from [WebAnyOne](https://www.webanyone.net/)