### PR TITLE
Preference center unsubscribe toggle fix

### DIFF
--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -23,6 +23,11 @@ class CategoryModel extends FormModel
     protected $requestStack;
 
     /**
+     * @var array
+     */
+    private $categoriesByBundleCache = [];
+
+    /**
      * CategoryModel constructor.
      */
     public function __construct(RequestStack $requestStack)
@@ -187,13 +192,12 @@ class CategoryModel extends FormModel
      */
     public function getLookupResults($bundle, $filter = '', $limit = 10)
     {
-        static $results = [];
-
         $key = $bundle.$filter.$limit;
-        if (!isset($results[$key])) {
-            $results[$key] = $this->getRepository()->getCategoryList($bundle, $filter, $limit, 0);
+
+        if (!empty($this->categoriesByBundleCache[$key])) {
+            return $this->categoriesByBundleCache[$key];
         }
 
-        return $results[$key];
+        return $this->categoriesByBundleCache[$key] = $this->getRepository()->getCategoryList($bundle, $filter, $limit, 0);
     }
 }

--- a/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/channelfrequency.html.php
@@ -21,7 +21,8 @@ $channelNumber = 0;
         <tr>
             <td>
                 <div class="text-left">
-                    <input type="hidden" id="<?php echo $channel->value; ?>"
+                    <input type="hidden"
+                           id="<?php echo $channel->value; ?>-hidden"
                            name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                            value="">
                     <input type="checkbox" id="<?php echo $channel->value; ?>"

--- a/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
@@ -48,9 +48,9 @@ if (isset($form)) {
     // that's why we can't use the bodyclose customdeclaration
     if (isset($custom_tag)) {
         echo $custom_tag;
-        $view['assets']->addCustomDeclaration($view['form']->end($form), 'customTag');
+        $view['assets']->addCustomDeclaration($view['form']->rest($form), 'customTag');
     } else {
-        $view['assets']->addCustomDeclaration($view['form']->end($form), 'bodyClose');
+        $view['assets']->addCustomDeclaration($view['form']->rest($form), 'bodyClose');
     }
 }
 ?>

--- a/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
+++ b/app/bundles/CoreBundle/Views/Slots/saveprefsbutton.html.php
@@ -16,13 +16,13 @@ if (isset($form)) {
     echo '<script src="'.$view['assets']->getUrl('app/bundles/PageBundle/Assets/js/prefcenter.js').'"></script>';
 }
 ?>
-    <a href="javascript:void(null)"
+    <button href="javascript:void(null)"
         class="button btn btn-default btn-save"
         <?php if (isset($form)) : ?>onclick="saveUnsubscribePreferences('<?php echo $form->vars['id']; ?>')"<?php endif; ?>
         style="<?php echo $style; ?>"
         background="<?php echo $background; ?>">
         <?php echo $view['translator']->trans('mautic.page.form.saveprefs'); ?>
-    </a>
+    </button>
     <div style="clear:both"></div>
 <?php
 if (isset($form)) {

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -214,18 +214,14 @@ class PublicController extends CommonFormController
                         // set custom tag to inject end form
                         // update show pref center slots by looking for their presence in the html
                         /** @var \Mautic\CoreBundle\Templating\Helper\FormHelper $formHelper */
-                        $formHelper =$this->get('templating.helper.form');
+                        $formHelper = $this->get('templating.helper.form');
                         $params     = array_merge(
-                            $viewParameters,
                             [
                                 'form'                         => $formView,
                                 'startform'                    => $formHelper->start($formView),
                                 'custom_tag'                   => '<a name="end-'.$formView->vars['id'].'"></a>',
-                                'showContactFrequency'         => false !== strpos($html, 'data-slot="channelfrequency"') || false !== strpos($html, BuilderSubscriber::channelfrequency),
-                                'showContactSegments'          => false !== strpos($html, 'data-slot="segmentlist"') || false !== strpos($html, BuilderSubscriber::segmentListRegex),
-                                'showContactCategories'        => false !== strpos($html, 'data-slot="categorylist"') || false !== strpos($html, BuilderSubscriber::categoryListRegex),
-                                'showContactPreferredChannels' => false !== strpos($html, 'data-slot="preferredchannel"') || false !== strpos($html, BuilderSubscriber::preferredchannel),
-                            ]
+                            ],
+                            $viewParameters
                         );
                         // Replace tokens in preference center page
                         $event = new PageDisplayEvent($html, $prefCenter, $params);

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -19,6 +19,7 @@ use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\EventListener\BuilderSubscriber;
 use Mautic\PageBundle\PageEvents;
 use Mautic\QueueBundle\Queue\QueueName;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Response;
 
 class PublicController extends CommonFormController
