### PR TITLE
Updated supported versions and their dates in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,12 +27,16 @@ For example, Mautic 3.1 will continue receiving security advisories until the re
 | Branch | Beta Release | Initial Release | Active Support Until | Security Support Until *
 |--|--|--|--|--|
 |2.16|30 Jan 2020|13 Feb 2020|15 Jun 2020|15 Dec 2020
-|3.x|27 Jan 2020|15 Jun 2020|15 Jun 2021|15 Dec 2021
+|3.x|27 Jan 2020|15 Jun 2020|30 Aug 2021|28 Feb 2022
 |3.1|17 Aug 2020|24 Aug 2020|23 Nov 2020|30 Nov 2020
 |3.2|23 Nov 2020|30 Nov 2020|16 Feb 2021|22 Feb 2021
 |3.3|16 Feb 2021|22 Feb 2021|17 May 2021|24 May 2021
 |4.x|16 Feb 2021|30 Aug 2021|26 Sept 2022|27 Feb 2023
-|4.0|17 May 2021|30 Aug 2021|29 Nov 2021|29 Nov 2021
+|4.0|25 May 2021|30 Aug 2021|29 Nov 2021|29 Nov 2021
+|4.1|N/A|29 Nov 2021|21 Feb 2021|21 Feb 2021
+|4.2|17 Feb 2022|28 Feb 2021|23 May 2022|23 May 2022
+|4.3|17 May 2022|23 May 2022|27 Jun 2021|27 Jun 2022
+|4.4|27 Jun 2022|27 Jun 2022|26 Sept 2022|26 Sept 2022
 
 \* = Security Support for 2.16 will only be provided for Mautic itself, not for core dependencies that are EOL like Symfony 2.8.
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |  N/A
| New feature/enhancement? (use the a.x branch)      | 5.x
| Deprecations?                          | N/A
| BC breaks? (use the c.x branch)        | N/A
| Automated tests included?              | N/A
| Related user documentation PR URL      | mautic/mautic/blob/5.x/SECURITY.md
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

I was looking at the SECURITY.md and noticed that some of the dates were not matching the tagged versions in GitHub. Also some of the newer releases were completely missing so I added those as well.

Dates of beta and initial releases come from the tags here on GitHub.
Dates of security support come from the [release schedule](https://www.mautic.org/mautic-releases) where security support is listed.

I left out 5.x on purpose since there is currently only a development branch.

#### Steps to test this PR:

N/A
