### PR TITLE
add custom PHPCS fixer to prevent useless MAUTIC_TABLE_PREFIX defines

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,7 @@
 <?php
 
+require 'autoload.php';
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/app/bundles')
     ->exclude('CoreBundle/Tests/_support/_generated')
@@ -33,5 +35,7 @@ return (new PhpCsFixer\Config())
         'header_comment'        => [
             'header' => '',
         ],
+        'Mautic/no_table_prefix_definition_in_tests' => true,
     ])
+    ->registerCustomFixers([new Mautic\CodingStandards\PhpCSFixer\NoTablePrefixDefinitionInTestsFixer()])
     ->setFinder($finder);

--- a/app/bundles/AssetBundle/Tests/Asset/AbstractAssetTest.php
+++ b/app/bundles/AssetBundle/Tests/Asset/AbstractAssetTest.php
@@ -21,8 +21,6 @@ abstract class AbstractAssetTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
-
         $this->generateCsv();
 
         $assetData = [

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberTest.php
@@ -207,10 +207,6 @@ class ReportDevicesSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testReportGenerate(): void
     {
-        if (!defined('MAUTIC_TABLE_PREFIX')) {
-            define('MAUTIC_TABLE_PREFIX', '');
-        }
-
         $reportGeneratorEventMock  = $this->getReportGeneratorEventMock();
         $reportDevicesSubscriber   = $this->getReportDevicesSubscriber();
         $queryBuilderMock          = $this->getQueryBuilderMock();

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
@@ -45,7 +45,6 @@ class ChannelClickQueryBuilderTest extends TestCase
 
     public function setUp(): void
     {
-        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
         $this->randomParameterMock = $this->createMock(RandomParameterName::class);
         $this->dispatcherMock      = $this->createMock(EventDispatcherInterface::class);
         $this->connectionMock      = $this->createMock(Connection::class);

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
@@ -47,7 +47,6 @@ class ForeignValueFilterQueryBuilderTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
         $this->randomParameter     = new RandomParameterName();
         $this->dispatcher          = $this->createMock(EventDispatcherInterface::class);
         $this->connectionMock      = $this->createMock(Connection::class);

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderTest.php
@@ -57,7 +57,6 @@ class SegmentReferenceFilterQueryBuilderTest extends MauticMysqlTestCase
     public function setUp(): void
     {
         parent::setUp();
-        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
         $this->randomParameterMock = $this->createMock(RandomParameterName::class);
         $this->dispatcherMock      = $this->createMock(EventDispatcherInterface::class);
         $this->connectionMock      = $this->createMock(Connection::class);

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -47,10 +47,6 @@ final class MauticReportBuilderTest extends TestCase
         );
         $this->connection->method('getExpressionBuilder')->willReturn(new ExpressionBuilder($this->connection));
         $this->connection->method('quote')->willReturnMap([['', null, "''"]]);
-
-        if (!defined('MAUTIC_TABLE_PREFIX')) {
-            define('MAUTIC_TABLE_PREFIX', '');
-        }
     }
 
     public function testColumnSanitization(): void

--- a/app/codingstandards/PhpCSFixer/NoTablePrefixDefinitionInTestsFixer.php
+++ b/app/codingstandards/PhpCSFixer/NoTablePrefixDefinitionInTestsFixer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Mautic\CodingStandards\PhpCSFixer;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\StdinFileInfo;
+use PhpCsFixer\Tokenizer\Tokens;
+
+class NoTablePrefixDefinitionInTestsFixer extends AbstractFixer
+{
+    public function getName(): string
+    {
+        return sprintf('Mautic/%s', parent::getName());
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $matches = $tokens->findSequence([[T_STRING, 'define'], '(', [T_CONSTANT_ENCAPSED_STRING, "'MAUTIC_TABLE_PREFIX'"]]);
+
+        if ($matches) {
+            $begin_defined = $tokens->getPrevTokenOfKind(array_key_first($matches), [[T_STRING, 'defined']]);
+            $begin_if      = $tokens->getPrevTokenOfKind($begin_defined, [[T_IF, 'if']]);
+            if ($begin_defined) {
+                if ((int) $begin_if >= $begin_defined - 4) {
+                    $begin     = $begin_if;
+                    $end_token = ['}'];
+                } else {
+                    $begin     = $begin_defined;
+                    $end_token = [';'];
+                }
+
+                $end = $tokens->getNextTokenOfKind(array_key_last($matches), $end_token);
+
+                foreach (range($begin, $end) as $id) {
+                    $tokens->clearAt($id);
+                }
+                $tokens->removeLeadingWhitespace($end);
+            }
+        }
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_CONSTANT_ENCAPSED_STRING);
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+          'Test should not define the `MAUTIC_TABLE_PREFIX` const.',
+          [new CodeSample("<?php
+
+class ExampleTest {
+    public function setUp(): void
+    {
+        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
+    }
+}
+"),
+            new CodeSample("<?php
+
+class ExampleTest {
+    public function setUp(): void
+    {
+        if (!defined('MAUTIC_TABLE_PREFIX')) {
+            define('MAUTIC_TABLE_PREFIX', '');
+        }
+    }
+}
+")]
+        );
+    }
+
+    public function supports(\SplFileInfo $file): bool
+    {
+        return $file instanceof StdinFileInfo || preg_match('/\/Tests\/.*Test\.php$/', $file->getPathname());
+    }
+
+    /**
+     * run before the whitespace cleanup.
+     */
+    public function getPriority(): int
+    {
+        return 1;
+    }
+}

--- a/app/codingstandards/PhpCSFixer/NoTablePrefixDefinitionInTestsFixer.php
+++ b/app/codingstandards/PhpCSFixer/NoTablePrefixDefinitionInTestsFixer.php
@@ -70,7 +70,7 @@ class ExampleTest {
         }
     }
 }
-")]
+"), ]
         );
     }
 

