### PR TITLE
Improve report query: incompatible with sql_mode=only_full_group_by

### DIFF
--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -40,7 +40,7 @@ class ReportQueryEvent extends AbstractReportEvent
     }
 
     /**
-     * @return array
+     * @return QueryBuilder
      */
     public function getQuery()
     {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -733,21 +733,30 @@ class ReportModel extends FormModel
     }
 
     /**
-     * @return int
+     * Get the total of rows found by the query. Ignore pagination limits.
      */
-    private function getTotalCount(QueryBuilder $qb, array &$debugData)
+    private function getTotalCount(QueryBuilder $qb, array &$debugData): int
     {
         $countQb = clone $qb;
-        $countQb->resetQueryParts();
 
-        $countQb->select('count(*)')
-            ->from('('.$qb->getSQL().')', 'c');
+        // only COUNT the group by field(s) to comply with SQLs only_full_group_by mode
+        $groupBy = $qb->getQueryPart('groupBy');
+        if(!is_array($groupBy)){
+            throw new \Exception('A group by statement is required in order to get the total rows');
+        }
+        foreach ($groupBy as $field) {
+            $select = "COUNT(${field}),";
+        }
+        $countQb->add('select', substr($select,0,-1));
+
+        // get all results, ignore limit
+        $countQb->setMaxResults(null);
 
         if ($this->isDebugMode()) {
             $debugData['count_query'] = $countQb->getSQL();
         }
 
-        return (int) $countQb->execute()->fetchColumn();
+        return (int) $countQb->execute()->rowCount();
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ no]
| New feature/enhancement? (use the a.x branch)      | [ enhancement]
| Deprecations?                          | [ no]
| BC breaks? (use the c.x branch)        | [ no]
| Automated tests included?              | [ no]
| Related user documentation PR URL      |  
| Related developer documentation PR URL | 
| Issue(s) addressed                     |  Fixes an issue with MySQL compatbility:
```
Syntax error or access violation: 1055 Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'db.log_added.date_added' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

#### Description:

The current query builder code is incompatible with sql_mode=only_full_group_by. 

> When MySQL's only_full_group_by mode is turned on, it means that strict ANSI SQL rules will apply when using GROUP BY. With regard to your query, this means that if you GROUP BY of the proof_type column, then you can only select two things:
>
> - the proof_type column, or
> - aggregates of any other column
>
> By "aggregates" of other columns, I mean using an aggregate function such as MIN(), MAX(), or AVG() with another column. 

_[Answer from Tim Biegeleisen](https://stackoverflow.com/questions/41887460/select-list-is-not-in-group-by-clause-and-contains-nonaggregated-column-inc)_

This is a first step in making the report queries compatible with the new default sql_mode only_full_group_by.

If we want to go full compliant, we have to consider that some reports will not work anymore. As it will only allow aggregated clumns in the SELECT part of the query: count, min, max, average

I would prefer that, as it allows for fewer errors or misinterpretations of the data by the user.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a report
3. Compare the total number of records found before and after the PR is applied. They should be the same

