### PR TITLE
Form widget deprecation notice fix

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
@@ -2,9 +2,9 @@
   Variables
     - form
     - fields
+    - first
 #}
 {% block _leadlist_filters_entry_widget %}
-  {% set first = true %}
   {% set isPrototype = ('__name__' == form.vars.name) %}
   {% set filterType = form.field.vars.value %}
   {% set inGroup = form.vars.data is defined and form.vars.data.glue is defined and 'and' == form.vars.data.glue %}

--- a/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_widget.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_widget.html.twig
@@ -5,11 +5,10 @@
 {% block _leadlist_filters_widget %}
   {% for i, filter in form %}
     {% set isPrototype = '__name__' == filter.vars.name %}
-    {% set filterType = filter.field.vars.value %}
+    {% set isBehavior = form.parent.vars.fields.behaviors[filter.vars.value.field] is defined %}
     {% for object, objectfields in form.parent.vars.fields %}
       {% set isField = objectfields[filter.vars.value.field] is defined %}
-      {% set isBehavior = form.parent.vars.fields.behaviors[filter.vars.value.field] is defined %}
-      {% if isPrototype or isField or isBehavior %}
+      {% if (isPrototype or isField or isBehavior) and not filter.isRendered %}
         {{ form_widget(filter, {'first': (0 == i)}) }}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.atlassian.net/browse/TPROD-381

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fixing this deprecation notice:
```
2x: You are calling "form_widget" for field "0" which has already been rendered before, trying to render fields which were already rendered is deprecated since Symfony 4.2 and will throw an exception in 5.0.
    2x in ListControllerFunctionalTest::testBCSegmentWithPageHitInLeadObject from Mautic\LeadBundle\Tests\Controller
```
And also the UI issue that the filters were always independent like this
![Screenshot 2023-04-05 at 16 24 02](https://user-images.githubusercontent.com/1235442/230111021-b014924f-212c-406a-b8c0-968ad90b76a7.png)


but they should be connected like this:
![Screenshot 2023-04-05 at 16 22 22](https://user-images.githubusercontent.com/1235442/230110868-93e3f23c-5c67-4b8d-971f-58590521b8b5.png)

I double-checked that the `first` variable was not set to `false` in the PHP template: https://github.com/mautic/mautic/blob/4.4/app/bundles/LeadBundle/Views/FormTheme/Filter/_leadlist_filters_entry_widget.html.php#L28

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test creating a segment with filters based on the contact, company and behavior object. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
