### PR TITLE
fix failing test test

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -26,7 +26,7 @@ class PRedisConnectionHelperTest extends TestCase
         Assert::assertSame([['scheme'=>'tcp', 'host'=>'1.1.1.1']], PRedisConnectionHelper::getRedisEndpoints('tcp://1.1.1.1'));
 
         // domain should be resolved and an array of ip addresses returned
-        $connInfo = PRedisConnectionHelper::getRedisEndpoints('tcp://mautic.net:8888?test=car');
+        $connInfo = PRedisConnectionHelper::getRedisEndpoints('tcp://bing.com:8888?test=car');
         Assert::assertIsArray($connInfo);
         Assert::assertGreaterThan(1, count($connInfo));
         foreach ($connInfo as $c) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes failing CI

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There is one test that is hitting the mautic.net domain and it expects multiple IP addresses. Our dev ops team recently changed that and so the test started to fail. This change uses different domain (bing.com) instead.

#### Steps to test this PR:

Just see the CI green.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
