### PR TITLE
TPROD-312 - TPROD-349 - CoreBundle exceptions migrate views from php engine to twig

### DIFF
--- a/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
+++ b/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
@@ -94,10 +94,14 @@ Becomes
 
     ```
 - Regarding the `default` filter: pay special attention to the [documented use case](https://twig.symfony.com/doc/3.x/filters/default.html) where false is treated as an empty value. Consider using `?? true` instead of `|default(true)` when using the default filter on a variable that could already have a boolean value set.
-- You can use the `|trans` filter instead of `{% trans %}` tags for translations. This is especially handy if you need to do text replacements as you can chain filters this way.
+- You can use text replacement with the `{% trans %}` tag as it is built in:
+    ```
+    {% trans with {'%code%': status_code} %}message{% endtrans %}
+    ```
+    Alternatively, you can use the `|trans` filter instead. This is a bit more compact and and handy, since you can chain multiple filters. Combining translation with text replacement becomes:
 
     ````
     {{message | trans | replace({"%code%": status_code})}}
-    ```
+    ```    
 - [Symfony Best Practices for Templates](https://symfony.com/doc/current/best_practices.html#templates)
 - [Twig for Template Designers](https://twig.symfony.com/doc/3.x/templates.html) is a good overview on creating templates.

--- a/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
+++ b/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
@@ -94,14 +94,17 @@ Becomes
 
     ```
 - Regarding the `default` filter: pay special attention to the [documented use case](https://twig.symfony.com/doc/3.x/filters/default.html) where false is treated as an empty value. Consider using `?? true` instead of `|default(true)` when using the default filter on a variable that could already have a boolean value set.
-- You can use text replacement with the `{% trans %}` tag as it is built in:
+- You can use text replacement with the `{% trans %}` tag as a built-in functionality:
     ```
     {% trans with {'%code%': status_code} %}message{% endtrans %}
     ```
-    Alternatively, you can use the `|trans` filter instead. This is a bit more compact and and handy, since you can chain multiple filters. Combining translation with text replacement becomes:
-
+    Alternatively, you can use the more compact `|trans` filter instead.:
     ````
-    {{message | trans | replace({"%code%": status_code})}}
+    {{ message|trans({'%code%': status_code}) }}
     ```    
+    The nice thing about using filters, is that you can chain them:
+    ```
+    {{ message|striptags|trans({'%code%': status_code}) }}
+    ```
 - [Symfony Best Practices for Templates](https://symfony.com/doc/current/best_practices.html#templates)
 - [Twig for Template Designers](https://twig.symfony.com/doc/3.x/templates.html) is a good overview on creating templates.

--- a/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
+++ b/UPGRADE-PHP-TO-TWIG-TEMPLATES.md
@@ -80,6 +80,7 @@ Becomes
 - If you extend `MauticCoreBundle:Default:content.html.twig`, everything HAS to be in blocks. Trying to put any HTML elements outside a block will fail with the following error:
 
     > A template that extends another one cannot include content outside Twig blocks.
+- If you need to extend a Twig template but also need to override variabes inside of it, you can use [Embed](https://twig.symfony.com/doc/3.x/tags/embed.html)(`embed`) instead. This tag combines the functionality of `include` and `extends`.
 - You're probably used to writing `if !empty($variable) {}` in PHP. That checks if the variable is set and whether it is not empty. In Twig, you explicity have to write `if variable is defined and variable is not empty`. It's a lot more descriptive. In some cases, you can use Twig's [default filter](https://twig.symfony.com/doc/3.x/filters/default.html), like:
 
     ```Twig
@@ -93,6 +94,10 @@ Becomes
 
     ```
 - Regarding the `default` filter: pay special attention to the [documented use case](https://twig.symfony.com/doc/3.x/filters/default.html) where false is treated as an empty value. Consider using `?? true` instead of `|default(true)` when using the default filter on a variable that could already have a boolean value set.
-  
+- You can use the `|trans` filter instead of `{% trans %}` tags for translations. This is especially handy if you need to do text replacements as you can chain filters this way.
+
+    ````
+    {{message | trans | replace({"%code%": status_code})}}
+    ```
 - [Symfony Best Practices for Templates](https://symfony.com/doc/current/best_practices.html#templates)
 - [Twig for Template Designers](https://twig.symfony.com/doc/3.x/templates.html) is a good overview on creating templates.

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -69,17 +69,17 @@ class ExceptionController extends CommonController
         }
 
         $anonymous    = $this->get('mautic.security')->isAnonymous();
-        $baseTemplate = 'MauticCoreBundle:Default:slim.html.php';
+        $baseTemplate = 'MauticCoreBundle:Default:slim.html.twig';
         if ($anonymous) {
             if ($templatePage = $this->get('mautic.helper.theme')->getTheme()->getErrorPageTemplate($code)) {
                 $baseTemplate = $templatePage;
             }
         }
 
-        $template   = "MauticCoreBundle:{$layout}:{$code}.html.php";
+        $template   = "MauticCoreBundle:{$layout}:{$code}.html.twig";
         $templating = $this->get('mautic.helper.templating')->getTemplating();
         if (!$templating->exists($template)) {
-            $template = "MauticCoreBundle:{$layout}:base.html.php";
+            $template = "MauticCoreBundle:{$layout}:base.html.twig";
         }
 
         $statusText = isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '';

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -22,10 +22,10 @@ class ExceptionExtension extends AbstractExtension
 
     /**
      * Returns path root
-     * 
+     *
      * @return string
      */
-    public function getRoot()
+    public function getRoot(): string
     {
         $root = realpath(__DIR__.'/../../../../../../');
 

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -6,7 +6,6 @@ namespace Mautic\CoreBundle\Templating\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Twig\TwigTest;
 
 class ExceptionExtension extends AbstractExtension
 {

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -19,8 +19,6 @@ class ExceptionExtension extends AbstractExtension
         ];
     }
 
-    /**
-     */
     public function getRoot(): string
     {
         $root = realpath(__DIR__.'/../../../../../../');

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -21,7 +21,9 @@ class ExceptionExtension extends AbstractExtension
     }
 
     /**
-     * @param 
+     * Returns path root
+     * 
+     * @return string
      */
     public function getRoot()
     {

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -20,9 +20,6 @@ class ExceptionExtension extends AbstractExtension
     }
 
     /**
-     * Returns path root
-     *
-     * @return string
      */
     public function getRoot(): string
     {
@@ -30,5 +27,4 @@ class ExceptionExtension extends AbstractExtension
 
         return $root;
     }
-    
 }

--- a/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Templating/Twig/Extension/ExceptionExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Templating\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use Twig\TwigTest;
+
+class ExceptionExtension extends AbstractExtension
+{
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('getRootPath', [$this, 'getRoot'], ['is_safe' => ['all']]),
+        ];
+    }
+
+    /**
+     * @param 
+     */
+    public function getRoot()
+    {
+        $root = realpath(__DIR__.'/../../../../../../');
+
+        return $root;
+    }
+    
+}

