### PR TITLE
TPROD-370 - Fixed - Calling "Symfony\Bundle\FrameworkBundle\Test\WebTestCase::cre…

### DIFF
--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -119,6 +119,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
             throw new LogicException('You cannot re-create the client when a transaction rollback for cleanup is enabled. Turn it off using $useCleanupRollback property or avoid re-creating a client.');
         }
 
+        self::ensureKernelShutdown();
         parent::setUpSymfony($defaultConfigOptions);
     }
 


### PR DESCRIPTION
…ateClient()" while a kernel has been booted is deprecated since Symfony 4.4

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://mautic.atlassian.net/browse/TPROD-370 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

This PR fixes the following deprecation:

```
7x: Calling "Symfony\Bundle\FrameworkBundle\Test\WebTestCase::createClient()" while a kernel has been booted is deprecated since Symfony 4.4 and will throw an exception in 5.0, ensure the kernel is shut down before calling the method.
    1x in ConfigControllerFunctionalTest::testConfigNotFoundPageConfiguration from Mautic\ConfigBundle\Tests\Controller
    1x in FormApiControllerFunctionalTest::testSingleFormWorkflow from Mautic\FormBundle\Tests\Controller\Api
    1x in SubmissionFunctionalTest::testRequiredConditionalFieldIfNotEmpty from Mautic\FormBundle\Tests\Controller
    1x in SubmissionFunctionalTest::testRequiredConditionalFieldIfAllFieldsEmpty from Mautic\FormBundle\Tests\Controller
    1x in SubmissionFunctionalTest::testRequiredConditionalFieldIfRequiredStateShouldKickIn from Mautic\FormBundle\Tests\Controller
    1x in SubmissionFunctionalTest::testSendSubmissionWhenFieldHaveMysqlReservedWords from Mautic\FormBundle\Tests\Controller
    1x in WebhookFunctionalTest::setUp from Mautic\WebhookBundle\Tests\Functional
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. The PR touches only tests. Passing CI pipeline is enough to consider the PR tested.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
