### PR TITLE
Fixed infinite recursion in Search string helper

### DIFF
--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -202,6 +202,12 @@ class SearchStringHelper
                     if ($c === $this->closingChars[$key] && $openingCount === $closingCount) {
                         //found the matching character (accounts for nesting)
 
+                        //does group have a negative?
+                        if (0 === strpos($string, '!')) {
+                            $filters->{$baseName}[$keyCount]->not = 1;
+                            $string                               = substr($string, 1);
+                        }
+
                         //remove wrapping grouping chars
                         if (0 === strpos($string, $char) && substr($string, -1) === $c) {
                             $string = substr($string, 1, -1);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/SearchStringHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/SearchStringHelperTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Helper;
+
+use Mautic\CoreBundle\Helper\SearchStringHelper;
+
+class SearchStringHelperTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNegativeGroup(): void
+    {
+        $result = SearchStringHelper::parseSearchString('email:!(test@example.%)');
+
+        $this->assertArrayHasKey('email', $result->commands);
+        $this->assertEquals('email', $result->root[0]->command);
+        $this->assertEquals('test@example.%', $result->root[0]->string);
+        $this->assertEquals(1, $result->root[0]->not);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Problem is appeared when we try to find negative group i.e. `email:!(test@exam%)`.

The algorithm tries to remove `(` and `)`, but the first char is `!` and it skips the removal. After that the algorithm finds `(` and startss recursion.
Char `!` is never deleted and the recursion runs indefinitely 

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create contact with some email i.e. `test@example.com`
3. Go to contact list
4. Enter in the search field `email:!(test@ex%)` and press Enter

Expected: Contact list with contacts which emails are not starts with `test@ex`
Result: Ajax request is timeouted

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
