### PR TITLE
Replacing controller syntax for Symfony 5 that was forgotten from #11063

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
@@ -13,8 +13,8 @@
                 <i class="fa fa-navicon fs-16"></i>
             </a>
         </li>
-        {{ render(controller('MauticCoreBundle:Default:notifications')) }}
-        {{ render(controller('MauticCoreBundle:Default:globalSearch')) }}
+        {{ render(controller('Mautic\\CoreBundle\\Controller\\DefaultController::notificationsAction')) }}
+        {{ render(controller('Mautic\\CoreBundle\\Controller\\DefaultController::globalSearchAction')) }}
     </ul>
     <!--/ end: left nav -->
 

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -142,7 +142,7 @@ return [
             ],
             'mautic_contact_export_download' => [
                 'path'       => '/contacts/export/download/{fileName}',
-                'controller' => 'MauticLeadBundle:Lead:downloadExport',
+                'controller' => 'Mautic\LeadBundle\Controller\LeadController::downloadExportAction',
             ],
         ],
         'api' => [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This finishes the effort done in https://github.com/mautic/mautic/pull/11063 and resolves these deprecation notices:
```
242x: Referencing controllers with MauticCoreBundle:Default:globalSearch is deprecated since Symfony 4.1, use "Mautic\CoreBundle\Controller\DefaultController::globalSearchAction" instead.

242x: Referencing controllers with MauticCoreBundle:Default:notifications is deprecated since Symfony 4.1, use "Mautic\CoreBundle\Controller\DefaultController::notificationsAction" instead.

47x: Referencing controllers with MauticLeadBundle:Lead:downloadExport is deprecated since Symfony 4.1, use "Mautic\LeadBundle\Controller\LeadController::downloadExportAction" instead.
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure that the notification and global search UI work as before
3. Test downloading contact export.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
