### PR TITLE
Ensure all form fields are included within the form tag

### DIFF
--- a/app/bundles/CategoryBundle/Entity/CategoryRepository.php
+++ b/app/bundles/CategoryBundle/Entity/CategoryRepository.php
@@ -31,7 +31,7 @@ class CategoryRepository extends CommonRepository
      * @param int    $limit
      * @param int    $start
      *
-     * @return array
+     * @return mixed[]
      */
     public function getCategoryList($bundle, $search = '', $limit = 10, $start = 0, $includeGlobal = true)
     {

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class CategoryModel extends FormModel
 {
     /**
-     * @var mixed[]
+     * @var array<string,mixed[]>
      */
     private array $categoriesByBundleCache = [];
 
@@ -47,8 +47,8 @@ class CategoryModel extends FormModel
 
     public function getRepository(): CategoryRepository
     {
-        /** @var CategoryRepository $repository */
         $repository = $this->em->getRepository(Category::class);
+        \assert($repository instanceof CategoryRepository);
 
         return $repository;
     }
@@ -174,7 +174,7 @@ class CategoryModel extends FormModel
      *
      * @param string $bundle
      * @param string $filter
-     * @param string $limit
+     * @param int    $limit
      *
      * @return mixed[]
      */

--- a/app/bundles/CoreBundle/Entity/TranslationEntityInterface.php
+++ b/app/bundles/CoreBundle/Entity/TranslationEntityInterface.php
@@ -4,15 +4,10 @@ namespace Mautic\CoreBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-/**
- * Interface TranslationInterface.
- */
 interface TranslationEntityInterface
 {
     /**
-     * Get translation parent.
-     *
-     * @return mixed
+     * @return ?TranslationEntityInterface
      */
     public function getTranslationParent();
 
@@ -33,20 +28,16 @@ interface TranslationEntityInterface
     /**
      * Get ArrayCollection of translated entities.
      *
-     * @return ArrayCollection
+     * @return ?ArrayCollection
      */
     public function getTranslationChildren();
 
     /**
-     * Add entity to $translationChildren.
-     *
      * @return mixed
      */
     public function addTranslationChild(TranslationEntityInterface $child);
 
     /**
-     * Remove entity from $translationChildren.
-     *
      * @return mixed
      */
     public function removeTranslationChild(TranslationEntityInterface $child);
@@ -68,8 +59,6 @@ interface TranslationEntityInterface
     public function isTranslation($isChild = false);
 
     /**
-     * Get the language.
-     *
      * @return mixed
      */
     public function getLanguage();

--- a/app/bundles/CoreBundle/Entity/TranslationEntityTrait.php
+++ b/app/bundles/CoreBundle/Entity/TranslationEntityTrait.php
@@ -53,8 +53,6 @@ trait TranslationEntityTrait
     }
 
     /**
-     * Add translation.
-     *
      * @return $this
      */
     public function addTranslationChild(TranslationEntityInterface $child)
@@ -66,9 +64,6 @@ trait TranslationEntityTrait
         return $this;
     }
 
-    /**
-     * Remove translation.
-     */
     public function removeTranslationChild(TranslationEntityInterface $child): void
     {
         $this->translationChildren->removeElement($child);
@@ -77,7 +72,7 @@ trait TranslationEntityTrait
     /**
      * Get translated items.
      *
-     * @return \Doctrine\Common\Collections\Collection
+     * @return ?Collection
      */
     public function getTranslationChildren()
     {
@@ -85,8 +80,6 @@ trait TranslationEntityTrait
     }
 
     /**
-     * Set translation parent.
-     *
      * @return $this
      */
     public function setTranslationParent(TranslationEntityInterface $parent = null)
@@ -101,18 +94,13 @@ trait TranslationEntityTrait
     }
 
     /**
-     * Get translation parent.
-     *
-     * @return mixed
+     * @return ?TranslationEntityInterface
      */
     public function getTranslationParent()
     {
         return $this->translationParent;
     }
 
-    /**
-     * Remove translation parent.
-     */
     public function removeTranslationParent(): void
     {
         if (method_exists($this, 'isChanged')) {
@@ -123,8 +111,6 @@ trait TranslationEntityTrait
     }
 
     /**
-     * Set language.
-     *
      * @param string $language
      *
      * @return $this
@@ -141,8 +127,6 @@ trait TranslationEntityTrait
     }
 
     /**
-     * Get language.
-     *
      * @return string
      */
     public function getLanguage()
@@ -177,9 +161,6 @@ trait TranslationEntityTrait
         return count($children);
     }
 
-    /**
-     * Clear translations.
-     */
     public function clearTranslations(): void
     {
         $this->translationChildren = new ArrayCollection();
@@ -201,10 +182,10 @@ trait TranslationEntityTrait
             $parent = $this;
         }
 
-        if ($children = $parent->getTranslationChildren()) {
-            if ($children instanceof Collection) {
-                $children = $children->toArray();
-            }
+        $children = $parent->getTranslationChildren();
+
+        if ($children instanceof Collection) {
+            $children = $children->toArray();
         }
 
         if (!is_array($children)) {
@@ -219,7 +200,10 @@ trait TranslationEntityTrait
     }
 
     /**
-     * @return mixed
+     * @param string                      $getter
+     * @param ?TranslationEntityInterface $variantParent
+     *
+     * @return int
      */
     protected function getAccumulativeTranslationCount($getter, $variantParent = null)
     {

--- a/app/bundles/CoreBundle/Model/VariantModelTrait.php
+++ b/app/bundles/CoreBundle/Model/VariantModelTrait.php
@@ -83,7 +83,7 @@ trait VariantModelTrait
         if (!$isVariant && $entity instanceof TranslationEntityInterface) {
             // Translations could be assigned to a variant and thus applicable to be reset
             if ($translationParent = $entity->getTranslationParent()) {
-                $isVariant = $translationParent->isVariant();
+                $isVariant = $translationParent->isVariant(); /** @phpstan-ignore-line @todo for M6, extend the TranslationEntityInterface from The VariantEntityInterface */
             }
         }
 

--- a/app/bundles/CoreBundle/Resources/views/Slots/channelfrequency.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/channelfrequency.html.twig
@@ -33,7 +33,7 @@
                               and not form.lead_channels['frequency_number_' ~ channel.value].isRendered
                               and not form.lead_channels['frequency_time_' ~ channel.value].isRendered
                         %}
-                            <div class="col-md-6">
+                            <div class="col-md-6" data-contact-frequency="1">
                                 <label class="text-muted label1">{{ form.lead_channels['frequency_number_' ~ channel.value].vars.label|trans }}</label>
                                 {{ form_widget(form.lead_channels['frequency_number_' ~ channel.value]) }}
                                 {{ form_label(form.lead_channels['frequency_time_' ~ channel.value]) }}
@@ -54,7 +54,7 @@
                               and not form.lead_channels['contact_pause_start_date_' ~ channel.value].isRendered
                               and not form.lead_channels['contact_pause_end_date_' ~ channel.value].isRendered
                         %}
-                            <div class="col-md-6">
+                            <div class="col-md-6" data-contact-pause-dates="1">
                                 <label class="text-muted label3">{{ 'mautic.lead.frequency.dates.label'|trans }}</label>
                                 {{ form_widget(form.lead_channels['contact_pause_start_date_' ~ channel.value]) }}
                                 {{ form_label(form.lead_channels['contact_pause_end_date_' ~ channel.value]) }}

--- a/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
@@ -4,6 +4,16 @@
 {% if form is defined %}
     {# add form tag #}
     <script src="{{ getAssetUrl('app/bundles/PageBundle/Assets/js/prefcenter.js') }}"></script>
+
+    {# add close form tag before the custom tag to prevent cascading forms #}
+    {# in case there is already an unsubscribe form on the page #}
+    {# that's why we can't use the bodyclose customdeclaration #}
+    {% if (custom_tag is defined and custom_tag is not empty) %}
+        {{ custom_tag|raw }}
+        {{ assetAddCustomDeclaration(form_rest(form), 'customTag') }}
+    {% else %}
+        {{ assetAddCustomDeclaration(form_rest(form), 'bodyClose') }}
+    {% endif %}
 {% endif %}
 
     <a href="javascript:void(null)"
@@ -14,12 +24,3 @@
         {{ 'mautic.page.form.saveprefs'|trans }}
     </a>
     <div style="clear:both"></div>
-    {# add close form tag before the custom tag to prevent cascading forms #}
-    {# in case there is already an unsubscribe form on the page #}
-    {# that's why we can't use the bodyclose customdeclaration #}
-    {% if (custom_tag is defined and custom_tag is not empty) %}
-        {{ custom_tag }}
-        {{ assetaddScriptDeclaration(form_rest(form), 'customTag') }}
-    {% else %}
-        {{ assetaddScriptDeclaration(form_rest(form), 'bodyClose') }}
-    {% endif %}

--- a/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
@@ -14,3 +14,12 @@
         {{ 'mautic.page.form.saveprefs'|trans }}
     </a>
     <div style="clear:both"></div>
+    {# add close form tag before the custom tag to prevent cascading forms #}
+    {# in case there is already an unsubscribe form on the page #}
+    {# that's why we can't use the bodyclose customdeclaration #}
+    {% if (custom_tag is defined and custom_tag is not empty) %}
+        {{ custom_tag }}
+        {{ assetaddScriptDeclaration($view['form']->rest(form_rest(form)), 'customTag') }}
+    {% else %}
+        {{ assetaddScriptDeclaration($view['form']->rest(form_rest(form)), 'bodyClose') }}
+    {% endif %}

--- a/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
@@ -19,7 +19,7 @@
     {# that's why we can't use the bodyclose customdeclaration #}
     {% if (custom_tag is defined and custom_tag is not empty) %}
         {{ custom_tag }}
-        {{ assetaddScriptDeclaration($view['form']->rest(form_rest(form)), 'customTag') }}
+        {{ assetaddScriptDeclaration(form_rest(form), 'customTag') }}
     {% else %}
-        {{ assetaddScriptDeclaration($view['form']->rest(form_rest(form)), 'bodyClose') }}
+        {{ assetaddScriptDeclaration(form_rest(form), 'bodyClose') }}
     {% endif %}

--- a/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
@@ -2,6 +2,9 @@
 {% set background = saveprefsbutton.background|default('') %}
 
 {% if form is defined %}
+    {% do form.lead_channels.subscribed_channels.setRendered() %}
+    {% do form.buttons.save.setRendered() %}
+    {% do form.buttons.cancel.setRendered() %}
     {# add form tag #}
     <script src="{{ getAssetUrl('app/bundles/PageBundle/Assets/js/prefcenter.js') }}"></script>
 

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Mime\RawMessage;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/AbstractFormFieldHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/AbstractFormFieldHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
+use PHPUnit\Framework\Assert;
 
 class AbstractFormFieldHelperTest extends \PHPUnit\Framework\TestCase
 {
@@ -169,6 +170,33 @@ class AbstractFormFieldHelperTest extends \PHPUnit\Framework\TestCase
             [0 => 0],
             [0 => '0'],
         ];
+    }
+
+    public function testparseChoiceListWithNullValue(): void
+    {
+        Assert::assertEquals(
+            [0 => 'label4'],
+            AbstractFormFieldHelper::parseList(
+                [
+                    [
+                        'label' => 'label1',
+                        'value' => '',
+                    ],
+                    [
+                        'label' => 'label2',
+                        'value' => null,
+                    ],
+                    [
+                        'label' => 'label3',
+                        'value' => 0,
+                    ],
+                    [
+                        'label' => 'label4',
+                        'value' => '0',
+                    ],
+                ]
+            )
+        );
     }
 
     /**

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -37,6 +37,7 @@ class AssetExtension extends AbstractExtension
             new TwigFunction('assetGetCountryFlag', [$this, 'getCountryFlag']),
             new TwigFunction('assetGetBaseUrl', [$this, 'getBaseUrl'], ['is_safe' => ['html']]),
             new TwigFunction('assetMakeLinks', [$this, 'makeLinks'], ['is_safe' => ['html']]),
+            new TwigFunction('assetaddScriptDeclaration', [$this, 'addCustomDeclaration'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -166,5 +167,10 @@ class AssetExtension extends AbstractExtension
     public function makeLinks(string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
     {
         return $this->assetsHelper->makeLinks($text, $protocols, $attributes);
+    }
+
+    public function addCustomDeclaration(string $declaration, string $location): void
+    {
+        $this->assetsHelper->addCustomDeclaration($declaration, $location);
     }
 }

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -34,10 +34,10 @@ class AssetExtension extends AbstractExtension
             new TwigFunction('assetsGetImagesPath', [$this, 'getImagesPath']),
             new TwigFunction('assetsGetPrefix', [$this, 'getAssetPrefix']),
             new TwigFunction('assetAddScriptDeclaration', [$this, 'addScriptDeclaration']),
+            new TwigFunction('assetAddCustomDeclaration', [$this, 'addCustomDeclaration']),
             new TwigFunction('assetGetCountryFlag', [$this, 'getCountryFlag']),
             new TwigFunction('assetGetBaseUrl', [$this, 'getBaseUrl'], ['is_safe' => ['html']]),
             new TwigFunction('assetMakeLinks', [$this, 'makeLinks'], ['is_safe' => ['html']]),
-            new TwigFunction('assetaddScriptDeclaration', [$this, 'addCustomDeclaration'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -142,9 +142,18 @@ class AssetExtension extends AbstractExtension
         return $this->assetsHelper->getAssetPrefix($includeEndingslash);
     }
 
-    public function addScriptDeclaration(string $script, string $location = 'head'): AssetsHelper
+    public function addScriptDeclaration(string $script, string $location = 'head'): string
     {
-        return $this->assetsHelper->addScriptDeclaration($script, $location);
+        $this->assetsHelper->addScriptDeclaration($script, $location);
+
+        return '';
+    }
+
+    public function addCustomDeclaration(string $script, string $location): string
+    {
+        $this->assetsHelper->addCustomDeclaration($script, $location);
+
+        return '';
     }
 
     /**
@@ -167,10 +176,5 @@ class AssetExtension extends AbstractExtension
     public function makeLinks(string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
     {
         return $this->assetsHelper->makeLinks($text, $protocols, $attributes);
-    }
-
-    public function addCustomDeclaration(string $declaration, string $location): void
-    {
-        $this->assetsHelper->addCustomDeclaration($declaration, $location);
     }
 }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1329,7 +1329,9 @@ class EmailController extends FormController
             ]);
         }
 
-        if ($translationParent = $entity->getTranslationParent()) {
+        $translationParent = $entity->getTranslationParent();
+
+        if ($translationParent instanceof Email) {
             return $this->redirectToRoute('mautic_email_action', [
                 'objectAction' => 'send',
                 'objectId'     => $translationParent->getId(),

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -27,8 +27,6 @@ use Mautic\PageBundle\PageEvents;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Mautic\QueueBundle\Queue\QueueName;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
@@ -250,14 +248,14 @@ class PublicController extends CommonFormController
                             $showParameters,
                             [
                                 'form'       => $formView,
-                                'startform'  => $this->get('templating.helper.form')->start($formView),
+                                'startform'  => $this->renderView('@MauticCore/Default/form.html.twig', ['form' => $formView]),
                                 'custom_tag' => '<a name="end-'.$formView->vars['id'].'"></a>',
                             ]
                         );
 
                         $event = new PageDisplayEvent($html, $prefCenter, $eventParameters);
 
-                        $this->get('event_dispatcher')->dispatch(PageEvents::PAGE_ON_DISPLAY, $event);
+                        $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
 
                         $html = $event->getContent();
 
@@ -800,13 +798,13 @@ class PublicController extends CommonFormController
          * render that field just because a slot for it exists will result in an error.
          */
         $showParamsBasedOnContent = array_filter([
-            'showContactFrequency'         => false !== strpos($content, 'data-slot="channelfrequency"') || false !== strpos($content, BuilderSubscriber::channelfrequency),
-            'showContactSegments'          => false !== strpos($content, 'data-slot="segmentlist"') || false !== strpos($content, BuilderSubscriber::segmentListRegex),
-            'showContactCategories'        => false !== strpos($content, 'data-slot="categorylist"') || false !== strpos($content, BuilderSubscriber::categoryListRegex),
-            'showContactPreferredChannels' => false !== strpos($content, 'data-slot="preferredchannel"') || false !== strpos($content, BuilderSubscriber::preferredchannel),
+            'showContactFrequency'         => str_contains($content, 'data-slot="channelfrequency"') || str_contains($content, BuilderSubscriber::channelfrequency),
+            'showContactSegments'          => str_contains($content, 'data-slot="segmentlist"') || str_contains($content, BuilderSubscriber::segmentListRegex),
+            'showContactCategories'        => str_contains($content, 'data-slot="categorylist"') || str_contains($content, BuilderSubscriber::categoryListRegex),
+            'showContactPreferredChannels' => str_contains($content, 'data-slot="preferredchannel"') || str_contains($content, BuilderSubscriber::preferredchannel),
         ], fn (bool $value) =>!$value);
 
-        $showParamsBasedOnConfiguration = array_filter($viewParameters, fn ($key) => 0 === strpos($key, 'show'), ARRAY_FILTER_USE_KEY);
+        $showParamsBasedOnConfiguration = array_filter($viewParameters, fn ($key) => str_starts_with($key, 'show'), ARRAY_FILTER_USE_KEY);
 
         return array_merge($showParamsBasedOnConfiguration, $showParamsBasedOnContent);
     }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -169,8 +169,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         // Ensure that list emails are published
         if ('list' == $entity->getEmailType()) {
             // Ensure that this email has the same lists assigned as the translated parent if applicable
-            /** @var Email $translationParent */
             if ($translationParent = $entity->getTranslationParent()) {
+                \assert($translationParent instanceof Email);
                 $parentLists = $translationParent->getLists()->toArray();
                 $entity->setLists($parentLists);
             }

--- a/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
@@ -63,7 +63,7 @@
                     <hr />
                     <div id="preferred_channel" class="text-left">{{ form_row(form.lead_channels.preferred_channel) }}</div>
                 {% endif %}
-                {% set segmentCount = form.lead_lists.vars.choices|length %}
+                {% set segmentCount = form.lead_lists is defined ? form.lead_lists.vars.choices|length : 0 %}
                 {% if showContactSegments and segmentCount > 0 %}
                     <hr />
                     <div id="contact-segments">
@@ -76,7 +76,7 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                {% set categoryCount = form.global_categories.vars.choices|length %}
+                {% set categoryCount = form.global_categories is defined ? form.global_categories.vars.choices|length : 0 %}
                 {% if showContactCategories and categoryCount > 0 %}
                     <hr />
                     <div id="global-categories" class="text-left">

--- a/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
@@ -63,7 +63,8 @@
                     <hr />
                     <div id="preferred_channel" class="text-left">{{ form_row(form.lead_channels.preferred_channel) }}</div>
                 {% endif %}
-                {% if showContactSegments and  form.lead_lists|length > 0 %}
+                {% set segmentCount = form.lead_lists.vars.choices|length %}
+                {% if showContactSegments and segmentCount > 0 %}
                     <hr />
                     <div id="contact-segments">
                         <div class="text-left">{{ form_label(form.lead_lists) }}</div>
@@ -75,7 +76,8 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                {% if showContactCategories and form.global_categories|length > 0 %}
+                {% set categoryCount = form.global_categories.vars.choices|length %}
+                {% if showContactCategories and categoryCount > 0 %}
                     <hr />
                     <div id="global-categories" class="text-left">
                         <div>{{ form_label(form.global_categories) }}</div>

--- a/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
@@ -36,7 +36,7 @@
                 </div>
                 <table class="table table-striped">
                     {% if showContactFrequency %}
-                        {% for  key, channel in form.lead_channels.subscribed_channels.vars.choices %}
+                        {% for key, channel in form.lead_channels.subscribed_channels.vars.choices %}
                             {% set contactMe = leadChannels[channel.value] is defined %}
                             {% set checked = contactMe ? 'checked' : '' %}
                             {% set channelName =  getChannelLabel(channel.value)|lower %}
@@ -53,6 +53,28 @@
                                         <label for="{{ channel.value }}" id="is-contactable-{{ channel.value }}">
                                             {{ 'mautic.lead.contact.me.label'|trans({'%channel%' : channelName}) }}
                                         </label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div id="frequency_<?php echo $channel->value; ?>" class="text-left row">
+                                        {% if showContactFrequency %}
+                                            <div class="col-md-6" data-contact-frequency="1">
+                                                <label class="text-muted">{{ form.lead_channels['frequency_number_' ~ channel.value].vars.label|trans }}</label>
+                                                {{ form_widget(form.lead_channels['frequency_number_' ~ channel.value]) }}
+                                                {{ form_label(form.lead_channels['frequency_time_' ~ channel.value]) }}
+                                                {{ form_widget(form.lead_channels['frequency_time_' ~ channel.value]) }}
+                                            </div>
+                                        {% endif %}
+                                        {%  if showContactPauseDates %}
+                                            <div class="col-md-6" data-contact-pause-dates="1">
+                                                <label class="text-muted">{{ 'mautic.lead.frequency.dates.label'|trans }}</label>
+                                                {{ form_widget(form.lead_channels['contact_pause_start_date_' ~ channel.value]) }}
+                                                {{ form_label(form.lead_channels['contact_pause_end_date_' ~ channel.value]) }}
+                                                {{ form_widget(form.lead_channels['contact_pause_end_date_' ~ channel.value]) }}
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </td>
                             </tr>

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -93,8 +93,13 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+
+        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
         $this->assertStringContainsString('/email/unsubscribe/tracking_hash_unsubscribe_form_email', $crawler->filter('form')->eq(0)->attr('action'));
         $crawler = $this->client->submitForm('Save');
+
+        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
 
         $this->assertEquals(1, $crawler->filter('#success-message-text')->count());
         $expectedMessage = static::getContainer()->get('translator')->trans('mautic.email.preferences_center_success_message.text');

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -171,8 +171,8 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $crawler    = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
         $tokenInput = $crawler->filter('input[name="lead_contact_frequency_rules[_token]"]');
-        $this->assertTrue($this->client->getResponse()->isOk());
-        $this->assertEquals(1, $tokenInput->count());
+        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertEquals(1, $tokenInput->count(), $this->client->getResponse()->getContent());
     }
 
     /**

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -596,7 +596,7 @@ class PageController extends FormController
 
             // set the lookup values
             $parent = $entity->getTranslationParent();
-            if ($parent && isset($form['translationParent_lookup'])) {
+            if ($parent instanceof Page && isset($form['translationParent_lookup'])) {
                 $form->get('translationParent_lookup')->setData($parent->getTitle());
             }
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -382,8 +382,8 @@ class PublicController extends AbstractFormController
         }
 
         if ($this->dispatcher->hasListeners(PageEvents::PAGE_ON_DISPLAY)) {
-            $event = new PageDisplayEvent($content, $page);
-            if (isset($contact)) {
+            $event = new PageDisplayEvent($content, $page, $this->getPreferenceCenterConfig());
+            if (isset($contact) && $contact instanceof Lead) {
                 $event->setLead($contact);
             }
             $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
@@ -666,5 +666,19 @@ class PublicController extends AbstractFormController
         }
 
         return new JsonResponse($data);
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    private function getPreferenceCenterConfig(): array
+    {
+        return [
+            'showContactFrequency'         => $this->coreParametersHelper->get('show_contact_frequency'),
+            'showContactPauseDates'        => $this->coreParametersHelper->get('show_contact_pause_dates'),
+            'showContactPreferredChannels' => $this->coreParametersHelper->get('show_contact_preferred_channels'),
+            'showContactCategories'        => $this->coreParametersHelper->get('show_contact_categories'),
+            'showContactSegments'          => $this->coreParametersHelper->get('show_contact_segments'),
+        ];
     }
 }

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -614,7 +614,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
     private function createDOMXPathForContent(string $content): \DOMXPath
     {
         $domDocument = new \DOMDocument('1.0', 'utf-8');
-        $domDocument->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
+        $domDocument->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
 
         return new \DOMXPath($domDocument);
     }

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -404,10 +404,10 @@ final class BuilderSubscriber implements EventSubscriberInterface
         }
 
         $slotNamesAndConfig = [
-            'segmentlist'      => [static::segmentListRegex, (bool) $params['showContactSegments']],
-            'categorylist'     => [static::categoryListRegex, (bool) $params['showContactCategories']],
-            'preferredchannel' => [static::preferredchannel, (bool) $params['showContactPreferredChannels']],
-            'channelfrequency' => [static::channelfrequency, (bool) ($params['showContactFrequency'] || $params['showContactPauseDates'])],
+            'segmentlist'      => [static::segmentListRegex, (bool) ($params['showContactSegments'] ?? false)],
+            'categorylist'     => [static::categoryListRegex, (bool) ($params['showContactCategories'] ?? false)],
+            'preferredchannel' => [static::preferredchannel, (bool) ($params['showContactPreferredChannels'] ?? false)],
+            'channelfrequency' => [static::channelfrequency, (bool) (($params['showContactFrequency'] ?? false) || ($params['showContactPauseDates'] ?? false))],
             'saveprefsbutton'  => [static::saveprefsRegex, true],
         ];
 
@@ -449,7 +449,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             return $this->renderedContentCache[$templateName];
         }
 
-        $content = $this->twig->render($templateName, $templateParams);
+        $content = trim($this->twig->render($templateName, $templateParams));
 
         if ($wrapperTemplate) {
             // If the content is not empty, ensure that the $wrapperTemplate contains a place to put it.

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -3,6 +3,11 @@
 namespace Mautic\PageBundle\EventListener;
 
 use Doctrine\DBAL\Connection;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMXPath;
+use InvalidArgumentException;
 use Mautic\CoreBundle\Form\Type\GatedVideoType;
 use Mautic\CoreBundle\Form\Type\SlotButtonType;
 use Mautic\CoreBundle\Form\Type\SlotCategoryListType;
@@ -26,28 +31,30 @@ use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event as Events;
 use Mautic\PageBundle\Helper\TokenHelper;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\PageEvents;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
+use RuntimeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
 class BuilderSubscriber implements EventSubscriberInterface
 {
-    private string $pageTokenRegex      = '{pagelink=(.*?)}';
+    private const pageTokenRegex      = '{pagelink=(.*?)}';
 
-    private string $dwcTokenRegex       = '{dwc=(.*?)}';
+    private const dwcTokenRegex       = '{dwc=(.*?)}';
 
-    private string $langBarRegex        = '{langbar}';
+    private const langBarRegex        = '{langbar}';
 
-    private string $shareButtonsRegex   = '{sharebuttons}';
+    private const shareButtonsRegex   = '{sharebuttons}';
 
-    private string $titleRegex          = '{pagetitle}';
+    private const titleRegex          = '{pagetitle}';
 
-    private string $descriptionRegex    = '{pagemetadescription}';
+    private const descriptionRegex    = '{pagemetadescription}';
 
     public const segmentListRegex  = '{segmentlist}';
 
@@ -62,6 +69,15 @@ class BuilderSubscriber implements EventSubscriberInterface
     public const successmessage    = '{successmessage}';
 
     public const identifierToken   = '{leadidentifier}';
+
+    public const saveButtonContainerClass = 'prefs-saveprefs';
+
+    public const firstSlotAttribute       = ' data-prefs-center-first="1"';
+
+    /**
+     * @var array<string,string>
+     */
+    private array $renderedContentCache = [];
 
     public function __construct(
         private CorePermissions $security,
@@ -85,6 +101,24 @@ class BuilderSubscriber implements EventSubscriberInterface
             EmailEvents::EMAIL_ON_SEND    => ['onEmailGenerate', 0],
             EmailEvents::EMAIL_ON_DISPLAY => ['onEmailGenerate', 0],
         ];
+    }
+
+    public function onEmailBuild(EmailBuilderEvent $event): void
+    {
+        if ($event->tokensRequested([static::pageTokenRegex])) {
+            $tokenHelper = $this->builderTokenHelperFactory->getBuilderTokenHelper('page');
+            $event->addTokensFromHelper($tokenHelper, static::pageTokenRegex, 'title', 'id', true);
+        }
+    }
+
+    public function onEmailGenerate(EmailSendEvent $event): void
+    {
+        $content      = $event->getContent();
+        $plainText    = $event->getPlainText();
+        $clickthrough = $event->shouldAppendClickthrough() ? $event->generateClickthrough() : [];
+        $tokens       = $this->tokenHelper->findPageTokens($content.$plainText, $clickthrough);
+
+        $event->addTokens($tokens);
     }
 
     /**
@@ -111,14 +145,14 @@ class BuilderSubscriber implements EventSubscriberInterface
             $event->addAbTestWinnerCriteria('page.dwelltime', $dwellTime);
         }
 
-        if ($event->tokensRequested([$this->pageTokenRegex, $this->dwcTokenRegex])) {
-            $event->addTokensFromHelper($tokenHelper, $this->pageTokenRegex, 'title', 'id', true);
+        if ($event->tokensRequested([static::pageTokenRegex, static::dwcTokenRegex])) {
+            $event->addTokensFromHelper($tokenHelper, static::pageTokenRegex, 'title', 'id', true);
 
             // add only filter based dwc tokens
             $dwcTokenHelper = $this->builderTokenHelperFactory->getBuilderTokenHelper('dynamicContent', 'dynamiccontent:dynamiccontents');
             $expr           = $this->connection->createExpressionBuilder()->and('e.is_campaign_based <> 1 and e.slot_name is not null');
             $tokens         = $dwcTokenHelper->getTokens(
-                $this->dwcTokenRegex,
+                static::dwcTokenRegex,
                 '',
                 'name',
                 'slot_name',
@@ -129,17 +163,17 @@ class BuilderSubscriber implements EventSubscriberInterface
             $event->addTokens(
                 $event->filterTokens(
                     [
-                        $this->langBarRegex      => $this->translator->trans('mautic.page.token.lang'),
-                        $this->shareButtonsRegex => $this->translator->trans('mautic.page.token.share'),
-                        $this->titleRegex        => $this->translator->trans('mautic.core.title'),
-                        $this->descriptionRegex  => $this->translator->trans('mautic.page.form.metadescription'),
-                        self::segmentListRegex   => $this->translator->trans('mautic.page.form.segmentlist'),
-                        self::categoryListRegex  => $this->translator->trans('mautic.page.form.categorylist'),
-                        self::preferredchannel   => $this->translator->trans('mautic.page.form.preferredchannel'),
-                        self::channelfrequency   => $this->translator->trans('mautic.page.form.channelfrequency'),
-                        self::saveprefsRegex     => $this->translator->trans('mautic.page.form.saveprefs'),
-                        self::successmessage     => $this->translator->trans('mautic.page.form.successmessage'),
-                        self::identifierToken    => $this->translator->trans('mautic.page.form.leadidentifier'),
+                        static::langBarRegex      => $this->translator->trans('mautic.page.token.lang'),
+                        static::shareButtonsRegex => $this->translator->trans('mautic.page.token.share'),
+                        static::titleRegex        => $this->translator->trans('mautic.core.title'),
+                        static::descriptionRegex  => $this->translator->trans('mautic.page.form.metadescription'),
+                        static::segmentListRegex  => $this->translator->trans('mautic.page.form.segmentlist'),
+                        static::categoryListRegex => $this->translator->trans('mautic.page.form.categorylist'),
+                        static::preferredchannel  => $this->translator->trans('mautic.page.form.preferredchannel'),
+                        static::channelfrequency  => $this->translator->trans('mautic.page.form.channelfrequency'),
+                        static::saveprefsRegex    => $this->translator->trans('mautic.page.form.saveprefs'),
+                        static::successmessage    => $this->translator->trans('mautic.page.form.successmessage'),
+                        static::identifierToken   => $this->translator->trans('mautic.page.form.leadidentifier'),
                     ]
                 )
             );
@@ -317,153 +351,19 @@ class BuilderSubscriber implements EventSubscriberInterface
 
     public function onPageDisplay(Events\PageDisplayEvent $event): void
     {
-        $content = $event->getContent();
+        if (empty($content = $event->getContent())) {
+            return;
+        }
+
         $page    = $event->getPage();
         $params  = $event->getParams();
-
-        if (str_contains($content, $this->langBarRegex)) {
-            $langbar = $this->renderLanguageBar($page);
-            $content = str_ireplace($this->langBarRegex, $langbar, $content);
-        }
-
-        if (str_contains($content, $this->shareButtonsRegex)) {
-            $buttons = $this->renderSocialShareButtons();
-            $content = str_ireplace($this->shareButtonsRegex, $buttons, $content);
-        }
-
-        if (str_contains($content, $this->titleRegex)) {
-            $content = str_ireplace($this->titleRegex, $page->getTitle(), $content);
-        }
-
-        if (str_contains($content, $this->descriptionRegex)) {
-            $content = str_ireplace($this->descriptionRegex, $page->getMetaDescription(), $content);
-        }
+        $content = $this->replaceCommonTokens($content, $page);
 
         if ($page->getIsPreferenceCenter()) {
-            // replace slots
-            if (count($params)) {
-                $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
-                $xpath = new \DOMXPath($dom);
-
-                $divContent = $xpath->query('//*[@data-slot="segmentlist"]');
-                for ($i = 0; $i < $divContent->length; ++$i) {
-                    $slot            = $divContent->item($i);
-                    $slot->nodeValue = self::segmentListRegex;
-                    $slot->setAttribute('data-prefs-center', '1');
-                    $content         = $dom->saveHTML();
-                }
-
-                $divContent = $xpath->query('//*[@data-slot="categorylist"]');
-                for ($i = 0; $i < $divContent->length; ++$i) {
-                    $slot            = $divContent->item($i);
-                    $slot->nodeValue = self::categoryListRegex;
-                    $slot->setAttribute('data-prefs-center', '1');
-                    $content         = $dom->saveHTML();
-                }
-
-                $divContent = $xpath->query('//*[@data-slot="preferredchannel"]');
-                for ($i = 0; $i < $divContent->length; ++$i) {
-                    $slot            = $divContent->item($i);
-                    $slot->nodeValue = self::preferredchannel;
-                    $slot->setAttribute('data-prefs-center', '1');
-                    $content         = $dom->saveHTML();
-                }
-
-                $divContent = $xpath->query('//*[@data-slot="channelfrequency"]');
-                for ($i = 0; $i < $divContent->length; ++$i) {
-                    $slot            = $divContent->item($i);
-                    $slot->nodeValue = self::channelfrequency;
-                    $slot->setAttribute('data-prefs-center', '1');
-                    $content         = $dom->saveHTML();
-                }
-
-                $divContent = $xpath->query('//*[@data-slot="saveprefsbutton"]');
-                for ($i = 0; $i < $divContent->length; ++$i) {
-                    $slot            = $divContent->item($i);
-                    $saveButton      = $xpath->query('//*[@data-slot="saveprefsbutton"]//a')->item(0);
-                    $slot->nodeValue = self::saveprefsRegex;
-                    $slot->setAttribute('data-prefs-center', '1');
-                    $content         = $dom->saveHTML();
-
-                    $params['saveprefsbutton'] = [
-                        'style'      => $saveButton->getAttribute('style'),
-                        'background' => $saveButton->getAttribute('background'),
-                    ];
-                }
-
-                unset($slot, $xpath, $dom);
-            }
-            // replace tokens
-            if (str_contains($content, self::segmentListRegex)) {
-                $segmentList = $this->renderSegmentList($params);
-                $content     = str_ireplace(self::segmentListRegex, $segmentList, $content);
-            }
-
-            if (str_contains($content, self::categoryListRegex)) {
-                $categoryList = $this->renderCategoryList($params);
-                $content      = str_ireplace(self::categoryListRegex, $categoryList, $content);
-            }
-
-            if (str_contains($content, self::preferredchannel)) {
-                $preferredChannel = $this->renderPreferredChannel($params);
-                $content          = str_ireplace(self::preferredchannel, $preferredChannel, $content);
-            }
-
-            if (str_contains($content, self::channelfrequency)) {
-                $channelfrequency = $this->renderChannelFrequency($params);
-                $content          = str_ireplace(self::channelfrequency, $channelfrequency, $content);
-            }
-
-            if (str_contains($content, self::saveprefsRegex)) {
-                $savePrefs = $this->renderSavePrefs($params);
-                $content   = str_ireplace(self::saveprefsRegex, $savePrefs.($params['custom_tag'] ?? ''), $content);
-            }
-            // add form before first block of prefs center
-            if (isset($params['startform']) && str_contains($content, 'data-prefs-center')) {
-                $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
-                $xpath      = new \DOMXPath($dom);
-                // If use slots
-                $divContent = $xpath->query('//*[@data-prefs-center="1"]');
-                if (!$divContent->length) {
-                    // If use tokens
-                    $divContent = $xpath->query('//*[@data-prefs-center-first="1"]');
-                }
-
-                if ($divContent->length) {
-                    $slot    = $divContent->item(0);
-                    $newnode = $dom->createElement('startform');
-                    $slot->parentNode->insertBefore($newnode, $slot);
-                    $content = $dom->saveHTML();
-                    $content = str_replace('<startform></startform>', $params['startform'], $content);
-                }
-
-                /* Add close form tag before the custom tag to prevent cascading forms
-                 * in case there is already an unsubscribe form on the page
-                 * that's why we can't use the bodyclose customdeclaration
-                 */
-                if (!empty($params['form'])) {
-                    $formEnd = $this->twig->render('@MauticCore/Default/form_end.html.twig', $params);
-
-                    if (!empty($params['custom_tag'])) {
-                        $this->assetsHelper->addCustomDeclaration($formEnd, 'customTag');
-                    } else {
-                        $this->assetsHelper->addCustomDeclaration($formEnd, 'bodyClose');
-                    }
-                }
-            }
-
-            if (str_contains($content, self::successmessage)) {
-                $successMessage = $this->renderSuccessMessage($params);
-                $content        = str_ireplace(self::successmessage, $successMessage, $content);
-            }
+            $content = $this->handlePreferenceCenterReplacements($content, $params);
         }
 
-        $clickThrough = ['source' => ['page', $page->getId()]];
-        $tokens       = $this->tokenHelper->findPageTokens($content, $clickThrough);
-
-        if ([] !== $tokens) {
+        if ($tokens = $this->tokenHelper->findPageTokens($content, ['source' => ['page', $page->getId()]])) {
             $content = str_ireplace(array_keys($tokens), $tokens, $content);
         }
 
@@ -480,217 +380,298 @@ class BuilderSubscriber implements EventSubscriberInterface
         $event->setContent($content);
     }
 
-    /**
-     * Renders the HTML for the social share buttons.
-     *
-     * @return string
-     */
-    private function renderSocialShareButtons()
+    private function replaceCommonTokens(string $content, Page $page): string
     {
-        static $content = '';
+        return str_ireplace([
+            static::langBarRegex,
+            static::shareButtonsRegex,
+            static::titleRegex,
+            static::descriptionRegex,
+            static::successmessage,
+        ], [
+            false !== strpos($content, static::langBarRegex) ? $this->renderLanguageBar($page) : '',
+            false !== strpos($content, static::shareButtonsRegex) ? $this->renderSocialShareButtons() : '',
+            false !== strpos($content, static::titleRegex) ? $page->getTitle() : '',
+            false !== strpos($content, static::descriptionRegex) ? $page->getMetaDescription() : '',
+            false !== strpos($content, static::successmessage) ? $this->renderSuccessMessage() : '',
+        ], $content);
+    }
 
-        if (empty($content)) {
-            $shareButtons = $this->integrationHelper->getShareButtons();
+    /**
+     * @param array<string,mixed> $params
+     */
+    private function handlePreferenceCenterReplacements(string $content, array $params): string
+    {
+        $xpath = $this->createDOMXPathForContent($content);
 
-            $content = "<div class='share-buttons'>\n";
-            foreach ($shareButtons as $button) {
-                $content .= $button;
-            }
-            $content .= "</div>\n";
-
-            // load the css into the header by calling the sharebtn_css view
-            $this->twig->render('@MauticPage/SubscribedEvents/PageToken/sharebtn_css.html.twig');
+        if ($saveButton = $xpath->query('//*[@data-slot="saveprefsbutton"]//a')->item(0)) {
+            $params['saveprefsbutton'] = [
+                'style'      => $saveButton->getAttribute('style'),
+                'background' => $saveButton->getAttribute('background'),
+            ];
         }
 
-        return $content;
-    }
+        $slotNamesAndConfig = [
+            'segmentlist'      => [static::segmentListRegex, (bool) $params['showContactSegments']],
+            'categorylist'     => [static::categoryListRegex, (bool) $params['showContactCategories']],
+            'preferredchannel' => [static::preferredchannel, (bool) $params['showContactPreferredChannels']],
+            'channelfrequency' => [static::channelfrequency, (bool) ($params['showContactFrequency'] || $params['showContactPauseDates'])],
+            'saveprefsbutton'  => [static::saveprefsRegex, true],
+        ];
 
-    private function getAttributeForFirtSlot(): string
-    {
-        return 'data-prefs-center-first="1"';
-    }
-
-    /**
-     * Renders the HTML for the segment list.
-     *
-     * @return string
-     */
-    private function renderSegmentList(array $params = [])
-    {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class='pref-segmentlist' ".$this->getAttributeForFirtSlot().">\n";
-            $content .= $this->twig->render('@MauticCore/Slots/segmentlist.html.twig', $params);
-            $content .= "</div>\n";
+        foreach ($slotNamesAndConfig as $slotName => list($tokenValue, $shouldShow)) {
+            $this->setSlotContentToTokenForReplacement($xpath, $slotName, $tokenValue, $shouldShow);
         }
 
-        return $content;
+        $content = $this->replacePreferenceCenterTokens($xpath->document->saveHTML(), $params);
+
+        return $this->wrapPreferenceCenterInFormTag($content, $params);
+    }
+
+    private function replacePreferenceCenterTokens(string $content, array $params): string
+    {
+        return str_ireplace([
+            static::segmentListRegex,
+            static::categoryListRegex,
+            static::preferredchannel,
+            static::channelfrequency,
+            static::saveprefsRegex,
+        ], [
+            false !== strpos($content, static::segmentListRegex) ? $this->renderSegmentList($params) : '',
+            false !== strpos($content, static::categoryListRegex) ? $this->renderCategoryList($params) : '',
+            false !== strpos($content, static::preferredchannel) ? $this->renderPreferredChannel($params) : '',
+            false !== strpos($content, static::channelfrequency) ? $this->renderChannelFrequency($params) : '',
+            false !== strpos($content, static::saveprefsRegex) ? $this->renderSavePrefs($params) : '',
+        ], $content);
     }
 
     /**
-     * @return string
+     * @param mixed[] $templateParams
      */
-    private function renderCategoryList(array $params = [])
+    private function renderTemplate(string $templateName, array $templateParams, string $wrapperTemplate = '', string ...$wrapperTemplateValues): string
     {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class='pref-categorylist ' ".$this->getAttributeForFirtSlot().">\n";
-            $content .= $this->twig->render('@MauticCore/Slots/categorylist.html.twig', $params);
-            $content .= "</div>\n";
+        if (!empty($this->renderedContentCache[$templateName])) {
+            return $this->renderedContentCache[$templateName];
         }
 
-        return $content;
-    }
+        $content = $this->twig->render($templateName, $templateParams);
 
-    /**
-     * @return string
-     */
-    private function renderPreferredChannel(array $params = [])
-    {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class='pref-preferredchannel'>\n";
-            $content .= $this->twig->render('@MauticCore/Slots/preferredchannel.html.twig', $params);
-            $content .= "</div>\n";
-        }
-
-        return $content;
-    }
-
-    /**
-     * @return string
-     */
-    private function renderChannelFrequency(array $params = [])
-    {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class='pref-channelfrequency'>\n";
-            $content .= $this->twig->render('@MauticCore/Slots/channelfrequency.html.twig', $params);
-            $content .= "</div>\n";
-        }
-
-        return $content;
-    }
-
-    /**
-     * @return string
-     */
-    private function renderSavePrefs(array $params = [])
-    {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class='pref-saveprefs ' ".$this->getAttributeForFirtSlot().">\n";
-            $content .= $this->twig->render('@MauticCore/Slots/saveprefsbutton.html.twig', $params);
-            $content .= "</div>\n";
-        }
-
-        return $content;
-    }
-
-    /**
-     * @return string
-     */
-    private function renderSuccessMessage(array $params = [])
-    {
-        static $content = '';
-
-        if (empty($content)) {
-            $content = "<div class=\"pref-successmessage\">\n";
-            $content .= $this->twig->render('@MauticCore/Slots/successmessage.html.twig', $params);
-            $content .= "</div>\n";
-        }
-
-        return $content;
-    }
-
-    /**
-     * Renders the HTML for the language bar for a given page.
-     *
-     * @return string
-     */
-    private function renderLanguageBar($page)
-    {
-        static $langbar = '';
-
-        if (empty($langbar)) {
-            $parent   = $page->getTranslationParent();
-            $children = $page->getTranslationChildren();
-
-            // check to see if this page is grouped with another
-            if (empty($parent) && empty($children)) {
-                return;
+        if ($wrapperTemplate) {
+            // If the content is not empty, ensure that the $wrapperTemplate contains a place to put it.
+            if (!empty($content) && false === strpos($wrapperTemplate, '{templateContent}')) {
+                throw new InvalidArgumentException('Your $wrapperTemplate must contain the string {templateContent} where you want to insert the rendered template content.');
             }
 
-            $related = [];
+            $content = str_replace('{templateContent}', $content, sprintf($wrapperTemplate, ...$wrapperTemplateValues));
+        }
 
-            // get a list of associated pages/languages
-            if (!empty($parent)) {
-                $children = $parent->getTranslationChildren();
+        return $this->renderedContentCache[$templateName] = $content;
+    }
+
+    private function renderSocialShareButtons(): string
+    {
+        return $this->renderTemplate(
+            '@MauticPage/SubscribedEvents/PageToken/sharebtn_css.html.twig',
+            [],
+            '<div class="share-buttons">%s</div>',
+            implode($this->integrationHelper->getShareButtons())
+        );
+    }
+
+    private function renderSegmentList(array $params): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/segmentlist.html.twig',
+            $params,
+            '<div class="pref-segmentlist"%s>{templateContent}</div>',
+            static::firstSlotAttribute
+        );
+    }
+
+    private function renderCategoryList(array $params): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/categorylist.html.twig',
+            $params,
+            '<div class="pref-categorylist"%s>{templateContent}</div>',
+            static::firstSlotAttribute
+        );
+    }
+
+    private function renderPreferredChannel(array $params): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/preferredchannel.html.twig',
+            $params,
+            '<div class="pref-preferredchannel">{templateContent}</div>'
+        );
+    }
+
+    private function renderChannelFrequency(array $params): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/channelfrequency.html.twig',
+            $params,
+            '<div class="pref-channelfrequency">{templateContent}</div>'
+        );
+    }
+
+    private function renderSavePrefs(array $params): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/saveprefsbutton.html.twig',
+            $params,
+            '<div class="%s"%s>{templateContent}</div>',
+            static::saveButtonContainerClass,
+            static::firstSlotAttribute
+        );
+    }
+
+    private function renderSuccessMessage(): string
+    {
+        return $this->renderTemplate(
+            '@MauticCore/Slots/successmessage.html.twig',
+            [],
+            '<div class="pref-successmessage">{templateContent}</div>'
+        );
+    }
+
+    private function renderLanguageBar(Page $page): string
+    {
+        return $this->renderTemplate(
+            '@MauticPage/SubscribedEvents/PageToken/langbar.html.twig',
+            ['pages' => $this->getRelatedPagesForLanguageBar($page)]
+        );
+    }
+
+    /**
+     * @return array<int,mixed[]>
+     */
+    private function getRelatedPagesForLanguageBar(Page $page): array
+    {
+        $related  = [];
+        $parent   = $page->getTranslationParent();
+        $children = $page->getTranslationChildren();
+
+        if (empty($parent) && empty($children)) {
+            return $related;
+        }
+
+        // If this page has a parent, then fetch the children from the parent
+        if (!empty($parent)) {
+            $children = $parent->getTranslationChildren();
+        } else {
+            // Otherwise this is the parent page.
+            $parent = $page;
+        }
+
+        if (empty($children)) {
+            return $related;
+        }
+
+        $related[$parent->getId()] = $this->buildRelatedArrayForPage($parent);
+
+        foreach ($children as $child) {
+            $related[$child->getId()] = $this->buildRelatedArrayForPage($child);
+        }
+
+        uasort($related, function ($a, $b) {
+            return strnatcasecmp($a['lang'], $b['lang']);
+        });
+
+        return $related;
+    }
+
+    private function buildRelatedArrayForPage(Page $page): array
+    {
+        $language   = $page->getLanguage();
+        $translated = $this->translator->trans('mautic.page.lang.'.$language);
+
+        if ($translated == 'mautic.page.lang.'.$language) {
+            $translated = $language;
+        }
+
+        return [
+            'lang' => $translated,
+            // Add ntrd to not auto redirect to another language
+            'url'  => $this->pageModel->generateUrl($page, false).'?ntrd=1',
+        ];
+    }
+
+    private function setSlotContentToTokenForReplacement(DOMXPath $xpath, string $slotName, string $tokenValue, bool $shouldShow): void
+    {
+        $nodeList = $xpath->query(sprintf('//*[@data-slot="%s"]', $slotName));
+
+        /** @var DOMElement $node */
+        foreach ($nodeList as $node) {
+            if ($shouldShow) {
+                $node->nodeValue = $tokenValue;
+                $node->setAttribute('data-prefs-center', '1');
             } else {
-                $parent = $page; // parent is self
+                $node->parentNode->removeChild($node);
             }
-
-            if (!empty($children)) {
-                $lang  = $parent->getLanguage();
-                $trans = $this->translator->trans('mautic.page.lang.'.$lang);
-                if ($trans == 'mautic.page.lang.'.$lang) {
-                    $trans = $lang;
-                }
-                $related[$parent->getId()] = [
-                    'lang' => $trans,
-                    // Add ntrd to not auto redirect to another language
-                    'url'  => $this->pageModel->generateUrl($parent, false).'?ntrd=1',
-                ];
-                foreach ($children as $c) {
-                    $lang  = $c->getLanguage();
-                    $trans = $this->translator->trans('mautic.page.lang.'.$lang);
-                    if ($trans == 'mautic.page.lang.'.$lang) {
-                        $trans = $lang;
-                    }
-                    $related[$c->getId()] = [
-                        'lang' => $trans,
-                        // Add ntrd to not auto redirect to another language
-                        'url'  => $this->pageModel->generateUrl($c, false).'?ntrd=1',
-                    ];
-                }
-            }
-
-            // sort by language
-            uasort(
-                $related,
-                fn ($a, $b): int => strnatcasecmp($a['lang'], $b['lang'])
-            );
-
-            if (empty($related)) {
-                return;
-            }
-
-            $langbar = $this->twig->render('@MauticPage/SubscribedEvents/PageToken/langbar.html.twig', ['pages' => $related]);
-        }
-
-        return $langbar;
-    }
-
-    public function onEmailBuild(EmailBuilderEvent $event): void
-    {
-        if ($event->tokensRequested([$this->pageTokenRegex])) {
-            $tokenHelper = $this->builderTokenHelperFactory->getBuilderTokenHelper('page');
-            $event->addTokensFromHelper($tokenHelper, $this->pageTokenRegex, 'title', 'id', true);
         }
     }
 
