### PR TITLE
Test fixes from 4.4.2 to 5.x merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,9 @@ jobs:
         mysqldump --print-defaults
 
     - name: Set SYMFONY_ENV to test
-      run: echo "SYMFONY_ENV=test" >> $GITHUB_ENV
+      run: |
+        echo "SYMFONY_ENV=test" >> $GITHUB_ENV
+        echo "MAUTIC_ENV=test" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: |

--- a/app/bundles/CoreBundle/Test/EnvLoader.php
+++ b/app/bundles/CoreBundle/Test/EnvLoader.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Test;
+
+use Symfony\Component\Dotenv\Dotenv;
+
+final class EnvLoader
+{
+    /**
+     * Loads the env variables from .env.dist or .env file for PHPUNIT tests.
+     */
+    public static function load(): void
+    {
+        $root    = __DIR__.'/../../../../';
+        $envFile = file_exists($root.'.env') ? $root.'.env' : $root.'.env.dist';
+        $dotenv  = new Dotenv();
+        $dotenv->load($envFile);
+    }
+}

--- a/app/bundles/CoreBundle/Test/Hooks/MauticExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/MauticExtension.php
@@ -39,13 +39,15 @@ class MauticExtension implements AfterTestHook, BeforeFirstTestHook
         }
     }
 
+    /**
+     * To set a custom table prefix clear test cache and run.
+     *
+     * Example usage: `MAUTIC_TEST_PREFIX='custom_prefix_' php bin/phpunit`
+     */
     public function executeBeforeFirstTest(): void
     {
-        if (!defined('MAUTIC_TABLE_PREFIX')) {
-            $x      = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-            $prefix = substr(str_shuffle(str_repeat($x, (int) ceil(4 / strlen($x)))), 1, 4).'_';
-            define('MAUTIC_TABLE_PREFIX', 'prefix'.$prefix);
-            echo 'using db prefix '.$prefix.PHP_EOL;
-        }
+        $prefix = false === getenv('MAUTIC_TEST_PREFIX') ? 'test_' : getenv('MAUTIC_TEST_PREFIX');
+        define('MAUTIC_TABLE_PREFIX', $prefix);
+        echo 'using db prefix "'.$prefix.'"'.PHP_EOL;
     }
 }

--- a/app/bundles/CoreBundle/Test/Hooks/MauticExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/MauticExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Test\Hooks;
 
+use Mautic\CoreBundle\Test\EnvLoader;
 use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Runner\AfterTestHook;
@@ -42,11 +43,12 @@ class MauticExtension implements AfterTestHook, BeforeFirstTestHook
     /**
      * To set a custom table prefix clear test cache and run.
      *
-     * Example usage: `MAUTIC_TEST_PREFIX='custom_prefix_' php bin/phpunit`
+     * Example usage: `MAUTIC_DB_PREFIX='custom_prefix_' php bin/phpunit`
      */
     public function executeBeforeFirstTest(): void
     {
-        $prefix = false === getenv('MAUTIC_TEST_PREFIX') ? 'test_' : getenv('MAUTIC_TEST_PREFIX');
+        EnvLoader::load();
+        $prefix = false === getenv('MAUTIC_DB_PREFIX') ? 'test_' : getenv('MAUTIC_DB_PREFIX');
         define('MAUTIC_TABLE_PREFIX', $prefix);
         echo 'using db prefix "'.$prefix.'"'.PHP_EOL;
     }

--- a/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
@@ -7,36 +7,22 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Table;
 use Mautic\InstallBundle\Helper\SchemaHelper;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Dotenv\Dotenv;
 
 class InstallSchemaTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var Connection
-     */
-    protected $connection;
+    private Connection $connection;
 
     /**
      * @var array<string, mixed>
      */
-    protected $dbParams;
+    private array $dbParams;
 
-    /**
-     * @var string
-     */
-    protected $indexTableName;
+    private string $indexTableName;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        // Load environment variables with same logic as the config_test.php
-        $env     = new Dotenv();
-        $root    = __DIR__.'/../../../../../';
-        $envFile = file_exists($root.'.env') ? $root.'.env' : $root.'.env.dist';
-        defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', getenv('MAUTIC_DB_PREFIX') ?: '');
-
-        $env->load($envFile);
         $this->dbParams = [
             'driver'        => getenv('DB_DRIVER') ?: 'pdo_mysql',
             'host'          => getenv('DB_HOST'),

--- a/app/config/config_test.php
+++ b/app/config/config_test.php
@@ -1,28 +1,14 @@
 <?php
 
 use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass;
+use Mautic\CoreBundle\Test\EnvLoader;
 use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\Mock\Client;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Dotenv\Dotenv;
 
 /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
-
-/*
- * @copyright   2014 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
 $loader->import('config.php');
 
-// Load environment variables from .env.test file
-$env     = new Dotenv();
-$root    = __DIR__.'/../../';
-$envFile = file_exists($root.'.env') ? $root.'.env' : $root.'.env.dist';
-
-$env->load($envFile);
+EnvLoader::load();
 
 // Define some constants from .env
 defined('MAUTIC_TABLE_PREFIX') || define('MAUTIC_TABLE_PREFIX', getenv('MAUTIC_DB_PREFIX') ?: '');
@@ -82,7 +68,6 @@ $container->loadFromExtension('doctrine', [
     ],
 ]);
 
-// Ensure the mautic.db_table_prefix is set to our phpunit configuration.
 $container->setParameter('mautic.db_table_prefix', MAUTIC_TABLE_PREFIX);
 
 $container->loadFromExtension('monolog', [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,3 +45,5 @@ parameters:
 		# Following 2 ignores are there due to https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
 		- '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.#'
 		- '#Parameter \#1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string given\.#'
+		# Following will be fixed in new PHP version. See https://github.com/doctrine/dbal/issues/4264
+		- '#Return type of call to static method Doctrine\\DBAL\\DriverManager::getConnection\(\) contains unresolvable type\.#'


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [N] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/11402

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

https://github.com/mautic/mautic/pull/11196 added dynamic table prefix to the tests for a good reason. However, it means that the cache must be cleared before every test execution. A developer can run test(s) many times per day and building the cache takes tens of seconds. That means it's a big lose of time.

This PR changes it to static prefix which can be defined by .env(.dist) file or by defining env var in the phpunit command execution itself. There is small chance that the developer uses the same table prefix on local, production and test environment so the problem with hard-coded prefixes should be discovered in some environment.

We had problem in https://github.com/mautic/mautic/pull/11438 that the CI tests were still failing even after the static table prefix. So this PR also contains unified loading of the env file and setting `MAUTIC_ENV=test` in the CI which actually fixed the issue as after that the config_test.php was properly loaded.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No testing is needed as no production code was changed. Just changes in how we run tests. So review the changes and check the CI that it is green and the output for PHPUNIT tests makes sense.