@@ -211,23 +212,23 @@ class PublicController extends CommonFormController
                     $savePrefsPresent = false !== strpos($html, 'data-slot="saveprefsbutton"') ||
                         false !== strpos($html, BuilderSubscriber::saveprefsRegex);
                     if ($savePrefsPresent) {
-                        // set custom tag to inject end form
-                        // update show pref center slots by looking for their presence in the html
-                        /** @var \Mautic\CoreBundle\Templating\Helper\FormHelper $formHelper */
-                        $formHelper = $this->get('templating.helper.form');
-                        $params     = array_merge(
+                        $showParameters  = $this->buildSlotShowParametersBasedOnContent($html, $viewParameters);
+                        $eventParameters = array_merge(
+                            $viewParameters,
+                            $showParameters,
                             [
-                                'form'                         => $formView,
-                                'startform'                    => $formHelper->start($formView),
-                                'custom_tag'                   => '<a name="end-'.$formView->vars['id'].'"></a>',
-                            ],
-                            $viewParameters
+                                'form'       => $formView,
+                                'startform'  => $this->get('templating.helper.form')->start($formView),
+                                'custom_tag' => '<a name="end-'.$formView->vars['id'].'"></a>',
+                            ]
                         );
-                        // Replace tokens in preference center page
-                        $event = new PageDisplayEvent($html, $prefCenter, $params);
-                        $this->get('event_dispatcher')
-                            ->dispatch(PageEvents::PAGE_ON_DISPLAY, $event);
+
+                        $event = new PageDisplayEvent($html, $prefCenter, $eventParameters);
+
+                        $this->get('event_dispatcher')->dispatch(PageEvents::PAGE_ON_DISPLAY, $event);
+
                         $html = $event->getContent();
+
                         if (!$session->has($successSessionName)) {
                             $successMessageDataSlots       = [
                                 'data-slot="successmessage"',
@@ -752,5 +753,39 @@ class PublicController extends CommonFormController
             ],
             $message
         );
+    }
+
+    /**
+     * The $viewParameters here have already been used to build the $form.
+     * Fields that are set to show based on the app configuration are part
+     * of the form. If the field is not configured to show, but a slot exists
+     * for that field in the content, then we need to keep the configuration
+     * value instead of letting the content determine if it should show. This
+     * is because of what was stated above - fields that are not configured to
+     * to show are not part of the form. Attempting to render them will result
+     * in an error.
+     *
+     * @param FormView $formView
+     */
+    private function buildSlotShowParametersBasedOnContent(string $content, array $viewParameters): array
+    {
+        /*
+         * Since we're going to be merging this with the $viewParameters, filter out `true` values. We do not
+         * want to change a configured value from `false` to `true` because a value of `false` in the $viewParameters
+         * means that the field is not configured to show and therefore is not part of the form. Attempting to
+         * render that field just because a slot for it exists will result in an error.
+         */
+        $showParamsBasedOnContent = array_filter([
+            'showContactFrequency'         => false !== strpos($content, 'data-slot="channelfrequency"') || false !== strpos($content, BuilderSubscriber::channelfrequency),
+            'showContactSegments'          => false !== strpos($content, 'data-slot="segmentlist"') || false !== strpos($content, BuilderSubscriber::segmentListRegex),
+            'showContactCategories'        => false !== strpos($content, 'data-slot="categorylist"') || false !== strpos($content, BuilderSubscriber::categoryListRegex),
+            'showContactPreferredChannels' => false !== strpos($content, 'data-slot="preferredchannel"') || false !== strpos($content, BuilderSubscriber::preferredchannel),
+        ], function (bool $value) { return !$value; });
+
+        $showParamsBasedOnConfiguration = array_filter($viewParameters, function ($key) {
+            return 0 === strpos($key, 'show');
+        }, ARRAY_FILTER_USE_KEY);
+
+        return array_merge($showParamsBasedOnConfiguration, $showParamsBasedOnContent);
     }
 }

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -72,7 +72,7 @@ JS;
                             <div id="frequency_<?php echo $channel->value; ?>" class="text-left row">
                                 <?php
                                 if ($showContactFrequency):?>
-                                    <div class="col-md-6">
+                                    <div class="col-md-6" data-contact-frequency="1">
                                         <label class="text-muted"><?php echo $view['translator']->trans($form['lead_channels']['frequency_number_'.$channel->value]->vars['label']); ?></label>
                                         <?php echo $view['form']->widget($form['lead_channels']['frequency_number_'.$channel->value]); ?>
                                         <?php echo $view['form']->label($form['lead_channels']['frequency_time_'.$channel->value]); ?>
@@ -83,7 +83,7 @@ JS;
                                     unset($form['lead_channels']['frequency_number_'.$channel->value]);
                                 endif; ?>
                                 <?php if ($showContactPauseDates):?>
-                                    <div class="col-md-6">
+                                    <div class="col-md-6" data-contact-pause-dates="1">
                                         <label class="text-muted"><?php echo $view['translator']->trans('mautic.lead.frequency.dates.label'); ?></label>
                                         <?php echo $view['form']->widget($form['lead_channels']['contact_pause_start_date_'.$channel->value]); ?>
                                         <?php echo $view['form']->label($form['lead_channels']['contact_pause_end_date_'.$channel->value]); ?>

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -54,7 +54,7 @@ JS;
                     <tr>
                         <td>
                             <div class="text-left">
