### PR TITLE
switch to self generated default SAML certificate

### DIFF
--- a/app/bundles/UserBundle/Security/SAML/Store/CredentialsStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/CredentialsStore.php
@@ -74,13 +74,32 @@ class CredentialsStore implements CredentialStoreInterface
 
     private function createDefaultCredentials(): X509Credential
     {
-        $reflection         = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
-        $vendorPath         = dirname(dirname($reflection->getFileName()));
-        $certificateContent = file_get_contents($vendorPath.'/litesaml/lightsaml/web/sp/saml.crt');
-        $privateKeyContent  = file_get_contents($vendorPath.'/litesaml/lightsaml/web/sp/saml.key');
-        $keyPassword        = '';
+        $cache_dir   = $this->coreParametersHelper->get('cache_path');
+        $keyPassword = '';
 
-        return $this->createCredentials($certificateContent, $privateKeyContent, $keyPassword);
+        if (!file_exists($cache_dir.'/saml_default.key') || !file_exists($cache_dir.'/saml_default.crt')) {
+            $dn = ['commonName' => 'Mautic dummy cert'];
+
+            // Generate a new private (and public) key pair
+            $privkey = openssl_pkey_new([
+              'private_key_bits' => 2048,
+              'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]);
+
+            // Generate a certificate signing request
+            $csr = openssl_csr_new($dn, $privkey, ['digest_alg' => 'sha256']);
+
+            // Generate a self-signed cert, valid for 365 days
+            $x509 = openssl_csr_sign($csr, null, $privkey, $days=365, ['digest_alg' => 'sha256']);
+
+            openssl_x509_export_to_file($x509, $cache_dir.'/saml_default.crt');
+            openssl_pkey_export_to_file($privkey, $cache_dir.'/saml_default.key', $keyPassword);
+        }
+
+        $cert       = file_get_contents($cache_dir.'/saml_default.crt');
+        $privateKey = file_get_contents($cache_dir.'/saml_default.key');
+
+        return $this->createCredentials($cert, $privateKey, $keyPassword);
     }
 
     private function createCertificate(string $certificateContent): X509Certificate

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class CredentialsStoreTest extends TestCase
 {
+    private string $cacheDir = __DIR__.'/../../../../../../../var/cache/test';
+
     /**
      * @var CoreParametersHelper|MockObject
      */
@@ -29,6 +31,10 @@ class CredentialsStoreTest extends TestCase
 
     public function testDefaultCredentialsAreUsedIfSamlIsDisabled()
     {
+        $this->coreParametersHelper->method('get')
+          ->withConsecutive(['saml_idp_metadata'], ['cache_path'])
+          ->willReturnOnConsecutiveCalls('', $this->cacheDir);
+
         $store = new CredentialsStore($this->coreParametersHelper, 'foobar');
 
         $credentials = $store->getByEntityId('foobar');
@@ -40,8 +46,8 @@ class CredentialsStoreTest extends TestCase
     public function testDefaultCredentialsAreUsedIfCustomCertificateIsNotProvided()
     {
         $this->coreParametersHelper->method('get')
-            ->withConsecutive(['saml_idp_metadata'], ['saml_idp_own_certificate'])
-            ->willReturnOnConsecutiveCalls('1', '');
+            ->withConsecutive(['saml_idp_metadata'], ['saml_idp_own_certificate'], ['cache_path'])
+            ->willReturnOnConsecutiveCalls('1', '', $this->cacheDir);
 
         $store = new CredentialsStore($this->coreParametersHelper, 'foobar');
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

When switching to symfony 5, we need to bump `litesaml/lightsaml` to at least `^2.0` to have Symfony 5 support.
It makes sense to update directly to the latest major version available, which is `^4.0`.

Since `litesaml/lightsaml ^3.0`, the `web` folder in the repo was removed, see [this commit](https://github.com/litesaml/lightsaml/pull/11/files).
That folder contained the dummy key (`web/sp/saml.key`) and cert (`web/sp/saml.crt`).

These keys are used in Mautic as fallback default keys if SAML is not configured, see [here](https://github.com/mautic/mautic/blob/5.x/app/bundles/UserBundle/Security/SAML/Store/CredentialsStore.php#L75).

As those keys are gone, and it's from a security pov a bad idea to use predefined keys in a general way, we should address this.

This PR generates those default keys and stores them in the cache folder.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
