### PR TITLE
make CacheProvider:: clear() compatible with method signature of symfony 5

### DIFF
--- a/app/bundles/CacheBundle/Cache/CacheProvider.php
+++ b/app/bundles/CacheBundle/Cache/CacheProvider.php
@@ -93,9 +93,9 @@ final class CacheProvider implements CacheProviderInterface
         return $this->getCacheAdapter()->hasItem($key);
     }
 
-    public function clear(): bool
+    public function clear(string $prefix = ''): bool
     {
-        return $this->getCacheAdapter()->clear();
+        return $this->getCacheAdapter()->clear($prefix);
     }
 
     public function deleteItem($key): bool

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -49,6 +49,8 @@ parameters:
 		- '#Parameter \#1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string given\.#'
 		# Following will be fixed in new PHP version. See https://github.com/doctrine/dbal/issues/4264
 		- '#Return type of call to static method Doctrine\\DBAL\\DriverManager::getConnection\(\) contains unresolvable type\.#'
+		# Following line can be removed after the switch to Symfony 5
+		- '#Method Symfony\\Component\\Cache\\Adapter\\AdapterInterface::clear\(\) invoked with 1 parameter, 0 required\.#'
 	scanFiles:
 		- plugins/MauticFocusBundle/Include/lessc.inc.php
 		# This is here because a few functions in the global namespace are defined in this file


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [?]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In Symfony >= 4.4, the signature of `AdapterInterface::clear()` changed: the `$prefix` parameter was added.
See the [4.4 upgrade notes](https://github.com/symfony/symfony/blob/ad6f6cf900e41d800de1d3f785eb246d2338c3e9/UPGRADE-4.4.md?plain=1#L7) and  [5.0 upgrade notes](https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.0.md?plain=1#L19).

In Symfony 4.4, this was not breaking yet, but it will be in >= 5.0
This PR prepares for Symfony 5 by adding the parameter.

Unsure if we need to document this as BC breaking change, as this would result in documenting all Symfony BC breaking changes.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