-    public function onEmailGenerate(EmailSendEvent $event): void
+    private function createDOMXPathForContent(string $content): DOMXPath
     {
-        $content      = $event->getContent();
-        $plainText    = $event->getPlainText();
-        $clickthrough = $event->shouldAppendClickthrough() ? $event->generateClickthrough() : [];
-        $tokens       = $this->tokenHelper->findPageTokens($content.$plainText, $clickthrough);
+        $domDocument = new DOMDocument('1.0', 'utf-8');
+        $domDocument->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
 
-        $event->addTokens($tokens);
+        return new DOMXPath($domDocument);
+    }
+
+    private function wrapPreferenceCenterInFormTag(string $content, array $params): string
+    {
+        if (!isset($params['startform']) || false === strpos($content, 'data-prefs-center')) {
+            return $content;
+        }
+
+        $xpath = $this->createDOMXPathForContent($content);
+        $node  = $this->getFirstNodeThatContainsAPreferenceCenterSlot($xpath);
+
+        if (null === $node) {
+            return $content;
+        }
+
+        $parentNode = $this->getFirstParentNodeThatContainsAllFormInputs($node);
+
+        $parentNode->insertBefore(new DOMElement('startform'), $parentNode->firstChild);
+        $parentNode->appendChild(new DOMElement('endform'));
+
+        return str_replace(['<startform></startform>', '<endform></endform>'], [$params['startform'], '</form>'], $xpath->document->saveHTML());
+    }
+
+    private function getFirstNodeThatContainsAPreferenceCenterSlot(DOMXPath $xpath): ?DOMNode
+    {
+        // Query if we're using slots.
+        $nodeList = $xpath->query('//*[@data-prefs-center="1"]');
+
+        if (!$nodeList->length) {
+            // If slots aren't found, query for tokens
+            $nodeList = $xpath->query('//*[@data-prefs-center-first="1"]');
+        }
+
+        if (false !== $nodeList) {
+            return $nodeList->item(0);
+        }
+
+        return null;
+    }
+
+    private function getFirstParentNodeThatContainsAllFormInputs(DOMNode $node): DOMNode
+    {
+        $content = implode(array_map([$node->ownerDocument, 'saveHTML'], iterator_to_array($node->childNodes)));
+
+        // Check if the save button exists in the content. If not, try again with the parentNode.
+        if (false === strpos($content, static::saveButtonContainerClass)) {
+            if (null === $node->parentNode) {
+                throw new RuntimeException("Can't get parent node of #document. Did you forget to insert a save button in your preference center form?");
+            }
+
+            return $this->getFirstParentNodeThatContainsAllFormInputs($node->parentNode);
+        }
+
+        return $node;
     }
 }

