### PR TITLE
Add orderBy to findOneBy to return more accurate eventLog result

### DIFF
--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -116,7 +116,8 @@ class AjaxController extends CommonAjaxController
                                     [
                                         'lead'  => $contactId,
                                         'event' => $eventId,
-                                    ]
+                                    ],
+                                    ['dateTriggered' => 'desc']
                                 );
 
                 if ($log && ($log->getTriggerDate() > new \DateTime())) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #11635

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fixes issue with wrong eventLog record being returned when trying to cancel if the user has multiple records with the same eventId.

#### Steps to test this PR:

Step 1: Create a Campaign that allows users to restart it
Step 2: In that Campaign create an event with a 1 hour delay that removes the user from the Campaign
Step 3: Have user go on Campaign and wait for the user to be removed and event to be fired
Step 4: Have user go on Campaign again, this time try to cancel the event before 1 hour. It should allow you to cancel the event.


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11636"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

