### PR TITLE
improve test speed of campaign count tests

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
+++ b/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
@@ -19,6 +19,8 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
 {
     protected function saveSomeCampaignLeadEventLogs(bool $emulatePendingCount = false): Campaign
     {
+        $relativeDate = date('Y-m-d', strtotime('-1 month'));
+
         /** @var LeadEventLogRepository $leadEventLogRepo */
         $leadEventLogRepo = $this->em->getRepository(LeadEventLog::class);
 
@@ -61,28 +63,28 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
         $leadEventLogA->setCampaign($campaign);
         $leadEventLogA->setEvent($eventA);
         $leadEventLogA->setLead($contactA);
-        $leadEventLogA->setDateTriggered(new \DateTime('2020-11-21 16:34:00', new \DateTimeZone('UTC')));
+        $leadEventLogA->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
         $leadEventLogA->setRotation(0);
 
         $leadEventLogB = new LeadEventLog();
         $leadEventLogB->setCampaign($campaign);
         $leadEventLogB->setEvent($eventA);
         $leadEventLogB->setLead($contactB);
-        $leadEventLogB->setDateTriggered(new \DateTime('2020-11-21 16:54:00', new \DateTimeZone('UTC')));
+        $leadEventLogB->setDateTriggered(new \DateTime($relativeDate.' 16:54:00', new \DateTimeZone('UTC')));
         $leadEventLogB->setRotation(0);
 
         $leadEventLogC = new LeadEventLog();
         $leadEventLogC->setCampaign($campaign);
         $leadEventLogC->setEvent($eventB);
         $leadEventLogC->setLead($contactA);
-        $leadEventLogC->setDateTriggered(new \DateTime('2020-11-21 16:55:00', new \DateTimeZone('UTC')));
+        $leadEventLogC->setDateTriggered(new \DateTime($relativeDate.' 16:55:00', new \DateTimeZone('UTC')));
         $leadEventLogC->setRotation(0);
 
         $leadEventLogD = new LeadEventLog();
         $leadEventLogD->setCampaign($campaign);
         $leadEventLogD->setEvent($eventB);
         $leadEventLogD->setLead($contactB);
-        $leadEventLogD->setDateTriggered(new \DateTime('2020-11-21 17:04:00', new \DateTimeZone('UTC')));
+        $leadEventLogD->setDateTriggered(new \DateTime($relativeDate.' 17:04:00', new \DateTimeZone('UTC')));
         $leadEventLogD->setRotation(0);
 
         $leadEventLogRepo->saveEntities([$leadEventLogA, $leadEventLogB, $leadEventLogC, $leadEventLogD]);
@@ -90,14 +92,14 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
         $campaignLeadsA = new CampaignLeads();
         $campaignLeadsA->setLead($contactA);
         $campaignLeadsA->setCampaign($campaign);
-        $campaignLeadsA->setDateAdded(new \DateTime('2020-11-21'));
+        $campaignLeadsA->setDateAdded(new \DateTime($relativeDate));
         $campaignLeadsA->setRotation(0);
         $campaignLeadsA->setManuallyRemoved(false);
 
         $campaignLeadsB = new CampaignLeads();
         $campaignLeadsB->setLead($contactB);
         $campaignLeadsB->setCampaign($campaign);
-        $campaignLeadsB->setDateAdded(new \DateTime('2020-11-21'));
+        $campaignLeadsB->setDateAdded(new \DateTime($relativeDate));
         $campaignLeadsB->setRotation(0);
         $campaignLeadsB->setManuallyRemoved(false);
 
@@ -111,14 +113,14 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
             $leadEventLogD->setCampaign($campaign);
             $leadEventLogD->setEvent($eventA);
             $leadEventLogD->setLead($contactC);
-            $leadEventLogD->setDateTriggered(new \DateTime('2020-11-21 16:34:00', new \DateTimeZone('UTC')));
+            $leadEventLogD->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
             $leadEventLogD->setRotation(0);
             $leadEventLogRepo->saveEntity($leadEventLogD);
 
             $campaignLeadsC = new CampaignLeads();
             $campaignLeadsC->setLead($contactC);
             $campaignLeadsC->setCampaign($campaign);
-            $campaignLeadsC->setDateAdded(new \DateTime('2020-11-21'));
+            $campaignLeadsC->setDateAdded(new \DateTime($relativeDate));
             $campaignLeadsC->setRotation(0);
             $campaignLeadsC->setManuallyRemoved(true);
             $campaignLeadsRepo->saveEntity($campaignLeadsC);

--- a/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
@@ -19,7 +19,7 @@ final class SummarizeCommandTest extends AbstractCampaignTest
             SummarizeCommand::NAME,
             [
                 '--env'       => 'test',
-                '--max-hours' => 9999,
+                '--max-hours' => 730,
             ]
         );
 
@@ -37,13 +37,15 @@ final class SummarizeCommandTest extends AbstractCampaignTest
      */
     public function testBackwardSummarizationWhenThereAreLogs(): void
     {
+        $relativeDate = date('Y-m-d', strtotime('-1 month'));
+
         $campaign = $this->saveSomeCampaignLeadEventLogs();
 
         $this->runCommand(
             SummarizeCommand::NAME,
             [
                 '--env'       => 'test',
-                '--max-hours' => 9999999,
+                '--max-hours' => 730,
             ]
         );
 
@@ -55,17 +57,17 @@ final class SummarizeCommandTest extends AbstractCampaignTest
 
         Assert::assertCount(3, $summaries);
 
-        Assert::assertSame('2020-11-21T17:00:00+00:00', $summaries[0]->getDateTriggered()->format(DATE_ATOM));
+        Assert::assertSame($relativeDate.'T17:00:00+00:00', $summaries[0]->getDateTriggered()->format(DATE_ATOM));
         Assert::assertSame(1, $summaries[0]->getTriggeredCount());
         Assert::assertSame($campaign->getId(), $summaries[0]->getCampaign()->getId());
         Assert::assertSame('Event B', $summaries[0]->getEvent()->getName());
 
-        Assert::assertSame('2020-11-21T16:00:00+00:00', $summaries[1]->getDateTriggered()->format(DATE_ATOM));
+        Assert::assertSame($relativeDate.'T16:00:00+00:00', $summaries[1]->getDateTriggered()->format(DATE_ATOM));
         Assert::assertSame(2, $summaries[1]->getTriggeredCount());
         Assert::assertSame($campaign->getId(), $summaries[1]->getCampaign()->getId());
         Assert::assertSame('Event A', $summaries[1]->getEvent()->getName());
 
-        Assert::assertSame('2020-11-21T16:00:00+00:00', $summaries[2]->getDateTriggered()->format(DATE_ATOM));
+        Assert::assertSame($relativeDate.'T16:00:00+00:00', $summaries[2]->getDateTriggered()->format(DATE_ATOM));
         Assert::assertSame(1, $summaries[2]->getTriggeredCount());
         Assert::assertSame($campaign->getId(), $summaries[2]->getCampaign()->getId());
         Assert::assertSame('Event B', $summaries[2]->getEvent()->getName());

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -136,10 +136,13 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
 
     private function getStatTotalContacts(int $campaignId): int
     {
+        $from = date('Y-m-d', strtotime('-2 months'));
+        $to   = date('Y-m-d', strtotime('-1 month'));
+
         $stats = $this->campaignModel->getCampaignMetricsLineChartData(
             null,
-            new \DateTime('2020-10-21'),
-            new \DateTime('2020-11-22'),
+            new \DateTime($from),
+            new \DateTime($to),
             null,
             ['campaign_id' => $campaignId]
         );
@@ -178,10 +181,13 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
 
     private function getCrawlers(int $campaignId): Crawler
     {
+        $from = date('F d, Y', strtotime('-2 months'));
+        $to   = date('F d, Y', strtotime('-1 month'));
+
         $parameters = [
             'daterange' => [
-                'date_from' => 'Nov 1, 2020',
-                'date_to'   => 'Nov 30, 2020',
+                'date_from' => $from,
+                'date_to'   => $to,
             ],
         ];
 
@@ -232,7 +238,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
                 SummarizeCommand::NAME,
                 [
                     '--env'       => 'test',
-                    '--max-hours' => 9999999,
+                    '--max-hours' => 730,
                 ]
             );
         }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

While running the testsuite locally, I noticed the test speed for campaign tests was slower than some months ago.
When profiling those tests with Xhprof, I noticed that per test method there were 20K queries.

When looking up the code, I noticed there are 2 fixed dates used in `AbstractCampaignTest::saveSomeCampaignLeadEventLogs()`, `SummarizeCommandTest` and `CampaignControllerFunctionalTest` 

The test needs to loop over all hours(!) since that date (hence the large values of the `--max-hours` flags), which makes it slower and slower over time.

This PR addresses this, and improves the overall test speed of the github actions with +- 2 minutes.
Locally there may be more impact depending on the speed of the used database.

before:
https://github.com/mautic/mautic/actions/runs/4524320016
![Screenshot 2023-03-27 at 08 36 23](https://user-images.githubusercontent.com/3983285/227859902-47844ea0-c20b-4bed-a71b-b2f6d19071a1.png)


after:
https://github.com/mautic/mautic/actions/runs/4526562444
![Screenshot 2023-03-27 at 08 36 18](https://user-images.githubusercontent.com/3983285/227859898-3f1070bb-b6ad-4ea8-8c40-58ca93bb027c.png)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
