### PR TITLE
Fix BooleanType for Dynamics integration

### DIFF
--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -301,7 +301,10 @@ class DynamicsIntegration extends CrmAbstractIntegration
                                  'MoneyType',
                             ], true)) {
                                 $type = 'int';
-                            } elseif ('BooleanType' === $fieldType) {
+                            } elseif (in_array($fieldType, [
+                                'BooleanType',
+                                'Boolean',
+                            ], true)) {
                                 $type = 'boolean';
                             } elseif ('DateTimeType' === $fieldType) {
                                 $type = 'datetime';
@@ -846,10 +849,19 @@ class DynamicsIntegration extends CrmAbstractIntegration
             foreach ($fieldsToUpdate[$object] as $k => $v) {
                 foreach ($lead as $dk => $dv) {
                     if ($v === $dk) {
-                        if ($dv) {
-                            if (isset($availableFields[$object][$k])) {
-                                $mappedData[$availableFields[$object][$k]['dv']] = $dv;
+                        if (isset($dv)) {
+                          if (isset($availableFields[$object][$k])) {
+                            if ($availableFields[$object][$k]['type'] === 'boolean') {
+                              // Map boolean values correctly
+                              if ($dv === '1') {
+                                $mappedData[$availableFields[$object][$k]['dv']] = true;
+                              } else {
+                                $mappedData[$availableFields[$object][$k]['dv']] = false;
+                              }
+                            } else {
+                              $mappedData[$availableFields[$object][$k]['dv']] = $dv;
                             }
+                          }
                         }
                     }
                 }
@@ -878,9 +890,18 @@ class DynamicsIntegration extends CrmAbstractIntegration
             foreach ($config['leadFields'] as $k => $v) {
                 foreach ($lead as $dk => $dv) {
                     if ($v === $dk) {
-                        if ($dv) {
+                        if (isset($dv)) {
                             if (isset($availableFields[$object][$k])) {
+                              if ($availableFields[$object][$k]['type'] === 'boolean') {
+                                // Map boolean values correctly
+                                if ($dv === '1') {
+                                  $mappedData[$availableFields[$object][$k]['dv']] = true;
+                                } else {
+                                  $mappedData[$availableFields[$object][$k]['dv']] = false;
+                                }
+                              } else {
                                 $mappedData[$availableFields[$object][$k]['dv']] = $dv;
+                              }
                             }
                         }
                     }

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -301,7 +301,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
                                  'MoneyType',
                             ], true)) {
                                 $type = 'int';
-                            } elseif ('Boolean' === $fieldType) {
+                            } elseif ('BooleanType' === $fieldType) {
                                 $type = 'boolean';
                             } elseif ('DateTimeType' === $fieldType) {
                                 $type = 'datetime';

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -850,18 +850,18 @@ class DynamicsIntegration extends CrmAbstractIntegration
                 foreach ($lead as $dk => $dv) {
                     if ($v === $dk) {
                         if (isset($dv)) {
-                          if (isset($availableFields[$object][$k])) {
-                            if ($availableFields[$object][$k]['type'] === 'boolean') {
-                              // Map boolean values correctly
-                              if ($dv === '1') {
-                                $mappedData[$availableFields[$object][$k]['dv']] = true;
-                              } else {
-                                $mappedData[$availableFields[$object][$k]['dv']] = false;
-                              }
-                            } else {
-                              $mappedData[$availableFields[$object][$k]['dv']] = $dv;
+                            if (isset($availableFields[$object][$k])) {
+                                if ('boolean' === $availableFields[$object][$k]['type']) {
+                                    // Map boolean values correctly
+                                    if ('1' === $dv) {
+                                        $mappedData[$availableFields[$object][$k]['dv']] = true;
+                                    } else {
+                                        $mappedData[$availableFields[$object][$k]['dv']] = false;
+                                    }
+                                } else {
+                                    $mappedData[$availableFields[$object][$k]['dv']] = $dv;
+                                }
                             }
-                          }
                         }
                     }
                 }
@@ -892,16 +892,16 @@ class DynamicsIntegration extends CrmAbstractIntegration
                     if ($v === $dk) {
                         if (isset($dv)) {
                             if (isset($availableFields[$object][$k])) {
-                              if ($availableFields[$object][$k]['type'] === 'boolean') {
-                                // Map boolean values correctly
-                                if ($dv === '1') {
-                                  $mappedData[$availableFields[$object][$k]['dv']] = true;
+                                if ('boolean' === $availableFields[$object][$k]['type']) {
+                                    // Map boolean values correctly
+                                    if ('1' === $dv) {
+                                        $mappedData[$availableFields[$object][$k]['dv']] = true;
+                                    } else {
+                                        $mappedData[$availableFields[$object][$k]['dv']] = false;
+                                    }
                                 } else {
-                                  $mappedData[$availableFields[$object][$k]['dv']] = false;
+                                    $mappedData[$availableFields[$object][$k]['dv']] = $dv;
                                 }
-                              } else {
-                                $mappedData[$availableFields[$object][$k]['dv']] = $dv;
-                              }
                             }
                         }
                     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ X ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We had an issue when we tried to push boolean values to Dynamics CRM contact.
There seems to be a mismatch between the `AttributeTypeName` we filter for in Mautic and what we receive from Dynamics.
This resulted in the wrong data being stored in the Mautic db and errors when we tried to push data back to the Dynamics CRM.

The boolean field type of Dynamic fields are not recognized correctly.
In the `getAvailableLeadFields` function of the `DynamicsIntegration`, the condition looks for field `AttributeTypeName` `Boolean`, while Dynamics uses AttributeTypeName `BooleanType`. 
As a result, those boolean fields are handled as if they are of type string, resulting in errors when data gets pushed to Dynamics CRM. 

I changed the condition AttributeTypeName filter to `BooleanType` so it's in line with the other field types

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Connect with an active Dynamics CRM environment. (make sure that the contacts have boolean fields configured)
3. Put a breakpoint in the getAvailableLeadFields function, after the lead object fields are fetched from Dynamics CRM.
4. Check the Fields AttributeTypeName  ![image](https://user-images.githubusercontent.com/23356404/213725507-faccfb6f-4867-4d39-ab1f-7c5463ee85a7.png)
5. Make sure the field is correctly added to $dynamicsFields


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
