### PR TITLE
Removing a deprecation about min needing also allowEmptyString

### DIFF
--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
@@ -9,7 +9,7 @@ class LengthValidatorTest extends \PHPUnit\Framework\TestCase
 {
     public function testValidate()
     {
-        $constraint = new Length(['min' => 3]);
+        $constraint = new Length(['min' => 3, 'allowEmptyString' => true]);
         $validator  = new LengthValidator();
         $this->assertNull($validator->validate('valid', $constraint));
         // Not thrownig Symfony\Component\Validator\Exception\UnexpectedTypeException


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.atlassian.net/browse/TPROD-424

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Resolving this deprecation:
```
  2x: Using the "Symfony\Component\Validator\Constraints\Length" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true. In 5.0, it will become optional and default to false.
    2x in LengthValidatorTest::testValidate from Mautic\LeadBundle\Tests\Validator\Constraints
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No need to test. The fix is in the unit tests themselves. So if this PR has green CI checks then it's tested sucessfully.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
