### PR TITLE
Adding Symfony 4.0 and 4.1 Rector rule sets to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,7 @@ jobs:
         if [[ "${{ matrix.commands }}" == "PHPSTAN" ]]; then
           composer phpstan
         elif [[ "${{ matrix.commands }}" == "Rector" ]]; then
+          bin/console cache:warmup
           composer rector -- --dry-run --no-progress-bar
         elif [[ "${{ matrix.commands }}" == "CS Fixer" ]]; then
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -1099,7 +1099,7 @@ class CommonApiController extends AbstractFOSRestController implements MauticCon
 
         $form->submit($submitParams, 'PATCH' !== $method);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->setCategory($entity, $categoryId);
             $preSaveError = $this->preSaveEntity($entity, $form, $submitParams, $action);
 

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -464,8 +464,6 @@ class ThemeHelper implements ThemeHelperInterface
 
             return $tmpPath;
         }
-
-        return false;
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -38,11 +38,6 @@ class ConfigController extends AbstractFormController
     protected $request;
 
     /**
-     * @var Form
-     */
-    private $form;
-
-    /**
      * @var BasicIntegration|ConfigFormInterface
      */
     private $integrationObject;
@@ -86,10 +81,10 @@ class ConfigController extends AbstractFormController
         $this->request = $request;
 
         // Create the form
-        $this->form = $this->getForm();
+        $form = $this->getForm();
 
         if (Request::METHOD_POST === $request->getMethod()) {
-            return $this->submitForm();
+            return $this->submitForm($form);
         }
 
         // Clear the session of previously stored fields in case it got stuck
@@ -97,15 +92,15 @@ class ConfigController extends AbstractFormController
         $session = $this->get('session');
         $session->remove("$integration-fields");
 
-        return $this->showForm();
+        return $this->showForm($form);
     }
 
     /**
      * @return JsonResponse|Response
      */
