### PR TITLE
TPROD-374: Updated testcase to fix DomCrawler::text() passing second argument  `false`.

### DIFF
--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -238,7 +238,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/view/{$email->getId()}");
 
         // checking if pending count is removed from details page ui
-        $emailDetailsContainer = trim($crawler->filter('#email-details')->filter('tbody')->text());
+        $emailDetailsContainer = trim($crawler->filter('#email-details')->filter('tbody')->text(null, false));
         $this->assertStringNotContainsString('Pending', $emailDetailsContainer);
 
         $profile = $this->client->getProfile();

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -44,7 +44,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertEquals(1, $crawler->filter('#success-message-text')->count());
         $expectedMessage = self::$container->get('translator')->trans('mautic.email.preferences_center_success_message.text');
-        $this->assertEquals($expectedMessage, trim($crawler->filter('#success-message-text')->text()));
+        $this->assertEquals($expectedMessage, trim($crawler->filter('#success-message-text')->text(null, false)));
         $this->assertTrue($this->client->getResponse()->isOk());
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -117,7 +117,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $crawler            = $this->client->request(Request::METHOD_GET, '/s/segments?filters=["category:1"]');
         $leadListsTableRows = $crawler->filterXPath("//table[@id='leadListTable']//tbody//tr");
         $this->assertEquals(4, $leadListsTableRows->count());
-        $firstLeadListLinkTest = trim($leadListsTableRows->first()->filterXPath('//td[2]//div//a')->text());
+        $firstLeadListLinkTest = trim($leadListsTableRows->first()->filterXPath('//td[2]//div//a')->text(null, false));
         $this->assertEquals('Lead List 1 - Segment Category 1 (lead-list-1)', $firstLeadListLinkTest);
 
         $crawler            = $this->client->request(Request::METHOD_GET, '/s/segments?filters=["category:2"]');

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
@@ -64,7 +64,7 @@ class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $html = $this->client->submit($form);
         Assert::assertStringContainsString(
             'Match the columns from the imported file to Mautic\'s contact fields.',
-            $html->text()
+            $html->text(null, false)
         );
 
         $importButton = $html->selectButton('Import');
@@ -105,7 +105,7 @@ class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $html = $this->client->submit($form);
         Assert::assertStringContainsString(
             'Match the columns from the imported file to Mautic\'s contact fields.',
-            $html->text()
+            $html->text(null, false)
         );
 
         // Run command to import CSV.

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -47,7 +47,7 @@
     </testsuite>
   </testsuites>
   <php>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=999999"/>
     <env name="MAXMIND_LICENSE_KEY" value=""/>
     <env name="KERNEL_CLASS" value="AppKernel" />
     <const name="IS_PHPUNIT" value="true"/>

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -47,7 +47,7 @@
     </testsuite>
   </testsuites>
   <php>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=999999"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <env name="MAXMIND_LICENSE_KEY" value=""/>
     <env name="KERNEL_CLASS" value="AppKernel" />
     <const name="IS_PHPUNIT" value="true"/>

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -157,7 +157,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $form['tag_entity[tag]']->setValue($TagName);
         $crawler = $this->client->submit($form);
 
-        $this->assertStringContainsString($TagName.' has been updated!', strip_tags($crawler->text()), 'Must contain already exist.');
+        $this->assertStringContainsString($TagName.' has been updated!', strip_tags($crawler->text(null, false)), 'Must contain already exist.');
     }
 
     public function testBatchDeleteAction(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Resolves these deprecation notices:
```
6x: "Symfony\Component\DomCrawler\Crawler::text()" will normalize whitespaces by default in Symfony 5.0, set the second "$normalizeWhitespace" argument to false to retrieve the non-normalized version of the text.
    1x in EmailControllerFunctionalTest::testEmailDetailsPageShouldNotHavePendingCount from Mautic\EmailBundle\Tests\Controller
    1x in PublicControllerFunctionalTest::testContactPreferencesSaveMessage from Mautic\EmailBundle\Tests\Controller
    1x in LeadControllerTest::testRetrieveLeadListsBasedOnCategory from Mautic\LeadBundle\Tests\Controller
    1x in ImportControllerFunctionalTest::testScheduleImport from Mautic\LeadBundle\Tests\Functional\Controller
    1x in ImportControllerFunctionalTest::testImportCSVWithFileAsHeaderName from Mautic\LeadBundle\Tests\Functional\Controller
    1x in TagControllerTest::testNewActionDuplicateTag from MauticPlugin\MauticTagManagerBundle\Tests\Functional\Controller
```
