### PR TITLE
Reports using the 'segment activity log' datasource result in 500 errors

### DIFF
--- a/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
@@ -96,10 +96,6 @@ class SegmentLogReportSubscriber implements EventSubscriberInterface
         $qb->setParameter(':dateFrom', $event->getOptions()['dateFrom']->format('Y-m-d H:i:s'));
         $qb->setParameter(':dateTo', $event->getOptions()['dateTo']->format('Y-m-d H:i:s'));
 
-        if (!$event->hasGroupBy()) {
-            $qb->groupBy('l.id,log_added.object_id');
-        }
-
         if ($event->hasColumn(['u.first_name', 'u.last_name']) || $event->hasFilter(['u.first_name', 'u.last_name'])) {
             $qb->leftJoin('l', MAUTIC_TABLE_PREFIX.'users', 'u', 'u.id = l.owner_id');
         }

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
@@ -106,10 +106,6 @@ class SegmentLogReportSubscriberTest extends TestCase
             ->method('isNotNull')
             ->willReturn('');
 
-        $mockQueryBuilder->expects($this->exactly(1))
-            ->method('groupBy')
-            ->willReturn($mockQueryBuilder);
-
         // Mock event
         $mockEvent = $this->getMockBuilder(ReportGeneratorEvent::class)
             ->disableOriginalConstructor()
@@ -139,10 +135,6 @@ class SegmentLogReportSubscriberTest extends TestCase
                 'dateFrom' => new \DateTime(),
                 'dateTo'   => new \DateTime(),
             ]);
-
-        $mockEvent->expects($this->exactly(1))
-            ->method('hasGroupBy')
-            ->willReturn(false);
 
         $mockEvent->expects($this->exactly(2))
             ->method('hasColumn')


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #11516 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The core issue is this: #3969

But, in this report's case, the issue also happens when the user does not use a 'group by'. This is because the report itself adds a 'group by' if none is already present. My fix is to remove this 'group by' as I don't think it's necessary, we want to see all segment add/remove actions even if they're for the same lead or linked to the same object (whatever that object may be, I can't find any documentation about what that column references).

It, like all reports, will still 500 if the user adds a 'group by' themselves and doesn't add all select columns as well, but it at least fixes the "vanilla" report.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a Report in the manner described in issue #11516
3. It'll work now

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
