### PR TITLE
Fix contact tracking on external websites (samesite param in CookieHelper)

### DIFF
--- a/app/bundles/CoreBundle/Helper/CookieHelper.php
+++ b/app/bundles/CoreBundle/Helper/CookieHelper.php
@@ -51,7 +51,7 @@ class CookieHelper implements EventSubscriberInterface
     /**
      * @param int|string|float|bool|object|null $value
      */
-    public function setCookie(string $name, $value, ?int $expire = 1800, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httponly = null): void
+    public function setCookie(string $name, $value, ?int $expire = 1800, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httponly = null, ?string $sameSite = Cookie::SAMESITE_LAX): void
     {
         if (null !== $value) {
             $value = (string) $value;
@@ -66,7 +66,7 @@ class CookieHelper implements EventSubscriberInterface
             $secure ?? $this->secure,
             $httponly ?? $this->httponly,
             false,
-            ($secure ?? $this->secure) ? Cookie::SAMESITE_LAX : null
+            $sameSite
         );
 
         $this->cookies[$name] = $cookie;
@@ -75,9 +75,9 @@ class CookieHelper implements EventSubscriberInterface
     /**
      * Deletes a cookie by expiring it.
      */
-    public function deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httponly = null): void
+    public function deleteCookie(string $name, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httponly = null, ?string $sameSite = Cookie::SAMESITE_LAX): void
     {
-        $this->setCookie($name, '', -86400, $path, $domain, $secure, $httponly);
+        $this->setCookie($name, '', -86400, $path, $domain, $secure, $httponly, $sameSite);
     }
 
     public function onResponse(ResponseEvent $event): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
@@ -67,7 +67,7 @@ class CookieHelperTest extends TestCase
     }
 
     /**
-     * @testdox The helper is instantiated correctly when not secure and does not contain samesite=lax
+     * @testdox The helper is instantiated correctly when not secure and contain samesite=lax
      *
      * @covers \Mautic\CoreBundle\Helper\CookieHelper::__construct
      * @covers \Mautic\CoreBundle\Helper\CookieHelper::setCookie
@@ -88,7 +88,7 @@ class CookieHelperTest extends TestCase
         $headers->expects(self::once())
             ->method('setCookie')
             ->willReturnCallback(static function (Cookie $cookie): void {
-                Assert::assertStringNotContainsString('samesite=lax', (string) $cookie);
+                Assert::assertStringContainsString('samesite=lax', (string) $cookie);
                 Assert::assertStringNotContainsString('secure', (string) $cookie);
             });
 
@@ -97,6 +97,39 @@ class CookieHelperTest extends TestCase
         $kernel            = new AppKernel(MAUTIC_ENV, false);
         $request           = $this->createMock(Request::class);
 
+        $event             = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $cookieHelper->onResponse($event);
+    }
+
+    public function testSetCookieWhenSecureAndSameSiteNone(): void
+    {
+        $cookiePath   = '/';
+        $cookieDomain = 'https://test.test';
+        $cookieSecure = true;
+        $cookieHttp   = false;
+        $requestStack = $this->requestStackMock;
+        $cookieHelper = new CookieHelper($cookiePath, $cookieDomain, $cookieSecure, $cookieHttp, $requestStack);
+        $cookieName   = 'samesite_test';
+
+        $cookieHelper->setCookie(
+            name: $cookieName,
+            value: 'test',
+            sameSite: Cookie::SAMESITE_NONE
+        );
+
+        $headers = $this->createMock(ResponseHeaderBag::class);
+        $headers->expects(self::once())
+            ->method('setCookie')
+            ->willReturnCallback(static function (Cookie $cookie): void {
+                Assert::assertStringContainsString('samesite=none', (string) $cookie);
+                Assert::assertStringContainsString('secure', (string) $cookie);
+            });
+
+        $response          = $this->createMock(Response::class);
+        $response->headers = $headers;
+        $kernel            = new AppKernel(MAUTIC_ENV, false);
+        $request           = $this->createMock(Request::class);
         $event             = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
 
         $cookieHelper->onResponse($event);

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\RandomHelper\RandomHelperInterface;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 final class DeviceTrackingService implements DeviceTrackingServiceInterface
@@ -176,10 +177,10 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
     private function createTrackingCookies(LeadDevice $device)
     {
         // Device cookie
-        $this->cookieHelper->setCookie('mautic_device_id', $device->getTrackingId(), 31536000);
+        $this->cookieHelper->setCookie('mautic_device_id', $device->getTrackingId(), 31536000, sameSite: Cookie::SAMESITE_NONE);
 
         // Mainly for landing pages so that JS has the same access as 3rd party tracking code
-        $this->cookieHelper->setCookie('mtc_id', $device->getLead()->getId(), null);
-        $this->cookieHelper->setCookie('mtc_sid', $device->getTrackingId(), null);
+        $this->cookieHelper->setCookie('mtc_id', $device->getLead()->getId(), null, sameSite: Cookie::SAMESITE_NONE);
+        $this->cookieHelper->setCookie('mtc_sid', $device->getTrackingId(), null, sameSite: Cookie::SAMESITE_NONE);
     }
 }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -37,6 +37,7 @@ use Mautic\PageBundle\PageEvents;
 use Mautic\QueueBundle\Queue\QueueName;
 use Mautic\QueueBundle\Queue\QueueService;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -518,7 +519,11 @@ class PageModel extends FormModel
 
         //save hit to the cookie to use to update the exit time
         if ($hit) {
-            $this->cookieHelper->setCookie('mautic_referer_id', $hit->getId() ?: null);
+            $this->cookieHelper->setCookie(
+                name: 'mautic_referer_id',
+                value: $hit->getId() ?: null,
+                sameSite: Cookie::SAMESITE_NONE
+            );
         }
 
         if ($this->queueService->isQueueEnabled()) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
After changes made in #11448 the samesite=lex is added to all secure cookies. This causes problems with tracking user activity on external websites:
![image](https://github.com/mautic/mautic/assets/8580942/641f0c7e-b6fa-4d7a-81ac-0fe9299314bd)

This PR adds `samesite` as a parameter to the `CookieHelper`  and samesite=lax no longer depends on cookie security setting. 

I've added `samesite=none` param to all tracking cookies and `samesite=lax` as a default in `CookieHelper`.

After these changes the cookies are set correctly:
![image](https://github.com/mautic/mautic/assets/8580942/2636da0a-3b56-47bd-a8c8-2a23d5c2f3db)


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add Mautic tracking script to external website
3. Add website to valid domains in Mautic CORS configuration
4. Visit your external website and make some page hits
5. Check if contact activity and time spent on page is correct:
![image](https://github.com/mautic/mautic/assets/8580942/222a10a8-0c97-402c-add3-5fa7e8c0d973)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
