### PR TITLE
Change clean conditional values  with InputHelper::clean

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -936,10 +936,10 @@ class Field
 
             if ('notIn' === $this->conditions['expr']) {
                 // value not matched
-                if ('' !== $value && !in_array(InputHelper::string($value), $this->conditions['values'])) {
+                if ('' !== $value && !in_array(InputHelper::clean($value), $this->conditions['values'])) {
                     return true;
                 }
-            } elseif (in_array(InputHelper::string($value), $this->conditions['values'])) {
+            } elseif (in_array(InputHelper::clean($value), $this->conditions['values'])) {
                 return true;
             }
         }

--- a/app/bundles/FormBundle/Form/Type/FormFieldConditionType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldConditionType.php
@@ -37,7 +37,7 @@ class FormFieldConditionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->addEventSubscriber(new CleanFormSubscriber(['values' => 'string']));
+        $builder->addEventSubscriber(new CleanFormSubscriber(['values' => 'clean']));
 
         $choices = [];
         if (!empty($options['parent'])) {

--- a/app/bundles/FormBundle/Tests/Entity/FieldTest.php
+++ b/app/bundles/FormBundle/Tests/Entity/FieldTest.php
@@ -184,8 +184,8 @@ final class FieldTest extends \PHPUnit\Framework\TestCase
         $form->addField(0, $parentField);
         $field->setForm($form);
         $field->setParent($parentFieldId);
-        $specialValue = 'čé+äà>&"';
-        $field->setConditions(['expr' => 'in', 'values' => [InputHelper::string($specialValue)]]);
+        $specialValue = 'čé+äà>&"\'è';
+        $field->setConditions(['expr' => 'in', 'values' => [InputHelper::clean($specialValue)]]);
         $parentField->method('getId')->willReturn($parentFieldId);
         $parentField->method('getAlias')->willReturn($parentFieldAlias);
         $data = [$parentFieldAlias => [$specialValue]];


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Follow up for https://github.com/mautic/mautic/pull/11093
We need use clean of values, because some characters made form validation invalid

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create form with selectbox and value `J'è & Or`
3. Then make conditional field with condition for value in `J'è & Or`
4. Before PR you are not able to save field form becasue it retun validation error
5. After PR should work properly

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
