### PR TITLE
rename addFlash to addFlashMessage to prevent method collision

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -32,7 +32,7 @@
     * Transactional emails in campaigns ignore the DNC setting.
     * There are no unsubscribe headers in transactional emails.
     * The SortablePanels templates, JS and CSS was removed as unused.
-    * `Mautic\CoreBundle\Controller\CommonController::addFlash()` was renamed to `CommonController::addFlash()`to prevent naming collision with `Symfony\Bundle\FrameworkBundle\Controller\AbstractController::addFlash()`. Controllers adding flash messages should use `$this->addFlashMessage()`.
+    * `Mautic\CoreBundle\Controller\CommonController::addFlash()` was renamed to `CommonController::addFlashMessage()`to prevent naming collision with `Symfony\Bundle\FrameworkBundle\Controller\AbstractController::addFlash()`. Controllers adding flash messages should use `$this->addFlashMessage()`.
 
 # Dependency injection improvements
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -32,6 +32,7 @@
     * Transactional emails in campaigns ignore the DNC setting.
     * There are no unsubscribe headers in transactional emails.
     * The SortablePanels templates, JS and CSS was removed as unused.
+    * `Mautic\CoreBundle\Controller\CommonController::addFlash()` was renamed to `CommonController::addFlash()`to prevent naming collision with `Symfony\Bundle\FrameworkBundle\Controller\AbstractController::addFlash()`. Controllers adding flash messages should use `$this->addFlashMessage()`.
 
 # Dependency injection improvements
 

