### PR TITLE
Fix issue searching company on contact edit page when more than 100 companies in DB (issue #11455)

### DIFF
--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -450,9 +450,9 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
 
         $q->select($prefix.$valueColumn.' as value,
         case
-        when (comp.companycountry is not null and comp.companycity is not null) then concat(comp.companyname, " <small>", companycity,", ", companycountry, "</small>")
-        when (comp.companycountry is not null) then concat(comp.companyname, " <small>", comp.companycountry, "</small>")
-        when (comp.companycity is not null) then concat(comp.companyname, " <small>", comp.companycity, "</small>")
+        when (comp.companycountry is not null and comp.companycity is not null) then concat(comp.companyname, \' <small>\', companycity,\', \', companycountry, \'</small>\')
+        when (comp.companycountry is not null) then concat(comp.companyname, \' <small>\', comp.companycountry, \'</small>\')
+        when (comp.companycity is not null) then concat(comp.companyname, \' <small>\', comp.companycity, \'</small>\')
         else comp.companyname
         end
         as label')


### PR DESCRIPTION
Fix for #11455

## Issue:
You cannot search a company on the contact edit page if you have more than 100 companies in DB (error 500).

## How to reproduce
* Create at least 101 companies
* Create a contact and save
* Edit contact, go on Company name field, search one of your company, that is not in the first 100 loaded by default in the drop-down list. --> throw 500 in console

## How to test PR
* Reproduce all steps you should be able to have your company in dropdown field.