### PR TITLE
make rector happy with symfony 5.4

### DIFF
--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -50,7 +50,7 @@ class ApiSubscriber implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event)
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
@@ -57,7 +57,7 @@ class ApiSubscriberTest extends CommonMocks
     public function testOnKernelRequestWhenNotMasterRequest(): void
     {
         $this->event->expects($this->once())
-            ->method('isMasterRequest')
+            ->method('isMainRequest')
             ->willReturn(false);
 
         $this->coreParametersHelper->expects($this->never())
@@ -69,7 +69,7 @@ class ApiSubscriberTest extends CommonMocks
     public function testOnKernelRequestOnApiRequestWhenApiDisabled(): void
     {
         $this->event->expects($this->once())
-            ->method('isMasterRequest')
+            ->method('isMainRequest')
             ->willReturn(true);
 
         $this->event->expects($this->once())
@@ -100,7 +100,7 @@ class ApiSubscriberTest extends CommonMocks
     public function testOnKernelRequestOnApiRequestWhenApiEnabled(): void
     {
         $this->event->expects($this->once())
-            ->method('isMasterRequest')
+            ->method('isMainRequest')
             ->willReturn(true);
 
         $this->event->expects($this->once())

--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -39,9 +39,7 @@ class UploadController extends DropzoneController
         return $this->createSupportedJsonResponse($response->assemble());
     }
 
-    /**
-     * @required
-     */
+    #[\Symfony\Contracts\Service\Attribute\Required]
     public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;

--- a/app/bundles/CacheBundle/Command/ClearCacheCommand.php
+++ b/app/bundles/CacheBundle/Command/ClearCacheCommand.php
@@ -25,12 +25,12 @@ class ClearCacheCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('mautic:cache:clear')
-            ->setDescription('Clears Mautic\'s cache');
+        $this->setName('mautic:cache:clear');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         return (int) !$this->cacheProvider->clear();
     }
+    protected static $defaultDescription = 'Clears Mautic\'s cache';
 }

--- a/app/bundles/CampaignBundle/Command/ExecuteEventCommand.php
+++ b/app/bundles/CampaignBundle/Command/ExecuteEventCommand.php
@@ -45,7 +45,6 @@ class ExecuteEventCommand extends Command
     {
         $this
             ->setName('mautic:campaigns:execute')
-            ->setDescription('Execute specific scheduled events.')
             ->addOption(
                 '--scheduled-log-ids',
                 null,
@@ -68,6 +67,7 @@ class ExecuteEventCommand extends Command
 
         $this->writeCounts($output, $this->translator, $counter);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Execute specific scheduled events.';
 }

--- a/app/bundles/CampaignBundle/Command/SummarizeCommand.php
+++ b/app/bundles/CampaignBundle/Command/SummarizeCommand.php
@@ -55,8 +55,7 @@ class SummarizeCommand extends ModeratedCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Rebuild existing data. To be used only if database exceptions have been known to cause inaccuracies.'
-            )
-            ->setDescription('Builds historical campaign summary statistics if they do not already exist.');
+            );
 
         parent::configure();
     }
@@ -67,7 +66,7 @@ class SummarizeCommand extends ModeratedCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->checkRunStatus($input, $output)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $batchLimit = (int) $input->getOption('batch-limit');
@@ -82,6 +81,7 @@ class SummarizeCommand extends ModeratedCommand
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Builds historical campaign summary statistics if they do not already exist.';
 }

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -98,7 +98,6 @@ class TriggerCampaignCommand extends ModeratedCommand
     {
         $this
             ->setName('mautic:campaigns:trigger')
-            ->setDescription('Trigger timed events for published campaigns.')
             ->addOption(
                 '--campaign-id',
                 '-i',
@@ -204,7 +203,7 @@ class TriggerCampaignCommand extends ModeratedCommand
         if ($threadId && $maxThreads && (int) $threadId > (int) $maxThreads) {
             $this->output->writeln('--thread-id cannot be larger than --max-thread');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $this->limiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds, $threadId, $maxThreads, $campaignLimit);
@@ -214,7 +213,7 @@ class TriggerCampaignCommand extends ModeratedCommand
 
         $moderationKey = sprintf('%s-%s', $id, $threadId);
         if (!$this->checkRunStatus($input, $this->output, $moderationKey)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         // Specific campaign;
@@ -248,7 +247,7 @@ class TriggerCampaignCommand extends ModeratedCommand
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**
@@ -387,4 +386,5 @@ class TriggerCampaignCommand extends ModeratedCommand
             $this->segmentCountCacheHelper->setSegmentContactCount($segmentId, (int) $totalLeadCount);
         }
     }
+    protected static $defaultDescription = 'Trigger timed events for published campaigns.';
 }

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -52,7 +52,6 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
         $this
             ->setName('mautic:campaigns:rebuild')
             ->setAliases(['mautic:campaigns:update'])
-            ->setDescription('Rebuild campaigns based on contact segments.')
             ->addOption('--batch-limit', '-l', InputOption::VALUE_OPTIONAL, 'Set batch size of contacts to process per round. Defaults to 300.', 300)
             ->addOption(
                 '--max-contacts',
@@ -128,11 +127,11 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
         if ($threadId && $maxThreads && (int) $threadId > (int) $maxThreads) {
             $this->output->writeln('--thread-id cannot be larger than --max-thread');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         if (!$this->checkRunStatus($input, $output, $id)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $this->contactLimiter = new ContactLimiter($batchLimit, $contactId, $contactMinId, $contactMaxId, $contactIds, $threadId, $maxThreads);
@@ -142,7 +141,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
             if (null === $campaign) {
                 $output->writeln('<error>'.$this->translator->trans('mautic.campaign.rebuild.not_found', ['%id%' => $id]).'</error>');
 
-                return 1;
+                return \Symfony\Component\Console\Command\Command::FAILURE;
             }
 
             $this->updateCampaign($campaign);
@@ -165,7 +164,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**
@@ -202,4 +201,5 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
 
         $this->output->writeln('');
     }
+    protected static $defaultDescription = 'Rebuild campaigns based on contact segments.';
 }

--- a/app/bundles/CampaignBundle/Command/ValidateEventCommand.php
+++ b/app/bundles/CampaignBundle/Command/ValidateEventCommand.php
@@ -46,7 +46,6 @@ class ValidateEventCommand extends Command
     {
         $this
             ->setName('mautic:campaigns:validate')
-            ->setDescription('Validate if a contact has been inactive for a decision and execute events if so.')
             ->addOption(
                 '--decision-id',
                 null,
@@ -87,7 +86,7 @@ class ValidateEventCommand extends Command
                 .'</comment>'
             );
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $limiter = new ContactLimiter(null, $contactId, null, null, $contactIds);
@@ -95,6 +94,7 @@ class ValidateEventCommand extends Command
 
         $this->writeCounts($output, $this->translator, $counter);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Validate if a contact has been inactive for a decision and execute events if so.';
 }

--- a/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
+++ b/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
@@ -34,7 +34,6 @@ class ProcessMarketingMessagesQueueCommand extends ModeratedCommand
                     'mautic:campaigns:messages',
                 ]
             )
