### PR TITLE
Update subtree split to use latest version

### DIFF
--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -93,6 +93,6 @@ jobs:
 
             # Sync commits and tags for the configured subtree splits
             -   name: subtree split
-                uses: acrobat/subtree-splitter@v1.0.0
+                uses: acrobat/subtree-splitter@v1.1.3
                 with:
                     config-path: .github/workflows/gitsplit/${{ matrix.config }}.json # Reference the location where you saved your config file


### PR DESCRIPTION
We use https://github.com/acrobat/subtree-splitter in our release workflows to manage the splitting out from the monorepo (mautic/mautic) into all the mirror repos which supports using Composer-based workflows.

There have been several updates recently, some of which address some issues we had in the past with parallel workflows.

I am not sure how we can really test this though - we do have a debugging branch factored into the workflow which allows the workflow to run, but I am not sure if that would work any more?

Of note, we should (after merging) look to see if we can use batching per [this comment](https://github.com/acrobat/subtree-splitter/issues/1#issuecomment-1195157608) - see our bug report here: https://github.com/acrobat/subtree-splitter/issues/1.