### PR TITLE
Cache bundle add symfony 4 redis tag aware adapter

### DIFF
--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Mautic\CacheBundle\Cache\Adapter;
 
 use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
-use Mautic\CoreBundle\Helper\PRedisConnectionHelper;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
@@ -27,7 +26,7 @@ class RedisTagAwareAdapter extends TagAwareAdapter
 
         $options = array_key_exists('options', $servers) ? $servers['options'] : [];
 
-        $client = new \Predis\Client(PRedisConnectionHelper::getRedisEndpoints($servers['dsn']), $options);
+        $client  = RedisAdapter::createConnection($servers['dsn'], $options);
 
         parent::__construct(
             new RedisAdapter($client, $namespace, $lifetime),

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -14,7 +14,7 @@ namespace Mautic\CacheBundle\Cache\Adapter;
 
 use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
-use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter as TagAwareAdapter;
 
 class RedisTagAwareAdapter extends TagAwareAdapter
 {
@@ -28,9 +28,6 @@ class RedisTagAwareAdapter extends TagAwareAdapter
 
         $client  = RedisAdapter::createConnection($servers['dsn'], $options);
 
-        parent::__construct(
-            new RedisAdapter($client, $namespace, $lifetime),
-            new RedisAdapter($client, $namespace.'.tags.', $lifetime)
-        );
+        parent::__construct($client, $namespace, $lifetime);
     }
 }

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Helper;
 
 /**
+ * @depreacated in Mautic 5. Use Symfony 4 RedisAdapter for multiple instances https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html
+ *
  * Helper functions for simpler operations with arrays.
  */
 class PRedisConnectionHelper


### PR DESCRIPTION
Q | A
-- | --
Bug fix? (use the a.b branch) | [ ]
New feature/enhancement? (use the a.x branch) | [ ]
Deprecations? | [ ]
BC breaks? (use the c.x branch) | [ ]
Automated tests included? | [ ]
Related user documentation PR URL | mautic/mautic-documentation#...
Related developer documentation PR URL | mautic/developer-documentation#...
Issue(s) addressed | Fixes https://forum.mautic.org/t/mautic-cache-redis-config/20176/2


#### Description:
Current Redis integration with CacheBundle returns an error on `clear:cache` command https://forum.mautic.org/t/mautic-cache-redis-config/20176

Instead of fixing it, We noticed Redis Cache Adapter in Symfony 4 can do it the same
https://symfony.com/doc/4.4/components/cache/adapters/redis_adapter.html

It supports multiple servers too. PRedisConnectionHelper marked deprecated (probably built for Mautic 3/Symfony 4)

#### Steps to test this PR:
- Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs here)
- Setup Redis
- Try `clear:cache` command
