### PR TITLE
Adding back the node_modules to the list of excluded files

### DIFF
--- a/app/assets/scaffold/build/exclude_files.txt
+++ b/app/assets/scaffold/build/exclude_files.txt
@@ -26,12 +26,12 @@ bin/phpunit
 bin/security-checker
 bin/simple-phpunit
 build/*
-deleted_files.txt
 modified_files.txt
+node_modules/*
 package-lock.json
 package.json
 phpstan*.neon
-rector.yaml
+rector.php
 tests/*
 vendor/babdev/*
 vendor/liip/*

--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -26,8 +26,8 @@ bin/phpunit
 bin/security-checker
 bin/simple-phpunit
 build/*
-index_dev.php
 modified_files.txt
+node_modules/*
 package-lock.json
 package.json
 phpstan*.neon


### PR DESCRIPTION
As the assets will be concatinated into the media folder during the build

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/pull/12234#discussion_r1171565941

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In https://github.com/mautic/mautic/pull/12234#discussion_r1189571730 where I was moving hard-coded JS libraries to NPM I thought that we'll have to include the node_modules folder in the production build. But as my colleagues pointed out, it's not necessary. The production assets are concatenated, minifield and moved to the media folder. So the node_modules folder is needed only for development. Not the production build.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check that UI actions like clicking through the UI, loading modal boxes is not broken in dev and prod environment. For prod environment firstly run `bin/console mautic:assets:generate` command do build the production assets.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
