### PR TITLE
Use timezone during the build graph data

### DIFF
--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -5,6 +5,7 @@ namespace Mautic\CoreBundle\Helper\Chart;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 
 /**
  * Methods to get the chart data as native queries to get better performance and work with date/time native SQL queries.
@@ -17,6 +18,8 @@ class ChartQuery extends AbstractChart
      * @var Connection
      */
     protected $connection;
+
+    private DateTimeHelper $dateTimeHelper;
 
     /**
      * @var GeneratedColumnsProviderInterface
@@ -69,9 +72,10 @@ class ChartQuery extends AbstractChart
      */
     public function __construct(Connection $connection, \DateTime $dateFrom, \DateTime $dateTo, $unit = null)
     {
-        $this->unit       = (null === $unit) ? $this->getTimeUnitFromDateRange($dateFrom, $dateTo) : $unit;
-        $this->isTimeUnit = (in_array($this->unit, ['H', 'i', 's']));
-        $this->connection = $connection;
+        $this->dateTimeHelper = new DateTimeHelper();
+        $this->unit           = (null === $unit) ? $this->getTimeUnitFromDateRange($dateFrom, $dateTo) : $unit;
+        $this->isTimeUnit     = (in_array($this->unit, ['H', 'i', 's']));
+        $this->connection     = $connection;
         $this->setDateRange($dateFrom, $dateTo);
     }
 
@@ -338,7 +342,7 @@ class ChartQuery extends AbstractChart
                          * format, so we transform it into d-M-Y.
                          */
                         if ('W' === $this->unit && isset($item['date'])) {
-                            list($year, $week) = explode(' ', $item['date']);
+                            [$year, $week]     = explode(' ', $item['date']);
                             $newDate           = new \DateTime();
                             $newDate->setISODate($year, $week);
                             $item['date'] = $newDate->format('d-M-Y');
@@ -594,8 +598,11 @@ class ChartQuery extends AbstractChart
             }
         }
 
-        $dbUnit = $this->translateTimeUnit($this->unit);
+        $dbUnit                = $this->translateTimeUnit($this->unit);
+        $columnName            = $tablePrefix.'.'.$column;
+        $defaultTimezoneOffset = $this->dateTimeHelper->getLocalTimezoneOffset();
+        $columnName            = "CONVERT_TZ($columnName, '+00:00', '{$defaultTimezoneOffset}')";
 
