### PR TITLE
Exception logging for commands

### DIFF
--- a/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
+++ b/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
@@ -7,29 +7,21 @@ namespace Mautic\CoreBundle\EventListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 
-/**
- * Class ConsoleErrorListener.
- */
 class ConsoleErrorListener
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
 
-    public function onConsoleError(ConsoleErrorEvent $event)
+    public function onConsoleError(ConsoleErrorEvent $event): void
     {
         $command   = $event->getCommand();
         $exception = $event->getError();
 
         // Log error with trace
-        $trace = (MAUTIC_ENV == 'dev') ? "\n[stack trace]\n".$exception->getTraceAsString() : '';
-
         $message = sprintf(
             '%s: %s (uncaught exception) at %s line %s while running console command `%s`%s',
             get_class($exception),
@@ -37,10 +29,9 @@ class ConsoleErrorListener
             $exception->getFile(),
             $exception->getLine(),
             empty($command) ? 'UNKNOWN' : $command->getName(),
-            $trace
+            "\n[stack trace]\n".$exception->getTraceAsString()
         );
 
-        // Use notice so it makes it to the log all "perttified" (using error spits it out to console and not the log)
-        $this->logger->notice($message);
+        $this->logger->error($message);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/ConsoleErrorListenerTest.php
@@ -52,7 +52,7 @@ class ConsoleErrorListenerTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->logger->expects($this->once())
-            ->method('notice');
+            ->method('error');
 
         $this->listener->onConsoleError($event);
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR increases log severity and verbosity when an error is triggered during execution of a command. This will help hunt down errors when a command fails.


#### Steps to test this PR:

1. Create a temporary error in a command.
2. Run the "broken" command.
3. Check if that error is logged with severity "error" (was "notice" previously) and the error message contains a stack trace.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
