### PR TITLE
Fix #11607 for 5.x

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
@@ -308,7 +308,7 @@ class MandrillTransport extends AbstractTokenHttpTransport implements CallbackTr
     {
         $this->start();
 
-        return parent::start($message, $failedRecipients);
+        return parent::send($message, $failedRecipients);
     }
 
     /**

--- a/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/MandrillTransport.php
@@ -272,6 +272,10 @@ class MandrillTransport extends AbstractTokenHttpTransport implements CallbackTr
      */
     public function start()
     {
+        if ($this->started) {
+            return;
+        }
+
         $key = $this->getApiKey();
         if (empty($key)) {
             // BC support @deprecated - remove in 3.0
@@ -291,6 +295,20 @@ class MandrillTransport extends AbstractTokenHttpTransport implements CallbackTr
         );
 
         $this->started = true;
+    }
+
+    /**
+     * @param string[]|null $failedRecipients An array of failures by-reference
+     *
+     * @return int
+     *
+     * @throws \Swift_TransportException
+     */
+    public function send(\Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    {
+        $this->start();
+
+        return parent::start($message, $failedRecipients);
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fix #11607

Mandrill Transport was not started on calling mautic:campaigns:trigger if mailing mode is immediately.
As result we send email and handle response as Mandrill failed to authenticate. After that we send email on every mautic:campaigns:trigger with some interval (one hour).

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Configuration -> Email Settings
3. Set Service to send mail through to Mandrill
4. Set API Key to actual mandrill API Key
5. Set How should email be handled? to Send immediately
6. Save configuration
7. Create and publish segment with some contacts
8. Create and publish Campaign with segment and Email Action
9. As result email is sending on mautic:campaigns:trigger call with one hour interval
In DataBase field campaign_lead_event_log.metadata we can see error: Mandrill failed to authenticate
Expected result: Send email only once, campaign_lead_event_log.metadata has not error

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