-        return 'DATE_FORMAT('.$tablePrefix.'.'.$column.', \''.$dbUnit.'\')';
+        return 'DATE_FORMAT('.$columnName.', \''.$dbUnit.'\')';
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/Chart/ChartQueryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/Chart/ChartQueryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional\Helper\Chart;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadEventLog;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Segment\Stat\ChartQuery\SegmentContactsLineChartQuery;
+
+class ChartQueryTest extends MauticMysqlTestCase
+{
+    public function testSegmentContactsLineChartQuery(): void
+    {
+        $lead = new Lead();
+        $lead->setEmail('test@test.com');
+
+        // Create a segment
+        $segment = new LeadList();
+        $segment->setName('Test Segment A');
+        $segment->setPublicName('Test Segment A');
+        $segment->setAlias('test-segment-a');
+
+        $leadEventLogs = new LeadEventLog();
+        $leadEventLogs->setLead($lead);
+        $leadEventLogs->setBundle('lead');
+        $leadEventLogs->setObject('segment');
+        $leadEventLogs->setAction('added');
+        $leadEventLogs->setObjectId($segment->getId());
+        $leadEventLogs->setDateAdded(new \DateTime('2023-01-31 23:49:59'));
+
+        $leadEventLogs = new LeadEventLog();
+        $leadEventLogs->setLead($lead);
+        $leadEventLogs->setBundle('lead');
+        $leadEventLogs->setObject('segment');
+        $leadEventLogs->setAction('added');
+        $leadEventLogs->setObjectId($segment->getId());
+        $leadEventLogs->setDateAdded(new \DateTime('2023-01-30 23:49:59'));
+
+        $this->em->persist($lead);
+        $this->em->persist($segment);
+        $this->em->persist($leadEventLogs);
+
+        $this->em->flush();
+
+        $dateFrom = new \DateTime('2023-01-27');
+        $dateTo   = new \DateTime('2023-01-30');
+
+        $filter = '{"leadlist_id":{"value":"'.$segment->getId().'","list_column_name":"t.lead_id"},"t.leadlist_id":"'.$segment->getId().'"}';
+        $query  = new SegmentContactsLineChartQuery($this->em->getConnection(), $dateFrom, $dateTo, json_decode($filter, true));
+
+        // assume UTC 2023-01-30 23:49:59 is 2023-01-31 00:49:59 in UTC+1, then do not add it to graph
+        $this->assertEmpty(array_filter($query->getAddedEventLogStats()));
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumns;
 use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ChartQueryTest extends \PHPUnit\Framework\TestCase
@@ -18,6 +19,8 @@ class ChartQueryTest extends \PHPUnit\Framework\TestCase
      * @var \DateTime
      */
     private $dateFrom;
+
+    private DateTimeHelper $dateTimeHelper;
 
     /**
      * @var \DateTime
@@ -53,12 +56,13 @@ class ChartQueryTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->dateFrom     = new \DateTime('2018-01-01 12:00:00');
-        $this->dateTo       = new \DateTime('2018-02-01 12:00:00');
-        $this->unit         = 'd';
-        $this->dateColumn   = 'date_sent';
-        $this->connection   = $this->createMock(Connection::class);
-        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->dateFrom       = new \DateTime('2018-01-01 12:00:00');
+        $this->dateTo         = new \DateTime('2018-02-01 12:00:00');
+        $this->unit           = 'd';
+        $this->dateColumn     = 'date_sent';
+        $this->connection     = $this->createMock(Connection::class);
+        $this->queryBuilder   = $this->createMock(QueryBuilder::class);
+        $this->dateTimeHelper = new DateTimeHelper();
 
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
     }
@@ -69,15 +73,15 @@ class ChartQueryTest extends \PHPUnit\Framework\TestCase
 
         $this->queryBuilder->expects($this->once())
             ->method('select')
-            ->with('DATE_FORMAT(t.date_sent, \'%Y-%m-%d\') AS date, COUNT(*) AS count');
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_sent, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\') AS date, COUNT(*) AS count');
 
         $this->queryBuilder->expects($this->once())
             ->method('groupBy')
-            ->with('DATE_FORMAT(t.date_sent, \'%Y-%m-%d\')');
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_sent, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\')');
 
         $this->queryBuilder->expects($this->once())
             ->method('orderBy')
-            ->with('DATE_FORMAT(t.date_sent, \'%Y-%m-%d\')');
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_sent, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\')');
 
         $this->queryBuilder->expects($this->once())
             ->method('setMaxResults')
@@ -330,7 +334,7 @@ class ChartQueryTest extends \PHPUnit\Framework\TestCase
 
         $this->queryBuilder->expects($this->once())
             ->method('select')
-            ->with("DATE_FORMAT(t.date_added, '%Y-%m-%d') AS date, COUNT(*) AS count");
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_added, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\') AS date, COUNT(*) AS count');
 
         $this->queryBuilder->expects($this->once())
             ->method('from')
@@ -338,11 +342,11 @@ class ChartQueryTest extends \PHPUnit\Framework\TestCase
 
         $this->queryBuilder->expects($this->once())
             ->method('groupBy')
-            ->with("DATE_FORMAT(t.date_added, '%Y-%m-%d')");
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_added, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\')');
 
         $this->queryBuilder->expects($this->once())
             ->method('orderBy')
-            ->with("DATE_FORMAT(t.date_added, '%Y-%m-%d')");
+            ->with('DATE_FORMAT(CONVERT_TZ(t.date_added, \'+00:00\', \''.$this->dateTimeHelper->getLocalTimezoneOffset().'\'), \'%Y-%m-%d\')');
 
         $this->queryBuilder->expects($this->once())
             ->method('setMaxResults')

--- a/app/bundles/EmailBundle/Tests/Stats/SentHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stats/SentHelperTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Result;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumns;
 use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\EmailBundle\Stats\FetchOptions\EmailStatOptions;
 use Mautic\EmailBundle\Stats\Helper\SentHelper;
@@ -21,6 +22,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 class SentHelperTest extends \PHPUnit\Framework\TestCase
 {
     private Collector $collector;
+
+    private DateTimeHelper $dateTimeHelper;
 
     private SentHelper $sentHelper;
 
@@ -62,6 +65,7 @@ class SentHelperTest extends \PHPUnit\Framework\TestCase
         $this->userHelperMock           = $this->createMock(UserHelper::class);
         $this->queryBuilder             = $this->createMock(QueryBuilder::class);
         $this->result                   = $this->createMock(Result::class);
+        $this->dateTimeHelper           = new DateTimeHelper();
 
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
 
@@ -95,7 +99,7 @@ class SentHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->queryBuilder->expects($this->once())
             ->method('select')
-            ->with("DATE_FORMAT(t.generated_sent_date, '%Y-%m-%d') AS date, COUNT(*) AS count")
+            ->with("DATE_FORMAT(CONVERT_TZ(t.generated_sent_date, '+00:00', '".$this->dateTimeHelper->getLocalTimezoneOffset()."'), '%Y-%m-%d') AS date, COUNT(*) AS count")
             ->willReturnSelf();
 
         $this->result->method('fetchAllAssociative')->willReturn([
@@ -139,7 +143,7 @@ class SentHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->queryBuilder->expects($this->once())
             ->method('select')
-            ->with("DATE_FORMAT(t.date_sent, '%Y-%m-%d %H:00') AS date, COUNT(*) AS count")
+            ->with("DATE_FORMAT(CONVERT_TZ(t.date_sent, '+00:00', '".$this->dateTimeHelper->getLocalTimezoneOffset()."'), '%Y-%m-%d %H:00') AS date, COUNT(*) AS count")
             ->willReturnSelf();
 
         $this->result->expects($this->once())


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
If you are using different timezone like UTC and then use graph data, for example in detail of segment there is wrong query to use UTC store datetime for logs. This PR fixed it

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  Create a contact and add it to the segment
3. Then go to DB and change In lead_event_log table date_added for this event log to 2023-01-30 23:49:59
4. Then go to segment detail and change the filter of the segment detail graph  from 2023-01-27 to 2023-01-30
5. You see the log in the graph even if the real log was on 31. 01 for locale timezone
6. After PR contact's log should not be in the graph

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
