### PR TITLE
Deprecating Pipedrive

### DIFF
--- a/app/migrations/Version20230519081315.php
+++ b/app/migrations/Version20230519081315.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use MauticPlugin\MauticCrmBundle\Integration\PipedriveIntegration;
+
+final class Version20230519081315 extends AbstractMauticMigration
+{
+    public function preUp(Schema $schema): void
+    {
+        $connection  = $this->entityManager->getConnection();
+        $pluginInUse = $connection->prepare("SELECT 1 from {$this->prefix}plugin_integration_settings WHERE name='Pipedrive' AND is_published = 1")->executeQuery()->rowCount();
+
+        if (!$pluginInUse) {
+            throw new SkipMigration('The Pipedrive plugin is not used on this instance, no need to add deprecation notifications');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table   = "{$this->prefix}notifications";
+        $header  = 'The Pipedrive plugin will be removed in Mautic 5.0.0';
+        $message = PipedriveIntegration::DEPRECATION_MESSAGE;
+        $sql     = "INSERT INTO {$table} (user_id, type, header, message, date_added, icon_class, is_read) SELECT u.id ,'warning', '{$header}', '{$message}', NOW(), 'fa-warning', 0 FROM {$this->prefix}users u";
+        $this->addSql($sql);
+    }
+}

--- a/plugins/MauticCrmBundle/Command/FetchPipedriveDataCommand.php
+++ b/plugins/MauticCrmBundle/Command/FetchPipedriveDataCommand.php
@@ -54,6 +54,7 @@ class FetchPipedriveDataCommand extends ContainerAwareCommand
     {
         $container = $this->getContainer();
         $this->io  = new SymfonyStyle($input, $output);
+        $this->io->warning(PipedriveIntegration::DEPRECATION_MESSAGE);
 
         /** @var PipedriveIntegration $integrationObject */
         $integrationObject = $this->integrationHelper

--- a/plugins/MauticCrmBundle/Command/PushDataToPipedriveCommand.php
+++ b/plugins/MauticCrmBundle/Command/PushDataToPipedriveCommand.php
@@ -69,6 +69,7 @@ class PushDataToPipedriveCommand extends ContainerAwareCommand
         $integrationObject = $this->integrationHelper
             ->getIntegrationObject(PipedriveIntegration::INTEGRATION_NAME);
         $this->io          = new SymfonyStyle($input, $output);
+        $this->io->warning(PipedriveIntegration::DEPRECATION_MESSAGE);
 
         $pushed = 0;
 

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -18,14 +18,20 @@ use MauticPlugin\MauticCrmBundle\Services\Transport;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * @deprecated will be removed in Mautic 5. See DEPRECATION_MESSAGE bellow.
+ */
 class PipedriveIntegration extends CrmAbstractIntegration
 {
+    public const DEPRECATION_MESSAGE = 'The Pipedrive plugin is deprecated and will be removed in Mautic 5. See <a href="https://www.mautic.org/blog/integrator/exciting-news-new-integration-plugin-pipedrive-crm" target=”_blank”>the announcement</a> for more details.';
+
     const INTEGRATION_NAME         = 'Pipedrive';
     const PERSON_ENTITY_TYPE       = 'person';
     const LEAD_ENTITY_TYPE         = 'lead';
@@ -288,6 +294,14 @@ class PipedriveIntegration extends CrmAbstractIntegration
      */
     public function appendToForm(&$builder, $data, $formArea)
     {
+        $builder->add(
+            'deprecationWarning',
+            HiddenType::class,
+            [
+                'label'             => 'Deprecated!',
+                'label_attr'        => ['class' => ''],
+            ]
+        );
         if ('features' == $formArea) {
             $builder->add(
                 'objects',
@@ -350,12 +364,13 @@ class PipedriveIntegration extends CrmAbstractIntegration
 
         if ('authorization' == $section) {
             return [
+                '<b>'.PipedriveIntegration::DEPRECATION_MESSAGE.'</b><br><br>'.
                 $translator->trans('mautic.pipedrive.webhook_callback').$router->generate(
                     'mautic_integration.pipedrive.webhook',
                     [],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 ),
-                'info',
+                'warning',
             ];
         }
 

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\Router;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
- * @deprecated will be removed in Mautic 5. See DEPRECATION_MESSAGE bellow.
+ * @deprecated will be removed in Mautic 5. See DEPRECATION_MESSAGE below.
  */
 class PipedriveIntegration extends CrmAbstractIntegration
 {

--- a/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/PipedriveIntegration.php
@@ -18,7 +18,6 @@ use MauticPlugin\MauticCrmBundle\Services\Transport;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -294,14 +293,6 @@ class PipedriveIntegration extends CrmAbstractIntegration
      */
     public function appendToForm(&$builder, $data, $formArea)
     {
-        $builder->add(
-            'deprecationWarning',
-            HiddenType::class,
-            [
-                'label'             => 'Deprecated!',
-                'label_attr'        => ['class' => ''],
-            ]
-        );
         if ('features' == $formArea) {
             $builder->add(
                 'objects',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [y]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | https://www.mautic.org/blog/integrator/exciting-news-new-integration-plugin-pipedrive-crm
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR complements https://github.com/mautic/mautic/pull/12081 which is removing the Pipedrive plugin from Mautic 5.

See https://www.mautic.org/blog/integrator/exciting-news-new-integration-plugin-pipedrive-crm for the reasons why.

The deprecation notice was added into multiple places:
1. Into the PipeDriveIntegration class so it's visible to the developers:
![Screenshot 2023-05-19 at 11 16 24](https://github.com/mautic/mautic/assets/1235442/5439ddc5-0d52-47d6-a289-a03b091bc375)
2. To the Pipedrive config form:
![Screenshot 2023-05-19 at 11 01 53](https://github.com/mautic/mautic/assets/1235442/7a5e001d-b6ae-4086-b71c-e264cde0d586)
3. To the notification center for all Mautic users if the Pipedrive plugin is enabled:
![Screenshot 2023-05-19 at 11 04 11](https://github.com/mautic/mautic/assets/1235442/b5d9e23d-a862-4547-b8ff-282448d444c1)
4. To both of the Pipedrive commands:
```
$ bin/console mautic:integration:pipedrive:push

 [WARNING] The Pipedrive plugin is deprecated and will be removed in Mautic 5. See <a                                   
           href="https://www.mautic.org/blog/integrator/exciting-news-new-integration-plugin-pipedrive-crm"             
           target=”_blank”>the announcement</a> for more details.                                                       
                                                                                                                       
Pushing Leads
...
```
```
$ bin/console mautic:integration:pipedrive:fetch

 [WARNING] The Pipedrive plugin is deprecated and will be removed in Mautic 5. See <a                                   
           href="https://www.mautic.org/blog/integrator/exciting-news-new-integration-plugin-pipedrive-crm"             
           target=”_blank”>the announcement</a> for more details.                                                       
                                                                                                                        
...
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the Pipedrive plugin, check the new warning and enable it so the migration bellow will add the user notifications.
3. Run `bin/console doctrine:migrations:migrate`. It will add new notification for all Mautic users.
4. Run the commands above to confirm the warning messages are there.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