-                                <input type="hidden" id="<?php echo $channel->value; ?>"
+                                <input type="hidden" id="<?php echo $channel->value; ?>-hidden"
                                        name="lead_contact_frequency_rules[lead_channels][subscribed_channels][<?php echo $key; ?>]"
                                        value="">
                                 <input type="checkbox" id="<?php echo $channel->value; ?>"

--- a/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
+++ b/app/bundles/EmailBundle/Views/Lead/preference_options.html.php
@@ -107,41 +107,40 @@ JS;
                 else:
                     unset($form['lead_channels']['preferred_channel']);
                 endif; ?>
-                <?php if ($showContactSegments && count($form['lead_lists'])):?>
-                <hr />
-                <div id="contact-segments"> <div class="text-left"><?php echo  $view['form']->label($form['lead_lists']); ?></div>
-                    <?php
-                    foreach ($form['lead_lists'] as $key=>$leadList) {
-                        ?>
-                        <div id="segment-<?php echo $key; ?>" class="text-left">
-                            <?php echo $view['form']->widget($leadList); ?>
-                            <?php echo $view['form']->label($leadList); ?>
-                        </div>
-                    <?php
-                    }
 
-                    unset($form['lead_lists']);
-                    ?>
+                <?php if ($showContactSegments && count($form['lead_lists']->vars['choices'])):?>
+                    <hr />
+                    <div id="contact-segments"> <div class="text-left"><?php echo  $view['form']->label($form['lead_lists']); ?></div>
+                        <?php
+                        $segmentNumber = count($form['lead_lists']->vars['choices']);
+                        for ($i = ($segmentNumber - 1); $i >= 0; --$i): ?>
+                            <div id="segment-<?php echo $i; ?>" class="text-left">
+                                <?php echo $view['form']->widget($form['lead_lists'][$i]); ?>
+                                <?php echo $view['form']->label($form['lead_lists'][$i]); ?>
+                            </div>
+                        <?php
+                        endfor;
+                        unset($form['lead_lists']);
+                        ?>
                 </div>
                     <?php
                 else:
                     unset($form['lead_lists']);
                 endif; ?>
