### PR TITLE
Contact timeline twig fixes

### DIFF
--- a/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.twig
@@ -41,7 +41,7 @@
         <h6 class="mt-lg mb-sm"><strong>{{ 'mautic.email.timeline.open_details'|trans }}</strong></h6>
         {% for key, detail in item.openDetails %}
             {% if 'bouces' != key %}
-              {% if showMore is empty and loop.index > 5 %}
+              {% if showMore is not defined and loop.index > 5 %}
                   {% set showMore = true %}
                   <div style="display:none">
               {% endif %}

--- a/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.twig
@@ -1,7 +1,7 @@
 {% if event.extra is defined %}
   {% set timeOnPage = 'mautic.core.unknown'|trans %}
 
-  {% if event.extra.hit.dateLeft is defined %}
+  {% if event.extra.hit.dateLeft %}
       {% set timeOnPage = (event.extra.hit.dateLeft.timestamp - event.extra.hit.dateHit.timestamp) %}
 
       {# format the time #}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ N ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR fixes two issues I have found after migrating lead bundle to twig templates:
- Error 500 when contact has open email event on timeline
```
[2023-03-14 13:13:59] mautic.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "Variable "showMore" does not exist." at /var/www/html/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.twig line 44 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): Variable \"showMore\" does not exist. at /var/www/html/app/bundles/EmailBundle/Views/SubscribedEvents/Timeline/index.html.twig:44)
[stacktrace]
```
- Error 500 when contact has pagehit without `dateLeft` specified
```
[2023-03-14 13:23:32] mautic.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "Impossible to access an attribute ("getTimestamp") on a null variable." at /var/www/html/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.twig line 5 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): Impossible to access an attribute (\"getTimestamp\") on a null variable. at /var/www/html/app/bundles/PageBundle/Views/SubscribedEvents/Timeline/index.html.twig:5)
[stacktrace]
```
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an email with a link and send it to the contact
3. Open email (while not logged into Mautic in the same browser session)
4. Open link in new browser tab, but do not click on this tab (close it immediately)
5. Log in to Mautic and open the contact details page. Check email open and page views events
![image](https://user-images.githubusercontent.com/8580942/225019323-eb03bf9d-1792-4dc1-b458-08208b12c6ca.png)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