--- a/app/bundles/CoreBundle/Views/Default/head.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/head.html.twig
@@ -2,10 +2,9 @@
     <meta charset="UTF-8" />
     <title>
         {% if headerTitle is defined and headerTitle is not empty %}
-            {{ headerTitle|replace({'<': ' <'})|striptags }}
-        {% else %}
-            {{ pageTitle|default('Mautic')|striptags }}
+            {{ headerTitle|replace({'<': ' <'})|striptags }} |
         {% endif %}
+        {{ pageTitle|default('Mautic') }}
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="icon" type="image/x-icon" href="{{ asset('media/images/favicon.ico') }}" />

--- a/app/bundles/CoreBundle/Views/Default/head.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/head.html.twig
@@ -1,6 +1,12 @@
 <head>
     <meta charset="UTF-8" />
-    <title>{{ headerTitle|striptags }} | {{ pageTitle|default('Mautic')|striptags }}</title>
+    <title>
+        {% if headerTitle is defined and headerTitle is not empty %}
+            {{ headerTitle|replace({'<': ' <'})|striptags }}
+        {% else %}
+            {{ pageTitle|default('Mautic')|striptags }}
+        {% endif %}
+    </title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="icon" type="image/x-icon" href="{{ asset('media/images/favicon.ico') }}" />
     <link rel="icon" sizes="192x192" href="{{ asset('media/images/favicon.ico') }}">

--- a/app/bundles/CoreBundle/Views/Default/slim.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/slim.html.twig
@@ -3,11 +3,15 @@
     {% include('MauticCoreBundle:Default:head.html.twig') %}
     <body>
         {{ outputScripts('bodyOpen') }}
+       
         <section id="app-content" class="container content-only">
             {{ include('MauticCoreBundle:Notification:flashes.html.twig', {
                 alertType: 'standard'
             }) }}
