### PR TITLE
Fixing dependencies for 3 commands after some PRs were merged

### DIFF
--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -4,6 +4,7 @@ namespace Mautic\CoreBundle\Command;
 
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,9 +22,9 @@ class CleanupMaintenanceCommand extends ModeratedCommand
     private TranslatorInterface $translator;
     private EventDispatcherInterface $dispatcher;
 
-    public function __construct(TranslatorInterface $translator, EventDispatcherInterface $dispatcher, PathsHelper $pathsHelper)
+    public function __construct(TranslatorInterface $translator, EventDispatcherInterface $dispatcher, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
 
         $this->translator = $translator;
         $this->dispatcher = $dispatcher;

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -3,6 +3,7 @@
 namespace Mautic\CoreBundle\Command;
 
 use Doctrine\DBAL\DBALException;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\LeadBundle\Model\IpAddressModel;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,11 +19,11 @@ class UnusedIpDeleteCommand extends ModeratedCommand
 
     private IpAddressModel $ipAddressModel;
 
-    public function __construct(IpAddressModel $ipAddressModel, PathsHelper $pathsHelper)
+    public function __construct(IpAddressModel $ipAddressModel, PathsHelper $pathsHelper, CoreParametersHelper $coreParametersHelper)
     {
         $this->ipAddressModel = $ipAddressModel;
 
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
     protected function configure(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -234,7 +234,7 @@ class ModeratedCommandTest extends TestCase
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('get')
-            ->willReturn(['dsn' => null]);
+            ->willReturn(['dsn' => '']);
 
         $this->input->method('getOption')
             ->willReturnCallback(

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
 
 class ModeratedCommandTest extends TestCase
 {
@@ -234,7 +235,7 @@ class ModeratedCommandTest extends TestCase
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('get')
-            ->willReturn(['dsn' => '']);
+            ->willReturn(['dsn' => 'redis://localhost:6379']);
 
         $this->input->method('getOption')
             ->willReturnCallback(
@@ -250,7 +251,7 @@ class ModeratedCommandTest extends TestCase
                 }
             );
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(LockAcquiringException::class);
 
         $this->fakeModeratedCommand->run($this->input, $this->output);
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use Symfony\Component\Lock\Exception\LockAcquiringException;
 
 class ModeratedCommandTest extends TestCase
 {
@@ -235,7 +234,7 @@ class ModeratedCommandTest extends TestCase
     {
         $this->coreParametersHelper->expects($this->once())
             ->method('get')
-            ->willReturn(['dsn' => 'redis://localhost:6379']);
+            ->willReturn(['dsn' => '']);
 
         $this->input->method('getOption')
             ->willReturnCallback(
@@ -251,7 +250,7 @@ class ModeratedCommandTest extends TestCase
                 }
             );
 
-        $this->expectException(LockAcquiringException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->fakeModeratedCommand->run($this->input, $this->output);
     }

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -28,7 +28,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         [$sentCount, ,] = $emailModel->sendEmailToLists($email, [$segment], null, false, null, null, null, 3, 2);
         $this->assertEquals($sentCount, 7);
         [$sentCount, ,] = $emailModel->sendEmailToLists($email, [$segment], null, false, null, null, null, 3, 3);
-        $this->assertEquals($sentCount, 7);
+        $this->assertEquals($sentCount, 8);
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -26,7 +26,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         [$sentCount, ,] = $emailModel->sendEmailToLists($email, [$segment], null, false, null, null, null, 3, 1);
         $this->assertEquals($sentCount, 8);
         [$sentCount, ,] = $emailModel->sendEmailToLists($email, [$segment], null, false, null, null, null, 3, 2);
-        $this->assertEquals($sentCount, 8);
+        $this->assertEquals($sentCount, 7);
         [$sentCount, ,] = $emailModel->sendEmailToLists($email, [$segment], null, false, null, null, null, 3, 3);
         $this->assertEquals($sentCount, 7);
     }

--- a/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Schema\SchemaException;
 use Mautic\CoreBundle\Command\ModeratedCommand;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Field\BackgroundService;
@@ -32,9 +33,10 @@ class CreateCustomFieldCommand extends ModeratedCommand
         BackgroundService $backgroundService,
         TranslatorInterface $translator,
         LeadFieldRepository $leadFieldRepository,
-        PathsHelper $pathsHelper
+        PathsHelper $pathsHelper,
+        CoreParametersHelper $coreParametersHelper
     ) {
-        parent::__construct($pathsHelper);
+        parent::__construct($pathsHelper, $coreParametersHelper);
         $this->backgroundService   = $backgroundService;
         $this->translator          = $translator;
         $this->leadFieldRepository = $leadFieldRepository;

--- a/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
@@ -42,7 +42,7 @@ class CreateCustomFieldCommandTest extends TestCase
                 $this->translatorMock,
                 $this->leadFieldRepositoryMock,
                 $this->pathsHelperMock,
-                $this->coreParametersHelper
+                $this->coreParametersHelper,
             ])
             ->onlyMethods(['completeRun', 'checkRunStatus'])
             ->getMock();

--- a/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Command;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Field\BackgroundService;
@@ -19,6 +20,7 @@ class CreateCustomFieldCommandTest extends TestCase
     private TranslatorInterface $translatorMock;
     private LeadFieldRepository $leadFieldRepositoryMock;
     private PathsHelper $pathsHelperMock;
+    private CoreParametersHelper $coreParametersHelper;
 
     protected function setUp(): void
     {
@@ -26,6 +28,7 @@ class CreateCustomFieldCommandTest extends TestCase
         $this->translatorMock          = $this->createMock(TranslatorInterface::class);
         $this->leadFieldRepositoryMock = $this->createMock(LeadFieldRepository::class);
         $this->pathsHelperMock         = $this->createMock(PathsHelper::class);
+        $this->coreParametersHelper    = $this->createMock(CoreParametersHelper::class);
     }
 
     /**
@@ -39,6 +42,7 @@ class CreateCustomFieldCommandTest extends TestCase
                 $this->translatorMock,
                 $this->leadFieldRepositoryMock,
                 $this->pathsHelperMock,
+                $this->coreParametersHelper
             ])
             ->onlyMethods(['completeRun', 'checkRunStatus'])
             ->getMock();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When I merged https://github.com/mautic/mautic/pull/10347 some CI checks started to fail:
```
 ------ ------------------------------------------------------------------ 
  Line   app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php      
 ------ ------------------------------------------------------------------ 
  26     Method Mautic\CoreBundle\Command\ModeratedCommand::__construct()  
         invoked with 1 parameter, 2 required.                             
 ------ ------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------ 
  Line   app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php          
 ------ ------------------------------------------------------------------ 
  25     Method Mautic\CoreBundle\Command\ModeratedCommand::__construct()  
         invoked with 1 parameter, 2 required.                             
 ------ ------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------- 
  Line   app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php  
 ------ ------------------------------------------------------------------- 
  37     Method Mautic\CoreBundle\Command\ModeratedCommand::__construct()   
         invoked with 1 parameter, 2 required.                              
 ------ ------------------------------------------------------------------- 
```
Rather than reverting it I'm fixing the dependencies for these 3 commands

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