-                <?php if ($showContactCategories && count($form['global_categories'])):?>
-                <hr />
-                <div id="global-categories" class="text-left">
-                    <div><?php echo  $view['form']->label($form['global_categories']); ?></div>
-                    <?php $categoryNumber = count($form['global_categories']->vars['choices']);
-                    for ($i = ($categoryNumber - 1); $i >= 0; --$i): ?>
-                        <div id="category-<?php echo $i; ?>" class="text-left">
-                            <?php echo $view['form']->widget($form['global_categories'][$i]); ?>
-                            <?php echo $view['form']->label($form['global_categories'][$i]); ?>
-                        </div>
-                    <?php
-                    endfor;
-                    unset($form['global_categories']);
-                    ?>
-                </div>
+                <?php if ($showContactCategories && count($form['global_categories']->vars['choices'])):?>
+                    <hr />
+                    <div id="global-categories" class="text-left">
+                        <div><?php echo  $view['form']->label($form['global_categories']); ?></div>
+                        <?php $categoryNumber = count($form['global_categories']->vars['choices']);
+                        for ($i = ($categoryNumber - 1); $i >= 0; --$i): ?>
+                            <div id="category-<?php echo $i; ?>" class="text-left">
+                                <?php echo $view['form']->widget($form['global_categories'][$i]); ?>
+                                <?php echo $view['form']->label($form['global_categories'][$i]); ?>
+                            </div>
+                        <?php
+                        endfor;
+                        ?>
+                    </div>
                 <?php
                 else:
                     unset($form['global_categories']);

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -965,9 +965,8 @@ Mautic.toggleLeadList = function(toggleId, leadId, listId) {
 
 Mautic.togglePreferredChannel = function(channel) {
     if (channel === 'all') {
-        var channelsForm = mQuery('form[name="contact_channels"]');
-        var status = channelsForm.find('#contact_channels_subscribed_channels_0:checked').length;
-        channelsForm.find('tbody input:checkbox').each(function() {
+        var status = document.getElementById('lead_contact_frequency_rules_subscribed_channels_0').checked;
+        mQuery('div#channels tbody th input:checkbox').each(function() {
             if (this.checked != status) {
                 this.checked = status;
                 Mautic.setPreferredChannel(this.value);
@@ -979,22 +978,23 @@ Mautic.togglePreferredChannel = function(channel) {
 };
 
 Mautic.setPreferredChannel = function(channel) {
-    mQuery( '#frequency_' + channel ).slideToggle();
-    mQuery( '#frequency_' + channel ).removeClass('hide');
+    mQuery('#frequency_' + channel).slideToggle();
+    mQuery('#frequency_' + channel).removeClass('hide');
+    const idPrefix = '#lead_contact_frequency_rules_lead_channels_';
     if (mQuery('#' + channel)[0].checked) {
         mQuery('#is-contactable-' + channel).removeClass('text-muted');
-        mQuery('#lead_contact_frequency_rules_frequency_number_' + channel).prop("disabled" , false).trigger("chosen:updated");
+        mQuery(idPrefix + 'frequency_number_' + channel).prop("disabled" , false).trigger("chosen:updated");
         mQuery('#preferred_' + channel).prop("disabled" , false);
-        mQuery('#lead_contact_frequency_rules_frequency_time_' + channel).prop("disabled" , false).trigger("chosen:updated");
-        mQuery('#lead_contact_frequency_rules_contact_pause_start_date_' + channel).prop("disabled" , false);
-        mQuery('#lead_contact_frequency_rules_contact_pause_end_date_' + channel).prop("disabled" , false);
+        mQuery(idPrefix + 'frequency_time_' + channel).prop("disabled" , false).trigger("chosen:updated");
+        mQuery(idPrefix + 'contact_pause_start_date' + channel).prop("disabled" , false);
+        mQuery(idPrefix + 'contact_pause_end_date_' + channel).prop("disabled" , false);
     } else {
         mQuery('#is-contactable-' + channel).addClass('text-muted');
-        mQuery('#lead_contact_frequency_rules_frequency_number_' + channel).prop("disabled" , true).trigger("chosen:updated");
+        mQuery(idPrefix + 'frequency_number_' + channel).prop("disabled" , true).trigger("chosen:updated");
         mQuery('#preferred_' + channel).prop("disabled" , true);
-        mQuery('#lead_contact_frequency_rules_frequency_time_' + channel).prop("disabled" , true).trigger("chosen:updated");
-        mQuery('#lead_contact_frequency_rules_contact_pause_start_date_' + channel).prop("disabled" , true);
-        mQuery('#lead_contact_frequency_rules_contact_pause_end_date_' + channel).prop("disabled" , true);
+        mQuery(idPrefix + 'frequency_time_' + channel).prop("disabled" , true).trigger("chosen:updated");
+        mQuery(idPrefix + 'contact_pause_start_date' + channel).prop("disabled" , true);
+        mQuery(idPrefix + 'contact_pause_end_date_' + channel).prop("disabled" , true);
     }
 };
 

--- a/app/bundles/PageBundle/Assets/js/prefcenter.js
+++ b/app/bundles/PageBundle/Assets/js/prefcenter.js
@@ -52,17 +52,15 @@ if (typeof MauticPrefCenterLoaded === 'undefined') {
     }
 
     function togglePreferredChannel(channel) {
-        var status = document.getElementById(channel).checked;
-        if (status) {
-            document.getElementById('lead_contact_frequency_rules_frequency_number_' + channel).disabled = false;
-            document.getElementById('lead_contact_frequency_rules_frequency_time_' + channel).disabled = false;
-            document.getElementById('lead_contact_frequency_rules_contact_pause_start_date_' + channel).disabled = false;
-            document.getElementById('lead_contact_frequency_rules_contact_pause_end_date_' + channel).disabled = false;
-        } else {
-            document.getElementById('lead_contact_frequency_rules_frequency_number_' + channel).disabled = true;
-            document.getElementById('lead_contact_frequency_rules_frequency_time_' + channel).disabled = true;
-            document.getElementById('lead_contact_frequency_rules_contact_pause_start_date_' + channel).disabled = true;
-            document.getElementById('lead_contact_frequency_rules_contact_pause_end_date_' + channel).disabled = true;
+        const checkbox = document.querySelector('input[type="checkbox"]#' + channel);
+        const status = checkbox.checked;
+        const idPrefix = 'lead_contact_frequency_rules_lead_channels_';
+        const inputs = ['frequency_number_', 'frequency_time_', 'contact_pause_start_date_', 'contact_pause_end_date_'];
+        for (let i = 0; i < inputs.length; i++) {
+            var element = document.getElementById(idPrefix + inputs[i] + channel);
+            if (element) {
+                element.disabled = !status;
+            }
         }
     }
 

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -424,11 +424,11 @@ class BuilderSubscriber implements EventSubscriberInterface
             static::descriptionRegex,
             static::successmessage,
         ], [
-            $this->renderLanguageBar($page),
-            $this->renderSocialShareButtons(),
-            $page->getTitle(),
-            $page->getMetaDescription(),
-            $this->renderSuccessMessage(),
+            false !== strpos($content, static::langBarRegex) ? $this->renderLanguageBar($page) : '',
+            false !== strpos($content, static::shareButtonsRegex) ? $this->renderSocialShareButtons() : '',
+            false !== strpos($content, static::titleRegex) ? $page->getTitle() : '',
+            false !== strpos($content, static::descriptionRegex) ? $page->getMetaDescription() : '',
+            false !== strpos($content, static::successmessage) ? $this->renderSuccessMessage() : '',
         ], $content);
     }
 
@@ -469,11 +469,11 @@ class BuilderSubscriber implements EventSubscriberInterface
             static::channelfrequency,
             static::saveprefsRegex,
         ], [
-            $this->renderSegmentList($params),
-            $this->renderCategoryList($params),
-            $this->renderPreferredChannel($params),
-            $this->renderChannelFrequency($params),
-            $this->renderSavePrefs($params),
+            false !== strpos($content, static::segmentListRegex) ? $this->renderSegmentList($params) : '',
+            false !== strpos($content, static::categoryListRegex) ? $this->renderCategoryList($params) : '',
+            false !== strpos($content, static::preferredchannel) ? $this->renderPreferredChannel($params) : '',
+            false !== strpos($content, static::channelfrequency) ? $this->renderChannelFrequency($params) : '',
+            false !== strpos($content, static::saveprefsRegex) ? $this->renderSavePrefs($params) : '',
         ], $content);
     }
 

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -386,9 +386,13 @@ class BuilderSubscriber implements EventSubscriberInterface
 
     public function onPageDisplay(Events\PageDisplayEvent $event)
     {
+        if (empty($content = $event->getContent())) {
+            return;
+        }
+
         $page    = $event->getPage();
         $params  = $event->getParams();
-        $content = $this->replaceCommonTokens($event->getContent(), $page);
+        $content = $this->replaceCommonTokens($content, $page);
 
         if ($page->getIsPreferenceCenter()) {
             $content = $this->handlePreferenceCenterReplacements($content, $params);

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -631,10 +631,7 @@ class BuilderSubscriber implements EventSubscriberInterface
         for ($i = 0; $i < $nodeList->length; ++$i) {
             $slot            = $nodeList->item($i);
             $slot->nodeValue = $tokenValue;
-
-            if (static::successmessage !== $tokenValue) {
-                $slot->setAttribute('data-prefs-center', '1');
-            }
+            $slot->setAttribute('data-prefs-center', '1');
         }
     }
 

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -83,27 +83,25 @@ class BuilderSubscriber implements EventSubscriberInterface
      */
     private $pageModel;
 
-    const pageTokenRegex           = '{pagelink=(.*?)}';
-    const dwcTokenRegex            = '{dwc=(.*?)}';
-    const langBarRegex             = '{langbar}';
-    const shareButtonsRegex        = '{sharebuttons}';
-    const titleRegex               = '{pagetitle}';
-    const descriptionRegex         = '{pagemetadescription}';
-    const segmentListRegex         = '{segmentlist}';
-    const categoryListRegex        = '{categorylist}';
-    const channelfrequency         = '{channelfrequency}';
-    const preferredchannel         = '{preferredchannel}';
-    const saveprefsRegex           = '{saveprefsbutton}';
-    const successmessage           = '{successmessage}';
-    const identifierToken          = '{leadidentifier}';
-    const saveButtonContainerClass = 'prefs-saveprefs';
-    const firstSlotAttribute       = ' data-prefs-center-first="1"';
+    public const pageTokenRegex           = '{pagelink=(.*?)}';
+    public const dwcTokenRegex            = '{dwc=(.*?)}';
+    public const langBarRegex             = '{langbar}';
+    public const shareButtonsRegex        = '{sharebuttons}';
+    public const titleRegex               = '{pagetitle}';
+    public const descriptionRegex         = '{pagemetadescription}';
+    public const segmentListRegex         = '{segmentlist}';
+    public const categoryListRegex        = '{categorylist}';
+    public const channelfrequency         = '{channelfrequency}';
+    public const preferredchannel         = '{preferredchannel}';
+    public const saveprefsRegex           = '{saveprefsbutton}';
+    public const successmessage           = '{successmessage}';
+    public const identifierToken          = '{leadidentifier}';
+    public const saveButtonContainerClass = 'prefs-saveprefs';
+    public const firstSlotAttribute       = ' data-prefs-center-first="1"';
+    public const prefCenterAttribute      = ' data-prefs-center="1"';
 
     private $renderedContentCache  = [];
 
-    /**
-     * BuilderSubscriber constructor.
-     */
     public function __construct(
         CorePermissions $security,
         TokenHelper $tokenHelper,
@@ -513,7 +511,8 @@ class BuilderSubscriber implements EventSubscriberInterface
             'MauticCoreBundle:Slots:segmentlist.html.php',
             $params,
             '<div class="pref-segmentlist"%s>{templateContent}</div>',
-            static::firstSlotAttribute
+            static::firstSlotAttribute,
+            static::prefCenterAttribute
         );
     }
 
@@ -523,7 +522,8 @@ class BuilderSubscriber implements EventSubscriberInterface
             'MauticCoreBundle:Slots:categorylist.html.php',
             $params,
             '<div class="pref-categorylist"%s>{templateContent}</div>',
-            static::firstSlotAttribute
+            static::firstSlotAttribute,
+            static::prefCenterAttribute
         );
     }
 
@@ -532,7 +532,8 @@ class BuilderSubscriber implements EventSubscriberInterface
         return $this->renderTemplate(
             'MauticCoreBundle:Slots:preferredchannel.html.php',
             $params,
-            '<div class="pref-preferredchannel">{templateContent}</div>'
+            '<div class="pref-preferredchannel"%s>{templateContent}</div>',
+            static::prefCenterAttribute
         );
     }
 
