### PR TITLE
A/B tests various fixes 

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -36,7 +36,7 @@ class EmailController extends FormController
     use BuilderControllerTrait;
     use FormErrorMessagesTrait;
     use EntityContactsTrait;
-    const EXAMPLE_EMAIL_SUBJECT_PREFIX = '[TEST]';
+    public const EXAMPLE_EMAIL_SUBJECT_PREFIX = '[TEST]';
 
     /**
      * @param int $page
@@ -316,18 +316,16 @@ class EmailController extends FormController
                 $variantSettings = $c->getVariantSettings();
 
                 if (is_array($variantSettings) && isset($variantSettings['winnerCriteria'])) {
-                    if ($c->isPublished()) {
-                        if (!isset($lastCriteria)) {
-                            $lastCriteria = $variantSettings['winnerCriteria'];
-                        }
-
-                        //make sure all the variants are configured with the same criteria
-                        if ($lastCriteria != $variantSettings['winnerCriteria']) {
-                            $variantError = true;
-                        }
-
-                        $weight += $variantSettings['weight'];
+                    if (!isset($lastCriteria)) {
+                        $lastCriteria = $variantSettings['winnerCriteria'];
                     }
+
+                    //make sure all the variants are configured with the same criteria
+                    if ($lastCriteria != $variantSettings['winnerCriteria']) {
+                        $variantError = true;
+                    }
+
+                    $weight += $variantSettings['weight'];
                 } else {
                     $variantSettings['winnerCriteria'] = '';
                     $variantSettings['weight']         = 0;
@@ -386,6 +384,7 @@ class EmailController extends FormController
                     'trackables'   => $trackableLinks,
                     'logs'         => $logs,
                     'isEmbedded'   => $this->request->get('isEmbedded') ? $this->request->get('isEmbedded') : false,
+                    'stats'        => $this->request->query->get('stats', false),
                     'variants'     => [
                         'parent'     => $parent,
                         'children'   => $children,

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -5,6 +5,7 @@ namespace Mautic\EmailBundle\EventListener;
 use Doctrine\ORM\EntityManager;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
+use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -53,7 +54,11 @@ class BroadcastSubscriber implements EventSubscriberInterface
         $emails = $this->model->getRepository()->getPublishedBroadcasts($event->getId());
 
         while (false !== ($email = $emails->next())) {
+            /** @var Email $emailEntity */
             $emailEntity                                            = $email[0];
+            if ($emailEntity->isVariant(true)) {
+                continue;
+            }
             list($sentCount, $failedCount, $failedRecipientsByList) = $this->model->sendEmailToLists(
                 $emailEntity,
                 null,

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -240,13 +240,8 @@ if (!$isEmbedded) {
             $isVariant = $showTranslations || $showVariants ?: 0;
             $dateFrom  = new \DateTime($dateRangeForm->children['date_from']->vars['data']);
             $dateTo    = new \DateTime($dateRangeForm->children['date_to']->vars['data']);
-
-            $statsParam = [];
-            if ($statsFilter) {
-                $statsParam = ['stats' => $statsFilter];
-            }
             ?>
-            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d')] + $statsParam); ?>">
+            <div id="emailGraphStats" data-graph-url="<?php echo $view['router']->path('mautic_email_graph_stats', ['objectId' => $email->getId(), 'isVariant' => $isVariant, 'dateFrom' => $dateFrom->format('Y-m-d'), 'dateTo' => $dateTo->format('Y-m-d'), 'stats' => $stats]); ?>">
                 <div class="spinner">
                     <i class="fa fa-spin fa-spinner"></i>
                 </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

**Backport for https://github.com/mautic/mautic/pull/11915**

This PR covers some fixes for A/B testing
We've noticed some issues:

- Switch between variant, and all do not work properly
![image](https://user-images.githubusercontent.com/462477/216513372-fb1eccd5-ec92-40b2-aa2b-5fbf992081b7.png)
- percentage and graphs doe don't work If one of email is unscheduled or unpublished
![image](https://user-images.githubusercontent.com/462477/216513531-a39c187e-7625-43de-972f-7a4266089245.png)
- send by broadcast send also children emails, even IF we already send some emails during parent email sending

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create A/B testing scheduled emails with 100 contacts, for example
3. Send it by the broadcast command `mautic:broadcast:send --limit=10`
4. See like your command send 20 emails (we expect 10 split 50% for each)
5. Check graphs and see like email was not sent divided 50% for each email; there is a difference
6. Wait until one of the emails is unscheduled or unpublished
7. Then check graphs na percentage in the A/B tabs on the detail email page
8. We expect to see a graph and the correct percentage
9. After applying PR, should all these issues be fixed
