### PR TITLE
Use `hasSession()` over `getSession()` to check whether the session exists

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -86,7 +86,7 @@ class AppKernel extends Kernel
          * If we've already sent the response headers, and we have a session
          * set in the request, set that as the session in the container.
          */
-        if (headers_sent() && $request->getSession()) {
+        if (headers_sent() && $request->hasSession()) {
             $this->getContainer()->set('session', $request->getSession());
         }
 


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [all existing functional tests] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | /
| Related developer documentation PR URL | /
| Issue(s) addressed                     | Fixes https://mautic.atlassian.net/browse/TPROD-288

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I went through all 32 occurrences of `getSession()` usage and ensured it won't cause any trouble when it start's throwing an exception in Symfony 5 instead of `null` in Symfony 4. It's mostly used during authentication where the request should have the session but mostly, it would fail today too if it wouldn't have the session as it would fail on `calling [some method] on null` error.

I suggest to change it in one place only where we use `getSession()` as `hasSession()` as it is in the condition and the return value is not assigned to any variable.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. As the change is made in a method handling all requests in Mautic then just refreshing any page will test it. If you see no error then the test was successful.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