--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -231,7 +231,7 @@ class ClientController extends FormController
                     }
                     $client->setRole($this->getUser()->getRole());
                     $model->saveEntity($client);
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.api.client.notice.created',
                         [
                             '%name%'         => $client->getName(),
@@ -342,7 +342,7 @@ class ClientController extends FormController
                 if ($valid = $this->isFormValid($form)) {
                     //form is valid so process the data
                     $model->saveEntity($client, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $client->getName(),

--- a/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
@@ -30,7 +30,7 @@ class SecurityController extends CommonController
             } else {
                 $msg = $error->getMessage();
             }
-            $this->addFlash($msg, [], 'error', null, false);
+            $this->addFlashMessage($msg, [], 'error', null, false);
         }
 
         if ($session->has('_security.target_path')) {

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -335,7 +335,7 @@ class AssetController extends FormController
                     //remove the asset from request
                     $request->files->remove('asset');
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $entity->getTitle(),
                         '%menu_link%' => 'mautic_asset_index',
                         '%url%'       => $this->generateUrl('mautic_asset_action', [
@@ -498,7 +498,7 @@ class AssetController extends FormController
                     //remove the asset from request
                     $request->files->remove('asset');
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $entity->getTitle(),
                         '%menu_link%' => 'mautic_asset_index',
                         '%url%'       => $this->generateUrl('mautic_asset_action', [

--- a/app/bundles/CategoryBundle/Controller/BatchContactController.php
+++ b/app/bundles/CategoryBundle/Controller/BatchContactController.php
@@ -49,11 +49,11 @@ class BatchContactController extends AbstractFormController
             $this->actionModel->addContactsToCategories($contactIds, $categoriesToAdd);
             $this->actionModel->removeContactsFromCategories($contactIds, $categoriesToRemove);
 
-            $this->addFlash('mautic.lead.batch_leads_affected', [
+            $this->addFlashMessage('mautic.lead.batch_leads_affected', [
                 '%count%'     => count($ids),
             ]);
         } else {
-            $this->addFlash('mautic.core.error.ids.missing');
+            $this->addFlashMessage('mautic.core.error.ids.missing');
         }
 
         return new JsonResponse([

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -229,7 +229,7 @@ class CategoryController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash('mautic.category.notice.created', [
+                    $this->addFlashMessage('mautic.category.notice.created', [
                         '%name%' => $entity->getTitle(),
                     ]);
                 }
@@ -335,7 +335,7 @@ class CategoryController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.category.notice.updated',
                         [
                             '%name%' => $entity->getTitle(),

--- a/app/bundles/ChannelBundle/Controller/BatchContactController.php
+++ b/app/bundles/ChannelBundle/Controller/BatchContactController.php
@@ -59,11 +59,11 @@ class BatchContactController extends AbstractFormController
             $this->channelActionModel->update($ids, $subscribedChannels);
             $this->frequencyActionModel->update($ids, $params, $preferredChannel);
 
-            $this->addFlash('mautic.lead.batch_leads_affected', [
+            $this->addFlashMessage('mautic.lead.batch_leads_affected', [
                 '%count%'     => count($ids),
             ]);
         } else {
-            $this->addFlash('mautic.core.error.ids.missing');
+            $this->addFlashMessage('mautic.core.error.ids.missing');
         }
 
         return new JsonResponse([

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -123,7 +123,7 @@ class ConfigController extends FormController
                             $configurator->write();
                             $dispatcher->dispatch($configEvent, ConfigEvents::CONFIG_POST_SAVE);
 
-                            $this->addFlash('mautic.config.config.notice.updated');
+                            $this->addFlashMessage('mautic.config.config.notice.updated');
 
                             $cacheHelper->refreshConfig();
 
@@ -131,7 +131,7 @@ class ConfigController extends FormController
                                 $openTab = $formData['coreconfig']['last_shown_tab'];
                             }
                         } catch (\RuntimeException $exception) {
-                            $this->addFlash('mautic.config.config.error.not.updated', ['%exception%' => $exception->getMessage()], 'error');
+                            $this->addFlashMessage('mautic.config.config.error.not.updated', ['%exception%' => $exception->getMessage()], 'error');
                         }
 
                         $this->setLocale($request, $tokenStorage, $params);

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -45,7 +45,7 @@ abstract class AbstractFormController extends CommonController
                 $returnUrl = $this->generateUrl('mautic_dashboard_index');
             }
 
-            $this->addFlash(
+            $this->addFlashMessage(
                 'mautic.core.action.entity.unlocked',
                 [
                     '%name%' => urldecode($request->get('name')),

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -426,7 +426,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
                         $this->afterEntitySave($entity, $form, 'edit', $valid);
 
-                        $this->addFlash(
+                        $this->addFlashMessage(
                             'mautic.core.notice.updated',
                             [
                                 '%name%'      => $entity->getName(),

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -318,11 +318,11 @@ class AjaxController extends CommonController
                         $dataArray['statusHtml'] = $html;
                     }
                 } catch (RecordCanNotUnpublishException $e) {
-                    $this->addFlash($e->getMessage());
+                    $this->addFlashMessage($e->getMessage());
                     $status = Response::HTTP_UNPROCESSABLE_ENTITY;
                 }
             } else {
-                $this->addFlash('mautic.core.error.access.denied');
+                $this->addFlashMessage('mautic.core.error.access.denied');
                 $status = Response::HTTP_FORBIDDEN;
             }
         }

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -711,13 +711,13 @@ class CommonController extends AbstractController implements MauticController
     }
 
     /**
-     * @param string      $message
-     * @param array|null  $messageVars
-     * @param string|null $level
-     * @param string|null $domain
-     * @param bool|null   $addNotification
+     * @param string       $message
+     * @param array<mixed> $messageVars
+     * @param string|null  $level
+     * @param string|null  $domain
+     * @param bool|null    $addNotification
      */
-    public function addFlashMessage($message, $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false)
+    public function addFlashMessage($message, $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false): void
     {
         $this->flashBag->add($message, $messageVars, $level, $domain, $addNotification);
     }

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -320,7 +320,7 @@ class CommonController extends AbstractController implements MauticController
         //set flashes
         if (!empty($flashes)) {
             foreach ($flashes as $flash) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $flash['msg'],
                     !empty($flash['msgVars']) ? $flash['msgVars'] : [],
                     !empty($flash['type']) ? $flash['type'] : 'notice',
@@ -717,7 +717,7 @@ class CommonController extends AbstractController implements MauticController
      * @param string|null $domain
      * @param bool|null   $addNotification
      */
-    public function addFlash($message, $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false)
+    public function addFlashMessage($message, $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false)
     {
         $this->flashBag->add($message, $messageVars, $level, $domain, $addNotification);
     }

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -59,7 +59,7 @@ class ThemeController extends FormController
                                 try {
                                     $fileData->move($dir, $fileName);
                                     $themeHelper->install($dir.'/'.$fileName);
-                                    $this->addFlash('mautic.core.theme.installed', ['%name%' => $themeName]);
+                                    $this->addFlashMessage('mautic.core.theme.installed', ['%name%' => $themeName]);
                                 } catch (\Exception $e) {
                                     $form->addError(
                                         new FormError(

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -409,7 +409,7 @@ class DashboardController extends AbstractFormController
         $path = $dir.'/'.$name.'.json';
 
         if (!file_exists($path) || !is_readable($path)) {
-            $this->addFlash('mautic.dashboard.upload.filenotfound', [], 'error', 'validators');
+            $this->addFlashMessage('mautic.dashboard.upload.filenotfound', [], 'error', 'validators');
 
             return $this->redirectToRoute('mautic_dashboard_action', ['objectAction' => 'import']);
         }

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -147,7 +147,7 @@ class DynamicContentController extends FormController
                 if ($valid = $this->isFormValid($form)) {
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -292,7 +292,7 @@ class DynamicContentController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -499,7 +499,7 @@ class EmailController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -701,7 +701,7 @@ class EmailController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),
@@ -1421,9 +1421,9 @@ class EmailController extends FormController
                 }
 
                 if (0 != count($errors)) {
-                    $this->addFlash(implode('; ', $errors));
+                    $this->addFlashMessage(implode('; ', $errors));
                 } else {
-                    $this->addFlash('mautic.email.notice.test_sent_multiple.success');
+                    $this->addFlashMessage('mautic.email.notice.test_sent_multiple.success');
                 }
             }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -354,7 +354,7 @@ class FormController extends CommonFormController
                             // Save and trigger listeners
                             $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 'mautic.core.notice.created',
                                 [
                                     '%name%'      => $entity->getName(),
@@ -632,7 +632,7 @@ class FormController extends CommonFormController
                             // Reset objectId to entity ID (can be session ID in case of cloned entity)
                             $objectId = $entity->getId();
 
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 'mautic.core.notice.updated',
                                 [
                                     '%name%'      => $entity->getName(),

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -289,7 +289,7 @@ class InstallController extends CommonController
                 case 'warning':
                 case 'error':
                 case 'notice':
-                    $this->addFlash($message, [], $type);
+                    $this->addFlashMessage($message, [], $type);
                     break;
                 default:
                     // If type not a flash type, assume form field error

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -47,11 +47,11 @@ class BatchSegmentController extends AbstractFormController
                 $this->actionModel->removeContacts($contactIds, $segmentsToRemove);
             }
 
-            $this->addFlash('mautic.lead.batch_leads_affected', [
+            $this->addFlashMessage('mautic.lead.batch_leads_affected', [
                 '%count%' => count($contactIds),
             ]);
         } else {
-            $this->addFlash('mautic.core.error.ids.missing');
+            $this->addFlashMessage('mautic.core.error.ids.missing');
         }
 
         return new JsonResponse([

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -235,7 +235,7 @@ class CompanyController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -413,7 +413,7 @@ class CompanyController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),
@@ -797,7 +797,7 @@ class CompanyController extends FormController
             if (!empty($deleteIds)) {
                 $entities = $model->deleteEntities($deleteIds);
                 $deleted  = count($entities);
-                $this->addFlash(
+                $this->addFlashMessage(
                     'mautic.company.notice.batch_deleted',
                     [
                         '%count%'     => $deleted,

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -168,7 +168,7 @@ class FieldController extends FormController
                                 );
                             $valid = false;
                         }
-                        $this->addFlash(
+                        $this->addFlashMessage(
                                 $flashMessage,
                                 [
                                     '%name%'      => $field->getLabel(),
@@ -294,7 +294,7 @@ class FieldController extends FormController
                         //form is valid so process the data
                         $model->saveEntity($field, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                        $this->addFlash('mautic.core.notice.updated', [
+                        $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $field->getLabel(),
                             '%menu_link%' => 'mautic_contactfield_index',
                             '%url%'       => $this->generateUrl('mautic_contactfield_action', [

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -227,7 +227,7 @@ class ImportController extends FormController
         if (!file_exists($fullPath) && self::STEP_UPLOAD_CSV !== $step) {
             // Force step one if the file doesn't exist
             $this->logger->log(LogLevel::WARNING, "File {$fullPath} does not exist anymore. Reseting import to step STEP_UPLOAD_CSV.");
-            $this->addFlash('mautic.import.file.missing', ['%file%' => $this->getImportFileName($object)], FlashBag::LEVEL_ERROR);
+            $this->addFlashMessage('mautic.import.file.missing', ['%file%' => $this->getImportFileName($object)], FlashBag::LEVEL_ERROR);
             $step = self::STEP_UPLOAD_CSV;
             $this->session->set('mautic.'.$object.'.import.step', self::STEP_UPLOAD_CSV);
         }
@@ -455,7 +455,7 @@ class ImportController extends FormController
 
                     // In case the user decided to queue the import
                     if ($this->importInCli($form, $object)) {
-                        $this->addFlash('mautic.'.$object.'.batch.import.created');
+                        $this->addFlashMessage('mautic.'.$object.'.batch.import.created');
                         $this->resetImport($object);
 
                         return $this->indexAction($request);

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -526,7 +526,7 @@ class LeadController extends FormController
 
                     $identifier = $this->translator->trans($lead->getPrimaryIdentifier());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $identifier,
@@ -563,7 +563,7 @@ class LeadController extends FormController
                     }
 
                     $formErrors = $this->getFormErrorMessages($form);
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $this->getFormErrorMessage($formErrors),
                         [],
                         'error'
@@ -726,7 +726,7 @@ class LeadController extends FormController
 
                     $identifier = $this->translator->trans($lead->getPrimaryIdentifier());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $identifier,
@@ -742,7 +742,7 @@ class LeadController extends FormController
                     );
                 } else {
                     $formErrors = $this->getFormErrorMessages($form);
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $this->getFormErrorMessage($formErrors),
                         [],
                         'error'
@@ -1453,7 +1453,7 @@ class LeadController extends FormController
                         $subject = EmojiHelper::toHtml($email['subject']);
                         if ($mailer->send(true, false)) {
                             $mailer->createEmailStat();
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 'mautic.lead.email.notice.sent',
                                 [
                                     '%subject%' => $subject,
@@ -1614,7 +1614,7 @@ class LeadController extends FormController
                 }
             }
 
-            $this->addFlash(
+            $this->addFlashMessage(
                 'mautic.lead.batch_leads_affected',
                 [
                     '%count%'     => $count,
@@ -1713,7 +1713,7 @@ class LeadController extends FormController
                 $model->saveEntities($persistEntities);
             }
 
-            $this->addFlash(
+            $this->addFlashMessage(
                 'mautic.lead.batch_leads_affected',
                 [
                     '%count%'     => $count,
@@ -1809,7 +1809,7 @@ class LeadController extends FormController
             }
             // Save entities
             $model->saveEntities($entities);
-            $this->addFlash(
+            $this->addFlashMessage(
                 'mautic.lead.batch_leads_affected',
                 [
                     '%count%'     => $count,
@@ -1908,7 +1908,7 @@ class LeadController extends FormController
             }
             // Save entities
             $model->saveEntities($entities);
-            $this->addFlash(
+            $this->addFlashMessage(
                 'mautic.lead.batch_leads_affected',
                 [
                     '%count%'     => $count,
@@ -2116,7 +2116,7 @@ class LeadController extends FormController
             LeadEvents::POST_CONTACT_EXPORT_SCHEDULED
         );
 
-        $this->addFlash('mautic.lead.export.being.prepared', ['%user_email%' => $this->user->getEmail()]);
+        $this->addFlashMessage('mautic.lead.export.being.prepared', ['%user_email%' => $this->user->getEmail()]);
         $response['message'] = 'Contact export scheduled for CSV file type.';
         $response['flashes'] = $this->getFlashContent();
 

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -188,7 +188,7 @@ class ListController extends FormController
                     $list->setDateModified(new \DateTime());
                     $model->saveEntity($list);
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $list->getName().' ('.$list->getAlias().')',
                         '%menu_link%' => 'mautic_segment_index',
                         '%url%'       => $this->generateUrl('mautic_segment_action', [
@@ -340,7 +340,7 @@ class ListController extends FormController
                     //form is valid so process the data
                     $segmentModel->saveEntity($segment, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $segment->getName().' ('.$segment->getAlias().')',
                         '%menu_link%' => 'mautic_segment_index',
                         '%url%'       => $this->generateUrl('mautic_segment_action', [

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -292,7 +292,7 @@ class MobileNotificationController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -457,7 +457,7 @@ class MobileNotificationController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -296,7 +296,7 @@ class NotificationController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -459,7 +459,7 @@ class NotificationController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -393,7 +393,7 @@ class PageController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $entity->getTitle(),
                         '%menu_link%' => 'mautic_page_index',
                         '%url%'       => $this->generateUrl('mautic_page_action', [
@@ -548,7 +548,7 @@ class PageController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $entity->getTitle(),
                         '%menu_link%' => 'mautic_page_index',
                         '%url%'       => $this->generateUrl('mautic_page_action', [

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -418,7 +418,7 @@ class PluginController extends FormController
             return $this->accessDenied();
         }
 
-        $this->addFlash(
+        $this->addFlashMessage(
             $reloadFacade->reloadPlugins()
         );
 

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -139,7 +139,7 @@ class PointController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $entity->getName(),
                         '%menu_link%' => 'mautic_point_index',
                         '%url%'       => $this->generateUrl('mautic_point_action', [
@@ -272,7 +272,7 @@ class PointController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $entity->getName(),
                         '%menu_link%' => 'mautic_point_index',
                         '%url%'       => $this->generateUrl('mautic_point_action', [

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -213,7 +213,7 @@ class TriggerController extends FormController
 
                         $model->saveEntity($entity);
 
-                        $this->addFlash('mautic.core.notice.created', [
+                        $this->addFlashMessage('mautic.core.notice.created', [
                             '%name%'      => $entity->getName(),
                             '%menu_link%' => 'mautic_pointtrigger_index',
                             '%url%'       => $this->generateUrl('mautic_pointtrigger_action', [
@@ -362,7 +362,7 @@ class TriggerController extends FormController
                             $triggerEventModel->deleteEntities($deletedEvents);
                         }
 
-                        $this->addFlash('mautic.core.notice.updated', [
+                        $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $entity->getName(),
                             '%menu_link%' => 'mautic_pointtrigger_index',
                             '%url%'       => $this->generateUrl('mautic_pointtrigger_action', [

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -349,7 +349,7 @@ class ReportController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),
@@ -467,7 +467,7 @@ class ReportController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/ReportBundle/Controller/ScheduleController.php
+++ b/app/bundles/ReportBundle/Controller/ScheduleController.php
@@ -46,19 +46,19 @@ class ScheduleController extends CommonAjaxController
         $security = $this->security;
 
         if (empty($report)) {
-            $this->addFlash('mautic.report.notfound', ['%id%' => $reportId], FlashBag::LEVEL_ERROR, 'messages');
+            $this->addFlashMessage('mautic.report.notfound', ['%id%' => $reportId], FlashBag::LEVEL_ERROR, 'messages');
 
             return $this->flushFlash();
         }
 
         if (!$security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $report->getCreatedBy())) {
-            $this->addFlash('mautic.core.error.accessdenied', [], FlashBag::LEVEL_ERROR);
+            $this->addFlashMessage('mautic.core.error.accessdenied', [], FlashBag::LEVEL_ERROR);
 
             return $this->flushFlash();
         }
 
         if ($report->isScheduled()) {
-            $this->addFlash('mautic.report.scheduled.already', ['%id%' => $reportId], FlashBag::LEVEL_ERROR);
+            $this->addFlashMessage('mautic.report.scheduled.already', ['%id%' => $reportId], FlashBag::LEVEL_ERROR);
 
             return $this->flushFlash();
         }
@@ -66,7 +66,7 @@ class ScheduleController extends CommonAjaxController
         $report->setAsScheduledNow($this->user->getEmail());
         $model->saveEntity($report);
 
-        $this->addFlash(
+        $this->addFlashMessage(
             'mautic.report.scheduled.to.now',
             ['%id%' => $reportId, '%email%' => $this->user->getEmail()]
         );

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -283,7 +283,7 @@ class SmsController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -445,7 +445,7 @@ class SmsController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -153,7 +153,7 @@ class StageController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getName(),
@@ -302,7 +302,7 @@ class StageController extends AbstractFormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getName(),

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -180,7 +180,7 @@ class ProfileController extends FormController
                                 $messageVars = $fetchLanguage['vars'];
                             }
 
-                            $this->addFlash($message, $messageVars);
+                            $this->addFlashMessage($message, $messageVars);
                         }
                     }
 

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -35,9 +35,9 @@ class PublicController extends FormController
                 } else {
                     try {
                         $model->sendResetEmail($user);
-                        $this->addFlash('mautic.user.user.notice.passwordreset');
+                        $this->addFlashMessage('mautic.user.user.notice.passwordreset');
                     } catch (\Exception $exception) {
-                        $this->addFlash('mautic.user.user.notice.passwordreset.error', [], 'error');
+                        $this->addFlashMessage('mautic.user.user.notice.passwordreset.error', [], 'error');
                     }
 
                     return $this->redirectToRoute('login');
@@ -89,7 +89,7 @@ class PublicController extends FormController
                             $user->setPassword($encodedPassword);
                             $model->saveEntity($user);
 
-                            $this->addFlash('mautic.user.user.notice.passwordreset.success');
+                            $this->addFlashMessage('mautic.user.user.notice.passwordreset.success');
 
                             $request->getSession()->remove('resetToken');
 
@@ -106,7 +106,7 @@ class PublicController extends FormController
                             ],
                         ]);
                     } else {
-                        $this->addFlash('mautic.user.user.notice.passwordreset.missingtoken');
+                        $this->addFlashMessage('mautic.user.user.notice.passwordreset.missingtoken');
 
                         return $this->redirectToRoute('mautic_user_passwordresetconfirm');
                     }

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -139,7 +139,7 @@ class RoleController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity);
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $entity->getName(),
                         '%menu_link%' => 'mautic_role_index',
                         '%url%'       => $this->generateUrl('mautic_role_action', [
@@ -250,7 +250,7 @@ class RoleController extends FormController
                     //form is valid so process the data
                     $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $entity->getName(),
                         '%menu_link%' => 'mautic_role_index',
                         '%url%'       => $this->generateUrl('mautic_role_action', [

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -82,7 +82,7 @@ class SecurityController extends CommonController implements EventSubscriberInte
                 $msg = $error->getMessage();
             }
 
-            $this->addFlash($msg, [], 'error', null, false);
+            $this->addFlashMessage($msg, [], 'error', null, false);
         }
         $request->query->set('tmpl', 'login');
 

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -161,11 +161,11 @@ class UserController extends FormController
                                 $messageVars = $fetchLanguage['vars'];
                             }
 
-                            $this->addFlash($message, $messageVars);
+                            $this->addFlashMessage($message, $messageVars);
                         }
                     }
 
-                    $this->addFlash('mautic.core.notice.created', [
+                    $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $user->getName(),
                         '%menu_link%' => 'mautic_user_index',
                         '%url%'       => $this->generateUrl('mautic_user_action', [
@@ -291,11 +291,11 @@ class UserController extends FormController
                                 $messageVars = $fetchLanguage['vars'];
                             }
 
-                            $this->addFlash($message, $messageVars);
+                            $this->addFlashMessage($message, $messageVars);
                         }
                     }
 
-                    $this->addFlash('mautic.core.notice.updated', [
+                    $this->addFlashMessage('mautic.core.notice.updated', [
                         '%name%'      => $user->getName(),
                         '%menu_link%' => 'mautic_user_index',
                         '%url%'       => $this->generateUrl('mautic_user_action', [
@@ -479,7 +479,7 @@ class UserController extends FormController
                     \assert($auditLogModel instanceof AuditLogModel);
                     $auditLogModel->writeToLog($log);
 
-                    $this->addFlash('mautic.user.user.notice.messagesent', ['%name%' => $user->getName()]);
+                    $this->addFlashMessage('mautic.user.user.notice.messagesent', ['%name%' => $user->getName()]);
                 }
             }
             if ($cancelled || $valid) {

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -37,7 +37,7 @@ class ClearbitController extends FormController
             $lead->getPermissionUser()
         )
         ) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.clearbit.forbidden'),
                 [],
                 'error'
@@ -85,14 +85,14 @@ class ClearbitController extends FormController
             if ('POST' === $request->getMethod()) {
                 try {
                     $lookupHelper->lookupContact($lead, array_key_exists('notify', $data));
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.lead.batch_leads_affected',
                         [
                             '%count%'     => 1,
                         ]
                     );
                 } catch (\Exception $ex) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $ex->getMessage(),
                         [],
                         'error'
@@ -171,7 +171,7 @@ class ClearbitController extends FormController
         }
 
         if (0 === $count) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.clearbit.empty'),
                 [],
                 'error'
@@ -185,7 +185,7 @@ class ClearbitController extends FormController
             );
         } else {
             if ($count > 20) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.clearbit.toomany'),
                     [],
                     'error'
@@ -235,7 +235,7 @@ class ClearbitController extends FormController
                         try {
                             $lookupHelper->lookupContact($lead, $notify);
                         } catch (\Exception $ex) {
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                     $ex->getMessage(),
                                     [],
                                     'error'
@@ -246,7 +246,7 @@ class ClearbitController extends FormController
                 }
 
                 if ($count) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                             'mautic.lead.batch_leads_affected',
                             [
                                 '%count%'     => $count,
@@ -297,7 +297,7 @@ class ClearbitController extends FormController
             $website = $company->getFieldValue('companywebsite');
 
             if (!$website) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.clearbit.compempty'),
                     [],
                     'error'
@@ -338,14 +338,14 @@ class ClearbitController extends FormController
             if ('POST' === $request->getMethod()) {
                 try {
                     $lookupHelper->lookupCompany($company, array_key_exists('notify', $data));
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.company.batch_companies_affected',
                         [
                             '%count%'     => 1,
                         ]
                     );
                 } catch (\Exception $ex) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $ex->getMessage(),
                         [],
                         'error'
@@ -423,7 +423,7 @@ class ClearbitController extends FormController
         }
 
         if (0 === $count) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.clearbit.compempty'),
                 [],
                 'error'
@@ -437,7 +437,7 @@ class ClearbitController extends FormController
             );
         } else {
             if ($count > 20) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.clearbit.comptoomany'),
                     [],
                     'error'
@@ -487,7 +487,7 @@ class ClearbitController extends FormController
                         try {
                             $lookupHelper->lookupCompany($company, $notify);
                         } catch (\Exception $ex) {
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 $ex->getMessage(),
                                 [],
                                 'error'
@@ -498,7 +498,7 @@ class ClearbitController extends FormController
                 }
 
                 if ($count) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.company.batch_companies_affected',
                         [
                             '%count%'     => $count,

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -37,7 +37,7 @@ class FullContactController extends FormController
             $lead->getPermissionUser()
         )
         ) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.fullcontact.forbidden'),
                 [],
                 'error'
@@ -85,14 +85,14 @@ class FullContactController extends FormController
             if ('POST' === $request->getMethod()) {
                 try {
                     $lookupHelper->lookupContact($lead, array_key_exists('notify', $data));
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.lead.batch_leads_affected',
                         [
                             '%count%'     => 1,
                         ]
                     );
                 } catch (\Exception $ex) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $ex->getMessage(),
                         [],
                         'error'
@@ -171,7 +171,7 @@ class FullContactController extends FormController
         }
 
         if (0 === $count) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.fullcontact.empty'),
                 [],
                 'error'
@@ -185,7 +185,7 @@ class FullContactController extends FormController
             );
         } else {
             if ($count > 20) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.fullcontact.toomany'),
                     [],
                     'error'
@@ -235,7 +235,7 @@ class FullContactController extends FormController
                         try {
                             $lookupHelper->lookupContact($lead, $notify);
                         } catch (\Exception $ex) {
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 $ex->getMessage(),
                                 [],
                                 'error'
@@ -246,7 +246,7 @@ class FullContactController extends FormController
                 }
 
                 if ($count) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.lead.batch_leads_affected',
                         [
                             '%count%'     => $count,
@@ -297,7 +297,7 @@ class FullContactController extends FormController
             $website = $company->getFieldValue('companywebsite');
 
             if (!$website) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.fullcontact.compempty'),
                     [],
                     'error'
@@ -338,14 +338,14 @@ class FullContactController extends FormController
             if ('POST' === $request->getMethod()) {
                 try {
                     $lookupHelper->lookupCompany($company, array_key_exists('notify', $data));
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.company.batch_companies_affected',
                         [
                             '%count%'     => 1,
                         ]
                     );
                 } catch (\Exception $ex) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         $ex->getMessage(),
                         [],
                         'error'
@@ -423,7 +423,7 @@ class FullContactController extends FormController
         }
 
         if (0 === $count) {
-            $this->addFlash(
+            $this->addFlashMessage(
                 $this->translator->trans('mautic.plugin.fullcontact.compempty'),
                 [],
                 'error'
@@ -437,7 +437,7 @@ class FullContactController extends FormController
             );
         } else {
             if ($count > 20) {
-                $this->addFlash(
+                $this->addFlashMessage(
                     $this->translator->trans('mautic.plugin.fullcontact.comptoomany'),
                     [],
                     'error'
@@ -487,7 +487,7 @@ class FullContactController extends FormController
                         try {
                             $lookupHelper->lookupCompany($company, $notify);
                         } catch (\Exception $ex) {
-                            $this->addFlash(
+                            $this->addFlashMessage(
                                 $ex->getMessage(),
                                 [],
                                 'error'
@@ -498,7 +498,7 @@ class FullContactController extends FormController
                 }
 
                 if ($count) {
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.company.batch_companies_affected',
                         [
                             '%count%'     => $count,

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -153,7 +153,7 @@ class MonitoringController extends FormController
                     // update the audit log
                     $this->updateAuditLog($entity, $ipLookupHelper, 'create');
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.created',
                         [
                             '%name%'      => $entity->getTitle(),
@@ -306,7 +306,7 @@ class MonitoringController extends FormController
                     // update the audit log
                     $this->updateAuditLog($entity, $ipLookupHelper, 'update');
 
-                    $this->addFlash(
+                    $this->addFlashMessage(
                         'mautic.core.notice.updated',
                         [
                             '%name%'      => $entity->getTitle(),

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -172,7 +172,7 @@ class TagController extends FormController
                     $found = $model->getRepository()->countOccurrences($tag->getTag());
                     if (0 !== $found) {
                         $valid = false;
-                        $this->addFlash('mautic.core.notice.updated', [
+                        $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [
@@ -183,7 +183,7 @@ class TagController extends FormController
                     } else {
                         $model->saveEntity($tag);
 
-                        $this->addFlash('mautic.core.notice.created', [
+                        $this->addFlashMessage('mautic.core.notice.created', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [
@@ -294,7 +294,7 @@ class TagController extends FormController
                     }
 
                     if (!$valid) {
-                        $this->addFlash('mautic.core.notice.updated', [
+                        $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [
@@ -306,7 +306,7 @@ class TagController extends FormController
                         //form is valid so process the data
                         $tagModel->saveEntity($tag, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                        $this->addFlash('mautic.core.notice.updated', [
+                        $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $tag->getTag(),
                             '%menu_link%' => 'mautic_tagmanager_index',
                             '%url%'       => $this->generateUrl('mautic_tagmanager_action', [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [x]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In Symfony 5, a helper method was added: `Symfony\Bundle\FrameworkBundle\Controller\AbstractController::addFlash()`, see [the source code](https://github.com/symfony/symfony/commit/30418cfaf3934a26698b7db220bdf909a4fbea2e#diff-af6672a1436a317ff73aea4f4bb77153b29876d8b9df1fe778425dba20bcd1c9R199).

This method collides with `Mautic\CoreBundle\Controller\CommonController::addFlash()` which extends `AbstractController::addFlash()`
There are 2 options: 
* changing the logic to make `CommonController::addFlash()` compatible with `AbstractController::addFlash()`
* renaming the method

As there is other business logic in Mautic (message is translated, possibility to add notification, ...), only the rename option is viable at this point.

This PR addresses this.
This PR contains BC breaking changes, so we need to document this


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. add a contact / company / ... (actually anything that shows a flash message after an action
3. verify the message is shown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
