### PR TITLE
Fix show Focus Items Builder - correction of reading sending data

### DIFF
--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -16,7 +16,7 @@ class AjaxController extends CommonAjaxController
      */
     protected function checkIframeAvailabilityAction(Request $request): JsonResponse
     {
-        $url = $request->request->get('website');
+        $url = $request->query->get('website');
 
         /** @var IframeAvailabilityChecker $availabilityChecker */
         $availabilityChecker = $this->get('mautic.focus.helper.iframe_availability_checker');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y]
| New feature/enhancement? (use the a.x branch)      | [N ]
| Deprecations?                          | [ N]
| BC breaks? (use the c.x branch)        | [N ]
| Automated tests included?              | [ N] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #11706  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Bug generated by changing request method from POST to GET in PR: https://github.com/mautic/mautic/pull/10567.
checkIframeAvailabilityAction in AjaxController used to get data by POST request method and finally Focus Item Builder page show error 500 with log message:

`mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "MauticPlugin\MauticFocusBundle\Helper\IframeAvailabilityChecker::check(): Argument #1 ($url) must be of type string, null given, called in /plugins/MauticFocusBundle/Controller/AjaxController.php on line 24" at /plugins/MauticFocusBundle/Helper/IframeAvailabilityChecker.php line 27 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): MauticPlugin\\MauticFocusBundle\\Helper\\IframeAvailabilityChecker::check(): Argument #1 ($url) must be of type string, null given, called in /plugins/MauticFocusBundle/Controller/AjaxController.php on line 24 at /plugins/MauticFocusBundle/Helper/IframeAvailabilityChecker.php:27)"} {"hostname":"","pid":25446}` 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to edit Focus Items and click  Builder. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
