### PR TITLE
WIP getting the point action forms to use templates if any

### DIFF
--- a/app/bundles/PageBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PointSubscriber.php
@@ -53,7 +53,7 @@ class PointSubscriber implements EventSubscriberInterface
             'description' => 'mautic.page.point.action.urlhit_descr',
             'callback'    => [PointActionHelper::class, 'validateUrlHit'],
             'formType'    => PointActionUrlHitType::class,
-            'formTheme'   => 'MauticPageBundle:FormTheme\Point',
+            'formTheme'   => 'MauticPageBundle:FormTheme:Point/pointaction_urlhit_widget.html.twig',
         ];
 
         $event->addAction('url.hit', $action);

--- a/app/bundles/PageBundle/Views/FormTheme/Point/pointaction_urlhit_widget.html.twig
+++ b/app/bundles/PageBundle/Views/FormTheme/Point/pointaction_urlhit_widget.html.twig
@@ -18,7 +18,7 @@ $timeFrames = [
 
 <div class="row">
     <div class="col-xs-12">
-        <?php echo $view['form']->row($form['page_url']); ?>
+        {{ form_row(form.page_url) }}
     </div>
 </div>
 

--- a/app/bundles/PointBundle/Views/Point/actionform.html.twig
+++ b/app/bundles/PointBundle/Views/Point/actionform.html.twig
@@ -1,3 +1,5 @@
+{% form_theme form with formThemes %}
+<pre>{{ formThemes|json_encode }}</pre>
 {% for child in form %}
     {{ form_row(child) }}
 {% endfor %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I found that there is one Twig template in the PageBundle that has the PHP syntax inside. I was tracking why is that and found that the Point Action forms cannot have templates as of now. I'm trying to fix that but it seems that the template is not used. And the file name is different than what described in the Subscriber.

<img width="577" alt="Screen Shot 2023-02-24 at 13 43 47" src="https://user-images.githubusercontent.com/1235442/221182698-38b19873-763e-42dd-83fd-bb6949a879b7.png">


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new Point Action
3. Select "Visits specific URL"
4. The time inputs should have unit at the end of the field.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
