### PR TITLE
Fix handling of not-parsable URL's in page tracking model

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -416,7 +416,7 @@ class TrackableModel extends AbstractCommonModel
      *
      * @param $url
      *
-     * @return bool|array<$trackingKey, $trackingUrl>
+     * @return bool|array<string, string> array 0=trackingKey, 1=$trackingUrl
      */
     protected function prepareUrlForTracking($url)
     {

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -416,7 +416,7 @@ class TrackableModel extends AbstractCommonModel
      *
      * @param $url
      *
-     * @return array[$trackingKey, $trackingUrl]|false
+     * @return bool|array<$trackingKey, $trackingUrl>
      */
     protected function prepareUrlForTracking($url)
     {
@@ -439,7 +439,8 @@ class TrackableModel extends AbstractCommonModel
         // Convert URL
         $urlParts = parse_url($url);
 
-        if (!$this->isValidUrl($urlParts, false)) {
+        // We need to ignore not parsable and invalid urls
+        if (false === $urlParts || !$this->isValidUrl($urlParts, false)) {
             return false;
         }
 

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -413,12 +413,10 @@ class TrackableModel extends AbstractCommonModel
 
     /**
      * Validate and parse link for tracking.
-     *
-     * @param $url
-     *
-     * @return bool|array<string, string> array 0=trackingKey, 1=$trackingUrl
+     * 
+     * @return bool|non-empty-array<mixed, mixed>
      */
-    protected function prepareUrlForTracking($url)
+    protected function prepareUrlForTracking(string $url)
     {
         // Ensure it's clean
         $url = trim($url);

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -413,7 +413,7 @@ class TrackableModel extends AbstractCommonModel
 
     /**
      * Validate and parse link for tracking.
-     * 
+     *
      * @return bool|non-empty-array<mixed, mixed>
      */
     protected function prepareUrlForTracking(string $url)


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [Y]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [N] <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #11488  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Just check the code, the return value from parse_url may be false which is further handled as array.