### PR TITLE
Add exit code to some mautic commands for mautic 5

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -217,16 +217,18 @@ class TriggerCampaignCommand extends ModeratedCommand
 
         // Specific campaign;
         if ($id) {
+            $statusCode = 0;
             /** @var \Mautic\CampaignBundle\Entity\Campaign $campaign */
             if ($campaign = $this->campaignRepository->getEntity($id)) {
                 $this->triggerCampaign($campaign);
             } else {
                 $output->writeln('<error>'.$this->translator->trans('mautic.campaign.rebuild.not_found', ['%id%' => $id]).'</error>');
+                $statusCode = 1;
             }
 
             $this->completeRun();
 
-            return 0;
+            return $statusCode;
         }
 
         // All published campaigns

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -228,7 +228,7 @@ class TriggerCampaignCommand extends ModeratedCommand
 
             $this->completeRun();
 
-            return $statusCode;
+            return (int) $statusCode;
         }
 
         // All published campaigns

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -139,7 +139,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
             if (null === $campaign) {
                 $output->writeln('<error>'.$this->translator->trans('mautic.campaign.rebuild.not_found', ['%id%' => $id]).'</error>');
 
-                return 0;
+                return 1;
             }
 
             $this->updateCampaign($campaign);

--- a/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
+++ b/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
@@ -73,7 +73,7 @@ class ProcessWebhookQueuesCommand extends Command
         if (!count($webhooks)) {
             $output->writeln('<error>No published webhooks found. Try again later.</error>');
 
-            return 0;
+            return 1;
         }
 
         $output->writeLn('<info>Processing Webhooks</info>');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [  ]
| New feature/enhancement? (use the a.x branch)      | [ x ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

### Description:

This is M5 version for https://github.com/mautic/mautic/pull/11963

Added error exit codes to the following mautic console commands for mautic 5:

- mautic:campaigns:trigger
- mautic:campaigns:rebuild (alias mautic:campaigns:update)
- mautic:webhooks:process

#### Steps to test this PR:

1. Test the console commands in terminal before implemented the code changes; as followed with non exiisting ids in your mautic test environment [for the third command just code review]:

- First: `php bin/console mautic:campaigns:trigger -i874567 || echo fail`
As result in terminal you just get: `Campaign #874567 does not exist` and you won´t get the testing `fail` (of echo fail) output.

- Second: `php bin/console mautic:campaigns:rebuild -i874567 || echo fail`
As result in terminal you just get: `Campaign #874567 does not exist` and you won´t get the testing `fail` (of echo fail) output.

[- Third: For the third, just code review possible.
It can´t be easily tested the way before with `php bin/console mautic:webhooks:process -i874567 || echo fail` because before and after code changes you will always get the message `Webhook Bundle is in immediate process mode. To use the command function change to command mode.'
So for this one, just code review]

2. Implement code changes as a patch in your mautic testsystem or pull down.

3. Test the first three console commands in terminal after implemented the code changes; as followed with non existing ids in your mautic test environment:
 - First: `php bin/console mautic:campaigns:trigger -i874567 || echo fail`
 As result in terminal you just get: `Campaign #874567 does not exist` and now you will get the testing  `fail` (of echo fail) output, too.

- Second: `php bin/console mautic:campaigns:rebuild -i874567 || echo fail`
As result in terminal you just get: `Campaign #874567 does not exist` and now you will get the testing `fail` (of echo fail) output, too.

[- Third: For the third, just code review possible.
It can´t be easily tested the way before with `php bin/console mautic:webhooks:process -i874567 || echo fail` because before and after code changes you will always get the message `Webhook Bundle is in immediate process mode. To use the command function change to command mode.'
So for this one, just code review]