### PR TITLE
WIP: Fix the fallback locale issue

### DIFF
--- a/app/bundles/CoreBundle/Command/PullTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PullTransifexCommand.php
@@ -107,7 +107,8 @@ EOT
                             $translationsConnector = $transifex->get('translations');
                             $response              = $translationsConnector->getTranslation('mautic', $alias, $language);
                             $translation           = json_decode((string) $response->getBody(), true);
-                            $path                  = $translationDir.$language.'/'.$bundle.'/'.basename($file);
+                            $filename              = str_replace('.ini', '.'.$language.'.ini', basename($file));
+                            $path                  = $translationDir.$language.'/'.$bundle.'/'.$filename;
 
                             // Verify the directories exist
                             if (!is_dir($translationDir.$language)) {

--- a/app/bundles/CoreBundle/Helper/Language/Installer.php
+++ b/app/bundles/CoreBundle/Helper/Language/Installer.php
@@ -27,6 +27,8 @@ class Installer
      */
     private $filesystem;
 
+    private string $languageCode;
+
     /**
      * Installer constructor.
      *
@@ -48,6 +50,7 @@ class Installer
     {
         $this->sourceDirectory  = $sourceDirectory.'/'.$languageCode;
         $this->installDirectory = $this->translationsDirectory.'/'.$languageCode;
+        $this->languageCode     = $languageCode;
 
         $this->createLanguageDirectory();
         $this->copyConfig();
@@ -109,7 +112,8 @@ class Installer
         $iniFinder = new Finder();
         $iniFinder->files()->name('*.ini')->in($sourceDirectory);
         foreach ($iniFinder as $iniFile) {
-            $this->filesystem->copy($iniFile->getPathname(), $targetDirectory.'/'.$iniFile->getFilename());
+            $filename = str_replace('.ini', '.'.$this->languageCode.'.ini', $iniFile->getFilename());
+            $this->filesystem->copy($iniFile->getPathname(), $targetDirectory.'/'.$filename);
         }
     }
 }

--- a/app/bundles/CoreBundle/Loader/TranslationLoader.php
+++ b/app/bundles/CoreBundle/Loader/TranslationLoader.php
@@ -114,6 +114,7 @@ class TranslationLoader extends ArrayLoader implements LoaderInterface
         }
 
         $domain        = substr($file->getFilename(), 0, -4);
+        $domain        = str_replace('.'.$locale, '', $domain);
         $thisCatalogue = parent::load($messages, $locale, $domain);
         $catalogue->addCatalogue($thisCatalogue);
     }

--- a/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
@@ -48,10 +48,10 @@ class TranslatorHelper extends BaseHelper
      */
     public function getJsLang()
     {
-        $defaultMessages = $this->translator->getCatalogue('en_US')->all('javascript') ?? [];
+        $defaultMessages = $this->translator->getCatalogue('en_US')->all('javascript');
 
         $fallbackLocales = $this->translator->getFallbackLocales();
-        foreach($fallbackLocales as $fallbackLocale) {
+        foreach ($fallbackLocales as $fallbackLocale) {
             $defaultMessages = array_merge($defaultMessages, $this->translator->getCatalogue($fallbackLocale)->all('javascript'));
         }
 

--- a/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
+++ b/app/bundles/CoreBundle/Templating/Helper/TranslatorHelper.php
@@ -48,8 +48,14 @@ class TranslatorHelper extends BaseHelper
      */
     public function getJsLang()
     {
-        $defaultMessages = $this->translator->getCatalogue('en_US')->all('javascript');
-        $messages        = $this->translator->getCatalogue()->all('javascript');
+        $defaultMessages = $this->translator->getCatalogue('en_US')->all('javascript') ?? [];
+
+        $fallbackLocales = $this->translator->getFallbackLocales();
+        foreach($fallbackLocales as $fallbackLocale) {
+            $defaultMessages = array_merge($defaultMessages, $this->translator->getCatalogue($fallbackLocale)->all('javascript'));
+        }
+
+        $messages = $this->translator->getCatalogue()->all('javascript');
 
         $oldKeys = [
             'chosenChooseOne'     => $this->trans('mautic.core.form.chooseone'),

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
@@ -40,10 +40,10 @@ class InstallerTest extends \PHPUnit\Framework\TestCase
         $this->assertFileExists($languagePath.'/CampaignBundle');
 
         // did it copy the INI files?
-        $this->assertFileExists($languagePath.'/CoreBundle/messages.ini');
-        $this->assertFileExists($languagePath.'/CoreBundle/flashes.ini');
-        $this->assertFileExists($languagePath.'/CampaignBundle/messages.ini');
-        $this->assertFileExists($languagePath.'/CampaignBundle/flashes.ini');
+        $this->assertFileExists($languagePath.'/CoreBundle/messages.es.ini');
+        $this->assertFileExists($languagePath.'/CoreBundle/flashes.es.ini');
+        $this->assertFileExists($languagePath.'/CampaignBundle/messages.es.ini');
+        $this->assertFileExists($languagePath.'/CampaignBundle/flashes.es.ini');
 
         // did it ignore the bundle's extra files?
         $this->assertFileDoesNotExist($languagePath.'/CoreBundle/random.txt');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
To find the translations Symfony uses the following way `locale`-> `parent locale` -> `region-less locale` -> `fallback locale`, e.g. `de_CH` -> `de` -> `en_US`.  [Fallback Translation Locales](https://symfony.com/doc/current/translation.html#fallback-translation-locales).

Now it dosn't work as expected. 

One way to fix it is to add the locale to the filename of the translation files, as described [here](https://symfony.com/doc/current/translation.html#translation-resource-file-names-and-locations), e.g. `messages.ini -> messages.de.ini`. This PR does it.

#### Steps to reproduce:
1. Load translations for two languages, e.g. `de_CH` and `de`
2. Change the option `translator`->`fallback` to `de` in the file `app/config/config.php`
3. Select the `de_CH` as the user language
4. There are no loaded translations
5. Restore the option `translator`->`fallback` to `en_US` in the file `app/config/config.php`
6. Translations for the `en_US` locale are used instead of the region-less locale `de`

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Use the same steps as when reproducing. It is important to reload translations and clear the cache.
3. Translations for the `de` locale are used in both cases

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
