### PR TITLE
Remove unused WebfactoryExceptionsBundle dev dependency

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -105,7 +105,7 @@ class AppKernel extends Kernel
         return parent::handle($request, $type, $catch);
     }
 
-    public function registerBundles(): array
+    public function registerBundles(): iterable
     {
         $bundles = [
             // Symfony/Core Bundles
@@ -203,7 +203,6 @@ class AppKernel extends Kernel
 
         if (in_array($this->getEnvironment(), ['dev', 'test'])) {
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
-            $bundles[] = new Webfactory\Bundle\ExceptionsBundle\WebfactoryExceptionsBundle();
             $bundles[] = new Fidry\PsyshBundle\PsyshBundle();
             $bundles[] = new Symfony\Bundle\MakerBundle\MakerBundle();
         }

--- a/app/config/routing_dev.php
+++ b/app/config/routing_dev.php
@@ -14,10 +14,6 @@ $profiler = $loader->import('@WebProfilerBundle/Resources/config/routing/profile
 $profiler->addPrefix('/_profiler');
 $collection->addCollection($profiler);
 
-//error pages
-$errors = $loader->import('@WebfactoryExceptionsBundle/Resources/config/routing.yml');
-$collection->addCollection($errors);
-
 //main
 $collection->addCollection($loader->import('routing.php'));
 

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
     "symfony/maker-bundle": "^1.38",
     "symfony/phpunit-bridge": "~5.1.0",
     "symfony/var-dumper": "~4.4.0",
-    "symfony/web-profiler-bundle": "~4.4.0",
-    "webfactory/exceptions-bundle": "~4.3"
+    "symfony/web-profiler-bundle": "~4.4.0"
   },
   "replace": {
     "mautic/grapes-js-builder-bundle": "self.version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c178be9653f5db5140afa49fb4d4a684",
+    "content-hash": "dd412cb18cf72b72868217ec2b7f6822",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -17434,53 +17434,6 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
-        },
-        {
-            "name": "webfactory/exceptions-bundle",
-            "version": "4.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webfactory/exceptions-bundle.git",
-                "reference": "2d9c86117b19e4b87de5f406d85162f1f54598c3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webfactory/exceptions-bundle/zipball/2d9c86117b19e4b87de5f406d85162f1f54598c3",
-                "reference": "2d9c86117b19e4b87de5f406d85162f1f54598c3",
-                "shasum": ""
-            },
-            "require": {
-                "symfony/twig-bundle": "^2.2||^3.0||^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "symfony/framework-bundle": "^2.2||^3.0||^4.0"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-4": {
-                    "Webfactory\\Bundle\\ExceptionsBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "webfactory GmbH",
-                    "email": "info@webfactory.de",
-                    "homepage": "http://www.webfactory.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Building blocks for more user-friendly error pages, plus a simple controller to display error pages during development (helpful prior to Symfony 2.6.3)",
-            "homepage": "https://www.webfactory.de/blog/symfony2-exception-handling-and-custom-error-pages-explained",
-            "support": {
-                "issues": "https://github.com/webfactory/exceptions-bundle/issues",
-                "source": "https://github.com/webfactory/exceptions-bundle/tree/4.5.0"
-            },
-            "time": "2019-12-10T14:07:41+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR removes the `webfactory/exceptions-bundle` dev dependency (and thus the `WebfactoryExceptionsBundle`), as it's not used anywhere.

This dependency was added long long time ago (Mautic 1), but is not used anymore.

The Symfony update requires this package to update to the 5 release, but in https://github.com/webfactory/exceptions-bundle/pull/33 all logic was removed.
The only part left is [1 template](https://github.com/webfactory/exceptions-bundle/blob/master/src/Resources/views/Exception/blocks.html.twig), which we don't include or use.


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. use the `index_dev.php` entrypoint
3. Make a coding error (e.g. rename a method), so it triggers an error page
4. check the error page still shows relevant developer info

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
