### PR TITLE
AJAX requests use the site_url instead of the current domain [backport]

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -47,5 +47,6 @@ class DetailsTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
         Assert::assertSame(200, $response->getStatusCode());
         Assert::assertStringContainsString($campaign->getName(), $response->getContent());
+        Assert::assertStringContainsString(sprintf('data-target-url="/s/campaigns/view/%s/contact/1"', $campaign->getId()), $response->getContent());
     }
 }

--- a/app/bundles/CampaignBundle/Views/Campaign/details.html.php
+++ b/app/bundles/CampaignBundle/Views/Campaign/details.html.php
@@ -232,7 +232,7 @@ switch (true) {
             <?php endif; ?>
             <!--/ #events-container -->
             <div class="tab-pane fade in bdr-w-0 page-list" id="leads-container" data-target-url="<?php
-                    echo $view['router']->url(
+                    echo $view['router']->path(
                         'mautic_campaign_contacts',
                         ['objectId' => $campaign->getId(), 'page' => $app->getSession()->get('mautic.campaign.contact.page', 1)]
                     );

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -78,6 +78,8 @@ class ListControllerTest extends MauticMysqlTestCase
         //Make sure that contact grid is not loaded synchronously
         self::assertStringNotContainsString('Kane', $response->getContent());
         self::assertStringNotContainsString('Jacques', $response->getContent());
+        //Make sure the data-target-url is not an absolute URL
+        self::assertStringContainsString(sprintf('data-target-url="/s/segment/view/%s/contact/1"', $segment->getId()), $response->getContent());
     }
 
     public function testSegmentContactGrid(): void

--- a/app/bundles/LeadBundle/Views/List/details.html.php
+++ b/app/bundles/LeadBundle/Views/List/details.html.php
@@ -169,7 +169,7 @@ $view['slots']->set(
         <!-- start: tab-content -->
         <div class="tab-content pa-md">
             <div class="tab-pane active bdr-w-0 page-list" id="contacts-container" data-target-url="<?php
-            echo $view['router']->url(
+            echo $view['router']->path(
                 'mautic_segment_contacts',
                 ['objectId' => $list->getId(), 'page' => $app->getSession()->get('mautic.segment.contact.page', 1)]
             );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

Backport for PR: https://github.com/mautic/mautic/pull/12037
 
When a Mautic instance is setup with 2 domains, one publicly accessible and one not (e.g. internal.mautic.com and public.mautic.com), and the site_url is set to the public mautic (so emails add the correct URls, images, etc) then AJAX requests when browsing the internal site will incorrectly use the public URL.

Specifically: 
- Campaign detail view fetches contacts using a JS request, which will use the wrong URL
- Segment detail view fetches contacts using a JS request, which will use the wrong URL

This PR simply replaces the absolute URL in the data-target-url with the path, so the JS automatically uses the current domain regardless of which one it is.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Set the site URL to a subdomain
3. Clear caches
4. Create a campaign and some contacts that will be added to the campaign
5. Visit the campaign detail page
6. Check the network tab, the request to fetch contacts should NOT use the subdomain site URL (without this patch, it would use the site url)
7. Then do the same for segments.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
