### PR TITLE
Fix broken JS in 3b.chosen.ajax.js that makes dropdown broken in campaign builder

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/libraries/3b.chosen.ajax.js
+++ b/app/bundles/CoreBundle/Assets/js/libraries/3b.chosen.ajax.js
@@ -139,11 +139,11 @@
                     div.text(untrimmed_val);
                     $('body').append(div);
                     w = div.width() + 25;
-                    f_width = field.closest('.chosen-choices').outerWidth();
+                    f_width = field.closest('.chosen-container').outerWidth();
 
                     // Mautic - only apply container width if not hidden which will result in a bad size
                     if (w > f_width - 10) {
-                        w = f_width;
+                        w = f_width - 10;
                     }
 
                     div.remove();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ 
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | N/A
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
We have noticed that in certain case sin UI of campaign builder, you are able to break the dropdown in action modal.
<img width="599" alt="Capture d’écran 2023-03-29 à 10 56 39" src="https://user-images.githubusercontent.com/14075239/228482272-a770b229-1bf3-4bfb-ac53-4e4c2f9ee5df.png">
<img width="422" alt="Capture d’écran 2023-03-29 à 10 56 23" src="https://user-images.githubusercontent.com/14075239/228482281-77518640-6c59-427a-811d-8b4a5692064b.png">


#### Steps to test this PR:
1. Create a lot of email
2. Try search in bar to break the UI
3. See with PR you cannot reproduce.