@@ -541,7 +542,8 @@ class BuilderSubscriber implements EventSubscriberInterface
         return $this->renderTemplate(
             'MauticCoreBundle:Slots:channelfrequency.html.php',
             $params,
-            '<div class="pref-channelfrequency">{templateContent}</div>'
+            '<div class="pref-channelfrequency"%s>{templateContent}</div>',
+            static::prefCenterAttribute
         );
     }
 
@@ -552,7 +554,8 @@ class BuilderSubscriber implements EventSubscriberInterface
             $params,
             '<div class="%s"%s>{templateContent}</div>',
             static::saveButtonContainerClass,
-            static::firstSlotAttribute
+            static::firstSlotAttribute,
+            static::prefCenterAttribute
         );
     }
 

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -4,17 +4,86 @@ declare(strict_types=1);
 
 namespace Mautic\PageBundle\Tests\Functional\EventListener;
 
+use DateTime;
+use Mautic\CoreBundle\Test\AbstractMauticTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
-use Mautic\PageBundle\Event\PageDisplayEvent;
-use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class BuilderSubscriberTest extends WebTestCase
+class BuilderSubscriberTest extends AbstractMauticTestCase
 {
-    public function testOnPageDisplayCorrectlyWrapsForm(): void
+    const TOKEN_SELECTOR       = '#lead_contact_frequency_rules__token';
+    const SAVE_BUTTON_SELECTOR = '#lead_contact_frequency_rules_buttons_save';
+    const FORM_SELECTOR        = 'form[name="lead_contact_frequency_rules"]';
+
+    public function testOnPageDisplayCorrectlyWrapsAllFrequencyFormInputsIncludingTokenAndSaveButton(): void
     {
-        $subscriber = static::$kernel->getContainer()->get('mautic.pagebuilder.subscriber');
-        //$event      = new PageDisplayEvent($this->getPageContent(), new Page(), )
+        $emailStat = $this->createStat(
+            $email = $this->createEmail(),
+            $lead  = $this->createLead()
+        );
+
+        $this->em->flush();
+
+        $unsubscribeUrl = $this->router->generate('mautic_email_unsubscribe', [
+            'idHash'     => $emailStat->getTrackingHash(),
+            'urlEmail'   => $lead->getEmail(),
+            'secretHash' => $this->container->get('mautic.helper.mailer_hash')->getEmailHash($lead->getEmail()),
+        ], UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        $crawler = $this->client->request('GET', $unsubscribeUrl);
+        $form    = $crawler->filter(static::FORM_SELECTOR);
+
+        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR));
+        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR));
+    }
+
+    private function createStat(Email $email, Lead $lead): Stat
+    {
+        $stat = new Stat();
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+        $stat->setEmailAddress($lead->getEmail());
+        $stat->setDateSent(new DateTime());
+        $stat->setTrackingHash(uniqid());
+        $this->em->persist($stat);
+
+        return $stat;
+    }
+
+    private function createEmail(): Email
+    {
+        $email = new Email();
+        $email->setName('Example');
+        $email->setPreferenceCenter($this->createPage());
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setEmail('test@example.com');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createPage(): Page
+    {
+        $page = new Page();
+        $page->setTitle('Preference Center');
+        $page->setAlias('preference-center');
+        $page->setIsPreferenceCenter(true);
+        $page->setContent($this->getPageContent());
+        $page->setIsPublished(true);
+        $this->em->persist($page);
+
+        return $page;
     }
 
     private function getPageContent(): string
@@ -30,11 +99,7 @@ class BuilderSubscriberTest extends WebTestCase
         <div data-slot="channelfrequency"></div>
     </div>
     <div>
-        <div data-slot="saveprefsbutton">
-            <a href="javascript:void(null)" class="button btn btn-default btn-save" style="display:inline-block;text-decoration:none;border-color:#4e5d9d;border-width: 10px 20px;border-style:solid;-webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; background-color: #4e5d9d; font-size: 16px; color: #ffffff;">
-                Save preferences
-            </a>        
-        </div>
+        <div data-slot="saveprefsbutton"></div>
     </div>
 </body>
 </html>

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -37,8 +37,8 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         $crawler = $this->client->request('GET', $unsubscribeUrl);
         $form    = $crawler->filter(static::FORM_SELECTOR);
 
-        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token.', $form->html()));
-        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button.', $form->html()));
+        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $form->html()));
+        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $form->html()));
     }
 
     private function createStat(Email $email, Lead $lead): Stat

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -19,6 +19,10 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
     const SAVE_BUTTON_SELECTOR = '.prefs-saveprefs';
     const FORM_SELECTOR        = 'form[name="lead_contact_frequency_rules"]';
 
