### PR TITLE
Plugins are not logging the security token

### DIFF
--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -4,6 +4,7 @@ namespace Mautic\PluginBundle\EventListener;
 
 use DOMDocument;
 use Mautic\PluginBundle\Event\PluginIntegrationRequestEvent;
+use Mautic\PluginBundle\Helper\oAuthHelper;
 use Mautic\PluginBundle\PluginEvents;
 use Monolog\Logger;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -59,7 +60,8 @@ class IntegrationSubscriber implements EventSubscriberInterface
         } else {
             $this->logger->debug("$name REQUEST URL: ".$event->getMethod().' '.$event->getUrl());
             if ('' !== $headers) {
-                $this->logger->debug("$name REQUEST HEADERS: \n".$headers.PHP_EOL);
+                $hashHeader = oAuthHelper::hashSensitiveHeaderData($headers);
+                $this->logger->debug("$name REQUEST HEADERS: \n".$hashHeader.PHP_EOL);
             }
             if ('' !== $params) {
                 $this->logger->debug("$name REQUEST PARAMS: \n".$params.PHP_EOL);

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -41,6 +41,15 @@ class oAuthHelper
         $this->request           = $request;
     }
 
+    public static function hashSensitiveHeaderData(string $data): string
+    {
+        $isSensitive = preg_match('/(Authorization.*Bearer\s*)(\S*)\s/', $data, $match);
+
+        return 1 === $isSensitive
+            ? $match[1].hash('sha1', $match[2])
+            : $data;
+    }
+
     /**
      * @param $url
      * @param $parameters


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ yes ]
| New feature/enhancement? (use the a.x branch)      | [ no ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ no ]
| Automated tests included?              | [ no ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Integrated plugins are logging the security. This PR hashes the token before logging.

now
![image](https://user-images.githubusercontent.com/96085911/208681234-659a0592-0c61-4d95-9ec4-94620c2599d5.png)
before
![image](https://user-images.githubusercontent.com/96085911/208681418-dc7d84b4-166d-4a80-8b0f-d1875250cb60.png)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Activate the hubspot plugin and add the Access token.
3. Close and open the fubspot integration modal window.
4. Find the logged data. The token is now hashed. This was not the case before 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
