### PR TITLE
Optimize segment load query

### DIFF
--- a/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
+++ b/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
@@ -156,7 +156,7 @@ class SegmentContactsLineChartQuery extends ChartQuery
     {
         $subQuery = $this->connection->createQueryBuilder();
         $subQuery->select('el.date_added - INTERVAL 10 SECOND')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_event_log', 'el')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_event_log el FORCE INDEX ('.MAUTIC_TABLE_PREFIX.'IDX_SEARCH)')
             ->where(
                 $subQuery->expr()->andX(
                     $subQuery->expr()->eq('el.object', $subQuery->expr()->literal('segment')),


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ N ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ N ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Using forced index search in `SegmentContactsLineChartQuery::getFirstDateAddedSegmentEventLog` can significantly improve segment view load time.

Tests on table `mc_lead_event_log` with ~69 mln records:
```
MariaDB [mautic]> SELECT el.date_added - INTERVAL 10 SECOND FROM mc_lead_event_log el WHERE (el.object = 'segment') AND (el.bundle = 'lead') AND (el.object_id = 1104) ORDER BY el.date_added ASC LIMIT 1;
+------------------------------------+
| el.date_added - INTERVAL 10 SECOND |
+------------------------------------+
| 2022-01-13 14:15:10                |
+------------------------------------+
1 row in set (1 min 2.502 sec)

MariaDB [mautic]> SELECT el.date_added - INTERVAL 10 SECOND FROM mc_lead_event_log el FORCE INDEX (mc_IDX_SEARCH) WHERE (el.object = 'segment') AND (el.bundle = 'lead') AND (el.object_id = 1104) ORDER BY el.date_added ASC LIMIT 1;
+------------------------------------+
| el.date_added - INTERVAL 10 SECOND |
+------------------------------------+
| 2022-01-13 14:15:10                |
+------------------------------------+
1 row in set (3.180 sec)
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This test makes sense on huge mautic database
2. Open large segment view in Mautic panel before applying changes from this PR and note loading time
3. Apply changes from this PR
4. Open again same segment and compare loading times

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