-            ->setDescription('Process sending of messages queue.')
             ->addOption(
                 '--channel',
                 '-c',
@@ -57,7 +56,7 @@ class ProcessMarketingMessagesQueueCommand extends ModeratedCommand
         $key        = $channel.$channelId.$messageId;
 
         if (!$this->checkRunStatus($input, $output, $key)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $output->writeln('<info>'.$this->translator->trans('mautic.campaign.command.process.messages').'</info>');
@@ -74,6 +73,7 @@ class ProcessMarketingMessagesQueueCommand extends ModeratedCommand
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Process sending of messages queue.';
 }

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -33,7 +33,6 @@ class SendChannelBroadcastCommand extends ModeratedCommand
     protected function configure()
     {
         $this->setName('mautic:broadcasts:send')
-            ->setDescription('Process contacts pending to receive a channel broadcast.')
             ->setHelp(
                 <<<'EOT'
                 The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
@@ -100,12 +99,12 @@ EOT
             if ((int) $threadId > (int) $maxThreads) {
                 $output->writeln('--thread-id cannot be larger than --max-thread');
 
-                return 1;
+                return \Symfony\Component\Console\Command\Command::FAILURE;
             }
         }
 
         if (!$this->checkRunStatus($input, $output, $key)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $event = new ChannelBroadcastEvent($channel, $channelId, $output);
@@ -137,6 +136,7 @@ EOT
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Process contacts pending to receive a channel broadcast.';
 }

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -39,7 +39,6 @@ class ApplyUpdatesCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:update:apply')
-            ->setDescription('Updates the Mautic application')
             ->setDefinition(
                 [
                     new InputOption(
@@ -87,7 +86,7 @@ EOT
         if (true === $this->coreParametersHelper->get('composer_updates', false)) {
             $output->writeln('<error>'.$this->translator->trans('mautic.core.command.update.composer').'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         try {
@@ -109,7 +108,7 @@ EOT
             );
         }
 
-        return 1;
+        return \Symfony\Component\Console\Command\Command::FAILURE;
     }
 
     /**
@@ -145,4 +144,5 @@ EOT
 
         return 0;
     }
+    protected static $defaultDescription = 'Updates the Mautic application';
 }

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -33,7 +33,6 @@ class CleanupMaintenanceCommand extends ModeratedCommand
     protected function configure()
     {
         $this->setName('mautic:maintenance:cleanup')
-            ->setDescription('Updates the Mautic application')
             ->setDefinition(
                 [
                     new InputOption(
@@ -68,7 +67,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->checkRunStatus($input, $output)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $daysOld       = $input->getOption('days-old');
@@ -77,7 +76,7 @@ EOT
         $gdpr          = $input->getOption('gdpr');
         if (empty($daysOld) && empty($gdpr)) {
             // Safety catch; bail
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         if (!empty($gdpr)) {
@@ -95,7 +94,7 @@ EOT
             if (!$helper->ask($input, $output, $question)) {
                 $this->completeRun();
 
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
         }
 
@@ -126,6 +125,7 @@ EOT
 
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Updates the Mautic application';
 }

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -25,7 +25,6 @@ class ConvertConfigCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:theme:json-config')
-            ->setDescription('Converts theme config to JSON from PHP')
             ->setDefinition([
                 new InputOption(
                     'theme', null, InputOption::VALUE_REQUIRED,
@@ -63,7 +62,7 @@ EOT
         if (empty($themePath)) {
             $output->writeln("\n\n<error>The specified theme ($theme) does not exist.</error>");
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $jsonConfigPath = $themePath.'/config.json';
@@ -71,7 +70,7 @@ EOT
         if (file_exists($jsonConfigPath)) {
             $output->writeln("\n\n<error>The specified theme ($theme) already has a JSON config file.");
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $configPath = $themePath.'/config.php';
@@ -79,7 +78,7 @@ EOT
         if (!file_exists($configPath)) {
             $output->writeln("\n\n<error>The php config file for the specified theme ($theme) could not be found.</error>");
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $config = include $configPath;
@@ -87,7 +86,7 @@ EOT
         if (!is_array($config) || !array_key_exists('name', $config)) {
             $output->writeln("\n\n<error>The php config file for the specified theme ($theme) is not a valid config file.</error>");
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $jsonConfig = json_encode($config, JSON_PRETTY_PRINT);
@@ -95,7 +94,7 @@ EOT
         if (!file_put_contents($jsonConfigPath, $jsonConfig)) {
             $output->writeln("\n\n<error>Error writing json config file for the specified theme ($theme).</error>");
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } else {
             $output->writeln("\n\n<info>Successfully wrote json config file for the specified theme ($theme).</info>");
         }
@@ -110,6 +109,7 @@ EOT
             $output->writeln("\n\n<info>PHP config file for theme ($theme) was preserved.</info>");
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Converts theme config to JSON from PHP';
 }

--- a/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
@@ -27,7 +27,6 @@ class FindUpdatesCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:update:find')
-            ->setDescription('Fetches updates for Mautic')
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command checks for updates for the Mautic application.
 
@@ -49,6 +48,7 @@ EOT
             $output->writeln($this->translator->trans('mautic.core.updater.cli.update'));
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetches updates for Mautic';
 }

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -121,4 +121,5 @@ EOT
         $this->filesystem->copy("{$nodeModulesDir}/jquery/dist/jquery.min.js", "{$assetsDir}/js/jquery.min.js");
         $this->filesystem->copy("{$nodeModulesDir}/vimeo-froogaloop2/javascript/froogaloop.min.js", "{$assetsDir}/js/froogaloop.min.js");
     }
+    protected static $defaultDescription = 'Combines and minifies asset files into single production files';
 }

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -27,7 +27,6 @@ class InstallDataCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:install:data')
-            ->setDescription('Installs Mautic with sample data')
             ->setDefinition([
                 new InputOption(
                     'force', null, InputOption::VALUE_NONE, 'Bypasses the verification check.'
@@ -56,7 +55,7 @@ EOT
             $question       = new ConfirmationQuestion($questionString, false);
 
             if (!$helper->ask($input, $output, $question)) {
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
         }
 
@@ -114,6 +113,7 @@ EOT
             $this->translator->trans('mautic.core.command.install_data_success')
         );
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Installs Mautic with sample data';
 }

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -47,7 +47,6 @@ class MaxMindDoNotSellPurgeCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:max-mind:purge')
-            ->setDescription('Purge data connected to MaxMind Do Not Sell list.')
             ->addOption(
                 'dry-run',
                 'd',
@@ -88,7 +87,7 @@ EOT
             if (0 == count($doNotSellContacts)) {
                 $output->writeln('<info>No matches found.</info>');
 
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
 
             $output->writeln('Found '.count($doNotSellContacts)." contacts with an IP from the Do Not Sell list.\n");
@@ -96,7 +95,7 @@ EOT
             if ($dryRun) {
                 $output->writeln('<info>Dry run; skipping purge.</info>');
 
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
 
             $output->writeln('<info>Step 2: Purging data...</info>');
@@ -110,11 +109,11 @@ EOT
             $purgeProgress->finish();
             $output->writeln("\n<info>Purge complete.</info>\n");
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         } catch (\Exception $e) {
             $output->writeln("\n<error>".$e->getMessage().'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
     }
 
@@ -164,4 +163,5 @@ EOT
 
         return false;
     }
+    protected static $defaultDescription = 'Purge data connected to MaxMind Do Not Sell list.';
 }

--- a/app/bundles/CoreBundle/Command/PullTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PullTransifexCommand.php
@@ -49,7 +49,6 @@ class PullTransifexCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME)
-            ->setDescription('Fetches translations for Mautic from Transifex')
             ->addOption('language', null, InputOption::VALUE_OPTIONAL, 'Optional language to pull', null)
             ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle', null)
             ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Optional path to a directory where to store the traslations.', null)
@@ -78,7 +77,7 @@ EOT
         } catch (InvalidConfigurationException $e) {
             $output->writeln($this->translator->trans('mautic.core.command.transifex_no_credentials'));
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $statistics = $transifex->getConnector(Statistics::class);
@@ -133,7 +132,7 @@ EOT
                 } catch (\Exception $exception) {
                     $output->writeln($this->translator->trans('mautic.core.command.transifex_error_pulling_data', ['%message%' => $exception->getMessage()]));
 
-                    return 1;
+                    return \Symfony\Component\Console\Command\Command::FAILURE;
                 }
             }
         }
@@ -154,6 +153,7 @@ EOT
 
         $output->writeln($this->translator->trans('mautic.core.command.transifex_resource_downloaded'));
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetches translations for Mautic from Transifex';
 }

--- a/app/bundles/CoreBundle/Command/PushTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PushTransifexCommand.php
@@ -45,7 +45,6 @@ class PushTransifexCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME)
-            ->setDescription('Pushes Mautic translation resources to Transifex')
             ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle', null)
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is used to push translation resources to Transifex
@@ -71,7 +70,7 @@ EOT
                 'mautic.core.command.transifex_no_credentials')
             );
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $resources = $transifex->getConnector(Resources::class);
@@ -136,6 +135,7 @@ EOT
             }
         );
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Pushes Mautic translation resources to Transifex';
 }

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -28,7 +28,6 @@ class UnusedIpDeleteCommand extends ModeratedCommand
     protected function configure(): void
     {
         $this->setName('mautic:unusedip:delete')
-            ->setDescription('Deletes IP addresses that are not used in any other database table')
             ->addOption(
                 '--limit',
                 '-l',
@@ -49,7 +48,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->checkRunStatus($input, $output)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         try {
@@ -60,10 +59,11 @@ EOT
             $output->writeln(sprintf('<error>Deletion of unused IP addresses failed because of database error: %s</error>', $e->getMessage()));
             $this->completeRun();
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Deletes IP addresses that are not used in any other database table';
 }

--- a/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
@@ -33,7 +33,6 @@ class UpdateDoNotSellListCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:donotsell:download')
-            ->setDescription('Fetch remote do not sell list from MaxMind')
             ->setHelp(
                 <<<'EOT'
                 The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
@@ -69,6 +68,7 @@ EOT
             }
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetch remote do not sell list from MaxMind';
 }

--- a/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
@@ -30,7 +30,6 @@ class UpdateIpDataStoreCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:iplookup:download')
-            ->setDescription('Fetch remote datastores for IP lookup services that leverage local lookups')
             ->setHelp(
                 <<<'EOT'
                 The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
@@ -65,6 +64,7 @@ EOT
             }
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetch remote datastores for IP lookup services that leverage local lookups';
 }

--- a/app/bundles/CoreBundle/Entity/UuidTrait.php
+++ b/app/bundles/CoreBundle/Entity/UuidTrait.php
@@ -10,27 +10,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 trait UuidTrait
 {
-    /**
-     * @Groups({
-     *     "category:read", "category:write",
-     *     "notification:read", "notification:write",
-     *     "company:read", "company:write",
-     *     "leadfield:read", "leadfield:write",
-     *     "page:read", "page:write",
-     *     "campaign:read", "campaign:write",
-     *     "point:read", "point:write",
-     *     "trigger:read", "trigger:write",
-     *     "message:read", "message:write",
-     *     "focus:read", "focus:write",
-     *     "sms:read", "sms:write",
-     *     "asset:read", "asset:write",
-     *     "dynamicContent:read", "dynamicContent:write",
-     *     "form:read", "form:write",
-     *     "stage:read", "stage:write",
-     *     "segment:read", "segment:write",
-     *     "email:read", "email:write"
-     * })
-     */
+    #[Groups(['category:read', 'category:write', 'notification:read', 'notification:write', 'company:read', 'company:write', 'leadfield:read', 'leadfield:write', 'page:read', 'page:write', 'campaign:read', 'campaign:write', 'point:read', 'point:write', 'trigger:read', 'trigger:write', 'message:read', 'message:write', 'focus:read', 'focus:write', 'sms:read', 'sms:write', 'asset:read', 'asset:write', 'dynamicContent:read', 'dynamicContent:write', 'form:read', 'form:write', 'stage:read', 'stage:write', 'segment:read', 'segment:write', 'email:read', 'email:write'])]
     private ?string $uuid = null;
 
     public static function addUuidField(ClassMetadataBuilder $builder): void

--- a/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
@@ -40,7 +40,7 @@ class AssetsSubscriber implements EventSubscriberInterface
 
     public function fetchCustomAssets(RequestEvent $event)
     {
-        if ($event->isMasterRequest() && $this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_ASSETS)) {
+        if ($event->isMainRequest() && $this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_ASSETS)) {
             $this->dispatcher->dispatch(
                 new CustomAssetsEvent($this->assetsHelper),
                 CoreEvents::VIEW_INJECT_CUSTOM_ASSETS

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -124,7 +124,7 @@ class CoreSubscriber implements EventSubscriberInterface
      */
     public function onKernelRequestAddGlobalJS(ControllerEvent $event)
     {
-        if (defined('MAUTIC_INSTALLER') || $this->userHelper->getUser()->isGuest() || !$event->isMasterRequest()) {
+        if (defined('MAUTIC_INSTALLER') || $this->userHelper->getUser()->isGuest() || !$event->isMainRequest()) {
             return;
         }
 

--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -77,7 +77,7 @@ class RouterSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -100,6 +100,6 @@ class CookieHelper implements EventSubscriberInterface
             return $this->request;
         }
 
-        return $this->request = $this->requestStack->getMasterRequest();
+        return $this->request = $this->requestStack->getMainRequest();
     }
 }

--- a/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessEmailQueueCommand.php
@@ -40,7 +40,6 @@ class ProcessEmailQueueCommand extends ModeratedCommand
     {
         $this
             ->setName('mautic:emails:send')
-            ->setDescription('Processes SwiftMail\'s mail queue')
             ->addOption('--message-limit', null, InputOption::VALUE_OPTIONAL, 'Limit number of messages sent at a time. Defaults to value set in config.')
             ->addOption('--time-limit', null, InputOption::VALUE_OPTIONAL, 'Limit the number of seconds per batch. Defaults to value set in config.')
             ->addOption('--do-not-clear', null, InputOption::VALUE_NONE, 'By default, failed messages older than the --recover-timeout setting will be attempted one more time then deleted if it fails again.  If this is set, sending of failed messages will continue to be attempted.')
@@ -70,11 +69,11 @@ EOT
         if ('file' != $queueMode) {
             $output->writeln('Mautic is not set to queue email.');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         if (!$this->checkRunStatus($input, $output, $lockName)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         if (empty($timeout)) {
@@ -189,6 +188,7 @@ EOT
             return (int) $returnCode;
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Processes SwiftMail\'s mail queue';
 }

--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -47,7 +47,6 @@ class ProcessFetchEmailCommand extends Command
                     'mautic:emails:fetch',
                 ]
             )
-            ->setDescription('Fetch and process monitored email.')
             ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.')
             ->setHelp(
                 <<<'EOT'
@@ -72,6 +71,7 @@ EOT
             $output->writeln($log);
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetch and process monitored email.';
 }

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -56,7 +56,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             /**
              * @param mixed[] $parameters
              */
-            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null): string
             {
                 return $id;
             }

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -41,7 +41,6 @@ class InstallCommand extends Command
     {
         $this
             ->setName(self::COMMAND)
-            ->setDescription('Installs Mautic')
             ->setHelp('This command allows you to trigger the install process. It will try to get configuration values both from app/config/local.php and command line options/arguments, where the latter takes precedence.')
             ->addArgument(
                 'site_url',
@@ -170,7 +169,7 @@ class InstallCommand extends Command
         if ($this->installer->checkIfInstalled()) {
             $output->writeln('Mautic already installed');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $output->writeln([
@@ -358,7 +357,7 @@ class InstallCommand extends Command
             '================',
         ]);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**
@@ -453,4 +452,5 @@ class InstallCommand extends Command
             $output->writeln("  - [$type] $message");
         }
     }
+    protected static $defaultDescription = 'Installs Mautic';
 }

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -93,7 +93,7 @@ return [
                     'translator',
                     'kernel',
                     'validator',
-                    'security.password_encoder',
+                    'security.password_hasher',
                     'mautic.doctrine.loader.mautic_fixtures_loader',
                 ],
             ],

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -25,7 +25,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -54,7 +54,7 @@ class InstallService
 
     private ValidatorInterface $validator;
 
-    private UserPasswordEncoder $encoder;
+    private UserPasswordHasher $hasher;
 
     private FixturesLoaderInterface $fixturesLoader;
 
@@ -66,7 +66,7 @@ class InstallService
         TranslatorInterface $translator,
         KernelInterface $kernel,
         ValidatorInterface $validator,
-        UserPasswordEncoder $encoder,
+        UserPasswordHasher $hasher,
         FixturesLoaderInterface $fixturesLoader
     ) {
         $this->configurator   = $configurator;
@@ -76,7 +76,7 @@ class InstallService
         $this->translator     = $translator;
         $this->kernel         = $kernel;
         $this->validator      = $validator;
-        $this->encoder        = $encoder;
+        $this->hasher         = $hasher;
         $this->fixturesLoader = $fixturesLoader;
     }
 
@@ -460,13 +460,13 @@ class InstallService
             return $messages;
         }
 
-        $encoder = $this->encoder;
+        $hasher = $this->hasher;
 
         $user->setFirstName(InputHelper::clean($data['firstname']));
         $user->setLastName(InputHelper::clean($data['lastname']));
         $user->setUsername(InputHelper::clean($data['username']));
         $user->setEmail(InputHelper::email($data['email']));
-        $user->setPassword($encoder->encodePassword($user, $data['password']));
+        $user->setPassword($hasher->hashPassword($user, $data['password']));
 
         $adminRole = null;
         try {

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -14,7 +14,7 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\InstallBundle\Install\InstallService;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -32,7 +32,7 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
     private $translator;
     private $kernel;
     private $validator;
-    private $encoder;
+    private UserPasswordHasher $hasher;
 
     /**
      * @var MockObject&FixturesLoaderInterface
@@ -52,7 +52,7 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
         $this->translator           = $this->createMock(TranslatorInterface::class);
         $this->kernel               = $this->createMock(KernelInterface::class);
         $this->validator            = $this->createMock(ValidatorInterface::class);
-        $this->encoder              = $this->createMock(UserPasswordEncoder::class);
+        $this->hasher               = $this->createMock(UserPasswordHasher::class);
         $this->fixtureLoader        = $this->createMock(FixturesLoaderInterface::class);
 
         $this->installer = new InstallService(
@@ -63,7 +63,7 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
             $this->translator,
             $this->kernel,
             $this->validator,
-            $this->encoder,
+            $this->hasher,
             $this->fixtureLoader
         );
     }

--- a/app/bundles/IntegrationsBundle/Command/SyncCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/SyncCommand.php
@@ -32,7 +32,6 @@ class SyncCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME)
-            ->setDescription('Fetch objects from integration.')
             ->addArgument(
                 'integration',
                 InputOption::VALUE_REQUIRED,
@@ -106,7 +105,7 @@ class SyncCommand extends Command
         } catch (InvalidValueException $e) {
             $io->error($e->getMessage());
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         try {
@@ -120,11 +119,12 @@ class SyncCommand extends Command
 
             $io->error($e->getMessage());
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $io->success('Execution time: '.number_format(microtime(true) - $_SERVER['REQUEST_TIME_FLOAT'], 3));
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetch objects from integration.';
 }

--- a/app/bundles/LeadBundle/Command/ContactScheduledExportCommand.php
+++ b/app/bundles/LeadBundle/Command/ContactScheduledExportCommand.php
@@ -39,7 +39,6 @@ class ContactScheduledExportCommand extends Command
     {
         $this
             ->setName(self::COMMAND_NAME)
-            ->setDescription('Export contacts which are scheduled in `contact_export_scheduler` table.')
             ->addOption(
                 '--ids',
                 null,
@@ -73,6 +72,7 @@ class ContactScheduledExportCommand extends Command
 
         $output->writeln('Contact export email(s) sent: '.$count);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Export contacts which are scheduled in `contact_export_scheduler` table.';
 }

--- a/app/bundles/LeadBundle/Command/DeduplicateCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateCommand.php
@@ -35,7 +35,6 @@ class DeduplicateCommand extends Command
         parent::configure();
 
         $this->setName(self::NAME)
-            ->setDescription('Merge contacts based on same unique identifiers')
             ->addOption(
                 '--newer-into-older',
                 null,
@@ -77,7 +76,7 @@ EOT
         if (!$duplicateCount) {
             $output->writeln('<error>No contacts to deduplicate.</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $stopwatch->start('deduplicate');
@@ -149,6 +148,7 @@ EOT
         $output->writeln('');
         $output->writeln("Duration: {$event->getDuration()} ms, Memory: {$event->getMemory()} bytes");
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Merge contacts based on same unique identifiers';
 }

--- a/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
@@ -30,7 +30,6 @@ class DeduplicateIdsCommand extends Command
         parent::configure();
 
         $this->setName(self::NAME)
-            ->setDescription('Merge contacts based on same unique identifiers')
             ->addOption(
                 '--newer-into-older',
                 null,
@@ -63,7 +62,7 @@ EOT
         if (!$contactIds) {
             $output->writeln('<error>No contacts to deduplicate.</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $output->writeln("{$duplicateCount} contacts passed to deduplicate");
@@ -80,6 +79,7 @@ EOT
         $event = $stopwatch->stop('deduplicate');
         $output->writeln("Duration: {$event->getDuration()} ms, Memory: {$event->getMemory()} bytes");
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Merge contacts based on same unique identifiers';
 }

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -32,7 +32,6 @@ class ImportCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Imports data to Mautic')
             ->addOption('--id', '-i', InputOption::VALUE_OPTIONAL, 'Specific ID to import. Defaults to next in the queue.', false)
             ->addOption('--limit', '-l', InputOption::VALUE_OPTIONAL, 'Maximum number of records to import for this script execution.', 0)
             ->setHelp(
@@ -58,14 +57,14 @@ EOT
             if (!$import) {
                 $output->writeln('<error>'.$this->translator->trans('mautic.core.error.notfound', [], 'flashes').'</error>');
 
-                return 1;
+                return \Symfony\Component\Console\Command\Command::FAILURE;
             }
         } else {
             $import = $this->importModel->getImportToProcess();
 
             // No import waiting in the queue. Finish silently.
             if (null === $import) {
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
         }
 
@@ -87,7 +86,7 @@ EOT
                 ]
             ).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (ImportDelayedException $e) {
             $output->writeln('<info>'.$this->translator->trans(
                 'mautic.lead.import.delayed',
@@ -96,7 +95,7 @@ EOT
                 ]
             ).'</info>');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         // Success
@@ -111,6 +110,7 @@ EOT
             ]
         ).'</info>');
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Imports data to Mautic';
 }

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -32,7 +32,6 @@ class UpdateLeadListsCommand extends ModeratedCommand
         $this
             ->setName('mautic:segments:update')
             ->setAliases(['mautic:segments:rebuild'])
-            ->setDescription('Update contacts in smart segments based on new contact data.')
             ->addOption(
                 '--batch-limit',
                 '-b',
@@ -74,7 +73,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
         $output                = ($input->getOption('quiet')) ? new NullOutput() : $output;
 
         if (!$this->checkRunStatus($input, $output, $id)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         if ($enableTimeMeasurement) {
@@ -87,7 +86,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
             if (!$list) {
                 $output->writeln('<error>'.$this->translator->trans('mautic.lead.list.rebuild.not_found', ['%id%' => $id]).'</error>');
 
-                return 1;
+                return \Symfony\Component\Console\Command\Command::FAILURE;
             }
 
             $this->rebuildSegment($list, $batch, $max, $output);
@@ -120,7 +119,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
             $output->writeln('<fg=magenta>'.$this->translator->trans('mautic.lead.list.rebuild.total.time', ['%time%' => $totalTime]).'</>'."\n");
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     private function rebuildSegment(LeadList $segment, int $batch, int $max, OutputInterface $output): void
@@ -142,4 +141,5 @@ class UpdateLeadListsCommand extends ModeratedCommand
             );
         }
     }
+    protected static $defaultDescription = 'Update contacts in smart segments based on new contact data.';
 }

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -195,9 +195,7 @@ trait CustomFieldsApiControllerTrait
         }
     }
 
-    /**
-     * @required
-     */
+    #[\Symfony\Contracts\Service\Attribute\Required]
     public function setRequestStack(RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -193,9 +193,7 @@ trait FrequencyRuleTrait
         $leadModel->setFrequencyRules($lead, $formData, $this->leadLists);
     }
 
-    /**
-     * @required
-     */
+    #[\Symfony\Contracts\Service\Attribute\Required]
     public function setDoNotContactModel(\Mautic\LeadBundle\Model\DoNotContact $doNotContactModel): void
     {
         $this->doNotContactModel = $doNotContactModel;
@@ -203,9 +201,8 @@ trait FrequencyRuleTrait
 
     /**
      * The name is different, so it won't collide with other setters.
-     *
-     * @required
      */
+    #[\Symfony\Contracts\Service\Attribute\Required]
     public function setRequestStackObject(RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -413,9 +413,7 @@ trait LeadDetailsTrait
         );
     }
 
-    /**
-     * @required
-     */
+    #[\Symfony\Contracts\Service\Attribute\Required]
     public function setRequestStackLeadDetailsTrait(?RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;

--- a/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
@@ -46,7 +46,6 @@ class CreateCustomFieldCommand extends ModeratedCommand
         parent::configure();
 
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Create custom field column in the background')
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
             ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
             ->setHelp(
@@ -66,7 +65,7 @@ EOT
         $moderationKey = sprintf('%s-%s-%s', self::COMMAND_NAME, $leadFieldId, $userId);
 
         if (!$this->checkRunStatus($input, $output, $moderationKey)) {
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
         if (!$leadFieldId) {
             $leadField = $this->leadFieldRepository->getFieldThatIsMissingColumn();
@@ -74,7 +73,7 @@ EOT
             if (!$leadField) {
                 $output->writeln('<info>'.$this->translator->trans('mautic.lead.field.all_fields_have_columns').'</info>');
 
-                return 0;
+                return \Symfony\Component\Console\Command\Command::SUCCESS;
             }
 
             $leadFieldId = $leadField->getId();
@@ -86,41 +85,42 @@ EOT
         } catch (LeadFieldWasNotFoundException $e) {
             $output->writeln('<error>'.$this->translator->trans('mautic.lead.field.notfound').'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (ColumnAlreadyCreatedException $e) {
             $output->writeln('<error>'.$this->translator->trans('mautic.lead.field.column_already_created').'</error>');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         } catch (AbortColumnCreateException $e) {
             $output->writeln('<error>'.$this->translator->trans('mautic.lead.field.column_creation_aborted').'</error>');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         } catch (CustomFieldLimitException $e) {
             $output->writeln('<error>'.$this->translator->trans($e->getMessage()).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (DriverException $e) {
             $output->writeln('<error>'.$this->translator->trans($e->getMessage()).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (SchemaException $e) {
             $output->writeln('<error>'.$this->translator->trans($e->getMessage()).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (\Doctrine\DBAL\Exception $e) {
             $output->writeln('<error>'.$this->translator->trans($e->getMessage()).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         } catch (\Mautic\CoreBundle\Exception\SchemaException $e) {
             $output->writeln('<error>'.$this->translator->trans($e->getMessage()).'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $output->writeln('');
         $output->writeln('<info>'.$this->translator->trans('mautic.lead.field.column_was_created', ['%id%' => $leadFieldId]).'</info>');
         $this->completeRun();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Create custom field column in the background';
 }

--- a/app/bundles/MarketplaceBundle/Command/InstallCommand.php
+++ b/app/bundles/MarketplaceBundle/Command/InstallCommand.php
@@ -27,7 +27,6 @@ class InstallCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME);
-        $this->setDescription('Installs a plugin that is available at Packagist.org');
         $this->addArgument('package', InputArgument::REQUIRED, 'The Packagist package to install (e.g. mautic/example-plugin)');
         $this->addOption('dry-run', null, null, 'Simulate the installation of the package. Doesn\'t actually install it.');
 
@@ -75,6 +74,7 @@ class InstallCommand extends Command
 
         $output->writeln('All done! '.$input->getArgument('package').' has successfully been installed.');
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Installs a plugin that is available at Packagist.org';
 }

--- a/app/bundles/MarketplaceBundle/Command/ListCommand.php
+++ b/app/bundles/MarketplaceBundle/Command/ListCommand.php
@@ -27,7 +27,6 @@ class ListCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME);
-        $this->setDescription('Lists plugins that are available at Packagist.org');
         $this->addOption('page', 'p', InputOption::VALUE_OPTIONAL, 'Page number', 1);
         $this->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Packages per page', 15);
         $this->addOption('filter', 'f', InputOption::VALUE_OPTIONAL, 'Filter the packages', '');
@@ -64,6 +63,7 @@ class ListCommand extends Command
         $io->writeln("<fg=green>Total packages: {$this->pluginCollector->getTotal()}</>");
         $io->writeln("<fg=green>Execution time: {$event->getDuration()} ms</>");
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Lists plugins that are available at Packagist.org';
 }

--- a/app/bundles/MarketplaceBundle/Command/RemoveCommand.php
+++ b/app/bundles/MarketplaceBundle/Command/RemoveCommand.php
@@ -26,7 +26,6 @@ class RemoveCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::NAME);
-        $this->setDescription('Removes a plugin that is currently installed');
         $this->addArgument('package', InputArgument::REQUIRED, 'The Packagist package of the plugin to remove (e.g. mautic/example-plugin)');
 
         parent::configure();
@@ -41,7 +40,7 @@ class RemoveCommand extends Command
         if (!in_array($packageVendorAndName, $this->composer->getMauticPluginPackages())) {
             $output->writeln('This package cannot be removed, it must be of type mautic-plugin');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $removeResult = $this->composer->remove($packageVendorAndName);
@@ -51,11 +50,12 @@ class RemoveCommand extends Command
             $this->logger->error($message);
             $output->writeLn($message);
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $output->writeln($input->getArgument('package').' has successfully been removed.');
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Removes a plugin that is currently installed';
 }

--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -32,7 +32,6 @@ class FetchLeadsCommand extends Command
                     'mautic:integration:synccontacts',
                 ]
             )
-            ->setDescription('Fetch leads from integration.')
             ->addOption(
                 '--integration',
                 '-i',
@@ -291,6 +290,7 @@ class FetchLeadsCommand extends Command
             }
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Fetch leads from integration.';
 }

--- a/app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
+++ b/app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
@@ -31,7 +31,6 @@ class PushLeadActivityCommand extends Command
                     'mautic:integration:pushactivity',
                 ]
             )
-            ->setDescription('Push lead activity to integration.')
             ->addOption(
                 '--integration',
                 '-i',
@@ -90,6 +89,7 @@ class PushLeadActivityCommand extends Command
             }
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Push lead activity to integration.';
 }

--- a/app/bundles/PluginBundle/Command/ReloadCommand.php
+++ b/app/bundles/PluginBundle/Command/ReloadCommand.php
@@ -27,8 +27,7 @@ class ReloadCommand extends Command
                     'mautic:plugins:install',
                     'mautic:plugins:update',
                 ]
-            )
-            ->setDescription('Installs, updates, enable and/or disable plugins.');
+            );
 
         parent::configure();
     }