+    protected $configParams = [
+        'show_contact_preferences' => 1,
+    ];
+
     public function testOnPageDisplayCorrectlyWrapsAllFrequencyFormInputsIncludingTokenAndSaveButton(): void
     {
         $emailStat = $this->createStat(

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -37,8 +37,8 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         $crawler = $this->client->request('GET', $unsubscribeUrl);
         $form    = $crawler->filter(static::FORM_SELECTOR);
 
-        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR));
-        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR));
+        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token.', $form->html()));
+        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button.', $form->html()));
     }
 
     private function createStat(Email $email, Lead $lead): Stat

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Functional\EventListener;
+
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Event\PageDisplayEvent;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class BuilderSubscriberTest extends WebTestCase
+{
+    public function testOnPageDisplayCorrectlyWrapsForm(): void
+    {
+        $subscriber = static::$kernel->getContainer()->get('mautic.pagebuilder.subscriber');
+        //$event      = new PageDisplayEvent($this->getPageContent(), new Page(), )
+    }
+
+    private function getPageContent(): string
+    {
+        return <<<PAGE
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+    <title>{pagetitle}</title>
+</head>
+<body>
+    <div>
+        <div data-slot="channelfrequency"></div>
+    </div>
+    <div>
+        <div data-slot="saveprefsbutton">
+            <a href="javascript:void(null)" class="button btn btn-default btn-save" style="display:inline-block;text-decoration:none;border-color:#4e5d9d;border-width: 10px 20px;border-style:solid;-webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px; background-color: #4e5d9d; font-size: 16px; color: #ffffff;">
+                Save preferences
+            </a>        
+        </div>
+    </div>
+</body>
+</html>
+PAGE;
+    }
+}

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -26,8 +26,6 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
             $lead  = $this->createLead()
         );
 
