### PR TITLE
Fix marketing message sorting by category

### DIFF
--- a/app/bundles/ChannelBundle/Entity/MessageRepository.php
+++ b/app/bundles/ChannelBundle/Entity/MessageRepository.php
@@ -13,6 +13,7 @@ class MessageRepository extends CommonRepository
     {
         $args['qb'] = $this->createQueryBuilder($this->getTableAlias());
         $args['qb']->join('MauticChannelBundle:Channel', 'channel', 'WITH', 'channel.message = '.$this->getTableAlias().'.id');
+        $args['qb']->leftJoin('MauticCategoryBundle:Category', 'cat', 'WITH', 'cat.id = '.$this->getTableAlias().'.category');
 
         return parent::getEntities($args);
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
Sorting marketing messages by category causes the following error.

![image](https://user-images.githubusercontent.com/96085911/202867767-78e720a6-ed73-446e-8bff-954c94ecb62b.png)

This PR fixes the error. 
#### Steps to test this PR:
1. Create two or three marketing messages.
2. Try to sort by column
3. There is an error.
4. Swich on the other page, e.g. emails
5. Try to open the marketing messages page again
6. Not opening

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create two or three marketing messages.
3. Try to sort by column.
4. Sorting works well.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