@@ -37,6 +36,7 @@ class ReloadCommand extends Command
     {
         $output->writeLn($this->reloadFacade->reloadPlugins());
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Installs, updates, enable and/or disable plugins.';
 }

--- a/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
+++ b/app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
@@ -25,7 +25,6 @@ class ConsumeQueueCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:queue:process')
-            ->setDescription('Process queues')
             ->addOption(
                 '--queue-name',
                 '-i',
@@ -56,32 +55,33 @@ class ConsumeQueueCommand extends Command
         if (!$this->queueService->isQueueEnabled()) {
             $output->writeLn('You have not configured mautic to use queue mode, nothing will be processed');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $queueName = $input->getOption('queue-name');
         if (empty($queueName)) {
             $output->writeLn('You did not provide a valid queue name');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $messages = $input->getOption('messages');
         if (0 > $messages) {
             $output->writeLn('You did not provide a valid number of messages. It should be null or greater than 0');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $timeout = $input->getOption('timeout');
         if (0 > $timeout) {
             $output->writeLn('You did not provide a valid number of seconds. It should be null or greater than 0');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $this->queueService->consumeFromQueue($queueName, $messages, $timeout);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Process queues';
 }

--- a/app/bundles/ReportBundle/Scheduler/Command/ExportSchedulerCommand.php
+++ b/app/bundles/ReportBundle/Scheduler/Command/ExportSchedulerCommand.php
@@ -37,7 +37,6 @@ class ExportSchedulerCommand extends Command
     {
         $this
             ->setName('mautic:reports:scheduler')
-            ->setDescription('Processes scheduler for report\'s export')
             ->addOption('--report', 'report', InputOption::VALUE_OPTIONAL, 'ID of report. Process all reports if not set.');
     }
 
@@ -53,7 +52,7 @@ class ExportSchedulerCommand extends Command
         } catch (\InvalidArgumentException $e) {
             $output->writeln('<error>'.$this->translator->trans('mautic.report.schedule.command.invalid_parameter').'</error>');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         try {
@@ -64,6 +63,7 @@ class ExportSchedulerCommand extends Command
             $output->writeln('<error>'.$e->getMessage().'</error>');
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Processes scheduler for report\'s export';
 }

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -130,7 +130,7 @@ return [
                 'class'     => 'Mautic\UserBundle\Security\Authenticator\FormAuthenticator',
                 'arguments' => [
                     'mautic.helper.integration',
-                    'security.password_encoder',
+                    'security.password_hasher',
                     'event_dispatcher',
                     'request_stack',
                     'security.csrf.token_manager',
@@ -155,7 +155,7 @@ return [
                     'mautic.permission.repository',
                     'session',
                     'event_dispatcher',
-                    'security.password_encoder',
+                    'security.password_hasher',
                 ],
             ],
             'mautic.security.authentication_listener' => [
@@ -240,7 +240,7 @@ return [
                     'doctrine.orm.entity_manager',
                     'mautic.security.saml.username_mapper',
                     'mautic.user.model.user',
-                    'security.password_encoder',
+                    'security.password_hasher',
                     '%mautic.saml_idp_default_role%',
                 ],
             ],
@@ -290,7 +290,7 @@ return [
             'mautic.user.fixture.user' => [
                 'class'     => \Mautic\UserBundle\DataFixtures\ORM\LoadUserData::class,
                 'tag'       => \Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
-                'arguments' => ['security.password_encoder'],
+                'arguments' => ['security.password_hasher'],
             ],
         ],
     ],

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -19,8 +19,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 /**
  * @extends CommonApiController<User>
@@ -32,7 +32,7 @@ class UserApiController extends CommonApiController
      */
     protected $model = null;
 
-    private UserPasswordEncoderInterface $encoder;
+    private UserPasswordHasherInterface $hasher;
 
     public function __construct(
         CorePermissions $security,
@@ -41,7 +41,7 @@ class UserApiController extends CommonApiController
         RouterInterface $router,
         FormFactoryInterface $formFactory,
         AppVersion $appVersion,
-        UserPasswordEncoderInterface $encoder,
+        UserPasswordHasherInterface $hasher,
         RequestStack $requestStack,
         ManagerRegistry $doctrine,
         ModelFactory $modelFactory,
@@ -49,7 +49,7 @@ class UserApiController extends CommonApiController
         CoreParametersHelper $coreParametersHelper,
         MauticFactory $factory
     ) {
-        $this->encoder = $encoder;
+        $this->hasher  = $hasher;
         $userModel     = $modelFactory->getModel('user.user');
         \assert($userModel instanceof UserModel);
 
@@ -93,7 +93,7 @@ class UserApiController extends CommonApiController
 
         if (isset($parameters['plainPassword']['password'])) {
             $submittedPassword = $parameters['plainPassword']['password'];
-            $entity->setPassword($this->model->checkNewPassword($entity, $this->encoder, $submittedPassword));
+            $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword));
         }
 
         return $this->processForm($request, $entity, $parameters, 'POST');
@@ -128,7 +128,7 @@ class UserApiController extends CommonApiController
                 $entity = $this->model->getEntity();
                 if (isset($parameters['plainPassword']['password'])) {
                     $submittedPassword = $parameters['plainPassword']['password'];
-                    $entity->setPassword($this->model->checkNewPassword($entity, $this->encoder, $submittedPassword));
+                    $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword));
                 }
             }
         } else {
@@ -166,7 +166,7 @@ class UserApiController extends CommonApiController
                     }
                 }
 
