### PR TITLE
Avoid api cache clear

### DIFF
--- a/app/bundles/CoreBundle/Loader/RouteLoader.php
+++ b/app/bundles/CoreBundle/Loader/RouteLoader.php
@@ -73,18 +73,16 @@ class RouteLoader extends Loader
         $collection->addCollection($this->import('@FMElfinderBundle/Resources/config/routing.yaml'));
 
         //API
-        if ($this->coreParameters->get('api_enabled')) {
-            $event = new RouteEvent($this, 'api');
-            $this->dispatcher->dispatch(CoreEvents::BUILD_ROUTE, $event);
-            $apiCollection = $event->getCollection();
-            $apiCollection->addPrefix('/api');
+        $event = new RouteEvent($this, 'api');
+        $this->dispatcher->dispatch(CoreEvents::BUILD_ROUTE, $event);
+        $apiCollection = $event->getCollection();
+        $apiCollection->addPrefix('/api');
 
-            if ($forceSSL) {
-                $apiCollection->setSchemes('https');
-            }
-
-            $collection->addCollection($apiCollection);
+        if ($forceSSL) {
+            $apiCollection->setSchemes('https');
         }
+
+        $collection->addCollection($apiCollection);
 
         $secureCollection->addPrefix('/s');
         if ($forceSSL) {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -9,6 +9,25 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 {
+    protected function setUp(): void
+    {
+        // Disable API just for specific test.
+        $this->configParams['api_enabled'] = 'testDisabledApi' !== $this->getName();
+
+        parent::setUp();
+    }
+
+    public function testDisabledApi(): void
+    {
+        $this->client->request('POST', '/api/contacts/new', ['email' => 'apiemail1@email.com']);
+        $clientResponse = $this->client->getResponse();
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertEquals(
+            '{"errors":[{"message":"API disabled. You need to enable the API in the API settings of Mautic\u0027s Configuration.","code":403,"type":"api_disabled"}]}',
+            $clientResponse->getContent()
+        );
+    }
+
     public function testBatchNewEndpointDoesNotCreateDuplicates(): void
     {
         $payload = [

--- a/app/config/config_test.php
+++ b/app/config/config_test.php
@@ -124,10 +124,6 @@ $container->loadFromExtension('liip_test_fixtures', [
     'keep_database_and_schema' => true,
 ]);
 
-// Enable api by default
-$container->setParameter('mautic.api_enabled', true);
-$container->setParameter('mautic.api_enable_basic_auth', true);
-
 $loader->import('security_test.php');
 
 // Allow overriding config without a requiring a full bundle or hacks


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/10568

#### Description:

This PR solves the issue that after the API was enabled in UI the cache had to be cleared to actually make the API routes working. It's very annoying and every new Mautic user must search for the solution. We had a great discussion about this at @biozshock PR https://github.com/mautic/mautic/pull/11399 where you can read more details about reasoning for this change rather than the original change.

And I'd like to avoid merging [this alert](https://github.com/mautic/mautic/pull/11410) when we can solve the problem for good.

I measured the performance of having the API routes in the cache file or not but after [the optimization Symfony released in version 4.1](https://symfony.com/blog/new-in-symfony-4-1-fastest-php-router) I could not measure any difference. Here's the screenshot of the test with explanation what each of the requests mean. The response time was pretty much in the same range.

![Screen Shot 2022-08-30 at 10 06 01](https://user-images.githubusercontent.com/1235442/187438431-eccb471a-8059-4744-b83a-e15bc17ddc0d.png)


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Enable the API and Basic Auth
3. Use your favorite API tester like https://www.postman.com to access some API endpoint. For example `GET https://your-mautic/api/contacts`.

Before the change you get an error that the route does not exist. You'd have to clear the cache to make it work. After the change this works without the need to clear the cache.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
