### PR TITLE
fix for email graph stats when switching between variant and all

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -272,6 +272,9 @@ class EmailController extends FormController
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->get('form.factory')->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 
+        // Get the stats filter from the querystring.
+        $statsFilter = $this->request->get('stats', '');
+
         if (null === $email) {
             //set the return URL
             $returnUrl = $this->generateUrl('mautic_email_index', ['page' => $page]);
@@ -423,6 +426,7 @@ class EmailController extends FormController
                         ]
                     )->getContent(),
                     'dateRangeForm' => $dateRangeForm->createView(),
+                    'statsFilter'   => $statsFilter,
                 ],
                 'contentTemplate' => 'MauticEmailBundle:Email:details.html.php',
                 'passthroughVars' => [

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -240,8 +240,13 @@ if (!$isEmbedded) {
             $isVariant = $showTranslations || $showVariants ?: 0;
             $dateFrom  = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
             $dateTo    = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
+
+            $statsParam = [];
+            if ($statsFilter) {
+                $statsParam = ['stats' => $statsFilter];
+            }
             ?>
-            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')]); ?>">
+            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')] + $statsParam); ?>">
                 <div class="spinner">
                     <i class="fa fa-spin fa-spinner"></i>
                 </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

_This is a PR for 4.4, as we discovered the bug there.
the PR for 5.x is part of #11915 

#### Description:

when having variants of an email (e.g. by translating the mail), the stats on both the parent of the translation are not working as expected:
* on the parent
    * by default, the stats are shown for all variants together (good)
    * toggling the filter from `all` to `variant` reloads the page with an extra query param (good), but it doesn't change the graph (bad)
* on a variant
    * by default, the stats are shown for the specific variant together (good)
    * toggling the filter from `variant` to `all` reloads the page with an extra query param (good), but it doesn't change the graph (bad)

![Screenshot 2023-03-02 at 14 45 47](https://user-images.githubusercontent.com/3983285/222446007-a7ddb996-b1f2-47dc-8ca6-7f3a965cf86c.png)


this is caused because the extra query param is not passed to the subrequest.
This PR passes the needed param

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  create an email, and translate it.
3. create some contacts with with a different preferred languages (ideally, you know exactly how many, so you can validate the stats), and add them to a test segment
5. send the email to created segment
6. validate the sending stats, and verify the problem described in the description exists
7. apply the patch
8. validate the sending stats, and verify the problem described in the description is gone

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