-    private function submitForm()
+    private function submitForm(Form $form)
     {
-        if ($this->isFormCancelled($this->form)) {
+        if ($this->isFormCancelled($form)) {
             return $this->closeForm();
         }
 
@@ -114,7 +109,7 @@ class ConfigController extends AbstractFormController
         $fieldMappings = $settings['sync']['fieldMappings'] ?? [];
 
         // Submit the form
-        $this->form->handleRequest($this->request);
+        $form->handleRequest($this->request);
         if ($this->integrationObject instanceof ConfigFormSyncInterface) {
             $integration   = $this->integrationObject->getName();
             $settings      = $this->integrationConfiguration->getFeatureSettings();
@@ -131,7 +126,7 @@ class ConfigController extends AbstractFormController
 
             /** @var FieldValidationHelper $fieldValidator */
             $fieldValidator = $this->get('mautic.integrations.helper.field_validator');
-            $fieldValidator->validateRequiredFields($this->form, $this->integrationObject, $settings['sync']['fieldMappings']);
+            $fieldValidator->validateRequiredFields($form, $this->integrationObject, $settings['sync']['fieldMappings']);
 
             $this->integrationConfiguration->setFeatureSettings($settings);
         }
@@ -145,8 +140,8 @@ class ConfigController extends AbstractFormController
         // Show the form if there are errors and the plugin is published or the authorized button was clicked
         $integrationDetailsPost = $this->request->request->get('integration_details', []);
         $authorize              = !empty($integrationDetailsPost['in_auth']);
-        if (!$this->form->isValid() && ($this->integrationConfiguration->getIsPublished() || $authorize)) {
-            return $this->showForm();
+        if ($form->isSubmitted() && !$form->isValid() && ($this->integrationConfiguration->getIsPublished() || $authorize)) {
+            return $this->showForm($form);
         }
 
         // Save the integration configuration
@@ -156,12 +151,12 @@ class ConfigController extends AbstractFormController
         $eventDispatcher->dispatch(IntegrationEvents::INTEGRATION_CONFIG_AFTER_SAVE, $configEvent);
 
         // Show the form if the apply button was clicked
-        if ($this->isFormApplied($this->form)) {
+        if ($this->isFormApplied($form)) {
             // Regenerate the form
             $this->resetFieldsInSession();
-            $this->form = $this->getForm();
+            $form = $this->getForm();
 
-            return $this->showForm();
+            return $this->showForm($form);
         }
 
         // Otherwise close the modal
@@ -186,10 +181,10 @@ class ConfigController extends AbstractFormController
     /**
      * @return JsonResponse|Response
      */
-    private function showForm()
+    private function showForm(Form $form)
     {
         $integrationObject = $this->integrationObject;
-        $form              = $this->setFormTheme($this->form, 'IntegrationsBundle:Config:form.html.php');
+        $form              = $this->setFormTheme($form, 'IntegrationsBundle:Config:form.html.php');
         $formHelper        = $this->get('templating.helper.form');
 
         $showFeaturesTab =

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -690,6 +690,6 @@ class LeadApiController extends CommonApiController
     {
         $form->submit($data, 'PATCH' !== $this->request->getMethod());
 
-        return $form->isValid();
+        return $form->isSubmitted() && $form->isValid();
     }
 }

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -61,7 +61,7 @@ class TriggerApiController extends CommonApiController
                 $triggerEventForm = $this->createTriggerEventEntityForm($triggerEventEntity);
                 $triggerEventForm->submit($eventParams, 'PATCH' !== $method);
 
-                if (!$triggerEventForm->isValid()) {
+                if (!($triggerEventForm->isSubmitted() && $triggerEventForm->isValid())) {
                     $formErrors = $this->getFormErrorMessages($triggerEventForm);
                     $msg        = $this->getFormErrorMessage($formErrors);
 

--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,7 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
     // Define what rule sets will be applied
     $rectorConfig->sets([
         \Rector\Symfony\Set\SymfonySetList::SYMFONY_40,
+        \Rector\Symfony\Set\SymfonySetList::SYMFONY_41,
 
         // @todo implement the whole set. Start rule by rule bellow.
         // \Rector\Set\ValueObject\SetList::DEAD_CODE

--- a/rector.php
+++ b/rector.php
@@ -18,7 +18,12 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
     );
 
     // Define what rule sets will be applied
-    // $rectorConfig->sets([\Rector\Set\ValueObject\SetList::DEAD_CODE]); // @todo implement the whole set. Start rule by rule bellow.
+    $rectorConfig->sets([
+        \Rector\Symfony\Set\SymfonySetList::SYMFONY_40,
+
+        // @todo implement the whole set. Start rule by rule bellow.
+        // \Rector\Set\ValueObject\SetList::DEAD_CODE
+    ]);
 
     // Define what signle rules will be applied
     $rectorConfig->rule(\Rector\DeadCode\Rector\BooleanAnd\RemoveAndTrueRector::class);

--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
         \Rector\Symfony\Set\SymfonySetList::SYMFONY_40,
         \Rector\Symfony\Set\SymfonySetList::SYMFONY_41,
 
-        // @todo implement the whole set. Start rule by rule bellow.
+        // @todo implement the whole set. Start rule by rule below.
         // \Rector\Set\ValueObject\SetList::DEAD_CODE
     ]);
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [automated rule set] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes Symfony 4.0 and 4.1 deprecations

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The idea is that we'll have Rector rules that we need to get to Symfony 5 support (refactor the deprecated code) in CI so that all PRs (currently 260 open, kinda old PRs) will not add some deprecated code.

This PR starts with Symfony 4.0 and 4.1 rule set. Symfony 4.2 will follow but we need to merge https://github.com/mautic/mautic/pull/11447 first as it focuses on TranslatorInterface and change a lot of files.

I had to refactor `app/bundles/IntegrationsBundle/Controller/ConfigController.php` a little as using property of `$this->form` over just variable `$form` was breaking a Rector rule. It was an anti-pattern anyway as we can simply pass the form as input params to the private methods instead which is much cleaner.

The Symfony rule set also [needs the cache built](https://github.com/rectorphp/rector-symfony#provide-symfony-xml-service-list) so I added `bin/console cache:warmup` before we run Rector.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. There is very little chance that this PR broke something but if we want to be thorough then test:
3. Any API request [saving a contact](https://developer.mautic.org/#create-contact).
4. Export a theme.
5. Save a point trigger.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
