### PR TITLE
TPROD-379 FormError message cannot be null

### DIFF
--- a/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\EventListener\ImportCompanySubscriber;
 use Mautic\LeadBundle\Field\FieldList;
 use Mautic\LeadBundle\Model\CompanyModel;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Translation\Translator;
@@ -193,6 +194,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testImportCompanySubscriberDoesHaveTranslatorInitialized(): void
     {
+        /** @var FieldList&MockObject $fieldListMock */
         $fieldListMock         = $this->createMock(FieldList::class);
         $missingRequiredFields = ['Company Name'];
         $matchedFields         = ['Company Email'];
@@ -204,6 +206,8 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                 'isRequired'  => true,
             ])
             ->willReturn($missingRequiredFields);
+
+        /** @var TranslatorInterface&MockObject $translatorInterfaceMock */
         $translatorInterfaceMock = $this->createMock(TranslatorInterface::class);
         $subscriber              = new ImportCompanySubscriber(
             $fieldListMock,
@@ -211,11 +215,15 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
             $this->getCompanyModelFake(),
             $translatorInterfaceMock
         );
+
+        /** @var ImportValidateEvent&MockObject $importValidateEventMock */
         $importValidateEventMock = $this->createMock(ImportValidateEvent::class);
         $importValidateEventMock->expects($this->once())
             ->method('importIsForRouteObject')
             ->with('companies')
             ->willReturn(true);
+
+        /** @var Form&MockObject $formMock */
         $formMock = $this->createMock(Form::class);
         $importValidateEventMock->expects($this->exactly(2))
             ->method('getForm')
@@ -232,7 +240,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                     '%fieldOrFields%'  => 'field',
                 ],
                 'validators'
-            );
+            )->willReturn('A translated message');
 
         $subscriber->onValidateImport($importValidateEventMock);
     }


### PR DESCRIPTION
Passing a null message when instantiating a "Symfony\Component\Form\FormError" is deprecated since Symfony 4.4.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.atlassian.net/browse/TPROD-379

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Resolving deprecation message
```
1x: Passing a null message when instantiating a "Symfony\Component\Form\FormError" is deprecated since Symfony 4.4.
    1x in ImportCompanySubscriberTest::testImportCompanySubscriberDoesHaveTranslatorInitialized from Mautic\LeadBundle\Tests\EventListener
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No need to test. The issue is in a phpunit test so when the tests are passing this is good to go.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
