### PR TITLE
Replace deprecated NumberToLocalizedStringTransformer::ROUND_* constants

### DIFF
--- a/app/bundles/LeadBundle/Views/Field/properties_number.html.php
+++ b/app/bundles/LeadBundle/Views/Field/properties_number.html.php
@@ -9,17 +9,15 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
-
 $roundMode = (isset($roundMode)) ? $roundMode : '';
 $scale     = (isset($scale)) ? $scale : '';
 
 $options = [
-    NumberToLocalizedStringTransformer::ROUND_UP        => 'mautic.lead.field.form.number.roundup',
-    NumberToLocalizedStringTransformer::ROUND_DOWN      => 'mautic.lead.field.form.number.rounddown',
-    NumberToLocalizedStringTransformer::ROUND_HALF_UP   => 'mautic.lead.field.form.number.roundhalfup',
-    NumberToLocalizedStringTransformer::ROUND_HALF_EVEN => 'mautic.lead.field.form.number.roundhalfeven',
-    NumberToLocalizedStringTransformer::ROUND_HALF_DOWN => 'mautic.lead.field.form.number.roundhalfdown',
+    \NumberFormatter::ROUND_UP       => 'mautic.lead.field.form.number.roundup',
+    \NumberFormatter::ROUND_DOWN     => 'mautic.lead.field.form.number.rounddown',
+    \NumberFormatter::ROUND_HALFUP   => 'mautic.lead.field.form.number.roundhalfup',
+    \NumberFormatter::ROUND_HALFEVEN => 'mautic.lead.field.form.number.roundhalfeven',
+    \NumberFormatter::ROUND_HALFDOWN => 'mautic.lead.field.form.number.roundhalfdown',
 ];
 ?>
 


### PR DESCRIPTION
The NumberToLocalizedStringTransformer::ROUND_* constants have been deprecated, use \NumberFormatter::ROUND_* instead.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ x ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Replace a soon deprecated class with the builtin implementation.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
See if the tests are ok.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
