### PR TITLE
Bugfix 12044 - 500 error on Form when adding attributes to a field

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
@@ -31,7 +31,7 @@ final class HtmlExtensionTest extends TestCase
     {
         yield ['id="test-id" class="test-class"', [
             'id'    => 'test-id',
-            'class' => 'test-class',
+            'class' => ['test-class'],
         ]];
 
         yield ['id="test-id" class="test-class-one test-class-two"', [

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -23,7 +23,7 @@ final class HtmlExtension extends AbstractExtension
      * Takes a string of HTML attributes and returns them as a key => value array.
      * Attribute strings which represent a single value are still output as a string
      * An exception is made for html classes, which can either be single or multiple,
-     * so should always use an array to avoid overhead in the Twig templates having to write for 2 scenarios
+     * so should always use an array to avoid overhead in the Twig templates having to write for 2 scenarios.
      *
      * <example>
      *   $attributes = 'id="test-id" class="class-one class-two"';
@@ -65,9 +65,9 @@ final class HtmlExtension extends AbstractExtension
                 // Keeping index as 0, 1, 2, etc instead of 0, 3, 4, 6, etc. when
                 // there are too many spaces between values
                 $value = array_values($dirty);
-            
+
             // for 'class' attribute, we convert single value to an array
-            } else if ($attr === 'class' && !empty($value)) {
+            } elseif ('class' === $attr && !empty($value)) {
                 $value = [$value];
             }
 

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -65,7 +65,6 @@ final class HtmlExtension extends AbstractExtension
                 // Keeping index as 0, 1, 2, etc instead of 0, 3, 4, 6, etc. when
                 // there are too many spaces between values
                 $value = array_values($dirty);
-
             } elseif ('class' === $attr && !empty($value)) {
                 // for 'class' attribute, we convert single value to an array
                 $value = [$value];

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -66,8 +66,8 @@ final class HtmlExtension extends AbstractExtension
                 // there are too many spaces between values
                 $value = array_values($dirty);
 
-            // for 'class' attribute, we convert single value to an array
             } elseif ('class' === $attr && !empty($value)) {
+                // for 'class' attribute, we convert single value to an array
                 $value = [$value];
             }
 

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -21,6 +21,9 @@ final class HtmlExtension extends AbstractExtension
 
     /**
      * Takes a string of HTML attributes and returns them as a key => value array.
+     * Attribute strings which represent a single value are still output as a string
+     * An exception is made for html classes, which can either be single or multiple,
+     * so should always use an array to avoid overhead in the Twig templates having to write for 2 scenarios
      *
      * <example>
      *   $attributes = 'id="test-id" class="class-one class-two"';
@@ -62,6 +65,10 @@ final class HtmlExtension extends AbstractExtension
                 // Keeping index as 0, 1, 2, etc instead of 0, 3, 4, 6, etc. when
                 // there are too many spaces between values
                 $value = array_values($dirty);
+            
+            // for 'class' attribute, we convert single value to an array
+            } else if ($attr === 'class' && !empty($value)) {
+                $value = [$value];
             }
 
             $attributes[$attr] = $value;

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -212,7 +212,7 @@
 {% set optionLabelAttr = optionLabelAttr|merge({
         'class': optionLabelAttr.class|default([])|merge([defaultOptionLabelClass]),
 }) %}
-{% if 'class' in field.properties.labelAttributes %}
+{% if 'class' in field.properties.labelAttributes|default('') %}
   {% set wrapDiv = false %}
 {% endif %}
 {% set firstId = 'mauticform_' ~ containerType ~ '_' ~ type ~ '_' ~ field.alias ~ '_' ~ inputAlphanum(inputTransliterate(firstListValue|default(null))) ~ '1' %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ yes]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12044 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When adding fields to a form, there are issues with the attributes on a field label being processed in Twig that cause a 500 error. Eg. when adding a group (eg. checkboxes) to the fields of a form, and adding a single class as an attribute on the label, you get errors like 'a string is  being processed as an Array' or 'that value is empty and can't be processed'.
Most of it can be traced to the attributes data not being formatted in a way that the Twig templates (and logic present) is expecting.
To fix this, I'm making sure default values exist and trying to make sure they are formatted in a predictable way.

One big change: I modified the `htmlAttributesStringToArray` Twig Extension to ALWAYS output class attribute value as an array in Twig. In theory this shouldn't break anything but it's used all over the Form bundle, so forms need to be tested properly

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. make a new form
3. for fields, add a group fo 2 checkboxes
4. edit the attributes of that field and add `class="my-single-class"` to the label attributes
5. you should be able to save the form without getting a 500
6. you should be able to view the form without getting a 500
7. the label should contain that html class (inspect the html using the browser dev tools or check the source code)
8. Repeat the steps 4 - 7 with multiple classes, and with other attributes (eg. adding `id="some-id"`)
9. Add other types of fields and see that you still don't get 500 errors

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
