### PR TITLE
fix broken UI installer when using < recommended memory

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -58,7 +58,7 @@ class CheckStep implements StepInterface
      *
      * @var string
      */
-    public static $memory_limit = '512M';
+    public const RECOMMENDED_MEMORY_LIMIT = '512M';
 
     /**
      * @param Configurator $configurator Configurator service
@@ -230,7 +230,7 @@ class CheckStep implements StepInterface
         }
 
         $memoryLimit    = FileHelper::convertPHPSizeToBytes(ini_get('memory_limit'));
-        $suggestedLimit = FileHelper::convertPHPSizeToBytes(self::$memory_limit);
+        $suggestedLimit = FileHelper::convertPHPSizeToBytes(self::RECOMMENDED_MEMORY_LIMIT);
         if ($memoryLimit > -1 && $memoryLimit < $suggestedLimit) {
             $messages[] = 'mautic.install.memory.limit';
         }

--- a/app/bundles/InstallBundle/Resources/views/Install/check.html.twig
+++ b/app/bundles/InstallBundle/Resources/views/Install/check.html.twig
@@ -78,7 +78,7 @@
                          {% elseif message == 'mautic.install.php.version.has.only.security.support' %}
                              <li class="list-group-item">{{ message|trans ({'%phpversion%' : constant('PHP_VERSION')}) }}</li>
                          {% elseif message == 'mautic.install.memory.limit' %}
-                             <li class="list-group-item">{{ message|trans ({'%min_memory_limit%' : constant('Mautic\InstallBundle\Configurator\Step\CheckStep::memory_limit')}) }}</li>
+                             <li class="list-group-item">{{ message|trans ({'%min_memory_limit%' : constant('Mautic\\InstallBundle\\Configurator\\Step\\CheckStep::RECOMMENDED_MEMORY_LIMIT')}) }}</li>
                          {% else %}
                              <li class="list-group-item">{{ message|trans }}</li>
                          {% endif %}

--- a/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
+++ b/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
@@ -55,6 +55,8 @@ class InstallWorkflowTest extends MauticMysqlTestCase
     {
         // Step 0: System checks.
         $crawler      = $this->client->request(Request::METHOD_GET, '/installer');
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
         $submitButton = $crawler->selectButton('install_check_step[buttons][next]');
         $form         = $submitButton->form();
         $crawler      = $this->client->submit($form);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Locally, I have a `memory_limit` of 256M on CLI and in Apache.

This results in a broken UI installer on the `5.x` branch:

<img width="1173" alt="Screenshot 2023-03-25 at 10 32 54" src="https://user-images.githubusercontent.com/3983285/227709294-020a0644-3b20-452c-a835-f9e0a1972b26.png">

in the logfile, following error is present:
```
[2023-03-25 09:33:37] mautic.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "Constant "MauticInstallBundleConfiguratorStepCheckStep::memory_limit" is undefined." at /var/www/html/mautic/app/bundles/InstallBundle/Resources/views/Install/check.html.twig line 81 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): Constant \"MauticInstallBundleConfiguratorStepCheckStep::memory_limit\" is undefined. at /var/www/html/mautic/app/bundles/InstallBundle/Resources/views/Install/check.html.twig:81)"} {"hostname":"d81551e5e906","pid":63}
```

Running the tests locally, results in an error:

```
./bin/phpunit -d memory_limit=1G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist app/bundles/InstallBundle
PHPUnit 9.5.20 #StandWithUkraine

using db prefix "test_"
.....E...................                                         25 / 25 (100%)

Time: 00:10.882, Memory: 52.50 MB

There was 1 error:

1) Mautic\InstallBundle\Tests\Functional\InstallWorkflowTest::testInstallWorkflow
InvalidArgumentException: The current node list is empty.

/var/www/html/mautic/vendor/symfony/dom-crawler/Crawler.php:938
/var/www/html/mautic/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php:62

ERRORS!
Tests: 25, Assertions: 50, Errors: 1.

```

The reason is 2 fold:
* the class containing the `memory_limit` constant is not defined with double slashes, see [source code](https://github.com/mautic/mautic/blob/5.x/app/bundles/InstallBundle/Resources/views/Install/check.html.twig#L81).
  see also the `MauticInstallBundleConfiguratorStepCheckStep::memory_limit` in the error above.
  With correct double slashes this should be `Mautic\InstallBundle\Configurator\Step\CheckStep::memory_limit`
* `memory_limit` is not a constant, but a static property in that class

This PR addresses this regression, and adds a functional test to check both a lower and higher memory limit.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to reproduce this bug (locally or gitpod):

* checkout the 5.x branch
* add following line to the `app/config/local.php` file

    ```
    ini_set('memory_limit', '511M');
    ```
* run the tests the same way the testbot does, they should fail
    ```
    composer2 test -- app/bundles/InstallBundle/Tests/Functional/
    ```
* go to the UI in your browser, it should throw an error
* change the line in `app/config/local.php` to
    ```
    ini_set('memory_limit', '513M');
    ```
* the tests above should work again


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
