### PR TITLE
Fixing failing API-Library test for editing devices by PUT with ID th…

### DIFF
--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -453,7 +453,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      */
     protected function checkEntityAccess($entity, $action = 'view')
     {
-        if ('create' != $action && method_exists($entity, 'getCreatedBy')) {
+        if ('create' !== $action && is_object($entity) && method_exists($entity, 'getCreatedBy')) {
             $ownPerm   = "{$this->permissionBase}:{$action}own";
             $otherPerm = "{$this->permissionBase}:{$action}other";
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeviceApiControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testPutEditWithInexistingIdSoItShouldCreate(): void
+    {
+        $contact = new Lead();
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_PUT, '/api/devices/99999/edit', [
+            'device'            => 'desktop',
+            'deviceOsName'      => 'Ubuntu',
+            'deviceOsShortName' => 'UBT',
+            'deviceOsPlatform'  => 'x64',
+            'lead'              => $contact->getId(),
+        ]);
+
+        $clientResponse = $this->client->getResponse();
+
+        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode());
+    }
+}


### PR DESCRIPTION
…at does not work

TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/api-library/pull/289

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This is part of https://github.com/mautic/api-library/pull/289 which is fixing the API Library tests so we could get the checks working again. This PR fixes an issue with PHP 8.0:

```
TypeError: method_exists(): Argument https://github.com/mautic/mautic/issues/1 ($object_or_class) must be of type object|string, null given
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No need to test. Just code review. I added a functional test that is failing on the 5.x branch but is passing with the fix in this PR.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
