### PR TITLE
Stop rendering fields twice

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/FormTheme/Config/_config_emailconfig_widget.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/FormTheme/Config/_config_emailconfig_widget.html.twig
@@ -179,10 +179,6 @@
             {{ _self.row_if_exists(fields, 'resubscribe_message') }}
         </div>
         <div class="row">
-            {{ _self.row_if_exists(fields, 'unsubscribe_message') }}
-            {{ _self.row_if_exists(fields, 'resubscribe_message') }}
-        </div>
-        <div class="row">
             {{ _self.row_if_exists(fields, 'show_contact_preferences') }}
             {{ _self.row_if_exists(fields, 'show_contact_segments') }}
         </div>

--- a/app/bundles/FormBundle/Resources/views/FormTheme/Config/_config_formconfig_widget.html.twig
+++ b/app/bundles/FormBundle/Resources/views/FormTheme/Config/_config_formconfig_widget.html.twig
@@ -16,13 +16,11 @@
           <h3 class="panel-title">{{ 'mautic.config.tab.formresultsconfig'|trans }}</h3>
       </div>
       <div class="panel-body">
-          {% for child in form.children %}
-              <div class="row">
-                  <div class="col-md-6">
-                      {{ form_row(form.form_results_data_sources) }}
-                  </div>
-              </div>
-          {% endfor %}
+            <div class="row">
+                <div class="col-md-6">
+                    {{ form_row(form.form_results_data_sources) }}
+                </div>
+            </div>
       </div>
   </div>
 {% endblock %}

--- a/app/bundles/LeadBundle/Resources/views/Import/_mapping_form.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/_mapping_form.html.twig
@@ -30,7 +30,7 @@
         <div class="panel-body">
             {{ form_errors(form) }}
             {% for key, child in form.children %}
-                {% if 'properties' != key %}
+                {% if 'properties' != key and not child.isRendered %}
                     {{ cycle(['','','<div class="row">'], loop.index0)|raw }}
                     <div class="col-sm-4">
                         {{ form_row(child) }}

--- a/app/bundles/LeadBundle/Resources/views/Lead/form.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/form.html.twig
@@ -187,7 +187,7 @@
                                   <div class="form-group mb-0">
                                       <div class="row">
                                           {% for alias, field in groupFields %}
-                                              {% if 'company' != alias or form[alias] is defined or not form[alias].isRendered %}
+                                              {% if 'company' != alias and form[alias] is defined and not form[alias].isRendered %}
                                                   <div class="col-sm-8">
                                                       {{ form_row(form[alias]) }}
                                                   </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR fixes many deprecation notices like this one:
```
10x: You are calling "form_row" for field "unsubscribe_message" which has already been rendered before,
trying to render fields which were already rendered is deprecated since Symfony 4.2 and will throw an exception in 5.0.
```
Those deprecations obviously must be fixed before Symfony 5 upgrade.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. These views were affected by the change:
3. Contact edit form. Make sure that the custom fields are still rendered properly
4. Contact import mapping form
5. Email config form at the bottom. Make sure that the unsubscribe and resubscribe messages are still present.
6. Form config form.

There should be no visible change compared to the previous version of Mautic.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