-        $this->em->flush();
-
         $unsubscribeUrl = $this->router->generate('mautic_email_unsubscribe', [
             'idHash'     => $emailStat->getTrackingHash(),
             'urlEmail'   => $lead->getEmail(),
@@ -37,8 +35,8 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         $crawler = $this->client->request('GET', $unsubscribeUrl);
         $form    = $crawler->filter(static::FORM_SELECTOR);
 
-        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $form->html()));
-        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $form->html()));
+        Assert::assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $crawler->html()));
+        Assert::assertCount(1, $form->filter(static::SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $crawler->html()));
     }
 
     private function createStat(Email $email, Lead $lead): Stat
@@ -50,6 +48,7 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         $stat->setDateSent(new DateTime());
         $stat->setTrackingHash(uniqid());
         $this->em->persist($stat);
+        $this->em->flush();
 
         return $stat;
     }

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -79,6 +79,7 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         $page->setAlias('preference-center');
         $page->setIsPreferenceCenter(true);
         $page->setContent($this->getPageContent());
+        $page->setCustomHtml($this->getPageContent());
         $page->setIsPublished(true);
         $this->em->persist($page);
 

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class BuilderSubscriberTest extends AbstractMauticTestCase
 {
     const TOKEN_SELECTOR       = '#lead_contact_frequency_rules__token';
-    const SAVE_BUTTON_SELECTOR = '#lead_contact_frequency_rules_buttons_save';
+    const SAVE_BUTTON_SELECTOR = '.prefs-saveprefs';
     const FORM_SELECTOR        = 'form[name="lead_contact_frequency_rules"]';
 
     public function testOnPageDisplayCorrectlyWrapsAllFrequencyFormInputsIncludingTokenAndSaveButton(): void

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -97,13 +97,30 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
     <title>{pagetitle}</title>
+    <meta name="description" content="{pagemetadescription}">
 </head>
 <body>
     <div>
-        <div data-slot="channelfrequency"></div>
+        {langbar}
+        {sharebuttons}
     </div>
     <div>
-        <div data-slot="saveprefsbutton"></div>
+        {successmessage}
+        <div>
+            <div data-slot="segmentlist"></div>
+        </div>
+        <div>
+            <div data-slot="categorylist"></div>
+        </div>
+        <div>
+            <div data-slot="preferredchannel"></div>
+        </div>
+        <div>
+            <div data-slot="channelfrequency"></div>
+        </div>
+        <div>
+            <div data-slot="saveprefsbutton"></div>
+        </div>
     </div>
 </body>
 </html>

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList as Segment;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -44,6 +45,9 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
      * Tests both the default and custom preference center pages.
      *
      * @dataProvider frequencyFormRenderingDataProvider
+     *
+     * @param array<string,int> $configParams
+     * @param array<string,int> $selectorsAndExpectedCounts
      */
     public function testUnsubscribeFormRendersPreferenceCenterPageCorrectly(array $configParams, array $selectorsAndExpectedCounts, bool $hasPreferenceCenter = false, bool $useTokens = false): void
     {
@@ -96,8 +100,10 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         }
 
         if ($configParams['show_contact_frequency']) {
-            $prefForm      = $button->form();
-            $prefForm->get('lead_contact_frequency_rules[lead_channels][subscribed_channels][0]')->untick();
+            $prefForm = $button->form();
+            $checkbox = $prefForm->get('lead_contact_frequency_rules[lead_channels][subscribed_channels][0]');
+            \assert($checkbox instanceof ChoiceFormField);
+            $checkbox->untick();
             $this->client->submit($prefForm);
 
             Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
@@ -361,6 +367,9 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         return $stat;
     }
 
+    /**
+     * @param array<string,int> $configParams
+     */
     private function createEmail(array $configParams, bool $hasPreferenceCenter = true, bool $useTokens): Email
     {
         $email = new Email();
@@ -422,6 +431,9 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
         return $page;
     }
 
+    /**
+     * @param array<string,int> $configParams
+     */
     private function getPageContentWithSlots(array $configParams): string
     {
         $slots = '';
@@ -452,6 +464,9 @@ class BuilderSubscriberTest extends AbstractMauticTestCase
 PAGE;
     }
 
+    /**
+     * @param array<string,int> $configParams
+     */
     private function getPageContentWithTokens(array $configParams): string
     {
         $tokens = '';

--- a/app/bundles/PageBundle/Views/SubscribedEvents/PageToken/langbar.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/PageToken/langbar.html.php
@@ -10,7 +10,7 @@
  */
 $count = count($pages);
 
-if (empty($pages)) {
+if (0 === $count) {
     return '';
 }
 ?>

--- a/app/bundles/PageBundle/Views/SubscribedEvents/PageToken/langbar.html.php
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/PageToken/langbar.html.php
@@ -9,6 +9,10 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 $count = count($pages);
+
+if (empty($pages)) {
+    return '';
+}
 ?>
 
 <div class="page-lang-bar">


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [N] Only JS changes. No tests possible
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | 

#### Description:

⚠️ this PR is based on https://github.com/mautic/mautic/pull/11442 as it is built on top of refactoring made there, so that PR should be merged first, this one rebased so it contains only commits relative to this bug fix.

The original problem was that the user cannot unsubscribe from a preference center that is configured like so:
<img width="878" alt="Screen Shot 2022-06-02 at 16 55 19" src="https://user-images.githubusercontent.com/1235442/171658333-38787df5-5b8d-43bb-bad5-0e5288cce1a5.png">

When the contacts want to unsubscribe from an email using this preference center then they cannot due to this JS error when they uncheck the channel they want to unsubscribe from:
```
ncaught TypeError: Cannot set properties of null (setting 'disabled')
    at togglePreferredChannel (prefcenter.js?vafdd094b:62:106)
    at HTMLInputElement.onclick (50a40ac2348acbe5a5de0e6a244253f13b2fd4357e801ee0313a104d0a03ae34:116:198)
```
There were 3 bugs hidden in this JS function:
1. The ID was wrong. It was missing the `lead_channels_` part. From what I was able to dig up it was changed in https://github.com/acquia/mc-cs/pull/517 which was already a fix for the missing part.
2. It failed even when I fixed the missing part because the 2 of the inputs that were suppose to be disabled were missing due to the **Show pause contact preferences** set to **No**. So we have to check if the inputs exist before disabling them.
3. The information whether the channel checkbox is checked or not was always false because there is [a hidden input added](https://github.com/mautic/mautic/commit/ab86dc0e299dbbe57dfcb9c31a6105d717b983e2) before the checkbox with the same ID and name for reason I don't yet comprehend.

I was checking that the similar JS function exists in other 2 places:
1. https://github.com/mautic/mautic/blob/4.x/app/bundles/EmailBundle/Views/Lead/preference_options.html.php#L15-L30
2. https://github.com/mautic/mautic/blob/4.x/app/bundles/LeadBundle/Assets/js/lead.js#L981-L999

~~And it will not work for the reasons above either. I asked @kuzmany to help me understand about the bug number 3. Awaiting reply. That's why I didn't jump into fixing the other 2 places as the bun number 3 may be reverted if @kuzmany answers that it was a mistake.~~ Discussed with @kuzmany and fixed the other 2 issues as well.

Docs: https://docs.acquia.com/campaign-studio/components/landing-pages/preference-center/

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure the preference center like the screenshot above.
3. Create a Landing Page as a preference center
4. The issue occurs when user add HTML block and add tag {channelfrequency} instead of adding preference center block and select channel frequency. Also the issue is reproducible with text block.
5. Create a segment email with the preference center configured and use the unsubscribe link in it. 
6. Send the email to a segment with your testing contact in it
7. Open the email
8. Click the unsubscribe link
9. Check that you cannot unsubscribe before this change
10. Check that you can unsubscribe after this change
11. Also check the preference center is not attached to the email you send. It displays different UI when you click on the unsubscribe link. So test that the checkboxes work there correctly.
12. Also check the preference center in the administration. Go to contacts > open one contact detail page > select preference center in the context menu and ensure it works.
13. Check that other variations of the preference center still work.



#### Other areas of Mautic that may be affected by the change:
1. Just the preference center in the public page. Not the one in the contact detail page.


[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. None as we have no infrastructure how to test JS code.
