### PR TITLE
Use the tokenmanager to validate CSRF tokens

### DIFF
--- a/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -85,8 +86,6 @@ class RequestSubscriber implements EventSubscriberInterface
     private function isCsrfTokenFromRequestHeaderValid(Request $request)
     {
         $csrfRequestToken = $request->headers->get('X-CSRF-Token');
-        $csrfSessionToken = $this->tokenManager->getToken('mautic_ajax_post')->getValue();
-
-        return $csrfSessionToken === $csrfRequestToken;
+        return $this->tokenManager->isTokenValid(new CsrfToken('mautic_ajax_post', $csrfRequestToken));
     }
 }

--- a/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
@@ -86,6 +86,7 @@ class RequestSubscriber implements EventSubscriberInterface
     private function isCsrfTokenFromRequestHeaderValid(Request $request)
     {
         $csrfRequestToken = $request->headers->get('X-CSRF-Token');
+
         return $this->tokenManager->isTokenValid(new CsrfToken('mautic_ajax_post', $csrfRequestToken));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
@@ -40,6 +40,12 @@ class RequestSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getToken')
             ->willReturn(new CsrfToken($aCsrfTokenId, $aCsrfTokenValue));
 
+        $csrfTokenManagerMock
+          ->method('isTokenValid')
+          ->will($this->returnCallback(function (CsrfToken $token) use ($aCsrfTokenValue) {
+              return $token->getValue() === $aCsrfTokenValue;
+          }));
+
         $this->request = new Request();
 
         $this->event = $this->getMockBuilder(RequestEvent::class)


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In Symfony 5, the way CSRF tokens are handled changed, see [the source code](https://github.com/symfony/security-csrf/commit/4c6906a370bc9be11bad5d86dc148fc4fa71c307).


4.4: https://github.com/symfony/security-csrf/blob/4.4/CsrfTokenManager.php#L107
5.4: https://github.com/symfony/security-csrf/blob/5.4/CsrfTokenManager.php#L107

This means that comparing the 2 strings isn't enough, as the checked token has to be derandomised first.

This PR addresses by using the `CsrfTokenManager::isTokenValid()`

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. create a new contact via quick add
3. the contact is created as normal, and no `invalid CSRF` message is shown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
