### PR TITLE
Fixing saving campaigns

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -15,9 +15,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
-/**
- * Class Campaign.
- */
 class Campaign extends FormEntity implements PublishStatusIconAttributesInterface
 {
     /**
@@ -80,9 +77,6 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
      */
     private $allowRestart = false;
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
         $this->events = new ArrayCollection();
@@ -107,7 +101,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable('campaigns')
-            ->setCustomRepositoryClass('Mautic\CampaignBundle\Entity\CampaignRepository');
+            ->setCustomRepositoryClass(CampaignRepository::class);
 
         $builder->addIdColumns();
 
@@ -115,7 +109,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
 
         $builder->addCategory();
 
-        $builder->createOneToMany('events', 'Event')
+        $builder->createOneToMany('events', Event::class)
             ->setIndexBy('id')
             ->setOrderBy(['order' => 'ASC'])
             ->mappedBy('campaign')
@@ -123,20 +117,20 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
             ->fetchExtraLazy()
             ->build();
 
-        $builder->createOneToMany('leads', 'Lead')
-            ->setIndexBy('id')
+        $builder->createOneToMany('leads', Lead::class)
+            ->setIndexBy('lead_id')
             ->mappedBy('campaign')
             ->fetchExtraLazy()
             ->build();
 
-        $builder->createManyToMany('lists', 'Mautic\LeadBundle\Entity\LeadList')
+        $builder->createManyToMany('lists', LeadList::class)
             ->setJoinTable('campaign_leadlist_xref')
             ->setIndexBy('id')
             ->addInverseJoinColumn('leadlist_id', 'id', false, false, 'CASCADE')
             ->addJoinColumn('campaign_id', 'id', true, false, 'CASCADE')
             ->build();
 
-        $builder->createManyToMany('forms', 'Mautic\FormBundle\Entity\Form')
+        $builder->createManyToMany('forms', Form::class)
             ->setJoinTable('campaign_form_xref')
             ->setIndexBy('id')
             ->addInverseJoinColumn('form_id', 'id', false, false, 'CASCADE')

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testCreateNewCampaign(): void
+    {
+        $segment = new LeadList();
+        $segment->setName('test');
+        $segment->setAlias('test');
+        $segment->setPublicName('test');
+
+        $email = new Email();
+        $email->setName('test');
+        $email->setSubject('test');
+        $email->setCustomHtml('test');
+
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        $payload = [
+            'name'        => 'test',
+            'description' => 'Created via API',
+            'events'      => [
+                [
+                    'id'          => 'new_44', // Event ID will be replaced on /new
+                    'name'        => 'Send email',
+                    'description' => 'API test',
+                    'type'        => 'email.send',
+                    'eventType'   => 'action',
+                    'order'       => 1,
+                    'properties'  => [
+                        'email'      => $email->getId(),
+                        'email_type' => 'transactional',
+                    ],
+                    'triggerDate'         => null,
+                    'triggerInterval'     => 1,
+                    'triggerIntervalUnit' => 'd',
+                    'triggerMode'         => 'interval',
+                    'children'            => [],
+                    'parent'              => null,
+                    'decisionPath'        => 'yes',
+                ],
+            ],
+            'forms' => [],
+            'lists' => [
+                [
+                    'id' => $segment->getId(),
+                ],
+            ],
+            'canvasSettings' => [
+                'nodes' => [
+                    [
+                        'id'        => 'new_44', // Event ID will be replaced on /new
+                        'positionX' => '650',
+                        'positionY' => '189',
+                    ],
+                    [
+                        'id'        => 'lists',
+                        'positionX' => '629',
+                        'positionY' => '65',
+                    ],
+                ],
+                'connections' => [
+                    [
+                        'sourceId' => 'lists',
+                        'targetId' => 'new_44', // Event ID will be replaced on /new
+                        'anchors'  => [
+                            'source' => 'leadsource',
+                            'target' => 'top',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, 'api/campaigns/new', $payload);
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $response = json_decode($clientResponse->getContent(), true);
+        Assert::assertEquals($payload['name'], $response['campaign']['name']);
+        Assert::assertEquals($payload['description'], $response['campaign']['description']);
+        Assert::assertEquals($payload['events'][0]['name'], $response['campaign']['events'][0]['name']);
+        Assert::assertEquals($segment->getId(), $response['campaign']['lists'][0]['id']);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/pull/12166#issuecomment-1498907535

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The API Library tests showed that saving campaigns got broken. See https://github.com/mautic/mautic/pull/12166#issuecomment-1498907535 for more details. This PR fixes that. The issue was there for years but the new version of the `symfony/property-access` library is more strict. We were always indexing the `Mautic\CampaignBundle\Entity\Lead` entity by `id` property from the `Campaign` entity but such property does not exist. I replaced it with `lead_id` property.

Error this PR fixes:
```
Cannot find a field on \u0027Mautic\\CampaignBundle\\Entity\\Lead\u0027 that is mapped to column \u0027id\u0027. Either the field does not exist or an association exists but it has multiple join columns.
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Try to save an existing or new campaign

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
