### PR TITLE
Adding a test showing the bug

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -118,7 +118,6 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
             ->build();
 
         $builder->createOneToMany('leads', Lead::class)
-            ->setIndexBy('lead_id')
             ->mappedBy('campaign')
             ->fetchExtraLazy()
             ->build();

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaginBundle\Tests\Controller\Api;
+
+use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
+use Mautic\CampaignBundle\Entity\LeadRepository;
+use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTest;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTest
+{
+    public function testContactCampaignApiEndpoints(): void
+    {
+        $campaign = $this->saveSomeCampaignLeadEventLogs();
+        $contact  = new Lead();
+        $contact->setEmail('campaign@tester.email');
+
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $campaignMemberRepository = $this->em->getRepository(CampaignMember::class);
+        \assert($campaignMemberRepository instanceof LeadRepository);
+
+        // Add the contact to the campaign.
+        $this->client->request(Request::METHOD_POST, "/api/campaigns/{$campaign->getId()}/contact/{$contact->getId()}/add");
+        $clientResponse = $this->client->getResponse();
+        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        Assert::assertSame('{"success":1}', $clientResponse->getContent());
+
+        // Assert that the campaign member was really added.
+        /** @var CampaignMember[] $campaignMembers */
+        $campaignMembers = $campaignMemberRepository->findBy(['lead' => $contact->getId(), 'campaign' => $campaign->getId()]);
+        Assert::assertCount(1, $campaignMembers);
+        Assert::assertTrue($campaignMembers[0]->getManuallyAdded());
+        Assert::assertFalse($campaignMembers[0]->getManuallyRemoved());
+
+        // Get the contact's campaigns.
+        $this->client->request(Request::METHOD_GET, "/api/contacts/{$contact->getId()}/campaigns");
+        $clientResponse = $this->client->getResponse();
+        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $body = json_decode($clientResponse->getContent(), true);
+        Assert::assertSame(1, $body['total'], $clientResponse->getContent());
+        Assert::assertSame($campaign->getId(), $body['campaigns'][$campaign->getId()]['id'], $clientResponse->getContent());
+        Assert::assertSame($campaign->getName(), $body['campaigns'][$campaign->getId()]['name'], $clientResponse->getContent());
+        Assert::assertNotEmpty($body['campaigns'][$campaign->getId()]['dateAdded'], $clientResponse->getContent());
+        Assert::assertFalse($body['campaigns'][$campaign->getId()]['manuallyRemoved'], $clientResponse->getContent());
+        Assert::assertTrue($body['campaigns'][$campaign->getId()]['manuallyAdded'], $clientResponse->getContent());
+
+        // Get campaign contacts API endpoint.
+        $this->client->request(Request::METHOD_GET, "/api/campaigns/{$campaign->getId()}/contacts");
+        $clientResponse = $this->client->getResponse();
+        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $body = json_decode($clientResponse->getContent(), true);
+        Assert::assertSame(3, (int) $body['total']);
+        Assert::assertSame($contact->getId(), $body['contacts'][2]['lead_id']);
+
+        // Remove the contact from the campaign.
+        $this->client->request(Request::METHOD_POST, "/api/campaigns/{$campaign->getId()}/contact/{$contact->getId()}/remove");
+        $clientResponse = $this->client->getResponse();
+        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        Assert::assertSame('{"success":1}', $clientResponse->getContent());
+
+        // Assert that the campaign member was really removed.
+        /** @var CampaignMember[] $campaignMembers */
+        $campaignMembers = $campaignMemberRepository->findBy(['lead' => $contact->getId(), 'campaign' => $campaign->getId()]);
+        Assert::assertCount(1, $campaignMembers);
+        Assert::assertFalse($campaignMembers[0]->getManuallyAdded());
+        Assert::assertTrue($campaignMembers[0]->getManuallyRemoved());
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes [API Library test](https://github.com/mautic/api-library/commit/846a4f185e2f71af1b407d8a43b8ddbbc5d540ad/checks)

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In https://github.com/mautic/mautic/pull/12207 where I fixed the index by key to something that exists it broke code that was counting on the indexes being autoincrements and not contact IDs. The [API Library test](https://github.com/mautic/api-library/blob/main/tests/Api/CampaignsTest.php#L284)s found the issue:

```
1) Mautic\Tests\Api\CampaignsTest::testAddAndRemove
The response has unexpected status code (500).

Response: {"errors":[{"message":"PHP Warning - Undefined array key 0","code":500,"type":null}],"trace":[{"namespace":"","short_class":"","class":"","type":"","function":"","file":"\/var\/www\/html\/app\/bundles\/LeadBundle\/Controller\/Api\/LeadApiController.php","line":347,"args":[]},{"namespace":"Mautic\\CoreBundle\\ErrorHandler","short_class":"ErrorHandler","class":"Mautic\\CoreBundle\\ErrorHandler\\ErrorHandler","type":"-\u003E","function":"handleError","file":"\/var\/www\/html\/app\/bundles\/LeadBundle\/Controller\/Api\/LeadApiController.php","line":347,"args":[]},{"namespace":"Mautic\\LeadBundle\\Controller\\Api","short_class":"LeadApiController","class":"Mautic\\LeadBundle\\Controller\\Api\\LeadApiController","type":"-\u003E","function":"getCampaignsAction","file":"\/var\/www\/html\/vendor\/symfony\/http-kernel\/HttpKernel.php","line":169,"args":[]},{"namespace":"Symfony\\Component\\HttpKernel","short_class":"HttpKernel","class":"Symfony\\Component\\HttpKernel\\HttpKernel","type":"-\u003E...

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:89
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:[28](https://github.com/mautic/api-library/commit/846a4f185e2f71af1b407d8a43b8ddbbc5d540ad/checks#step:15:29)4
```

This PR adds similar test to Mautic's test suite so it's discoverable faster and removes the index by configuration so it would fall back to the previous behavior when it was misconfigured and ignored.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. The right test would be to ensure that [this API endpoint](https://developer.mautic.org/#get-campaign-memberships) works for you. However, with the functional tests I've added I don't think it's necessary. Also, this can be tested with the API Library tests that I'll do in a minute and post in the comments.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
