### PR TITLE
fix segment/campaign detail view's contacts tab pagination problem

### DIFF
--- a/app/bundles/LeadBundle/Views/Lead/grid.html.twig
+++ b/app/bundles/LeadBundle/Views/Lead/grid.html.twig
@@ -33,7 +33,7 @@
 </div>
 {% if items|length > 0 %}
     <div class="panel-footer">
-        {% set route = link|default('mautic_contact_index') %}
+        {% set route = route is defined ? route : (link|default('mautic_contact_index')) %}
         {% set routeParameters = routeParameters|default([]) %}
         {% if objectId is defined %}
           {% set routeParameters = routeParameters|merge({'objectId': objectId}) %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |  [ x ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12092 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

##### What happened?
When you click on a pagination link in a segment detail page’s contact tab, it's not show the next page result, but jumps to the /s/contacts.

##### How can we reproduce this issue?
Step 1: Select a segment with 2 pages or more, enter the detail page and then click the contacts tab.
Step 2: Click the page 2 link
Step 3: Notice it doesn't work

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to a segment with 2 pages or more, enter the detail page, then click the contacts tab
3. Click the page 2 link
4. It should now direct you to the second page.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