-                $entity->setPassword($this->model->checkNewPassword($entity, $this->encoder, $submittedPassword, true));
+                $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword, true));
                 break;
         }
     }

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Helper\LanguageHelper;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Class ProfileController.
@@ -19,7 +19,7 @@ class ProfileController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function indexAction(Request $request, LanguageHelper $languageHelper, UserPasswordEncoderInterface $encoder)
+    public function indexAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher)
     {
         // get current user
         $me    = $this->get('security.token_storage')->getToken()->getUser();
@@ -148,7 +148,7 @@ class ProfileController extends FormController
             // check to see if the password needs to be rehashed
             $formUser              = $request->request->get('user') ?? [];
             $submittedPassword     = $formUser['plainPassword']['password'] ?? null;
-            $overrides['password'] = $model->checkNewPassword($me, $encoder, $submittedPassword);
+            $overrides['password'] = $model->checkNewPassword($me, $hasher, $submittedPassword);
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($this->isFormValid($form)) {
                     foreach ($overrides as $k => $v) {

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -8,7 +8,7 @@ use Mautic\UserBundle\Form\Type\PasswordResetConfirmType;
 use Mautic\UserBundle\Form\Type\PasswordResetType;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class PublicController extends FormController
 {
@@ -55,7 +55,7 @@ class PublicController extends FormController
         ]);
     }
 
-    public function passwordResetConfirmAction(Request $request, UserPasswordEncoderInterface $encoder): mixed
+    public function passwordResetConfirmAction(Request $request, UserPasswordHasherInterface $hasher): mixed
     {
         /** @var \Mautic\UserBundle\Model\UserModel $model */
         $model = $this->getModel('user');
@@ -86,7 +86,7 @@ class PublicController extends FormController
                         $resetToken = $request->getSession()->get('resetToken');
 
                         if ($model->confirmResetToken($user, $resetToken)) {
-                            $encodedPassword = $model->checkNewPassword($user, $encoder, $data['plainPassword']);
+                            $encodedPassword = $model->checkNewPassword($user, $hasher, $data['plainPassword']);
                             $user->setPassword($encodedPassword);
                             $model->saveEntity($user);
 

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -13,7 +13,7 @@ use Mautic\UserBundle\Form\Type\ContactType;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserController extends FormController
 {
@@ -104,7 +104,7 @@ class UserController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function newAction(Request $request, LanguageHelper $languageHelper, UserPasswordEncoderInterface $encoder)
+    public function newAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher)
     {
         if (!$this->security->isGranted('user:users:create')) {
             return $this->accessDenied();
@@ -133,7 +133,7 @@ class UserController extends FormController
                 // check to see if the password needs to be rehashed
                 $formUser          = $request->request->get('user') ?? [];
                 $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-                $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
+                $password          = $model->checkNewPassword($user, $hasher, $submittedPassword);
 
                 if ($valid = $this->isFormValid($form)) {
                     // form is valid so process the data
@@ -187,7 +187,7 @@ class UserController extends FormController
                     ],
                 ]);
             } elseif ($valid && !$cancelled) {
-                return $this->editAction($request, $languageHelper, $encoder, $user->getId(), true);
+                return $this->editAction($request, $languageHelper, $hasher, $user->getId(), true);
             }
         }
 
@@ -210,7 +210,7 @@ class UserController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordEncoderInterface $encoder, $objectId, $ignorePost = false)
+    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, $objectId, $ignorePost = false)
     {
         if (!$this->security->isGranted('user:users:edit')) {
             return $this->accessDenied();
@@ -263,7 +263,7 @@ class UserController extends FormController
                 // check to see if the password needs to be rehashed
                 $formUser          = $request->request->get('user') ?? [];
                 $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-                $password          = $model->checkNewPassword($user, $encoder, $submittedPassword);
+                $password          = $model->checkNewPassword($user, $hasher, $submittedPassword);
 
                 if ($valid = $this->isFormValid($form)) {
                     // form is valid so process the data

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -7,7 +7,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 
 class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
@@ -20,16 +20,16 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
     }
 
     /**
-     * @var UserPasswordEncoder
+     * @var UserPasswordHasher
      */
-    private $encoder;
+    private $hasher;
 
     /**
      * {@inheritdoc}
      */
-    public function __construct(UserPasswordEncoder $encoder)
+    public function __construct(UserPasswordHasher $hasher)
     {
-        $this->encoder = $encoder;
+        $this->hasher = $hasher;
     }
 
     public function load(ObjectManager $manager)
@@ -39,8 +39,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
         $user->setLastName('User');
         $user->setUsername('admin');
         $user->setEmail('admin@yoursite.com');
-        $encoder = $this->encoder;
-        $user->setPassword($encoder->encodePassword($user, 'mautic'));
+        $user->setPassword($this->hasher->hashPassword($user, 'mautic'));
         $user->setRole($this->getReference('admin-role'));
         $manager->persist($user);
         $manager->flush();
@@ -52,8 +51,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
         $user->setLastName('User');
         $user->setUsername('sales');
         $user->setEmail('sales@yoursite.com');
-        $encoder = $this->encoder;
-        $user->setPassword($encoder->encodePassword($user, 'mautic'));
+        $user->setPassword($this->hasher->hashPassword($user, 'mautic'));
         $user->setRole($this->getReference('sales-role'));
         $manager->persist($user);
         $manager->flush();

--- a/app/bundles/UserBundle/Event/AuthenticationEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationEvent.php
@@ -168,7 +168,7 @@ class AuthenticationEvent extends Event
      */
     public function getUsername()
     {
-        return $this->token->getUsername();
+        return $this->token->getUserIdentifier();
     }
 
     /**

--- a/app/bundles/UserBundle/EventListener/SAMLSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SAMLSubscriber.php
@@ -33,7 +33,7 @@ class SAMLSubscriber implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        if (!$event->isMasterRequest()) {
+        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -15,9 +15,9 @@ use Mautic\UserBundle\Model\UserToken\UserTokenServiceInterface;
 use Mautic\UserBundle\UserEvents;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -95,7 +95,7 @@ class UserModel extends FormModel
      *
      * @return string
      */
-    public function checkNewPassword(User $entity, UserPasswordEncoderInterface $encoder, $submittedPassword, $validate = false)
+    public function checkNewPassword(User $entity, UserPasswordHasherInterface $hasher, $submittedPassword, $validate = false)
     {
         if ($validate) {
             if (strlen($submittedPassword) < 6) {
@@ -105,7 +105,7 @@ class UserModel extends FormModel
 
         if (!empty($submittedPassword)) {
             // hash the clear password submitted via the form
-            return $encoder->encodePassword($entity, $submittedPassword);
+            return $hasher->hashPassword($entity, $submittedPassword);
         }
 
         return $entity->getPassword();
@@ -237,11 +237,11 @@ class UserModel extends FormModel
      *
      * @param string $newPassword
      */
-    public function resetPassword(User $user, UserPasswordEncoder $encoder, $newPassword)
+    public function resetPassword(User $user, UserPasswordHasher $hasher, $newPassword)
     {
-        $encodedPassword = $this->checkNewPassword($user, $encoder, $newPassword);
+        $hashedPassword = $this->checkNewPassword($user, $hasher, $newPassword);
 
-        $user->setPassword($encodedPassword);
+        $user->setPassword($hashedPassword);
         $this->saveEntity($user);
     }
 

--- a/app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
+++ b/app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
@@ -111,7 +111,7 @@ final class AuthenticationListener
     private function onSuccess(Request $request, TokenInterface $token, Response $response = null): Response
     {
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('User "%s" has been authenticated successfully', $token->getUsername()));
+            $this->logger->info(sprintf('User "%s" has been authenticated successfully', $token->getUserIdentifier()));
         }
 
         $session = $request->getSession();

--- a/app/bundles/UserBundle/Security/Provider/UserProvider.php
+++ b/app/bundles/UserBundle/Security/Provider/UserProvider.php
@@ -10,7 +10,7 @@ use Mautic\UserBundle\Event\UserEvent;
 use Mautic\UserBundle\UserEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
@@ -41,7 +41,7 @@ class UserProvider implements UserProviderInterface
     protected $dispatcher;
 
     /**
-     * @var UserPasswordEncoder
+     * @var UserPasswordHasher
      */
     protected $encoder;
 
@@ -50,7 +50,7 @@ class UserProvider implements UserProviderInterface
         PermissionRepository $permissionRepository,
         Session $session,
         EventDispatcherInterface $dispatcher,
-        UserPasswordEncoder $encoder
+        UserPasswordHasher $encoder
     ) {
         $this->userRepository       = $userRepository;
         $this->permissionRepository = $permissionRepository;
@@ -157,12 +157,12 @@ class UserProvider implements UserProviderInterface
         if ($plainPassword) {
             // Encode plain text
             $user->setPassword(
-                $this->encoder->encodePassword($user, $plainPassword)
+                $this->encoder->hashPassword($user, $plainPassword)
             );
         } elseif (!$password = $user->getPassword()) {
             // Generate and encode a random password
             $user->setPassword(
-                $this->encoder->encodePassword($user, EncryptionHelper::generateKey())
+                $this->encoder->hashPassword($user, EncryptionHelper::generateKey())
             );
         }
 

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -32,9 +32,9 @@ class UserCreator implements UserCreatorInterface
     private $userModel;
 
     /**
-     * @var UserPasswordEncoder
+     * @var UserPasswordHasher
      */
-    private $encoder;
+    private $hasher;
 
     /**
      * @var int
@@ -55,13 +55,13 @@ class UserCreator implements UserCreatorInterface
         EntityManagerInterface $entityManager,
         UserMapper $userMapper,
         UserModel $userModel,
-        UserPasswordEncoder $encoder,
+        UserPasswordHasher $hasher,
         $defaultRole
     ) {
         $this->entityManager = $entityManager;
         $this->userMapper    = $userMapper;
         $this->userModel     = $userModel;
-        $this->encoder       = $encoder;
+        $this->hasher        = $hasher;
         $this->defaultRole   = (int) $defaultRole;
     }
 
@@ -78,7 +78,7 @@ class UserCreator implements UserCreatorInterface
         $defaultRole = $this->entityManager->getReference(\Mautic\UserBundle\Entity\Role::class, $this->defaultRole);
 
         $user = $this->userMapper->getUser($response);
-        $user->setPassword($this->userModel->checkNewPassword($user, $this->encoder, EncryptionHelper::generateKey()));
+        $user->setPassword($this->userModel->checkNewPassword($user, $this->hasher, EncryptionHelper::generateKey()));
         $user->setRole($defaultRole);
 
         $this->validateUser($user);

--- a/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
@@ -33,7 +33,7 @@ class SAMLSubscriberTest extends TestCase
     {
         $this->event = $this->createMock(RequestEvent::class);
         $this->event->expects($this->once())
-            ->method('isMasterRequest')
+            ->method('isMainRequest')
             ->willReturn(true);
 
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);

--- a/app/bundles/WebhookBundle/Command/DeleteWebhookLogsCommand.php
+++ b/app/bundles/WebhookBundle/Command/DeleteWebhookLogsCommand.php
@@ -34,8 +34,7 @@ class DeleteWebhookLogsCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName(static::COMMAND_NAME)
-            ->setDescription('Retains a rolling number of log records.');
+        $this->setName(static::COMMAND_NAME);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -50,6 +49,7 @@ class DeleteWebhookLogsCommand extends Command
             $output->writeln(sprintf('<info>%s logs deleted successfully for webhook id - %s</info>', $deletedLogCount, $webHookId));
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Retains a rolling number of log records.';
 }

--- a/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
+++ b/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
@@ -29,7 +29,6 @@ class ProcessWebhookQueuesCommand extends Command
     protected function configure()
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Process queued webhook payloads')
             ->addOption(
                 '--webhook-id',
                 '-i',
@@ -45,7 +44,7 @@ class ProcessWebhookQueuesCommand extends Command
         if ($this->coreParametersHelper->get('queue_mode') != $this->webhookModel::COMMAND_PROCESS) {
             $output->writeLn('Webhook Bundle is in immediate process mode. To use the command function change to command mode.');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $id = $input->getOption('webhook-id');
@@ -73,7 +72,7 @@ class ProcessWebhookQueuesCommand extends Command
         if (!count($webhooks)) {
             $output->writeln('<error>No published webhooks found. Try again later.</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $output->writeLn('<info>Processing Webhooks</info>');
@@ -84,11 +83,12 @@ class ProcessWebhookQueuesCommand extends Command
             $output->writeLn('<error>'.$e->getMessage().'</error>');
             $output->writeLn('<error>'.$e->getTraceAsString().'</error>');
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $output->writeLn('<info>Webhook Processing Complete</info>');
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
+    protected static $defaultDescription = 'Process queued webhook payloads';
 }

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -102,7 +102,7 @@ class FocusSubscriber implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event)
     {
-        if ($event->isMasterRequest()) {
+        if ($event->isMainRequest()) {
             // get the current event request
             $request    = $event->getRequest();
             $requestUri = $request->getRequestUri();

--- a/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
+++ b/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
@@ -24,7 +24,6 @@ class MauticSocialMonitoringCommand extends Command
     protected function configure()
     {
         $this->setName('mautic:social:monitoring')
-            ->setDescription('Looks at the records of monitors and iterates through them. ')
             ->addOption('mid', 'i', InputOption::VALUE_OPTIONAL, 'The id of a specific monitor record to process')
             ->addOption(
                 'batch-size',
@@ -48,7 +47,7 @@ class MauticSocialMonitoringCommand extends Command
         if (!$monitorList->count()) {
             $output->writeln('No published monitors found. Make sure the id you supplied is published');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         // max iterations
@@ -60,7 +59,7 @@ class MauticSocialMonitoringCommand extends Command
             $output->writeln('Result Code: '.$resultCode);
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**
@@ -137,4 +136,5 @@ class MauticSocialMonitoringCommand extends Command
 
         return $returnCode;
     }
+    protected static $defaultDescription = 'Looks at the records of monitors and iterates through them. ';
 }

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -155,7 +155,7 @@ abstract class MonitorTwitterBaseCommand extends Command
         if (false === $twitterIntegration || false === $twitterIntegration->getIntegrationSettings()->getIsPublished()) {
             $this->output->writeln($this->translator->trans('mautic.social.monitoring.twitter.not.published'));
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         \assert($twitterIntegration instanceof TwitterIntegration);
@@ -164,7 +164,7 @@ abstract class MonitorTwitterBaseCommand extends Command
         if (!$this->twitter->isAuthorized()) {
             $this->output->writeln($this->translator->trans('mautic.social.monitoring.twitter.not.configured'));
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         // get the mid from the cli
@@ -173,7 +173,7 @@ abstract class MonitorTwitterBaseCommand extends Command
         if (!$mid) {
             $this->output->writeln($this->translator->trans('mautic.social.monitoring.twitter.mid.empty'));
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         $this->twitterCommandHelper->setOutput($output);
@@ -183,7 +183,7 @@ abstract class MonitorTwitterBaseCommand extends Command
         if (!$monitor || !$monitor->getId()) {
             $this->output->writeln($this->translator->trans('mautic.social.monitoring.twitter.monitor.does.not.exist', ['%id%' => $mid]));
 
-            return 1;
+            return \Symfony\Component\Console\Command\Command::FAILURE;
         }
 
         // process the monitor
@@ -194,7 +194,7 @@ abstract class MonitorTwitterBaseCommand extends Command
             SocialEvents::MONITOR_POST_PROCESS
         );
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
@@ -11,8 +11,7 @@ class MonitorTwitterHashtagsCommand extends MonitorTwitterBaseCommand
      */
     protected function configure()
     {
-        $this->setName('social:monitor:twitter:hashtags')
-            ->setDescription('Looks at our monitoring records and finds hashtags');
+        $this->setName('social:monitor:twitter:hashtags');
 
         parent::configure();
     }
@@ -53,4 +52,5 @@ class MonitorTwitterHashtagsCommand extends MonitorTwitterBaseCommand
     {
         return 'twitter';
     }
+    protected static $defaultDescription = 'Looks at our monitoring records and finds hashtags';
 }

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
@@ -11,8 +11,7 @@ class MonitorTwitterMentionsCommand extends MonitorTwitterBaseCommand
      */
     protected function configure()
     {
-        $this->setName('social:monitor:twitter:mentions')
-            ->setDescription('Searches for mentioned tweets');
+        $this->setName('social:monitor:twitter:mentions');
 
         parent::configure();
     }
@@ -53,4 +52,5 @@ class MonitorTwitterMentionsCommand extends MonitorTwitterBaseCommand
     {
         return 'twitter';
     }
+    protected static $defaultDescription = 'Searches for mentioned tweets';
 }

--- a/rector.php
+++ b/rector.php
@@ -19,7 +19,6 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
             \Rector\Symfony\Rector\MethodCall\ContainerGetToConstructorInjectionRector::class => [
                 __DIR__.'/app/bundles/AssetBundle/Controller/UploadController.php', // This is just overrride of the DropzoneController.
                 __DIR__.'/app/bundles/CoreBundle/Factory/MauticFactory.php', // Requires quite a refactoring.
-                __DIR__.'/app/bundles/CoreBundle/Helper/TemplatingHelper.php', // Will be removed once Twig refactoring is done.
             ],
         ]
     );
@@ -40,7 +39,7 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
 
     // Define what rule sets will be applied
     $rectorConfig->sets([
-        \Rector\Symfony\Set\SymfonyLevelSetList::UP_TO_SYMFONY_44,
+        \Rector\Symfony\Set\SymfonyLevelSetList::UP_TO_SYMFONY_54,
         \Rector\Doctrine\Set\DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
         \Rector\Doctrine\Set\DoctrineSetList::DOCTRINE_BEHAVIORS_20,
         \Rector\Doctrine\Set\DoctrineSetList::DOCTRINE_CODE_QUALITY,


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

after the update of Symfony, there are a few changes needed to make it compatible with the Rector checks for Symfony 5.4

Following rules are taken into account:
* `Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest()` is deprecated
* Lazy Command Descriptions, see https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description
* switch to constants for command exit codes, see https://symfony.com/blog/new-in-symfony-5-1-misc-improvements-part-1#added-constants-for-command-exit-codes
* deprecation of the term "password encoding", see https://symfony.com/blog/new-in-symfony-5-3-passwordhasher-component

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