--- a/app/bundles/PageBundle/Resources/views/SubscribedEvents/PageToken/langbar.html.twig
+++ b/app/bundles/PageBundle/Resources/views/SubscribedEvents/PageToken/langbar.html.twig
@@ -3,6 +3,7 @@
     - pages
 #}
 {% set count = pages|length %}
+{% if count > 0 %}
 <div class="page-lang-bar">
     {% for page in pages %}
       {% set active = app.request.requestUri == page.url %}
@@ -18,3 +19,4 @@
       {% set count = count - 1 %}
     {% endfor %}
 </div>
+{% endif %}

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -42,7 +42,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
     private function assertPageContent(string $url, string $expectedContent): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
         self::assertSame($expectedContent, $crawler->text());
     }
 

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -1,0 +1,429 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Functional\EventListener;
+
+use DateTime;
+use Generator;
+use Mautic\CategoryBundle\Entity\Category;
+use Mautic\CoreBundle\Test\AbstractMauticTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList as Segment;
+use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class BuilderSubscriberTest extends AbstractMauticTestCase
+{
+    // Custom preference center page
+    const CUSTOM_SEGMENT_SELECTOR           = '.pref-segmentlist';
+    const CUSTOM_CATEGORY_SELECTOR          = '.pref-categorylist';
+    const CUSTOM_PREFERRED_CHANNEL_SELECTOR = '.pref-preferredchannel';
+    const CUSTOM_CHANNEL_FREQ_SELECTOR      = '.pref-channelfrequency';
+    const CUSTOM_SAVE_BUTTON_SELECTOR       = '.prefs-saveprefs';
+
+    // Default preference center page
+    const DEFAULT_SEGMENT_SELECTOR           = '#contact-segments';
+    const DEFAULT_CATEGORY_SELECTOR          = '#global-categories';
+    const DEFAULT_PREFERRED_CHANNEL_SELECTOR = '#preferred_channel';
+    const DEFAULT_CHANNEL_FREQ_SELECTOR      = '[data-contact-frequency="1"]';
+    const DEFAULT_PAUSE_DATES_SELECTOR       = '[data-contact-pause-dates="1"]';
+    const DEFAULT_SAVE_BUTTON_SELECTOR       = '#lead_contact_frequency_rules_buttons_save';
+
+    // Common to both custom and default
+    const TOKEN_SELECTOR = '#lead_contact_frequency_rules__token';
+    const FORM_SELECTOR  = 'form[name="lead_contact_frequency_rules"]';
+
+    /**
+     * Tests both the default and custom preference center pages.
+     *
+     * @dataProvider frequencyFormRenderingDataProvider
+     */
+    public function testUnsubscribeFormRendersPreferenceCenterPageCorrectly(array $configParams, array $selectorsAndExpectedCounts, bool $hasPreferenceCenter): void
+    {
+        $this->setUpSymfony(array_merge(['show_contact_preferences' => 1], $configParams));
+
+        $emailStat = $this->createStat(
+            $this->createEmail($hasPreferenceCenter),
+            $lead = $this->createLead()
+        );
+
+        $this->createSegment();
+        $this->createCategory();
+
+        $this->em->flush();
+
+        $unsubscribeUrl = $this->router->generate('mautic_email_unsubscribe', [
+            'idHash'     => $emailStat->getTrackingHash(),
+            'urlEmail'   => $lead->getEmail(),
+            'secretHash' => self::$container->get('mautic.helper.mailer_hash')->getEmailHash($lead->getEmail()),
+        ], UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        $crawler = $this->client->request('GET', $unsubscribeUrl);
+        $form    = $crawler->filter(static::FORM_SELECTOR);
+        $html    = $form->html();
+
+        foreach ($selectorsAndExpectedCounts as $selector => $expectedCount) {
+            $message = sprintf(
+                'The form HTML %s not contain the %s section. %s',
+                0 === $expectedCount ? 'should' : 'does',
+                $selector,
+                $html
+            );
+
+            Assert::assertCount(
+                $expectedCount,
+                $form->filter($selector),
+                $message
+            );
+        }
+
+        // Ensure the token and save button are always included within the <form> tag
+        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $html));
+
+        if ($hasPreferenceCenter) {
+            Assert::assertCount(1, $form->filter(static::CUSTOM_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
+        } else {
+            Assert::assertCount(1, $form->filter(static::DEFAULT_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
+        }
+    }
+
+    public function frequencyFormRenderingDataProvider(): Generator
+    {
+        // Custom Preference Center: All preferences enabled
+        yield [
+            [
+                'show_contact_segments'           => 1,
+                'show_contact_categories'         => 1,
+                'show_contact_preferred_channels' => 1,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Custom Preference Center: Segments & Categories disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 1,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Custom Preference Center: Preferred Channels & Frequency disabled
+        yield [
+            [
+                'show_contact_segments'           => 1,
+                'show_contact_categories'         => 1,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Custom Preference Center: Frequency enabled & Pause Dates disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Custom Preference Center: Frequency disabled & Pause Dates enabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Custom Preference Center: All preferences disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+            ],
+            true,
+        ];
+
+        // Default Preference Center: All preferences enabled
+        yield [
+            [
+                'show_contact_segments'           => 1,
+                'show_contact_categories'         => 1,
+                'show_contact_preferred_channels' => 1,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+
+        // Default Preference Center: Segments & Categories disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 1,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+
+        // Default Preference Center: Preferred Channels & Frequency disabled
+        yield [
+            [
+                'show_contact_segments'           => 1,
+                'show_contact_categories'         => 1,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+
+        // Default Preference Center: Frequency enabled & Pause Dates disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 1,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+
+        // Default Preference Center: Frequency disabled & Pause Dates enabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 1,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+
+        // Default Preference Center: All preferences disabled
+        yield [
+            [
+                'show_contact_segments'           => 0,
+                'show_contact_categories'         => 0,
+                'show_contact_preferred_channels' => 0,
+                'show_contact_frequency'          => 0,
+                'show_contact_pause_dates'        => 0,
+            ],
+            [
+                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+            ],
+            false,
+        ];
+    }
+
+    private function createStat(Email $email, Lead $lead): Stat
+    {
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+        $stat->setEmailAddress($lead->getEmail());
+        $stat->setDateSent(new DateTime());
+        $stat->setTrackingHash(uniqid());
+        $this->em->persist($stat);
+
+        return $stat;
+    }
+
+    private function createEmail(bool $hasPreferenceCenter = true): Email
+    {
+        $email = new Email();
+        $email->setName('Example');
+
+        if ($hasPreferenceCenter) {
+            $email->setPreferenceCenter($this->createPage());
+        }
+
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setEmail('test@example.com');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createSegment(): Segment
+    {
+        $segment = new Segment();
+        $segment->setName('My Segment');
+        $segment->setPublicName('My Segment');
+        $segment->setAlias('my-segment');
+        $segment->setIsPreferenceCenter(true);
+        $this->em->persist($segment);
+
+        return $segment;
+    }
+
+    private function createCategory(): Category
+    {
+        $category = new Category();
+        $category->setTitle('My Category');
+        $category->setAlias('my-category');
+        $category->setIsPublished(true);
+        $category->setBundle('global');
+        $this->em->persist($category);
+
+        return $category;
+    }
+
+    private function createPage(): Page
+    {
+        $page = new Page();
+        $page->setTitle('Preference Center');
+        $page->setAlias('preference-center');
+        $page->setIsPreferenceCenter(true);
+        $page->setContent($this->getPageContent());
+        $page->setCustomHtml($this->getPageContent());
+        $page->setIsPublished(true);
+        $this->em->persist($page);
+
+        return $page;
+    }
+
+    private function getPageContent(): string
+    {
+        return <<<PAGE
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+    <title>{pagetitle}</title>
+    <meta name="description" content="{pagemetadescription}">
+</head>
+<body>
+    <div>
+        {langbar}
+        {sharebuttons}
+    </div>
+    <div>
+        {successmessage}
+        <div>
+            <div data-slot="segmentlist"></div>
+        </div>
+        <div>
+            <div data-slot="categorylist"></div>
+        </div>
+        <div>
+            <div data-slot="preferredchannel"></div>
+        </div>
+        <div>
+            <div data-slot="channelfrequency"></div>
+        </div>
+        <div>
+            <div data-slot="saveprefsbutton"></div>
+        </div>
+    </div>
+</body>
+</html>
+PAGE;
+    }
+}

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -68,8 +68,11 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         ], UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $crawler = $this->client->request('GET', $unsubscribeUrl);
-        $form    = $crawler->filter(static::FORM_SELECTOR);
-        $html    = $form->html();
+
+        self::assertTrue($this->client->getResponse()->isSuccessful(), $this->client->getResponse()->getContent());
+
+        $form = $crawler->filter(static::FORM_SELECTOR);
+        $html = $form->html();
 
         foreach ($selectorsAndExpectedCounts as $selector => $expectedCount) {
             $message = sprintf(

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -15,6 +15,11 @@ use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
+ */
 class BuilderSubscriberTest extends AbstractMauticTestCase
 {
     // Custom preference center page
@@ -46,7 +51,7 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
      */
     public function testUnsubscribeFormRendersPreferenceCenterPageCorrectly(array $configParams, array $selectorsAndExpectedCounts, bool $hasPreferenceCenter): void
     {
-        $this->setUpSymfony(array_merge(['show_contact_preferences' => 1], $configParams));
+        $this->setUpSymfony(array_merge(['show_contact_preferences' => 1], $configParams, $this->configParams));
 
         $emailStat = $this->createStat(
             $this->createEmail($hasPreferenceCenter),

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
@@ -9,12 +9,14 @@ use Mautic\CoreBundle\Event\CustomAssetsEvent;
 use Mautic\InstallBundle\Install\InstallService;
 use MauticPlugin\GrapesJsBuilderBundle\Integration\Config;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AssetsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private Config $config,
-        private InstallService $installer
+        private InstallService $installer,
+        private RequestStack $requestStack
     ) {
     }
 
@@ -27,12 +29,21 @@ class AssetsSubscriber implements EventSubscriberInterface
 
     public function injectAssets(CustomAssetsEvent $assetsEvent): void
     {
-        if (!$this->installer->checkIfInstalled()) {
+        if (!$this->installer->checkIfInstalled() || !$this->isMauticAdministrationPage()) {
             return;
         }
+
         if ($this->config->isPublished()) {
             $assetsEvent->addScript('plugins/GrapesJsBuilderBundle/Assets/library/js/dist/builder.js');
             $assetsEvent->addStylesheet('plugins/GrapesJsBuilderBundle/Assets/library/js/dist/builder.css');
         }
+    }
+
+    /**
+     * Returns true for routes that starts with /s/.
+     */
+    private function isMauticAdministrationPage(): bool
+    {
+        return preg_match('/^\/s\//', $this->requestStack->getCurrentRequest()->getPathInfo()) >= 1;
     }
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | N/A
| Related developer documentation PR URL | N/A
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

~~⚠️ this PR needs a service from https://github.com/mautic/mautic/pull/10846 so this cannot be merged without merging that PR first.~~

⚠️ There is a followup ticket https://github.com/mautic/mautic/pull/11443 that fixes other issues, but this PR is big already so let's get it merged and then continue with that one.

[//]: # ( Required: )
#### Description:
This PR fixes how we're wrapping form elements on the unsubscribe / preference center page. 

In order to facilitate testing and readability, I also included many adjustments and refactorings to private methods within the BuilderSubscriber. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email with a custom preference center landing page
2. Send that email through a campaign to a user
3. Click unsubscribe and fill out the form.
4. On submit, you should receive a `CSRF token is invalid` error message

#### Steps to test this PR:
1. Redo reproduction steps
2. When you submit, the form should submit successfully
3. To test the refactoring, ensure that your preference center page has all available parts - frequency rules, segments, channels, etc.

