### PR TITLE
Remove config deprecations for DoctrineMigrationsBundle.

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -166,10 +166,14 @@ $container->loadFromExtension('doctrine', [
 
 //MigrationsBundle Configuration
 $container->loadFromExtension('doctrine_migrations', [
-    'dir_name'        => '%kernel.project_dir%/app/migrations',
-    'namespace'       => 'Mautic\\Migrations',
-    'table_name'      => '%env(MAUTIC_MIGRATIONS_TABLE_NAME)%',
-    'name'            => 'Mautic Migrations',
+    'migrations_paths' => [
+        'Mautic\\Migrations' => '%kernel.project_dir%/app/migrations',
+    ],
+    'storage' => [
+        'table_storage' => [
+            'table_name' => '%env(MAUTIC_MIGRATIONS_TABLE_NAME)%',
+        ],
+    ],
     'custom_template' => '%kernel.project_dir%/app/migrations/Migration.template',
 ]);
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ x ]

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Remove deprecations for DoctrineMigrationsBundle.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Run tests with `<env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>` in `app/phpunit.xml.dist` and check output does not have following lines:
-  `The "namespace" option is deprecated. Use "migrations_paths" instead.`
-  `The "table_name" option is deprecated. Use "storage.table_storage.table_name" instead.`
- `The "dir_name" option is deprecated. Use "migrations_paths" instead.`
- `The "name" option is deprecated.`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
