### PR TITLE
The Doctrine\DBAL\Driver\Exception::getErrorCode method is deprecated…

### DIFF
--- a/app/bundles/LeadBundle/Field/CustomFieldColumn.php
+++ b/app/bundles/LeadBundle/Field/CustomFieldColumn.php
@@ -137,7 +137,7 @@ class CustomFieldColumn
         } catch (DriverException $e) {
             $this->logger->warning($e->getMessage());
 
-            if (1118 === $e->getErrorCode() /* ER_TOO_BIG_ROWSIZE */) {
+            if (1118 === $e->getCode() /* ER_TOO_BIG_ROWSIZE */) {
                 throw new CustomFieldLimitException('mautic.lead.field.max_column_error');
             }
 

--- a/app/bundles/LeadBundle/Field/CustomFieldIndex.php
+++ b/app/bundles/LeadBundle/Field/CustomFieldIndex.php
@@ -70,7 +70,7 @@ class CustomFieldIndex
 
             $modifySchema->executeChanges();
         } catch (DriverException $e) {
-            if (1069 === $e->getErrorCode() /* ER_TOO_MANY_KEYS */) {
+            if (1069 === $e->getCode() /* ER_TOO_MANY_KEYS */) {
                 $this->logger->warning($e->getMessage());
             } else {
                 throw $e;

--- a/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
@@ -149,7 +149,7 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
 
         $driverExceptionInterface = $this->createMock(\Doctrine\DBAL\Driver\DriverException::class);
         $driverExceptionInterface->expects($this->once())
-            ->method('getErrorCode')
+            ->method('getCode')
             ->willReturn(1118);
 
         $driverException = new \Doctrine\DBAL\Exception\DriverException('Message', $driverExceptionInterface);


### PR DESCRIPTION
… (Use {@link getCode()}

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.atlassian.net/browse/TPROD-407

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is replacing this Doctrine deprecation notice:
```
1x: The Doctrine\DBAL\Driver\Exception::getErrorCode method is deprecated (Use {@link getCode()} or {@link getSQLState()} instead  Returns null if no driver specific error code is available for the error raised by the driver.).
    1x in CustomFieldColumnTest::testCustomFieldLimit from Mautic\LeadBundle\Tests\Field
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. The changed code should execute if you create way too many contact custom fields than the database can handle. If that happens, you should either see a warning in the form itself and/or logged message about that in the logs.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
