### PR TITLE
Optimized query for getting orphaned leads in a segment

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentService.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentService.php
@@ -247,14 +247,14 @@ class ContactSegmentService
 
         $this->contactSegmentQueryBuilder->queryBuilderGenerated($segment, $queryBuilder);
 
-        $qbO = new QueryBuilder($queryBuilder->getConnection());
-        $qbO->select('orp.lead_id as id, orp.leadlist_id')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'orp');
-        $qbO->leftJoin('orp', '('.$queryBuilder->getSQL().')', 'members', 'members.id=orp.lead_id');
+        $expr = $queryBuilder->expr();
+        $qbO  = $queryBuilder->createQueryBuilder();
+        $qbO->select('orp.lead_id as id, orp.leadlist_id');
+        $qbO->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'orp');
         $qbO->setParameters($queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
-        $qbO->andWhere($qbO->expr()->eq('orp.leadlist_id', ':orpsegid'));
-        $qbO->andWhere($qbO->expr()->isNull('members.id'));
-        $qbO->andWhere($qbO->expr()->eq('orp.manually_added', $qbO->expr()->literal(0)));
+        $qbO->andWhere($expr->eq('orp.leadlist_id', ':orpsegid'));
+        $qbO->andWhere($expr->eq('orp.manually_added', $expr->literal(0)));
+        $qbO->andWhere($expr->notIn('orp.lead_id', $queryBuilder->getSQL()));
         $qbO->setParameter(':orpsegid', $segment->getId());
         $this->addLeadLimiter($qbO, $batchLimiters, 'orp.lead_id');
 

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -1516,14 +1516,14 @@ class QueryBuilder extends \Doctrine\DBAL\Query\QueryBuilder
     public function guessPrimaryLeadContactIdColumn()
     {
         $parts     = $this->getQueryParts();
-
         $leadTable = $parts['from'][0]['alias'];
-        if (!isset($parts['join'][$leadTable])) {
-            return $leadTable.'.id';
+
+        if ('orp' === $leadTable) {
+            return 'orp.lead_id';
         }
 
-        if ('orp' == $leadTable) {
-            return 'orp.lead_id';
+        if (!isset($parts['join'][$leadTable])) {
+            return $leadTable.'.id';
         }
 
         $joins     = $parts['join'][$leadTable];


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR optimizes SQL query that fetches a list of contacts to be removed from a segment during a segment rebuild.

Actual query:
```sql
SELECT count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId FROM (
  SELECT DISTINCT orp.lead_id as leadIdPrimary, orp.lead_id as id, orp.leadlist_id FROM mautic_lead_lists_leads orp LEFT JOIN (
    SELECT l.id FROM mautic_leads l WHERE l.id IN (
      SELECT internal_object_id FROM mautic_sync_object_mapping par4 WHERE (par4.integration = 'Salesforce') AND (par4.integration_object_name = 'Lead') AND (par4.is_deleted = '0')
    )
  ) members ON members.id=orp.lead_id WHERE (orp.leadlist_id = '990') AND (members.id IS NULL) AND (orp.manually_added = '0')
) sss;
```

Optimized query:
```sql
SELECT count(leadIdPrimary) count, max(leadIdPrimary) maxId, min(leadIdPrimary) minId FROM (
  SELECT DISTINCT orp.lead_id as leadIdPrimary, orp.lead_id as id, orp.leadlist_id FROM mautic_lead_lists_leads orp WHERE (orp.leadlist_id = '990') AND orp.lead_id not in (SELECT internal_object_id FROM mautic_sync_object_mapping par4 WHERE (par4.integration = 'Salesforce') AND (par4.integration_object_name = 'Lead') AND (par4.is_deleted = '0')) AND (orp.manually_added = '0')
) sss;
```
#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

1. Create a segment with a condition that matches a couple contacts (e.g. Email => contains => some).
2. Wait until the segment is rebuilt and contains all contacts that match the condition.
3. Update the segment condition so that it does not match any of the contacts currently added to the segment.
4. Wait for a next segment rebuilt.
5. All the non-matching contacts should be removed from the segment.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
