### PR TITLE
Dynamic content used with regex fails

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -105,6 +105,8 @@ trait MatchFilterForLeadTrait
                 default:
                     if (is_numeric($leadVal)) {
                         $leadVal   = (int) $leadVal;
+                    }
+                    if (is_numeric($filterVal)) {
                         $filterVal = (int) $filterVal;
                     }
                     break;

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -102,14 +102,6 @@ trait MatchFilterForLeadTrait
                         $filterVal = explode('|', $filterVal);
                     }
                     break;
-                default:
-                    if (is_numeric($leadVal)) {
-                        $leadVal   = (int) $leadVal;
-                    }
-                    if (is_numeric($filterVal)) {
-                        $filterVal = (int) $filterVal;
-                    }
-                    break;
             }
 
             switch ($data['operator']) {

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -47,6 +47,15 @@ class MatchFilterForLeadTraitTest extends TestCase
         self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
 
+    public function testDWCContactWithRegex(): void
+    {
+        $this->lead['custom']        = 123;
+        $this->filter[0]['operator'] = 'regexp';
+        $this->filter[0]['filter']   = '(123|456)';
+
+        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+    }
+
     public function testDWCContactEndWidth(): void
     {
         $this->filter[0]['operator'] = 'endsWith';

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -10,11 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 class MatchFilterForLeadTraitTest extends TestCase
 {
-    private $lead = [
+    /** @var mixed[] $lead  */
+    private array $lead = [
         'id'     => 1,
         'custom' => 'my custom text',
     ];
 
+    /** @var mixed[] $filter  */
     private $filter = [
         0 => [
             'display' => null,
@@ -49,9 +51,9 @@ class MatchFilterForLeadTraitTest extends TestCase
 
     public function testDWCContactWithRegex(): void
     {
-        $this->lead['custom']        = 123;
+        $this->lead['custom']        = '04249';
         $this->filter[0]['operator'] = 'regexp';
-        $this->filter[0]['filter']   = '(123|456)';
+        $this->filter[0]['filter']   = '(13357|04249|20363)';
 
         self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
@@ -83,7 +85,7 @@ class MatchFilterForLeadTraitTest extends TestCase
     /**
      * @dataProvider dateMatchTestProvider
      */
-    public function testMatchFilterForLeadTraitForDate(?string $value, string $operator, bool $expect)
+    public function testMatchFilterForLeadTraitForDate(?string $value, string $operator, bool $expect):void
     {
         $filters = [
             [
@@ -248,6 +250,11 @@ class MatchFilterForLeadTraitTest extends TestCase
 class MatchFilterForLeadTraitTestable
 {
     use MatchFilterForLeadTrait;
+
+    public function setRepository(LeadListRepository $segmentRepository): void
+    {
+        $this->segmentRepository = $segmentRepository;
+    }
 
     public function match(array $filter, array $lead): bool
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -10,13 +10,13 @@ use PHPUnit\Framework\TestCase;
 
 class MatchFilterForLeadTraitTest extends TestCase
 {
-    /** @var mixed[] $lead  */
+    /** @var mixed[] */
     private array $lead = [
         'id'     => 1,
         'custom' => 'my custom text',
     ];
 
-    /** @var mixed[] $filter  */
+    /** @var mixed[] */
     private $filter = [
         0 => [
             'display' => null,
@@ -85,7 +85,7 @@ class MatchFilterForLeadTraitTest extends TestCase
     /**
      * @dataProvider dateMatchTestProvider
      */
-    public function testMatchFilterForLeadTraitForDate(?string $value, string $operator, bool $expect):void
+    public function testMatchFilterForLeadTraitForDate(?string $value, string $operator, bool $expect): void
     {
         $filters = [
             [

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -251,11 +251,6 @@ class MatchFilterForLeadTraitTestable
 {
     use MatchFilterForLeadTrait;
 
-    public function setRepository(LeadListRepository $segmentRepository): void
-    {
-        $this->segmentRepository = $segmentRepository;
-    }
-
     public function match(array $filter, array $lead): bool
     {
         return $this->matchFilterForLead($filter, $lead);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Dynamic content used with regex fails if text type field value is numeric.
If any text type filed value has numeric value to a contact and in dynamic content filter we are using regex operator with some regex in value then it does not works in email.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create 2 contact with zipcode 04249 and 42001
3. Create a segment and add above 2 contacts in segment
4. create a dynamic content, set Is campaign based? => false, add filter for zipcode field with regexp operator and **(13357|04249|20363)** as value
5. Create a landing page and use above dynamic content in page content
6. Create segment email and use  above landing page in email
7. Send email
8. open email and verify contact which have zipcode - 04249 , should display dynamic content



<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
