### PR TITLE
Fix missing MAUTIC_TABLE_PREFIX in isolated tests

### DIFF
--- a/app/bundles/CoreBundle/Test/IsolatedTestTrait.php
+++ b/app/bundles/CoreBundle/Test/IsolatedTestTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Mautic\CoreBundle\Test;
+
+trait IsolatedTestTrait
+{
+    /**
+     * Ensure the MAUTIC_TABLE_PREFIX const is correctly set in isolated tests.
+     *
+     * Those test runs don't get the constant set in MauticExtension::executeBeforeFirstTest(), so we need to redefine it.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('MAUTIC_TABLE_PREFIX')) {
+            EnvLoader::load();
+            $prefix = false === getenv('MAUTIC_DB_PREFIX') ? 'test_' : getenv('MAUTIC_DB_PREFIX');
+            define('MAUTIC_TABLE_PREFIX', $prefix);
+        }
+    }
+}

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Command/SyncCommandTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Command/SyncCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Tests\Unit\Command;
 
+use Mautic\CoreBundle\Test\IsolatedTestTrait;
 use Mautic\IntegrationsBundle\Command\SyncCommand;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
@@ -22,6 +23,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class SyncCommandTest extends TestCase
 {
+    use IsolatedTestTrait;
+
     private const INTEGRATION_NAME = 'Test';
 
     /**

--- a/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Pipedrive/Controller/PipedriveControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Tests\Pipedrive\Controller;
 
+use Mautic\CoreBundle\Test\IsolatedTestTrait;
 use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\PipedriveTest;
 
 /**
@@ -10,6 +11,8 @@ use MauticPlugin\MauticCrmBundle\Tests\Pipedrive\PipedriveTest;
  */
 class PipedriveControllerTest extends PipedriveTest
 {
+    use IsolatedTestTrait;
+
     public function testWithoutIntegration()
     {
         $this->makeRequest('POST', '');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

in #11494 (5.x) we had some very strange test failures by adding a db prefix (e.g. https://github.com/mautic/mautic/actions/runs/3111542353/jobs/5043943298), that didn't fail in #11496 (4.4).

The main reason is that isolated tests don't inherit the const from the main process.
this means that the test won't be aware of the defined prefix in `\Mautic\CoreBundle\Test\Hooks\MauticExtension::executeBeforeFirstTest`

If such an isolated test is the first test in the suite, it will bootstrap the app and create the database and schema without taking the prefix into account. This causes failutes for non-isolated tests that are executed afterwards and that will use the prefix.

This is exactly why we saw test failures in #11494 on the 5.x branch, but not  in #11496 on the 4.4 branch.

In #11057 a new functional tests was added, and it is an isolated one.
this test is the first functional in the suite, which means it will set up the database and schema.

first functional test on 4.4 branch:

<img width="1422" alt="Screenshot 2022-09-24 at 11 23 49" src="https://user-images.githubusercontent.com/3983285/192097488-b9f96c0b-017d-4960-b653-8788c25b9b1a.png">


first functional tests on 5.x branch:

<img width="1430" alt="Screenshot 2022-09-24 at 11 21 50" src="https://user-images.githubusercontent.com/3983285/192097510-13006826-34b5-4524-8160-43a83b2f85f6.png">


This PR ensures that isolated tests also are aware of the defined prefix.
This change is already present in #11494 to be able to pass the test.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->


1. clear `var/cache/test` and run following test without the patch applied
`MAUTIC_DB_PREFIX=bla_ MAUTIC_ENV=test SYMFONY_ENV=test composer test --  plugins/MauticCrmBundle/Tests/Pipedrive`
2. check the database tables, they have no prefix
3. apply the patch, clear `var/cache/test`, and rerun the command
4. check the database tables, they have a prefix