### PR TITLE
Datetime interval in UTC timezone for mautic:integration:fetchleads

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -550,7 +550,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      */
     protected function getSyncTimeframeDates(array $params)
     {
-        $fromDate = (isset($params['start'])) ? \DateTime::createFromFormat(\DateTime::ATOM, $params['start'])->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s') : null;
+        $fromDate = (isset($params['start'])) ? \DateTime::createFromFormat(\DateTime::ATOM, $params['start'])->setTimezone(new \DateTimeZone('UTC'))->format(DateTimeHelper::FORMAT_DB) : null;
         $toDate   = (isset($params['end'])) ? \DateTime::createFromFormat(\DateTime::ATOM, $params['end'])->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s') : null;
 
         return [$fromDate, $toDate];

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -550,10 +550,8 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      */
     protected function getSyncTimeframeDates(array $params)
     {
-        $fromDate = (isset($params['start'])) ? \DateTime::createFromFormat(\DateTime::ISO8601, $params['start'])->format('Y-m-d H:i:s')
-            : null;
-        $toDate = (isset($params['end'])) ? \DateTime::createFromFormat(\DateTime::ISO8601, $params['end'])->format('Y-m-d H:i:s')
-            : null;
+        $fromDate = (isset($params['start'])) ? \DateTime::createFromFormat(\DateTime::ATOM, $params['start'])->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s') : null;
+        $toDate   = (isset($params['end'])) ? \DateTime::createFromFormat(\DateTime::ATOM, $params['end'])->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s') : null;
 
         return [$fromDate, $toDate];
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | No
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | ?

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We have noticed that you could have timezone sync. command issue to fetch information from integration depending on your configuration.
This PR fixes it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Set a different timezone from UTC in your instance
3. Set an integration like Salesforce > create data and try to fetch data on a short timeframe. You'll see your contact is not fetched even if on the right timing of your command. This is because of the timezone setting.