--- a/app/composer.json
+++ b/app/composer.json
@@ -8,7 +8,8 @@
       "Mautic\\": "bundles/",
       "MauticPlugin\\": "plugins/",
       "Mautic\\Middleware\\": "middlewares/",
-      "Mautic\\Migrations\\": "migrations/"
+      "Mautic\\Migrations\\": "migrations/",
+      "Mautic\\CodingStandards\\": "codingstandards/"
     },
     "files": [
       "AppKernel.php",

--- a/composer.lock
+++ b/composer.lock
@@ -5701,7 +5701,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "04d980c8618173daf6506be50213027971bfb71a"
+                "reference": "0a510d87580bfe2be78d01f1667ea4934a96da7c"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5838,7 +5838,8 @@
                     "Mautic\\": "bundles/",
                     "MauticPlugin\\": "plugins/",
                     "Mautic\\Middleware\\": "middlewares/",
-                    "Mautic\\Migrations\\": "migrations/"
+                    "Mautic\\Migrations\\": "migrations/",
+                    "Mautic\\CodingStandards\\": "codingstandards/"
                 },
                 "files": [
                     "AppKernel.php",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I noticed that recent commits introduced new defines for `MAUTIC_TABLE_PREFIX`.
That logic was reworked a while ago, but somehow these keep coming back.
As they are pointless (the prefix definition in tests is handled earlier in the proces), 

This is also an experiment to see what the needed work is to define custom code style fixers.
It's really doable once you get over how it works.

I also added a PR to PHP-CS-Fixer to support descriptions for custom fixers, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6659

This would make it more visual what a custom fixer does, see below.
```diff
bin/php-cs-fixer describe Mautic/no_table_prefix_definition_in_tests
```
```
Description of Mautic/no_table_prefix_definition_in_tests rule.
Test should not define the `MAUTIC_TABLE_PREFIX` const.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,7 @@
    <?php

    class ExampleTest {
        public function setUp(): void
        {
   -        defined('MAUTIC_TABLE_PREFIX') or define('MAUTIC_TABLE_PREFIX', '');
        }
    }

   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,10 +1,7 @@
    <?php

    class ExampleTest {
        public function setUp(): void
        {
   -        if (!defined('MAUTIC_TABLE_PREFIX')) {
   -            define('MAUTIC_TABLE_PREFIX', '');
   -        }
        }
    }

   ----------- end diff -----------
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Testrun should be green

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
