### PR TITLE
Campaign events reschedules due to DST

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -222,7 +222,6 @@ class Interval implements ScheduleModeInterface
             );
 
             $groupDateTime = clone $compareFromDateTime;
-
         }
 
         if ($daysOfWeek) {
@@ -322,7 +321,6 @@ class Interval implements ScheduleModeInterface
                 // Get now in the contacts timezone then add the number of days from now and the original execution date
                 $groupExecutionDate = clone $compareFromDateTime;
                 $groupExecutionDate->setTimezone($contactTimezone);
-
             } catch (\Exception $exception) {
                 // Timezone is not recognized so use the default
                 $this->logger->debug(

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -14,6 +14,8 @@ use Psr\Log\LoggerInterface;
 
 class Interval implements ScheduleModeInterface
 {
+    const LOG_DATE_FORMAT = 'Y-m-d H:i:s T';
+
     /**
      * @var LoggerInterface
      */
@@ -50,7 +52,7 @@ class Interval implements ScheduleModeInterface
 
         try {
             $this->logger->debug(
-                'CAMPAIGN: ('.$event->getId().') Adding interval of '.$interval.$unit.' to '.$comparedToDateTime->format('Y-m-d H:i:s T')
+                'CAMPAIGN: ('.$event->getId().') Adding interval of '.$interval.$unit.' to '.$comparedToDateTime->format(self::LOG_DATE_FORMAT)
             );
             $comparedToDateTime->add((new DateTimeHelper())->buildInterval($interval, $unit));
         } catch (\Exception $exception) {
@@ -61,8 +63,8 @@ class Interval implements ScheduleModeInterface
 
         if ($comparedToDateTime > $compareFromDateTime) {
             $this->logger->debug(
-                'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format('Y-m-d H:i:s T').' is later than '
-                .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus returning '.$comparedToDateTime->format('Y-m-d H:i:s T')
+                'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format(self::LOG_DATE_FORMAT).' is later than '
+                .$compareFromDateTime->format(self::LOG_DATE_FORMAT).' and thus returning '.$comparedToDateTime->format(self::LOG_DATE_FORMAT)
             );
 
             //the event is to be scheduled based on the time interval
@@ -70,8 +72,8 @@ class Interval implements ScheduleModeInterface
         }
 
         $this->logger->debug(
-            'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format('Y-m-d H:i:s T').' is earlier than '
-            .$compareFromDateTime->format('Y-m-d H:i:s T').' and thus returning '.$compareFromDateTime->format('Y-m-d H:i:s T')
+            'CAMPAIGN: ('.$event->getId().') '.$comparedToDateTime->format(self::LOG_DATE_FORMAT).' is earlier than '
+            .$compareFromDateTime->format(self::LOG_DATE_FORMAT).' and thus returning '.$compareFromDateTime->format(self::LOG_DATE_FORMAT)
         );
 
         return $compareFromDateTime;
@@ -91,14 +93,26 @@ class Interval implements ScheduleModeInterface
             return $this->getExecutionDateTime($event, $compareFromDateTime, $dateTriggered);
         }
 
+        $interval      = $event->getTriggerInterval();
+        $unit          = $event->getTriggerIntervalUnit();
+
+        if ($interval && $unit) {
+            $dateTriggered->add((new DateTimeHelper())->buildInterval($interval, $unit));
+        }
+
+        if ($dateTriggered < $compareFromDateTime) {
+            $this->logger->debug(
+                sprintf('CAMPAIGN: (%s) %s is earlier than %s and thus setting %s', $event->getId(), $dateTriggered->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT), $compareFromDateTime->format(self::LOG_DATE_FORMAT))
+            );
+            $dateTriggered = clone $compareFromDateTime;
+        }
+
         $hour      = $event->getTriggerHour();
         $startTime = $event->getTriggerRestrictedStartHour();
         $endTime   = $event->getTriggerRestrictedStopHour();
         $dow       = $event->getTriggerRestrictedDaysOfWeek();
 
-        $diff = $dateTriggered->diff($compareFromDateTime);
-
-        return $this->getGroupExecutionDateTime($event->getId(), $log->getLead(), $diff, $dateTriggered, $hour, $startTime, $endTime, $dow);
+        return $this->getGroupExecutionDateTime($event->getId(), $log->getLead(), $dateTriggered, $hour, $startTime, $endTime, $dow);
     }
 
     /**
@@ -112,18 +126,19 @@ class Interval implements ScheduleModeInterface
         $endTime               = $event->getTriggerRestrictedStopHour();
         $daysOfWeek            = $event->getTriggerRestrictedDaysOfWeek();
 
-        // Get the difference between now and the date we're supposed to be executing
-        $compareFromDateTime = $compareFromDateTime ? clone $compareFromDateTime : new \DateTime('now');
-        $diff                = $compareFromDateTime->diff($executionDate);
-        $diff->f             = 0; // we don't care about microseconds
+        $interval = $event->getTriggerInterval();
+        $unit     = $event->getTriggerIntervalUnit();
+
+        if ($interval && $unit) {
+            $executionDate->add((new DateTimeHelper())->buildInterval($interval, $unit));
+        }
 
         /** @var Lead $contact */
         foreach ($contacts as $contact) {
             $groupExecutionDate = $this->getGroupExecutionDateTime(
                 $event->getId(),
                 $contact,
-                $diff,
-                $compareFromDateTime,
+                $executionDate,
                 $hour,
                 $startTime,
                 $endTime,
@@ -174,7 +189,6 @@ class Interval implements ScheduleModeInterface
     private function getGroupExecutionDateTime(
         $eventId,
         Lead $contact,
-        \DateInterval $diff,
         \DateTime $compareFromDateTime,
         \DateTime $hour = null,
         \DateTime $startTime = null,
@@ -189,7 +203,7 @@ class Interval implements ScheduleModeInterface
             $this->logger->debug(
                 sprintf('CAMPAIGN: Scheduling event ID %s for contact ID %s based on hour of %s', $eventId, $contact->getId(), $hour->format('H:i e'))
             );
-            $groupDateTime = $this->getExecutionDateTimeFromHour($contact, $hour, $diff, $eventId, $compareFromDateTime);
+            $groupDateTime = $this->getExecutionDateTimeFromHour($contact, $hour, $eventId, $compareFromDateTime);
         } elseif ($startTime && $endTime) {
             $this->logger->debug(
                 sprintf(
@@ -201,14 +215,14 @@ class Interval implements ScheduleModeInterface
                 )
             );
 
-            $groupDateTime = $this->getExecutionDateTimeBetweenHours($contact, $startTime, $endTime, $diff, $eventId, $compareFromDateTime);
+            $groupDateTime = $this->getExecutionDateTimeBetweenHours($contact, $startTime, $endTime, $eventId, $compareFromDateTime);
         } else {
             $this->logger->debug(
                 sprintf('CAMPAIGN: Scheduling event ID %s for contact ID %s without hour restrictions.', $eventId, $contact->getId())
             );
 
             $groupDateTime = clone $compareFromDateTime;
-            $groupDateTime->add($diff);
+
         }
 
         if ($daysOfWeek) {
@@ -235,7 +249,7 @@ class Interval implements ScheduleModeInterface
      *
      * @return \DateTime
      */
-    private function getExecutionDateTimeFromHour(Lead $contact, \DateTime $hour, \DateInterval $diff, $eventId, \DateTime $compareFromDateTime)
+    private function getExecutionDateTimeFromHour(Lead $contact, \DateTime $hour, $eventId, \DateTime $compareFromDateTime)
     {
         $groupHour = clone $hour;
 
@@ -253,8 +267,6 @@ class Interval implements ScheduleModeInterface
                 $groupExecutionDate = clone $compareFromDateTime;
                 $groupExecutionDate->setTimezone($contactTimezone);
 
-                $groupExecutionDate->add($diff);
-
                 $groupExecutionDate->setTime($groupHour->format('H'), $groupHour->format('i'));
 
                 return $groupExecutionDate;
@@ -268,7 +280,6 @@ class Interval implements ScheduleModeInterface
 
         $groupExecutionDate = clone $compareFromDateTime;
         $groupExecutionDate->setTimezone($this->getDefaultTimezone());
-        $groupExecutionDate->add($diff);
 
         $groupExecutionDate->setTime($groupHour->format('H'), $groupHour->format('i'));
 
@@ -284,7 +295,6 @@ class Interval implements ScheduleModeInterface
         Lead $contact,
         \DateTime $startTime,
         \DateTime $endTime,
-        \DateInterval $diff,
         $eventId,
         \DateTime $compareFromDateTime
     ) {
@@ -313,7 +323,6 @@ class Interval implements ScheduleModeInterface
                 $groupExecutionDate = clone $compareFromDateTime;
                 $groupExecutionDate->setTimezone($contactTimezone);
 
-                $groupExecutionDate->add($diff);
             } catch (\Exception $exception) {
                 // Timezone is not recognized so use the default
                 $this->logger->debug(
@@ -325,7 +334,6 @@ class Interval implements ScheduleModeInterface
         if (!isset($groupExecutionDate)) {
             $groupExecutionDate = clone $compareFromDateTime;
             $groupExecutionDate->setTimezone($this->getDefaultTimezone());
-            $groupExecutionDate->add($diff);
         }
 
         // Is the time between the start and end hours?
@@ -340,7 +348,7 @@ class Interval implements ScheduleModeInterface
             return $testStartDateTime;
         }
 
-        if ($groupExecutionDate > $testStopDateTime) {
+        if ($groupExecutionDate >= $testStopDateTime) {
             // Too late so try again tomorrow
             $groupExecutionDate->modify('+1 day')->setTime($startTime->format('H'), $startTime->format('i'));
         }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -126,13 +126,6 @@ class Interval implements ScheduleModeInterface
         $endTime               = $event->getTriggerRestrictedStopHour();
         $daysOfWeek            = $event->getTriggerRestrictedDaysOfWeek();
 
-        $interval = $event->getTriggerInterval();
-        $unit     = $event->getTriggerIntervalUnit();
-
-        if ($interval && $unit) {
-            $executionDate->add((new DateTimeHelper())->buildInterval($interval, $unit));
-        }
-
         /** @var Lead $contact */
         foreach ($contacts as $contact) {
             $groupExecutionDate = $this->getGroupExecutionDateTime(

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -5,6 +5,7 @@ namespace Mautic\CampaignBundle\Tests\Executioner\Scheduler\Mode;
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -671,7 +671,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
         return new Interval(new NullLogger(), $coreParametersHelper);
     }
 
-    public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange()
+    public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange(): void
     {
         $campaign = $this->createMock(Campaign::class);
         $campaign->method('getId')

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -670,4 +670,48 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
         return new Interval(new NullLogger(), $coreParametersHelper);
     }
+
+    public function testExecutionDateIsValidatedAsExpectedWithStartHourAndDaylightSavingsTimeChange()
+    {
+        $campaign = $this->createMock(Campaign::class);
+        $campaign->method('getId')
+                 ->willReturn(1);
+
+        $event = $this->createMock(Event::class);
+        $event->method('getTriggerMode')
+              ->willReturn(Event::TRIGGER_MODE_INTERVAL);
+        $event->method('getTriggerInterval')
+              ->willReturn(15);
+        $event->method('getTriggerIntervalUnit')
+              ->willReturn('D');
+        $event->method('getTriggerRestrictedStartHour')
+              ->willReturn(new \DateTime('1970-01-01 08:00:00'));
+        $event->method('getTriggerRestrictedStopHour')
+              ->willReturn(new \DateTime('1970-01-01 20:00:00'));
+        $event->method('getTriggerRestrictedDaysOfWeek')
+              ->willReturn([]);
+        $event->method('getCampaign')
+              ->willReturn($campaign);
+
+        $contact1 = $this->createMock(Lead::class);
+        $contact1->method('getId')
+                 ->willReturn(1);
+        $contact1->method('getTimezone')
+                 ->willReturn('America/New_York');
+
+        $log = new LeadEventLog();
+        $log->setCampaign($campaign);
+        $log->setEvent($event);
+        $log->setLead($contact1);
+        $log->setDateTriggered(new \DateTime('2021-10-24 17:00:00'));
+        $log->setTriggerDate(new \DateTime('2021-12-08 17:00:00'));
+        $log->setIsScheduled(true);
+
+        $interval = $this->getInterval();
+
+        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime());
+        $executionDate->setTimezone(new \DateTimeZone('UTC'));
+
+        $this->assertEquals('2021-11-08 17:00', $executionDate->format('Y-m-d H:i'));
+    }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -709,7 +709,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
 
         $interval = $this->getInterval();
 
-        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime());
+        $executionDate  = $interval->validateExecutionDateTime($log, new \DateTime('2021-11-08 17:00:00'));
         $executionDate->setTimezone(new \DateTimeZone('UTC'));
 
         $this->assertEquals('2021-11-08 17:00', $executionDate->format('Y-m-d H:i'));


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

Description:
Campaign events can get stuck in an hourly rescheduling loop with the following circumstances:

The event was evaluated prior to a time change that falls back an hour to be executed at a time after the time change. E.g. date_triggered = 2021-10-24 17:00:00 and trigger_date = 2021-11-08 14:00:00.
The event is scheduled at a relative time period at a specific hour or between two hours.

Steps to test this PR:
Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
Create a campaign with event which can be scheduled after 7th November 2021.
Add a contact in Eastern time zone where DST changes are applicable and add that contact to the segment which used in above campaign.
Change date_triggered date in mautic_campaign_lead_event_log to befoe DST 7th November 2021. and verify event get triggered at correct time
