### PR TITLE
Prevents throwing NoSuchPropertyException

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/EmailStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/EmailStep.php
@@ -75,6 +75,13 @@ class EmailStep implements StepInterface
     public $mailer_amazon_other_region;
 
     /**
+     * Sparkpost Region.
+     *
+     * @var string
+     */
+    public $mailer_sparkpost_region;
+
+    /**
      * Mailer API key if applicable.
      *
      * @var string


### PR DESCRIPTION
There is a fatal error on fresh install from git 5.x
[500 Error on 3rd step - mailer_sparkpost_region](https://forum.mautic.org/t/new-install-500-error-on-3rd-step-mailer-sparkpost-region/25114)
This was fixed by adding a missing property to the class `Mautic\InstallBundle\Configurator\Step\EmailStep`

<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11429"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

