### PR TITLE
Prepare database only once a test suite run

### DIFF
--- a/app/bundles/CoreBundle/Test/Hooks/SlowTestExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/SlowTestExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Test\Hooks;
+
+use PHPUnit\Runner\AfterLastTestHook;
+use PHPUnit\Runner\AfterTestHook;
+
+/**
+ * This extension outputs a list of slow test classes to the STDOUT.
+ * Enable this extension by setting the following environmental variable `MAUTIC_TEST_LOG_SLOW_TESTS=1`.
+ * You can set an optional threshold in seconds (e.g. `MAUTIC_TEST_SLOW_TESTS_THRESHOLD=1.5`).
+ */
+class SlowTestExtension implements AfterTestHook, AfterLastTestHook
+{
+    /**
+     * @var bool
+     */
+    private $enabled;
+
+    /**
+     * Threshold in seconds.
+     *
+     * @var float
+     */
+    private $threshold;
+
+    /**
+     * @var array<string, float>
+     */
+    private $classes = [];
+
+    public function __construct()
+    {
+        $this->enabled   = (bool) getenv('MAUTIC_TEST_LOG_SLOW_TESTS');
+        $this->threshold = (float) (getenv('MAUTIC_TEST_SLOW_TESTS_THRESHOLD') ?: 2);
+    }
+
+    public function executeAfterTest(string $test, float $time): void
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        if ($time <= $this->threshold) {
+            return;
+        }
+
+        $class = substr($test, 0, strpos($test, '::'));
+
+        if (!isset($this->classes[$class])) {
+            $this->classes[$class] = 0;
+        }
+
+        $this->classes[$class] += $time;
+    }
+
+    public function executeAfterLastTest(): void
+    {
+        if (!$this->classes) {
+            return;
+        }
+
+        arsort($this->classes);
+
+        fwrite(STDOUT, PHP_EOL.'Slow test classes:'.PHP_EOL.var_export($this->classes, true));
+    }
+}

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -19,8 +19,10 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      * Use transaction rollback for cleanup. Sometimes it is not possible to use it because of the following:
      *     1. A query that alters a DB schema causes an open transaction being committed immediately.
      *     2. Full-text search does not see uncommitted changes.
+     *
+     * @var bool
      */
-    protected bool $useCleanupRollback = true;
+    protected $useCleanupRollback = true;
 
     /**
      * @param array<mixed> $data

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -60,5 +60,6 @@
   </listeners>
   <extensions>
     <extension class="\Mautic\CoreBundle\Test\Hooks\MauticExtension" />
+    <extension class="\Mautic\CoreBundle\Test\Hooks\SlowTestExtension" />
   </extensions>
 </phpunit>


### PR DESCRIPTION
SlowTestExtension added

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR speeds up functional tests a bit by ensuring the database is recreated only once a test suite. It also speeds up running a single test in a developer's environment. Apart from this minor improvement, the PR adds an option to get a list of slow tests. See the [PHPUnit extension comment](https://github.com/mautic/mautic/pull/11585/files#diff-b1882b932223ee0f0678f04f9f2cee88947e3ed24113032e42cf8444ceff3dd3R10-R14).

#### Steps to test this PR:

This PR only touches tests. There is nothing to test apart from passing CI checks.