### PR TITLE
TPROD-399 EM::clear() refactoring Remove deprecated call from CampaignBundle.

### DIFF
--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -120,14 +120,14 @@ class MembershipManager
     }
 
     /**
-     * @param bool $isManualAction
+     * @param ArrayCollection<int, Lead> $contacts
+     * @param bool                       $isManualAction
      */
     public function addContacts(ArrayCollection $contacts, Campaign $campaign, $isManualAction = true)
     {
         // Get a list of existing campaign members
         $campaignMembers = $this->leadRepository->getCampaignMembers($contacts->getKeys(), $campaign);
 
-        /** @var Lead $contact */
         foreach ($contacts as $contact) {
             $this->advanceProgressBar();
 
@@ -167,7 +167,7 @@ class MembershipManager
         }
 
         // Clear entities from RAM
-        $this->leadRepository->clear();
+        $this->leadRepository->detachEntities($contacts->toArray());
     }
 
     /**
@@ -208,15 +208,15 @@ class MembershipManager
     }
 
     /**
-     * @param bool $isExit If true, the contact can be added by a segment/source. If false, the contact can only be added back
-     *                     by a manual process.
+     * @param ArrayCollection<int, Lead> $contacts
+     * @param bool                       $isExit   If true, the contact can be added by a segment/source. If false, the contact can only be added back
+     *                                             by a manual process.
      */
     public function removeContacts(ArrayCollection $contacts, Campaign $campaign, $isExit = false)
     {
         // Get a list of existing campaign members
         $campaignMembers = $this->leadRepository->getCampaignMembers($contacts->getKeys(), $campaign);
 
-        /** @var Lead $contact */
         foreach ($contacts as $contact) {
             $this->advanceProgressBar();
 
@@ -250,7 +250,7 @@ class MembershipManager
         }
 
         // Clear entities from RAM
-        $this->leadRepository->clear();
+        $this->leadRepository->detachEntities($campaignMembers);
     }
 
     public function setProgressBar(ProgressBar $progressBar = null)

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1180,7 +1180,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     }
 
     /**
-     * @return ArrayCollection
+     * @return ArrayCollection<int, Lead>
      */
     public function getContactCollection(array $ids)
     {

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
@@ -113,6 +113,6 @@ class TimelineEventLogCampaignSubscriber implements EventSubscriberInterface
         }
 
         $this->eventLogRepository->saveEntities($logs);
-        $this->eventLogRepository->clear();
+        $this->eventLogRepository->detachEntities($logs);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| New feature/enhancement? (use the a.x branch)      | [ x ]

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Remove deprecation `CampaignBundle`.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
Affected methods were seen during the tests in `CampaignBundle`.

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an orphaned Lead in campaign.
3. Launch the campaign, so orphaned lead will be removed.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