-            {{ include('MauticCoreBundle:Default:output.html.twig') }}
+
+            {# {{ include('MauticCoreBundle:Default:output.html.twig') }} #}
+            {% block _content %}{% endblock %}
+
         </section>
         {{ include('MauticCoreBundle:Helper:modal.html.twig', {
             id: 'MauticSharedModal',

--- a/app/bundles/CoreBundle/Views/Default/slim.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/slim.html.twig
@@ -16,7 +16,6 @@
                 alertType: 'standard'
             }) }}
 
-            {# {{ include('MauticCoreBundle:Default:output.html.twig') }} #}
             {% block _content %}{% endblock %}
 
         </section>

--- a/app/bundles/CoreBundle/Views/Default/slim.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/slim.html.twig
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 <html>
-    
-    {{ include('MauticCoreBundle:Default:head.html.twig') }}
+    {% set headerTitle = headerTitle|default('') %}
+    {% set pageTitle = pageTitle|default('Mautic') %}
+    {{ include('MauticCoreBundle:Default:head.html.twig', {
+            headerTitle: headerTitle|default(''),
+            pageTitle: pageTitle|default('Mautic'),
+        })
+    }}
+
     <body>
         {{ outputScripts('bodyOpen') }}
        

--- a/app/bundles/CoreBundle/Views/Default/slim.html.twig
+++ b/app/bundles/CoreBundle/Views/Default/slim.html.twig
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
-    {% include('MauticCoreBundle:Default:head.html.twig') %}
+    
+    {{ include('MauticCoreBundle:Default:head.html.twig') }}
     <body>
         {{ outputScripts('bodyOpen') }}
        

--- a/app/bundles/CoreBundle/Views/Error/403.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/403.html.twig
@@ -1,4 +1,3 @@
-{% embed 'MauticCoreBundle:Error:base.html.twig' with {
-  message: 'mautic.core.error.403',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Error:base.html.twig' %}
+
+{% set message = 'mautic.core.error.403' %}

--- a/app/bundles/CoreBundle/Views/Error/403.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/403.html.twig
@@ -1,0 +1,4 @@
+{% embed 'MauticCoreBundle:Error:base.html.twig' with {
+  message: 'mautic.core.error.403',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Error/404.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/404.html.twig
@@ -1,5 +1,4 @@
-{% embed 'MauticCoreBundle:Error:base.html.twig' with {
-  src: mautibotGetImage('openMouth'),
-  message: 'mautic.core.error.404',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Error:base.html.twig' %}
+
+{% set src = mautibotGetImage('openMouth') %}
+{% set message = 'mautic.core.error.404' %}

--- a/app/bundles/CoreBundle/Views/Error/404.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/404.html.twig
@@ -1,0 +1,5 @@
+{% embed 'MauticCoreBundle:Error:base.html.twig' with {
+  src: mautibotGetImage('openMouth'),
+  message: 'mautic.core.error.404',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Error/500.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/500.html.twig
@@ -1,5 +1,4 @@
-{% embed 'MauticCoreBundle:Error:base.html.twig' with {
-  src: mautibotGetImage('openMouth'),
-  message: 'mautic.core.error.500',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Error:base.html.twig' %}
+
+{% set src = mautibotGetImage('openMouth') %}
+{% set message = 'mautic.core.error.500' %}

--- a/app/bundles/CoreBundle/Views/Error/500.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/500.html.twig
@@ -1,0 +1,5 @@
+{% embed 'MauticCoreBundle:Error:base.html.twig' with {
+  src: mautibotGetImage('openMouth'),
+  message: 'mautic.core.error.500',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Error/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/base.html.twig
@@ -11,25 +11,25 @@
 
 {% set isInline = inline ?? false %}
 {% set isAjax = app.request.isxmlhttprequest ?? false %}
-{% set src = src |default(mautibotGetImage('wave'))  %}
-{% set message = message | default('mautic.core.error.generic') %}
+{% set src = src|default(mautibotGetImage('wave'))  %}
+{% set message = message|default('mautic.core.error.generic') %}
 {% set status_code = status_code | default('') %}
 
 {% if isAjax == false %}
     {% extends baseTemplate %}
+
+    {% set pageTitle = (isInline == false) ? status_text : pageTitle|default('') %}
 {% endif %}
 
-{% block pageTitle %}
-    {% if isAjax == false and isInline == false %}
-        {{ status_text }}
-    {% else %}
-        {% set pageTitle = pageTitle | default('Mautic')|striptags %}
-        {{ pageTitle }}
-    {% endif %}
-{% endblock %}
+{# {% block head %}
+{{ include('MauticCoreBundle:Default:head.html.twig', {
+        headerTitle: headerTitle|default(''),
+        pageTitle: (isInline == false) ? status_text : pageTitle|default(''),
+    })
+}}
+{% endblock %} #}
 
 {% block _content %}
-
     <div class="pa-20 mautibot-error{% if isInline %} inline well{% endif %}">
         <div class="row mt-lg pa-md">
             {% if isInline %}

--- a/app/bundles/CoreBundle/Views/Error/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/base.html.twig
@@ -34,7 +34,7 @@
         <div class="row mt-lg pa-md">
             {% if isInline %}
                 <div class="mautibot-content col-xs-12">
-                    <h1><i class="fa fa-warning fa-fw text-danger"></i>{{message | trans | replace({"%code%": status_code})}}</h1>
+                    <h1><i class="fa fa-warning fa-fw text-danger"></i>{{ message|trans({'%code%': status_code}) }}</h1>
                     <h4 class="mt-5"><strong>{{ status_code }}</strong> {{ status_text }}</h4>
                 </div>
             {% else %}
@@ -44,7 +44,7 @@
             </div>
             <div class="mautibot-content col-xs-8 col-md-9">
                 <blockquote class="np break-word">
-                    <h1><i class="fa fa-quote-left"></i> {{message | trans | replace({"%code%": status_code})}} <i class="fa fa-quote-right"></i></h1>
+                    <h1><i class="fa fa-quote-left"></i> {{ message|trans({'%code%': status_code}) }} <i class="fa fa-quote-right"></i></h1>
                     <h4 class="mt-5"><strong>{{ status_code }}</strong> {{ status_text }}</h4>
 
                     <footer class="text-right">Mautibot</footer>

--- a/app/bundles/CoreBundle/Views/Error/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/base.html.twig
@@ -1,0 +1,58 @@
+{# 
+/*
+ # @copyright   2014 Mautic Contributors. All rights reserved
+ # @author      Mautic
+ #
+ # @link        http://mautic.org
+ #
+ # @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+ #}
+
+{% set isInline = inline ?? false %}
+{% set isAjax = app.request.isxmlhttprequest ?? false %}
+{% set src = src |default(mautibotGetImage('wave'))  %}
+{% set message = message | default('mautic.core.error.generic') %}
+{% set status_code = status_code | default('') %}
+
+{% if isAjax == false %}
+    {% extends baseTemplate %}
+{% endif %}
+
+{% block pageTitle %}
+    {% if isAjax == false and isInline == false %}{{ status_text }}
+    {% else %}{{ pageTitle }}{% endif %}
+{% endblock %}
+
+{% block _content %}
+
+    <div class="pa-20 mautibot-error{% if isInline %}inline well{% endif %}">
+        <div class="row mt-lg pa-md">
+            {% if isInline %}
+                <div class="mautibot-content col-xs-12">
+                    <h1><i class="fa fa-warning fa-fw text-danger"></i>{{message | trans | replace({"%code%": status_code})}}</h1>
+                    <h4 class="mt-5"><strong>{{ status_code }}</strong> {{ status_text }}</h4>
+                </div>
+            {% else %}
+
+            <div class="mautibot-image col-xs-4 col-md-3">
+                <img class="img-responsive" src="{{src}}" />
+            </div>
+            <div class="mautibot-content col-xs-8 col-md-9">
+                <blockquote class="np break-word">
+                    <h1><i class="fa fa-quote-left"></i> {{message | trans | replace({"%code%": status_code})}} <i class="fa fa-quote-right"></i></h1>
+                    <h4 class="mt-5"><strong>{{ status_code }}</strong> {{ status_text }}</h4>
+
+                    <footer class="text-right">Mautibot</footer>
+                </blockquote>
+                <div class="pull-right">
+                    <a class="text-muted" href="http://mau.tc/report-issue" target="_new">{{ 'mautic.core.report_issue' | trans }}</a>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+    <div class="clearfix"></div>
+
+{% endblock %}
+

--- a/app/bundles/CoreBundle/Views/Error/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/base.html.twig
@@ -20,13 +20,17 @@
 {% endif %}
 
 {% block pageTitle %}
-    {% if isAjax == false and isInline == false %}{{ status_text }}
-    {% else %}{{ pageTitle }}{% endif %}
+    {% if isAjax == false and isInline == false %}
+        {{ status_text }}
+    {% else %}
+        {% set pageTitle = pageTitle | default('Mautic')|striptags %}
+        {{ pageTitle }}
+    {% endif %}
 {% endblock %}
 
 {% block _content %}
 
-    <div class="pa-20 mautibot-error{% if isInline %}inline well{% endif %}">
+    <div class="pa-20 mautibot-error{% if isInline %} inline well{% endif %}">
         <div class="row mt-lg pa-md">
             {% if isInline %}
                 <div class="mautibot-content col-xs-12">

--- a/app/bundles/CoreBundle/Views/Error/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Error/base.html.twig
@@ -21,14 +21,6 @@
     {% set pageTitle = (isInline == false) ? status_text : pageTitle|default('') %}
 {% endif %}
 
-{# {% block head %}
-{{ include('MauticCoreBundle:Default:head.html.twig', {
-        headerTitle: headerTitle|default(''),
-        pageTitle: (isInline == false) ? status_text : pageTitle|default(''),
-    })
-}}
-{% endblock %} #}
-
 {% block _content %}
     <div class="pa-20 mautibot-error{% if isInline %} inline well{% endif %}">
         <div class="row mt-lg pa-md">
@@ -57,6 +49,4 @@
         </div>
     </div>
     <div class="clearfix"></div>
-
 {% endblock %}
-

--- a/app/bundles/CoreBundle/Views/Exception/403.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/403.html.twig
@@ -1,0 +1,5 @@
+{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
+  src: mautibotGetImage('openMouth'),
+  message: 'mautic.core.error.403',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Exception/403.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/403.html.twig
@@ -1,5 +1,4 @@
-{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
-  src: mautibotGetImage('openMouth'),
-  message: 'mautic.core.error.403',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Exception:base.html.twig' %}
+
+{% set src = mautibotGetImage('openMouth') %}
+{% set message = 'mautic.core.error.403' %}

--- a/app/bundles/CoreBundle/Views/Exception/404.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/404.html.twig
@@ -1,5 +1,4 @@
-{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
-  src: mautibotGetImage('openMouth'),
-  message: 'mautic.core.error.404',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Exception:base.html.twig' %}
+
+{% set src = mautibotGetImage('openMouth') %}
+{% set message = 'mautic.core.error.404' %}

--- a/app/bundles/CoreBundle/Views/Exception/404.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/404.html.twig
@@ -1,0 +1,5 @@
+{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
+  src: mautibotGetImage('openMouth'),
+  message: 'mautic.core.error.404',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Exception/500.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/500.html.twig
@@ -1,0 +1,5 @@
+{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
+  src: mautibotGetImage('openMouth'),
+  message: 'mautic.core.error.500',
+} %}
+{% endembed %}

--- a/app/bundles/CoreBundle/Views/Exception/500.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/500.html.twig
@@ -1,5 +1,4 @@
-{% embed 'MauticCoreBundle:Exception:base.html.twig' with {
-  src: mautibotGetImage('openMouth'),
-  message: 'mautic.core.error.500',
-} %}
-{% endembed %}
+{% extends 'MauticCoreBundle:Exception:base.html.twig' %}
+
+{% set src = mautibotGetImage('openMouth') %}
+{% set message = 'mautic.core.error.500' %}

--- a/app/bundles/CoreBundle/Views/Exception/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/base.html.twig
@@ -21,28 +21,6 @@
 {% endif %}
 {% set previousExceptions = exception.previous %}
 
-
-{# $previousExceptions = $exception->getAllPrevious();
-
-$exceptionMessage = $exception->getMessage();
-if ($exceptionMessage) {
-    $exceptionMessage = ' - '.$exceptionMessage; #}
-
-{# {% set previousExceptions = getAllPreviousExceptions(exception) %} #}
-{# <pre>{{ dump(previousExceptions) }}</pre>
-<pre>{{ dump(exception) }}</pre> #}
-
-{# $previousExceptions = $exception->getAllPrevious(); #}
-{#
-$exceptions = [];
-$e = $this;
-while ($e = $e->getPrevious()) {
-    $exceptions[] = $e;
-}
-
-return $exceptions;
-#}
-
 {% set isInline = inline ?? false %}
 {% set isAjax = app.request.isxmlhttprequest ?? false %}
 {% set src = src|default(mautibotGetImage('wave'))  %}
@@ -53,14 +31,6 @@ return $exceptions;
     {% set headerTitle =  (isInline == false) ? "<strong>" ~ status_code ~ "</strong>" ~ status_text : headerTitle|default('') %}
     {% set pageTitle =  (isInline == false) ? exceptionMessage : pageTitle|default('Mautic') %}
 {% endif %}
-
-{# {% block head %}
-{{ include('MauticCoreBundle:Default:head.html.twig', {
-        headerTitle: (isInline == false) ? "<strong>" ~ status_code ~ "</strong>" ~ status_text : headerTitle|default(''),
-        pageTitle: (isInline == false) ? exceptionMessage : pageTitle|default('Mautic'),
-    })
-}}
-{% endblock %} #}
 
 {% block _content %}
 

--- a/app/bundles/CoreBundle/Views/Exception/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/base.html.twig
@@ -1,0 +1,146 @@
+{#
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+/** @var $exception \Symfony\Component\ErrorHandler\Exception\FlattenException */
+/** @var $logger \Symfony\Component\HttpKernel\Log\DebugLoggerInterface */
+#}
+
+
+{% set message = message | default('mautic.core.error.generic') %}
+{% set previousExceptions = [] %}
+{% set exceptionMessage = exception.message %}
+{% if exceptionMessage is defined and exceptionMessage is not empty%}
+    {% set exceptionMessage = ' - ' ~ exception.message %}
+{% endif %}
+{% set previousExceptions = exception.previous %}
+
+
+{# $previousExceptions = $exception->getAllPrevious();
+
+$exceptionMessage = $exception->getMessage();
+if ($exceptionMessage) {
+    $exceptionMessage = ' - '.$exceptionMessage; #}
+
+{# {% set previousExceptions = getAllPreviousExceptions(exception) %} #}
+{# <pre>{{ dump(previousExceptions) }}</pre>
+<pre>{{ dump(exception) }}</pre> #}
+
+{# $previousExceptions = $exception->getAllPrevious(); #}
+{#
+$exceptions = [];
+$e = $this;
+while ($e = $e->getPrevious()) {
+    $exceptions[] = $e;
+}
+
+return $exceptions;
+#}
+
+{% set isInline = inline ?? false %}
+{% set isAjax = app.request.isxmlhttprequest ?? false %}
+{% set src = src |default(mautibotGetImage('wave'))  %}
+
+{% if isAjax == false %}
+    {% extends baseTemplate %}
+{% endif %}
+
+{% block pageTitle %}
+    {% if isAjax == false and isInline == false %}
+        {% set pageTitle = pageTitle | default(exceptionMessage) %}
+        {% set header = header | default("<strong>" ~ status_code ~ "</strong>" ~ status_text) %}
+        {% set headerTitle = header %}
+    {% else %}
+        {% set pageTitle = pageTitle | default('Mautic')|striptags %}
+        {{ pageTitle }}
+    {% endif %}
+{% endblock %}
+
+{% block _content %}
+
+    <div class="pa-20 mautibot-error{% if isInline %} inline{% endif %}">
+
+        <div class="row">
+            {% if isInline %}
+            <div class="mautibot-content col-xs-12">
+                <h3><i class="fa fa-warning fa-fw text-danger"></i><strong>{{ status_code }}</strong> {{ status_text }}{{ exceptionMessage }}</h3>
+            </div>
+            {% else %}
+            <div class="mautibot-image col-xs-4 col-md-3">
+                <img class="img-responsive mautibot" src="{{ src }}" />
+            </div>
+            <div class="mautibot-content col-xs-8 col-md-9">
+                <blockquote class="np break-word">
+                    <h2><i class="fa fa-quote-left"></i> <strong>{{ status_code }}</strong> {{ status_text }}{{ exceptionMessage }} <i class="fa fa-quote-right"></i></h2>
+                    <footer class="text-right">Mautibot</footer>
+                </blockquote>
+                <div class="pull-right">
+                    <a class="text-muted" href="http://mau.tc/report-issue" target="_new">{{ 'mautic.core.report_issue' | trans }}</a>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+
+        {% if isInline %}
+        <div class="slimscroll" style="max-height: 200px;">
+        {% else %}
+        <div>
+        {% endif %}
+
+            <div class="row mt-20">
+                <div class="col-sm-12">
+                    <h5 class="ml-lg text-danger">{{ exception.class }}</h5>
+                    <div class="well well-sm ma-md">
+                        {{ include ('MauticCoreBundle:Exception:traces.html.twig', {
+                            'traces': exception.trace,
+                        })}}
+                    </div>
+                </div>
+            </div>
+
+            {% if previousExceptions and previousExceptions|length > 0 %}
+            <div class="row mt-20">
+                <div class="col-sm-12">
+                    <h5 class="ml-lg">{{ 'mautic.core.error.previousexceptions' | trans }}</h5>
+                    <div class="panel-group" id="previous" role="tablist" aria-multiselectable="true">
+                    {% for key, e  in previousExceptions %}
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="previous_heading_{{ key }}">
+                                <h4 class="panel-title pa-sm">
+                                    <a data-toggle="collapse" data-parent="#previous" href="#previous_body_{{ key }}" aria-expanded="true" aria-controls="collapseOne">
+                                        {{ e.message }}
+                                    </a>
+                                </h4>
+                            </div>
+                            <div id="previous_body_{{ key }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div class="panel-body">
+                                    <div class="pa-sm">
+                                        {{ include ('MauticCoreBundle:Exception:traces.html.twig', {
+                                            'traces': e.trace,
+                                        })}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+            </div>
+            
+        
+        </div>
+    </div>
+    <div class="clearfix"></div>
+
+    <pre>
+        {{ dump(exception) }}
+    </pre>
+
+{% endblock %}

--- a/app/bundles/CoreBundle/Views/Exception/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/base.html.twig
@@ -45,22 +45,22 @@ return $exceptions;
 
 {% set isInline = inline ?? false %}
 {% set isAjax = app.request.isxmlhttprequest ?? false %}
-{% set src = src |default(mautibotGetImage('wave'))  %}
+{% set src = src|default(mautibotGetImage('wave'))  %}
 
 {% if isAjax == false %}
     {% extends baseTemplate %}
+
+    {% set headerTitle =  (isInline == false) ? "<strong>" ~ status_code ~ "</strong>" ~ status_text : headerTitle|default('') %}
+    {% set pageTitle =  (isInline == false) ? exceptionMessage : pageTitle|default('Mautic') %}
 {% endif %}
 
-{% block pageTitle %}
-    {% if isAjax == false and isInline == false %}
-        {% set pageTitle = pageTitle | default(exceptionMessage) %}
-        {% set header = header | default("<strong>" ~ status_code ~ "</strong>" ~ status_text) %}
-        {% set headerTitle = header %}
-    {% else %}
-        {% set pageTitle = pageTitle | default('Mautic')|striptags %}
-        {{ pageTitle }}
-    {% endif %}
-{% endblock %}
+{# {% block head %}
+{{ include('MauticCoreBundle:Default:head.html.twig', {
+        headerTitle: (isInline == false) ? "<strong>" ~ status_code ~ "</strong>" ~ status_text : headerTitle|default(''),
+        pageTitle: (isInline == false) ? exceptionMessage : pageTitle|default('Mautic'),
+    })
+}}
+{% endblock %} #}
 
 {% block _content %}
 
@@ -142,5 +142,4 @@ return $exceptions;
     <pre>
         {{ dump(exception) }}
     </pre>
-
 {% endblock %}

--- a/app/bundles/CoreBundle/Views/Exception/base.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/base.html.twig
@@ -109,7 +109,4 @@
     </div>
     <div class="clearfix"></div>
 
-    <pre>
-        {{ dump(exception) }}
-    </pre>
 {% endblock %}

--- a/app/bundles/CoreBundle/Views/Exception/traces.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/traces.html.twig
@@ -56,9 +56,7 @@
 
 {% endmacro %}
 
-
-{# $root = realpath(__DIR__.'/../../../../../'); #}
-{% set root = '/var/www/html/docroot/' %}
+{% set root = getRootPath() %}
 
 <ol>
 {% for trace in traces %}
@@ -66,7 +64,7 @@
     {% if trace.file is defined and trace.file is not empty %}
         {% set traceFile = trace.file|split(root)|join('') %}
         <strong>
-            /{{ traceFile }}{% if trace.file is defined and trace.file is not empty %}:{{ trace.line }}{% endif %}
+            {{ traceFile }}{% if trace.file is defined and trace.file is not empty %}:{{ trace.line }}{% endif %}
         </strong>
         at
     {% endif %}

--- a/app/bundles/CoreBundle/Views/Exception/traces.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/traces.html.twig
@@ -1,0 +1,87 @@
+{% macro formatArgs(args) %}
+    {% set result = [] %}
+    {% for key, item in args %}
+        {# is an array with at least 2 items in, first one exists and is a string #}
+        {% if item is iterable 
+            and item|length == 2
+            and item[0] is defined 
+            and item[0] is not empty 
+            and item[0] is not iterable %}
+
+            {% if ('object' == item[0]) %}
+                {% set parts = item[1]|split('\\') %}
+                {% set short = parts|slice(0, -1)  %}
+                {% set formattedValue = '<em>object</em>(<abbr title="' ~ item[1] ~ '">' ~ parts|last ~ '</abbr>)' %}
+            {% elseif 'array' == item[0] %}
+                {% set s = (item[1] is iterable) ? _self.formatArgs(item[1]) : item[1] %}
+                {% set formattedValue = '<em>array</em>(' ~ s ~ ')' %}
+            {% elseif 'string' == item[0] %}
+                {% set formattedValue = "'" ~ item[1]|escape ~ "'" %}
+            {% elseif 'null' == item[0] %}
+                {% set formattedValue = '<em>null</em>' %}
+            {% elseif 'boolean' == item[0] %}
+                {% set s = dump(item[1]) %}
+                {% set s = s|lower %}
+                {% set formattedValue = '<em>' ~ s ~ '</em>' %}
+            {% elseif 'resource' == item[0] %}
+                {% set formattedValue = '<em>resource</em>' %}
+            {% else %}
+                {% set s = item[1]|escape %}
+                {% set s = dump( s|escape ) %}
+                {% set s = s|replace({"\n" : ''}) %}
+                {% set formattedValue = s %}
+            {% endif %}
+        {# is an array #}
+        {% elseif item is iterable and item|length and item[0] is defined %}
+            {% set formattedValue = '<em>array</em>' ~ _self.formatArgs(item) %}
+        {# is an object #}
+        {% elseif item is iterable and item|length and item[0] is not defined %}
+            {% set formattedValue = item.class %}
+        {# is a string #}
+        {% elseif item is not iterable and item is not empty and item|length %}
+            {% set formattedValue = '<em>' ~ item|escape ~ '</em>' %}
+        {% else %}
+            {% set formattedValue = '' %}
+        {% endif %}
+
+        {# Match integer #}
+        {% set newResult = (key matches '/^\\d+$/') ? (formattedValue | raw) : "'" ~ key ~ "' => " ~ (formattedValue  | raw) %}
+        {% set result = result|merge([newResult]) %}
+
+    {% endfor %}
+
+    {% autoescape %}
+    {{ result|join(', ') | raw }} 
+    {% endautoescape %}
+
+{% endmacro %}
+
+
+{# $root = realpath(__DIR__.'/../../../../../'); #}
+{% set root = '/var/www/html/docroot/' %}
+
+<ol>
+{% for trace in traces %}
+    <li class="pt-3 break-word">
+    {% if trace.file is defined and trace.file is not empty %}
+        {% set traceFile = trace.file|split(root)|join('') %}
+        <strong>
+            /{{ traceFile }}{% if trace.file is defined and trace.file is not empty %}:{{ trace.line }}{% endif %}
+        </strong>
+        at
+    {% endif %}
+    {% if trace.function is defined and trace.function is not empty %}
+        {% if trace.class is defined %}
+            {{ trace.class }} {{ trace.type }}
+        {% endif %}
+        {{ trace.function }} (
+        {% if trace.args is defined and trace.args is not empty %}
+            
+            {{ _self.formatArgs(trace.args) }}
+            
+        {% endif %}
+        )
+    {% endif %}
+    </li>
+{% endfor %}
+</ol>

--- a/app/bundles/CoreBundle/Views/Exception/traces.html.twig
+++ b/app/bundles/CoreBundle/Views/Exception/traces.html.twig
@@ -20,14 +20,14 @@
             {% elseif 'null' == item[0] %}
                 {% set formattedValue = '<em>null</em>' %}
             {% elseif 'boolean' == item[0] %}
-                {% set s = dump(item[1]) %}
+                {% set s = item[1] | json_encode | raw %}
                 {% set s = s|lower %}
                 {% set formattedValue = '<em>' ~ s ~ '</em>' %}
             {% elseif 'resource' == item[0] %}
                 {% set formattedValue = '<em>resource</em>' %}
             {% else %}
                 {% set s = item[1]|escape %}
-                {% set s = dump( s|escape ) %}
+                {% set s = s|escape | json_encode | raw %}
                 {% set s = s|replace({"\n" : ''}) %}
                 {% set formattedValue = s %}
             {% endif %}

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -49,7 +49,7 @@ final class DetailControllerTest extends MauticMysqlTestCase
             'mautic/unicorn',
             SymfonyResponse::HTTP_NOT_FOUND,
             'mautic/unicorn',
-            'Package \'mautic/unicorn\' not found in allowlist.',
+            'Package &#039;mautic/unicorn&#039; not found in allowlist.',
         ];
 
         // Package that exists in the allowlist with display name.


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Migrated the Error and Exceptions views in an effort to do subtasks of CoreBundle instead of the whole thing.
Some changes added to Default views of that bundle to avoid errors

To Do's [resolved]
- ~path for 'root' in Exceptions traces template is still hardcoded (no Twig equivalent, perhaps needs a Twig Extension)~
  - ~in `/app/bundles/CoreBundle/Views/Exception/traces.html.twig`~
- ~in the same template, some traces' values print differently than before eg. '1' prints as 'int(1)'. That's the value the data outputs in Twig. So I think it needs to be parsed in the code before it's passed to Twig (clean solution) or need to reformat it in Twig itself (dirtier fix)~
- ~headerTitle and pageTitle don't exist in the Twig templates but they did in the php ones. Need to figure out where those are coming from originally and why they aren't passed to Twig data.~

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Errors:
used when you are on Production
- 404: surf to a non-existing page, it should render a 404 page with the mautic mascot and a title in quotes
- 403: I couldn't really find a place that has restricted access. Maybe it's just in my installation. I'd figure you would see this page when you try to access a page while not logged in 
- 500: triggering a server error is a bit more difficult, for that you could break some php code in another bundle. 

Exceptions:
Same situations as for Errors, but you need to be in the dev environment
eg. surf via the `/index_dev.php` page if your test project supports it

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
