### PR TITLE
Fixing missed template include syntax

### DIFF
--- a/app/bundles/IntegrationsBundle/Resources/views/Config/form.html.twig
+++ b/app/bundles/IntegrationsBundle/Resources/views/Config/form.html.twig
@@ -137,7 +137,7 @@
         {{ form_row(objectFieldMapping['filter-keyword']) }}
 
         <div id="field-mappings-{{ object }}">
-        {{- include('Integrations/Config/field_mapping.html.twig', {
+        {{- include('@Integrations/Config/field_mapping.html.twig', {
             'form'        : form.featureSettings.sync.fieldMappings[object],
             'integration' : integrationObject.getName(),
             'object'      : object,

--- a/app/bundles/ReportBundle/Resources/views/Report/details_data_graphs.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/details_data_graphs.html.twig
@@ -7,7 +7,7 @@
                     </div><div class="row equal">
                     {%- set rowCount = 0 -%}
                 {% endif %}
-                {{ include('MauticReportBundle:Graph:' ~ graphs[key].type|capitalize ~ '.html.twig', {
+                {{ include('@MauticReport/Graph/' ~ graphs[key].type|capitalize ~ '.html.twig', {
                       'graph': graphs[key].data,
                       'options': graphs[key].options,
                       'report': report

--- a/plugins/MauticFocusBundle/Resources/views/Builder/Bar/parent.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/Bar/parent.less.twig
@@ -1,4 +1,4 @@
-{{ include('MauticFocusBundle:Builder:Bar/animations.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Bar/animations.less.twig', with_context=false) }}
 
 .mf-bar-iframe {
     width: 100%;
@@ -54,7 +54,7 @@
     }
 }
 
-{{ include('MauticFocusBundle:Builder:Bar/shared.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Bar/shared.less.twig', with_context=false) }}
 {{ include('@MauticFocus/Builder/Bar/collapser.less.twig', with_context=false) }}
 
 @media only screen and (max-width: 667px) {

--- a/plugins/MauticFocusBundle/Resources/views/Builder/Bar/style.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/Bar/style.less.twig
@@ -99,7 +99,7 @@
     }
 }
 
-{{ include('MauticFocusBundle:Builder:Bar/collapser.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Bar/collapser.less.twig', with_context=false) }}
 
 @media only screen and (max-width: 667px) {
     & .mf-bar-collapse, & .mf-bar-collapser {
@@ -108,7 +108,7 @@
 }
 
 {% if preview is not empty %}
-{{ include('MauticFocusBundle:Builder:Bar/animations.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Bar/animations.less.twig', with_context=false) }}
 {{ include('@MauticFocus/Builder/Bar/shared.less.twig', with_context=false) }}
 .mf-bar {
     &.mf-animate {

--- a/plugins/MauticFocusBundle/Resources/views/Builder/Modal/parent.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/Modal/parent.less.twig
@@ -1,4 +1,4 @@
-{{ include('MauticFocusBundle:Builder:Modal/animations.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Modal/animations.less.twig', with_context=false) }}
 {{ include('@MauticFocus/Builder/Modal/overlay.less.twig', with_context=false) }}
 .mf-modal-iframe {
     position: fixed;

--- a/plugins/MauticFocusBundle/Resources/views/Builder/Modal/style.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/Modal/style.less.twig
@@ -66,7 +66,7 @@
 }
 
 {% if preview is not empty %}
-{{ include('MauticFocusBundle:Builder:Modal/animations.less.twig', with_context=false) }}
+{{ include('@MauticFocus/Builder/Modal/animations.less.twig', with_context=false) }}
 {{ include('@MauticFocus/Builder/Modal/overlay.less.twig', with_context=false) }}
 
 .mf-modal, .mf-modal-overlay {

--- a/plugins/MauticFocusBundle/Resources/views/Builder/content.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/content.html.twig
@@ -8,7 +8,7 @@
   Notes
     - focus.htmlMode === htmlMode? is this always true?
 #}
-{% set templateBase = 'MauticFocusBundle:Builder:' ~ focus.style|capitalize ~ '/index.html.twig'  %}
+{% set templateBase = '@MauticFocus/Builder/' ~ focus.style|capitalize ~ '/index.html.twig'  %}
 {% set preview = preview|default(false) %}
 {% set clickUrl = clickUrl|default('#') %}
 {% set props = focus.properties %}

--- a/plugins/MauticFocusBundle/Resources/views/Builder/generate.js.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/generate.js.twig
@@ -23,7 +23,7 @@
     {%- set timeout = useTimeout * 1000 -%}
 {%- endif -%}
 
-{%- set cssContent = include('MauticFocusBundle:Builder:style.less.twig', {
+{%- set cssContent = include('@MauticFocus/Builder/style.less.twig', {
         'preview': preview,
         'focus': focus,
 }, with_context=false) -%}

--- a/plugins/MauticFocusBundle/Resources/views/Builder/parent.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/parent.less.twig
@@ -1,7 +1,7 @@
 {%- set less -%}
-  {{- include('MauticFocusBundle:Builder:Bar/parent.less.twig', with_context=false) -}}
-  {{- include('MauticFocusBundle:Builder:Modal/parent.less.twig', with_context=false) -}}
-  {{- include('MauticFocusBundle:Builder:Notification/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocusBundle/Builder/Bar/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocusBundle/Builder/Modal/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocusBundle/Builder/Notification/parent.less.twig', with_context=false) -}}
   {{- include('@MauticFocus/Builder/Page/parent.less.twig', with_context=false) -}}
 {%- endset -%}
 

--- a/plugins/MauticFocusBundle/Resources/views/Builder/parent.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/parent.less.twig
@@ -1,7 +1,7 @@
 {%- set less -%}
-  {{- include('@MauticFocusBundle/Builder/Bar/parent.less.twig', with_context=false) -}}
-  {{- include('@MauticFocusBundle/Builder/Modal/parent.less.twig', with_context=false) -}}
-  {{- include('@MauticFocusBundle/Builder/Notification/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocus/Builder/Bar/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocus/Builder/Modal/parent.less.twig', with_context=false) -}}
+  {{- include('@MauticFocus/Builder/Notification/parent.less.twig', with_context=false) -}}
   {{- include('@MauticFocus/Builder/Page/parent.less.twig', with_context=false) -}}
 {%- endset -%}
 

--- a/plugins/MauticFocusBundle/Resources/views/Builder/style.less.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/style.less.twig
@@ -60,15 +60,15 @@
     }
 }
 
-{{ include('MauticFocusBundle:Builder:Bar/style.less.twig', {
+{{ include('@MauticFocus/Builder/Bar/style.less.twig', {
         'preview': preview,
 }, with_context=false) }}
 
-{{ include('MauticFocusBundle:Builder:Modal/style.less.twig', {
+{{ include('@MauticFocus/Builder/Modal/style.less.twig', {
         'preview': preview,
 }, with_context=false) }}
 
-{{ include('MauticFocusBundle:Builder:Notification/style.less.twig', {
+{{ include('@MauticFocus/Builder/Notification/style.less.twig', {
         'preview': preview,
 }, with_context=false) }}
 

--- a/plugins/MauticFocusBundle/Tests/Twig/Fixtures/filters/less_compile.test
+++ b/plugins/MauticFocusBundle/Tests/Twig/Fixtures/filters/less_compile.test
@@ -1,0 +1,13 @@
+--TEST--
+compile LESS
+--TEMPLATE--
+{{ less|less_compile }}
+--DATA--
+return ['less' => "@primarycolor: #FF7F50;@color:#800080;h2{color: @primarycolor;}h3{color: @color;}"]
+--EXPECT--
+h2 {
+  color: #FF7F50;
+}
+h3 {
+  color: #800080;
+}

--- a/plugins/MauticFocusBundle/Tests/Twig/TwigIntegrationTest.php
+++ b/plugins/MauticFocusBundle/Tests/Twig/TwigIntegrationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticFocusBundle\Tests\Twig;
+
+use MauticPlugin\MauticFocusBundle\Twig\Extension\FocusBundleExtension;
+use Twig\Extension\ExtensionInterface;
+
+/**
+ * @see https://twig.symfony.com/doc/2.x/advanced.html#functional-tests
+ */
+class TwigIntegrationTest extends \Twig\Test\IntegrationTestCase
+{
+    /**
+     * @return ExtensionInterface[]
+     */
+    public function getExtensions(): array
+    {
+        return [
+            new FocusBundleExtension(),
+        ];
+    }
+
+    public function getFixturesDir()
+    {
+        return __DIR__.'/Fixtures/';
+    }
+}

--- a/plugins/MauticFocusBundle/Twig/Extension/FocusBundleExtension.php
+++ b/plugins/MauticFocusBundle/Twig/Extension/FocusBundleExtension.php
@@ -34,7 +34,7 @@ class FocusBundleExtension extends AbstractExtension
 
     public function compileLess(string $less): string
     {
-        require_once __DIR__.'/../../../Include/lessc.inc.php';
+        require_once __DIR__.'/../../Include/lessc.inc.php';
 
         return (new \lessc())->compile($less);
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This is fixing this error [reported by the API tests](https://github.com/mautic/api-library/commit/ac029331b447a45b7edd3b4357c593efa83e7484/checks):
```
Response: {"errors":[{"message":"Template reference \u0022MauticFocusBundle:Builder:style.less.twig\u0022 not found, did you mean \u0022@MauticFocus\/Builder\/style.less.twig\u0022?","code":500,"type":null}]
```
I scanned for other forgotten include statements and found some more with the old syntax.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Check that the API Library tests are passing for this PR: https://github.com/mautic/api-library/actions/workflows/tests.yml

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
