### PR TITLE
ensure the themes and plugins on 5.x will require Mautic core 5.x

### DIFF
--- a/.github/ci-files/composer.json
+++ b/.github/ci-files/composer.json
@@ -76,7 +76,7 @@
         "url": "../app",
         "options": {
             "versions": {
-                "mautic/core-lib": "4.x-dev"
+                "mautic/core-lib": "5.x-dev"
             },
             "symlink": false
         }

--- a/plugins/GrapesJsBuilderBundle/composer.json
+++ b/plugins/GrapesJsBuilderBundle/composer.json
@@ -32,7 +32,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/plugins/MauticCitrixBundle/composer.json
+++ b/plugins/MauticCitrixBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticClearbitBundle/composer.json
+++ b/plugins/MauticClearbitBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticCloudStorageBundle/composer.json
+++ b/plugins/MauticCloudStorageBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticCrmBundle/composer.json
+++ b/plugins/MauticCrmBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticEmailMarketingBundle/composer.json
+++ b/plugins/MauticEmailMarketingBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticFocusBundle/composer.json
+++ b/plugins/MauticFocusBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticFullContactBundle/composer.json
+++ b/plugins/MauticFullContactBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticGmailBundle/composer.json
+++ b/plugins/MauticGmailBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticOutlookBundle/composer.json
+++ b/plugins/MauticOutlookBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticSocialBundle/composer.json
+++ b/plugins/MauticSocialBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticTagManagerBundle/composer.json
+++ b/plugins/MauticTagManagerBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/plugins/MauticZapierBundle/composer.json
+++ b/plugins/MauticZapierBundle/composer.json
@@ -12,7 +12,6 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.4.0 <8.1",
-        "mautic/core-lib": "^4.0"
+        "mautic/core-lib": "^5.0"
     }
 }

--- a/themes/Mauve/composer.json
+++ b/themes/Mauve/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/aurora/composer.json
+++ b/themes/aurora/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/blank/composer.json
+++ b/themes/blank/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/brienz/composer.json
+++ b/themes/brienz/composer.json
@@ -1,14 +1,13 @@
 {
-    "name": "mautic/theme-brienz",
-    "description": "Mautic Brienz Theme",
-    "type": "mautic-theme",
-    "keywords": ["mautic","theme"],
-    "extra": {
-      "install-directory-name": "brienz"
-    },
-    "minimum-stability": "dev",
-    "require": {
-      "php": ">=7.4.0 <8.1",
-      "mautic/core-lib": "^4.0"
-    }
+  "name": "mautic/theme-brienz",
+  "description": "Mautic Brienz Theme",
+  "type": "mautic-theme",
+  "keywords": ["mautic","theme"],
+  "extra": {
+    "install-directory-name": "brienz"
+  },
+  "minimum-stability": "dev",
+  "require": {
+    "mautic/core-lib": "^5.0"
   }
+}

--- a/themes/cards/composer.json
+++ b/themes/cards/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/coffee/composer.json
+++ b/themes/coffee/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/confirmme/composer.json
+++ b/themes/confirmme/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/fresh-center/composer.json
+++ b/themes/fresh-center/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/fresh-fixed/composer.json
+++ b/themes/fresh-fixed/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/fresh-left/composer.json
+++ b/themes/fresh-left/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/fresh-wide/composer.json
+++ b/themes/fresh-wide/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/goldstar/composer.json
+++ b/themes/goldstar/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/nature/composer.json
+++ b/themes/nature/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/neopolitan/composer.json
+++ b/themes/neopolitan/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/oxygen/composer.json
+++ b/themes/oxygen/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/paprika/composer.json
+++ b/themes/paprika/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/skyline/composer.json
+++ b/themes/skyline/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/sparse/composer.json
+++ b/themes/sparse/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/sunday/composer.json
+++ b/themes/sunday/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/trulypersonal/composer.json
+++ b/themes/trulypersonal/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }

--- a/themes/vibrant/composer.json
+++ b/themes/vibrant/composer.json
@@ -8,7 +8,6 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.4.0 <8.1",
-    "mautic/core-lib": "^4.0"
+    "mautic/core-lib": "^5.0"
   }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

All Mautic plugins and themes in this repo contain a `composer.json` file that define the requirements.
The most important requirement being `mautic/core-lib`

The current config doesn't allow it to work correctly, as the `5.x-dev` version of a plugin requires `mautic/core-lib` 4
See e.g. https://github.com/mautic/mautic/blob/5.x/plugins/GrapesJsBuilderBundle/composer.json#L36 and https://packagist.org/packages/mautic/grapes-js-builder-bundle#5.x-dev

This results in following errors:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires mautic/grapes-js-builder-bundle 5.x-dev -> satisfiable by mautic/grapes-js-builder-bundle[5.x-dev].
    - mautic/grapes-js-builder-bundle 5.x-dev requires mautic/core-lib ^4.0 -> found mautic/core-lib[4.0.0-alpha1, ..., 4.x-dev] but it conflicts with your root composer.json require (5.x-dev).
...
```

This PR addresses this.
It also remove the PHP requirement, as that one is handled by `mautic/core-lib`

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->

not simple to test, as the normal flow requires actually releasing the packages
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
