### PR TITLE
Revert "TPROD-357 - CoreBundle - Standard - Migrate PHP Templates to Twig Templates"

### DIFF
--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -493,7 +493,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                 'entity'          => $entity,
                 'form'            => $this->getFormView($form, 'edit'),
             ],
-            'contentTemplate' => $this->getTemplateName('form.html.twig'),
+            'contentTemplate' => $this->getTemplateName('form.html.php'),
             'passthroughVars' => [
                 'mauticContent' => $this->getJsLoadMethodPrefix(),
                 'route'         => $this->generateUrl(
@@ -708,9 +708,6 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Get template base different than MauticCoreBundle:Standard.
      *
-     * NOTE: This should be abstract method or removed. All the Bundles that extend this
-     * Controller define a template base so the "Standard" templates are never used.
-     *
      * @return string
      */
     protected function getTemplateBase()
@@ -730,15 +727,14 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $originalFile = $file;
         if (self::ENGINE_TWIG === $engine && strpos($file, '.php')) {
             $file = str_replace('.php', '.twig', $file);
-            trigger_deprecation('mautic', '5.x', 'Using PHP Templates is deprecated, use Twig Templates instead.');
         }
         if ($this->get('templating')->exists($this->getTemplateBase().':'.$file)) {
             return $this->getTemplateBase().':'.$file;
         } elseif ($this->get('templating')->exists($this->getTemplateBase().':'.$originalFile)) {
             // If no Twig file is found, try to find a PHP file before falling back to standard files.
             return $this->getTemplateBase().':'.$originalFile;
-        //} elseif ($this->get('templating')->exists('MauticCoreBundle:Standard:'.$file)) {
-        //    return 'MauticCoreBundle:Standard:'.$file;
+        } elseif ($this->get('templating')->exists('MauticCoreBundle:Standard:'.$file)) {
+            return 'MauticCoreBundle:Standard:'.$file;
         } elseif (self::ENGINE_TWIG === $engine) {
             return $this->getTemplateName(str_replace('.twig', '.php', $file), self::ENGINE_PHP);
         }
@@ -958,7 +954,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             $this->getViewArguments(
                 [
                     'viewParameters'  => $viewParameters,
-                    'contentTemplate' => $this->getTemplateName('list.html.twig'),
+                    'contentTemplate' => $this->getTemplateName('list.html.php'),
                     'passthroughVars' => [
                         'mauticContent' => $this->getJsLoadMethodPrefix(),
                         'route'         => $this->generateUrl($this->getIndexRoute(), ['page' => $page]),
@@ -1072,7 +1068,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                 'entity'          => $entity,
                 'form'            => $this->getFormView($form, 'new'),
             ],
-            'contentTemplate' => $this->getTemplateName('form.html.twig'),
+            'contentTemplate' => $this->getTemplateName('form.html.php'),
             'passthroughVars' => [
                 'mauticContent' => $this->getJsLoadMethodPrefix(),
                 'route'         => $this->generateUrl(
@@ -1184,7 +1180,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
                     true
                 ),
             ],
-            'contentTemplate' => $this->getTemplateName('details.html.twig'),
+            'contentTemplate' => $this->getTemplateName('details.html.php'),
             'passthroughVars' => [
                 'mauticContent' => $this->getJsLoadMethodPrefix(),
                 'route'         => $route,

--- a/app/bundles/CoreBundle/Views/Standard/form.html.php
+++ b/app/bundles/CoreBundle/Views/Standard/form.html.php
@@ -1,0 +1,25 @@
+<?php
+
+$view->extend('MauticCoreBundle:FormTheme:form_simple.html.php');
+
+// Parse standard fields
+$standard          = ['category', 'language', 'isPublished', 'publishUp', 'publishDown'];
+$rightColumnFields = [];
+foreach ($standard as $field) {
+    $rightColumnFields[$field] = (isset($form[$field])) ? $view['form']->row($form[$field]) : '';
+}
+
+// Put toggles on right side
+foreach ($form as $field) {
+    $fieldName = $field->vars['name'];
+    if (!isset($rightColumnFields[$fieldName]) && in_array('yesno_button_group', $field->vars['block_prefixes'])) {
+        $rightColumnFields[$fieldName] = $view['form']->row($field);
+    }
+}
+
+$view['slots']->set('primaryFormContent', $view['form']->rest($form));
+$view['slots']->start('rightFormContent');
+foreach ($rightColumnFields as $field) {
+    echo $field;
+}
+$view['slots']->stop();

--- a/app/bundles/CoreBundle/Views/Standard/index.html.php
+++ b/app/bundles/CoreBundle/Views/Standard/index.html.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+$view->extend('MauticCoreBundle:Default:content.html.php');
+if (!$view['slots']->get('mauticContent')) {
+    if (isset($mauticContent)) {
+        $view['slots']->set('mauticContent', $mauticContent);
+    }
+}
+
+if (!$view['slots']->get('headerTitle')) {
+    if (!isset($headerTitle)) {
+        $headerTitle = 'Mautic';
+    }
+    $view['slots']->set('headerTitle', $view['translator']->trans($headerTitle));
+}
+
+$view['slots']->set(
+    'actions',
+    $view->render(
+        'MauticCoreBundle:Helper:page_actions.html.php',
+        [
+            'templateButtons' => [
+                'new' => $permissions[$permissionBase.':create'],
+            ],
+            'actionRoute'     => $actionRoute,
+            'indexRoute'      => $indexRoute,
+            'translationBase' => $translationBase,
+        ]
+    )
+);
+?>
+
+<div class="panel panel-default bdr-t-wdh-0 mb-0">
+    <?php echo $view->render(
+        'MauticCoreBundle:Helper:list_toolbar.html.php',
+        [
+            'searchValue'      => $searchValue,
+            'searchHelp'       => isset($searchHelp) ? $searchHelp : '',
+            'action'           => $currentRoute,
+            'actionRoute'      => $actionRoute,
+            'indexRoute'       => $indexRoute,
+            'translationBase'  => $translationBase,
+            'preCustomButtons' => (isset($toolBarButtons)) ? $toolBarButtons : null,
+            'templateButtons'  => [
+                'delete' => $permissions[$permissionBase.':delete'],
+            ],
+            'filters' => (isset($filters)) ? $filters : [],
+        ]
+    ); ?>
+
+    <div class="page-list">
+        <?php echo $view['content']->getCustomContent('content.above', $mauticTemplateVars); ?>
+        <?php $view['slots']->output('_content'); ?>
+        <?php echo $view['content']->getCustomContent('content.below', $mauticTemplateVars); ?>
+    </div>
+</div>

--- a/app/bundles/CoreBundle/Views/Standard/list.html.php
+++ b/app/bundles/CoreBundle/Views/Standard/list.html.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+if ('index' == $tmpl) {
+    $view->extend('MauticCoreBundle:Standard:index.html.php');
+}
+
+if (!isset($templateVariables)) {
+    $templateVariables = [];
+}
+
+if (!isset($sessionVar)) {
+    $sessionVar = 'entity';
+}
+
+if (!isset($nameAction)) {
+    $nameAction = 'view';
+}
+
+if (count($items)):
+    if ($items instanceof \Doctrine\ORM\Tools\Pagination\Paginator):
+        $items = $items->getIterator()->getArrayCopy();
+    endif;
+    $firstItem = reset($items);
+    ?>
+    <div class="table-responsive">
+        <table class="table table-hover table-striped table-bordered <?php echo $sessionVar; ?>-list">
+            <thead>
+            <tr>
+                <?php
+                if (empty($ignoreStandardColumns)):
+                    echo $view->render(
+                        'MauticCoreBundle:Helper:tableheader.html.php',
+                        [
+                            'checkall'        => 'true',
+                            'actionRoute'     => $actionRoute,
+                            'indexRoute'      => $indexRoute,
+                            'templateButtons' => [
+                                'delete' => !empty($permissions[$permissionBase.':deleteown']) || !empty($permissions[$permissionBase.':deleteown']) || !empty($permissions[$permissionBase.':delete']),
+                            ],
+                        ]
+                    );
+
+                    echo $view->render(
+                        'MauticCoreBundle:Helper:tableheader.html.php',
+                        [
+                            'sessionVar' => $sessionVar,
+                            'orderBy'    => $tablePrefix.'.name',
+                            'text'       => 'mautic.core.name',
+                            'class'      => 'col-name',
+                            'default'    => true,
+                        ]
+                    );
+
+                    if (method_exists($firstItem, 'getCategory')):
+                        echo $view->render(
+                            'MauticCoreBundle:Helper:tableheader.html.php',
+                            [
+                                'sessionVar' => $sessionVar,
+                                'orderBy'    => (isset($categoryTablePrefix) ? $categoryTablePrefix : 'cat').'.title',
+                                'text'       => 'mautic.core.category',
+                                'class'      => 'visible-md visible-lg col-focus-category',
+                            ]
+                        );
+                    endif;
+                endif;
+
+                if (isset($listHeaders)):
+                    foreach ($listHeaders as $header):
+                        if (!isset($header['sessionVar'])):
+                            $header['sessionVar'] = $sessionVar;
+                        endif;
+
+                        echo $view->render('MauticCoreBundle:Helper:tableheader.html.php', $header);
+                    endforeach;
+                endif;
+
+                if (empty($ignoreStandardColumns)):
+                    echo $view->render(
+                        'MauticCoreBundle:Helper:tableheader.html.php',
+                        [
+                            'sessionVar' => $sessionVar,
+                            'orderBy'    => $tablePrefix.'.id',
+                            'text'       => 'mautic.core.id',
+                            'class'      => 'visible-md visible-lg col-id',
+                        ]
+                    );
+                endif;
+                ?>
+                <?php echo $view['content']->getCustomContent('list.headers', $mauticTemplateVars); ?>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($items as $item): ?>
+                <tr>
+                    <?php if (empty($ignoreStandardColumns)): ?>
+                        <td>
+                            <?php
+                            echo $view->render(
+                                'MauticCoreBundle:Helper:list_actions.html.php',
+                                [
+                                    'item'            => $item,
+                                    'templateButtons' => [
+                                        'edit' => method_exists($item, 'getCreatedBy')
+                                            ?
+                                            $view['security']->hasEntityAccess(
+                                                $permissions[$permissionBase.':editown'],
+                                                $permissions[$permissionBase.':editother'],
+                                                $item->getCreatedBy()
+                                            )
+                                            :
+                                            $permissions[$permissionBase.':edit'],
+                                        'clone'  => isset($enableCloneButton) ? $permissions[$permissionBase.':create'] : false,
+                                        'delete' => method_exists($item, 'getCreatedBy')
+                                            ?
+                                            $view['security']->hasEntityAccess(
+                                                $permissions[$permissionBase.':deleteown'],
+                                                $permissions[$permissionBase.':deleteother'],
+                                                $item->getCreatedBy()
+                                            )
+                                            :
+                                            $permissions[$permissionBase.':delete'],
+                                        'abtest' => isset($enableAbTestButton) ? $permissions[$permissionBase.':create'] : false,
+                                    ],
+                                    'actionRoute'     => $actionRoute,
+                                    'indexRoute'      => $indexRoute,
+                                    'translationBase' => $translationBase,
+                                    'customButtons'   => isset($customButtons) ? $customButtons : [],
+                                ]
+                            );
+                            ?>
+                        </td>
+                        <td>
+                            <div>
+                                <?php if (method_exists($item, 'isPublished')): ?>
+                                    <?php echo $view->render(
+                                        'MauticCoreBundle:Helper:publishstatus_icon.html.php',
+                                        ['item' => $item, 'model' => $modelName]
+                                    ); ?>
+                                <?php endif; ?>
+                                <a data-toggle="ajax" href="<?php echo $view['router']->path(
+                                    $actionRoute,
+                                    ['objectId' => $item->getId(), 'objectAction' => $nameAction]
+                                ); ?>">
+                                    <?php echo $item->getName(); ?>
+                                    <?php echo $view['content']->getCustomContent('list.name', $mauticTemplateVars); ?>
+                                </a>
+                            </div>
+                            <?php if (method_exists($item, 'getDescription') && $description = $item->getDescription()): ?>
+                                <div class="text-muted mt-4">
+                                    <small><?php echo $description; ?></small>
+                                </div>
+                            <?php endif; ?>
+                        </td>
+                        <?php if (method_exists($item, 'getCategory')): ?>
+                            <td class="visible-md visible-lg">
+                                <?php $category = $item->getCategory(); ?>
+                                <?php $catName  = ($category)
+                                    ? $category->getTitle()
+                                    : $view['translator']->trans(
+                                        'mautic.core.form.uncategorized'
+                                    ); ?>
+                                <?php $color = ($category) ? '#'.$category->getColor() : 'inherit'; ?>
+                                <span style="white-space: nowrap;"><span class="label label-default pa-4" style="border: 1px solid #d5d5d5; background: <?php echo $color; ?>;"> </span> <span><?php echo $catName; ?></span></span>
+                            </td>
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php
+                    if (isset($listItemTemplate)):
+                        $templateVariables['item'] = $item;
+                        echo $view->render($listItemTemplate, $templateVariables);
+                    endif;
+                    ?>
+                    <?php if (empty($ignoreStandardColumns)): ?>
+                        <td class="visible-md visible-lg"><?php echo $item->getId(); ?></td>
+                    <?php endif; ?>
+                    <?php echo $view['content']->getCustomContent('list.columns', $mauticTemplateVars); ?>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <div class="panel-footer">
+        <?php echo $view->render(
+            'MauticCoreBundle:Helper:pagination.html.php',
+            [
+                'totalItems' => $totalItems,
+                'page'       => $page,
+                'limit'      => $limit,
+                'baseUrl'    => $view['router']->path($indexRoute),
+                'sessionVar' => $sessionVar,
+            ]
+        ); ?>
+    </div>
+<?php else: ?>
+    <?php echo $view->render('MauticCoreBundle:Helper:noresults.html.php'); ?>
+<?php endif; ?>

--- a/app/bundles/CoreBundle/Views/Standard/list.html.twig
+++ b/app/bundles/CoreBundle/Views/Standard/list.html.twig
@@ -1,0 +1,243 @@
+{% set mauticTemplateVars = mauticTemplateVars is defined ? mauticTemplateVars : [] %}
+{% set ignoreStandardColumns = ignoreStandardColumns is defined ? ignoreStandardColumns : [] %}
+{% set isIndex = tmpl == 'index' ? true : false %}
+{% set tmpl = 'list' %}
+
+{% extends isIndex ? 'MauticCoreBundle:Default:content.html.twig' : 'MauticCoreBundle:Default:raw_output.html.twig' %}
+
+{% block mauticContent %}
+    {% if not slot('mauticContent') %}
+        {% if mauticContent is defined %}
+            {{ mauticContent }}
+        {% endif %}
+    {% else %}
+        {{ slot('mauticContent') }}
+    {% endif %}
+{% endblock %}
+
+{% if not slot('headerTitle') %}
+    {% if headerTitle is not defined %}
+        {% set headerTitle = 'Mautic' %}
+    {% endif %}
+    {% set headerTitle = headerTitle|trans %}
+{% else %}
+    {% set headerTitle = slot('headerTitle') %}
+{% endif %}
+
+{% block headerTitle %}{{ headerTitle }}{% endblock %}
+
+{% block actions %}
+    {{- include('MauticCoreBundle:Helper:page_actions.html.twig',
+    {
+        'templateButtons' : {
+            'new' : permissions[permissionBase ~ ':create'],
+        },
+        'actionRoute'     : actionRoute,
+        'indexRoute'      : indexRoute,
+        'translationBase' : translationBase,
+    }) -}}
+{% endblock %}
+
+{% block content %}
+    {% if isIndex %}
+        <div class="panel panel-default bdr-t-wdh-0 mb-0">
+            {{- include('MauticCoreBundle:Helper:list_toolbar.html.twig',
+                {
+                    'searchValue'      : searchValue,
+                    'searchHelp'       : searchHelp is defined ? searchHelp : '',
+                    'action'           : currentRoute,
+                    'actionRoute'      : actionRoute,
+                    'indexRoute'       : indexRoute,
+                    'translationBase'  : translationBase,
+                    'preCustomButtons' : toolBarButtons is defined ? toolBarButtons : null,
+                    'templateButtons'  : {
+                        'delete' : permissions[permissionBase ~ ':delete'],
+                    },
+                    'filters' : filters is defined ? filters : [],
+            }) -}}
+
+            <div class="page-list">
+                {{ customContent('content.above', mauticTemplateVars) }}
+                {{ block('mainContent') }}
+                {{ customContent('content.below', mauticTemplateVars) }}
+            </div>
+        </div>
+    {% else %}
+        {{ block('mainContent') }}
+    {% endif %}
+{% endblock %}
+
+{% block mainContent %}
+    {% if templateVariables is not defined %}
+        {% set templateVariables = [] %}
+    {% endif %}
+
+    {% if sessionVar is not defined %}
+        {% set sessionVar = 'entity' %}
+    {% endif %}
+
+    {% if nameAction is not defined %}
+        {% set nameAction = 'view' %}
+    {% endif %}
+
+    {% if items|length %}
+        {% if items is instanceof('\Doctrine\ORM\Tools\Pagination\Paginator') %}
+            {% set item = items.getIterator().getArrayCopy() %}
+        {% endif %}
+
+        {% set firstItem = items|first %}
+        <div class="table-responsive">
+            <table class="table table-hover table-striped table-bordered {{ sessionVar }}-list">
+                <thead>
+                <tr>
+                    {% if ignoreStandardColumns is empty %}
+                        {{- include('MauticCoreBundle:Helper:tableheader.html.twig',
+                            {
+                                'checkall'        : 'true',
+                                'actionRoute'     : actionRoute,
+                                'indexRoute'      : indexRoute,
+                                'templateButtons' : {
+                                    'delete' : permissions[permissionBase ~ ':deleteown'] is not empty or permissions[permissionBase ~ ':deleteown'] is not empty or permissions[permissionBase ~ ':delete'] is not empty,
+                                },
+                        }) -}}
+                        {{- include(
+                            'MauticCoreBundle:Helper:tableheader.html.twig',
+                            {
+                                'sessionVar' : sessionVar,
+                                'orderBy'    : tablePrefix ~ '.name',
+                                'text'       : 'mautic.core.name',
+                                'class'      : 'col-name',
+                                'default'    : true,
+                            }
+                        ) -}}
+
+                        {% if attribute(firstItem, 'getCategory') is defined %}
+                            {{ include('MauticCoreBundle:Helper:tableheader.html.twig',
+                                {
+                                    'sessionVar' : sessionVar,
+                                    'orderBy'    : (categoryTablePrefix is defined ? categoryTablePrefix : 'cat') ~ '.title',
+                                    'text'       : 'mautic.core.category',
+                                    'class'      : 'visible-md visible-lg col-focus-category',
+                            }) }}
+                        {% endif %}
+                    {% endif %}
+
+                        {% if listHeaders is defined %}
+                            {% for header in listHeaders %}
+                                {% if header.sessionVar is not defined %}
+                                    {% set header = header|merge({'sessionVar': sessionVar}) %}
+                                {% endif %}
+                            {{- include('MauticCoreBundle:Helper:tableheader.html.twig', header) -}}
+                            {% endfor %}
+                        {% endif %}
+
+                        {% if ignoreStandardColumns is empty %}
+                        {{- include('MauticCoreBundle:Helper:tableheader.html.twig',
+                            {
+                                'sessionVar' : sessionVar,
+                                'orderBy'    : tablePrefix ~ '.id',
+                                'text'       : 'mautic.core.id',
+                                'class'      : 'visible-md visible-lg col-id',
+                        }) -}}
+                        {% endif %}
+
+                        {{ customContent('list.headers', mauticTemplateVars) }}
+                </tr>
+                </thead>
+                <tbody>
+                {% for item in items %}
+                    <tr>
+                        {% if ignoreStandardColumns is empty %}
+                            <td>
+                            {{- include('MauticCoreBundle:Helper:list_actions.html.twig',
+                                    {
+                                        'item'            : item,
+                                        'templateButtons' : {
+                                            'edit' : attribute(item, 'getCreatedBy') is defined
+                                                ?
+                                                securityHasEntityAccess(
+                                                    permissions[permissionBase ~ ':editown'],
+                                                    permissions[permissionBase ~ ':editother'],
+                                                    item.getCreatedBy()
+                                                )
+                                                :
+                                                permissions[permissionBase ~ ':edit'],
+                                            'clone'  : enableCloneButton is defined ? permissions[permissionBase ~ ':create'] : false,
+                                            'delete' : attribute(item, 'getCreatedBy') is defined
+                                                ?
+                                                securityHasEntityAccess(
+                                                    permissions[permissionBase ~ ':deleteown'],
+                                                    permissions[permissionBase ~ ':deleteother'],
+                                                    item.getCreatedBy()
+                                                )
+                                                :
+                                                permissions[permissionBase ~ ':delete'],
+                                            'abtest' : enableAbTestButton is defined ? permissions[permissionBase ~ ':create'] : false,
+                                        },
+                                        'actionRoute'     : actionRoute,
+                                        'indexRoute'      : indexRoute,
+                                        'translationBase' : translationBase,
+                                        'customButtons'   : customButtons is defined ? customButtons : [],
+                            }) -}}
+                            </td>
+                            <td>
+                                <div>
+                                    {% if attribute(item, 'isPublished') is defined %}
+                                    {{ include(
+                                            'MauticCoreBundle:Helper:publishstatus_icon.html.twig',
+                                            {'item' : item, 'model' : modelName}
+                                        ) }}
+                                    {% endif %}
+                                    <a data-toggle="ajax" href="{{ path(
+                                        actionRoute,
+                                        {'objectId' : item.getId(), 'objectAction' : nameAction}
+                                    ) }}">
+                                        {{ item.getName() }}
+                                        {{ customContent('list.name', mauticTemplateVars) }}
+                                    </a>
+                                </div>
+                                {% if attribute(item, 'getDescription') is defined and item.getDescription() %}
+                                    <div class="text-muted mt-4">
+                                        <small>{{ item.getDescription() }}</small>
+                                    </div>
+                                {% endif %}
+                            </td>
+                            {% if attribute(item, 'getCategory') is defined %}
+                                <td class="visible-md visible-lg">
+                                    {% set category = item.getCategory() %}
+                                    {% set catName, color = category
+                                        ? category.getTitle()
+                                        : 'mautic.core.form.uncategorized'|trans, category ? '#' ~ category.getColor() : 'inherit' %}
+                                    <span style="white-space: nowrap;"><span class="label label-default pa-4" style="border: 1px solid #d5d5d5; background: {{ color }};"> </span> <span>{{ catName }}</span></span>
+                                </td>
+                            {% endif %}
+                        {% endif %}
+                        {% if listItemTemplate is defined %}
+                            {% set templateVariables = templateVariables|merge({'item': item}) %}
+                            {{- include(listItemTemplate, templateVariables) -}}
+                        {% endif %}
+                        {% if ignoreStandardColumns is empty %}
+                            <td class="visible-md visible-lg">{{ item.getId() }}</td>
+                        {% endif %}
+
+                        {{ customContent('list.columns', mauticTemplateVars) }}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <div class="panel-footer">
+            {{- include('MauticCoreBundle:Helper:pagination.html.twig',
+                {
+                    'totalItems' : totalItems,
+                    'page'       : page,
+                    'limit'      : limit,
+                    'baseUrl'    : path(indexRoute),
+                    'sessionVar' : sessionVar,
+            }) -}}
+        </div>
+    {% else %}
+        {{- include('MauticCoreBundle:Helper:noresults.html.twig') -}}
+    {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Reverts mautic/mautic#12006

Because it broke Marketing Messages. The list of Marketing Messages is not accessible with error:
```
Template list.html.php not found 
at /app/bundles/CoreBundle/Controller/AbstractStandardFormController.php:746
```