### PR TITLE
Report details are updated to work with custom date format.

### DIFF
--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -118,26 +118,32 @@ $graphContent = $view->render(
                                             <a href="<?php echo $view['router']->path($columns[$key]['link'], ['objectAction' => 'view', 'objectId' => $row[$columns[$key]['alias']]]); ?>" class="label label-success">
                                                 <?php endif; ?>
                                                 <?php
-                                                $cellType = $columns[$key]['type'];
-                                                $cellVal  = $row[$columns[$key]['alias']];
+                                                    $cellType = $columns[$key]['type'];
+                                                    $cellVal  = $row[$columns[$key]['alias']];
 
-                                                // For grouping by datetime fields, so we don't get the timestamp on them
-                                                if ('datetime' === $cellType && 10 === strlen($cellVal)) {
-                                                    $cellType = 'date';
-                                                }
-                                                ?>
-                                                <?php
-                                                switch ($cellType) {
-                                                    case 'datetime':
-                                                        echo $view['date']->toFullConcat($cellVal, 'UTC');
-                                                        break;
-                                                    case 'date':
-                                                        echo $view['date']->toShort($cellVal, 'UTC');
-                                                        break;
-                                                    default:
-                                                        echo $view['formatter']->_($cellVal, $cellType);
-                                                        break;
-                                                }
+                                                    // If field is date or datetime, and is formatted with string
+                                                    // which does not convert back to date simply print the formatted string.
+                                                    if (in_array($cellType, ['date', 'datetime']) && !strtotime($cellVal)) {
+                                                        echo $cellVal;
+                                                    }
+                                                    else {
+                                                        // For grouping by datetime fields, so we don't get the timestamp on them
+                                                        if ('datetime' === $cellType && 10 === strlen($cellVal)) {
+                                                            $cellType = 'date';
+                                                        }
+
+                                                        switch ($cellType) {
+                                                            case 'datetime':
+                                                                echo $view['date']->toFullConcat($cellVal, 'UTC');
+                                                                break;
+                                                            case 'date':
+                                                                echo $view['date']->toShort($cellVal, 'UTC');
+                                                                break;
+                                                            default:
+                                                                echo $view['formatter']->_($cellVal, $cellType);
+                                                                break;
+                                                        }
+                                                    }
                                                 ?>
                                                 <?php if ($closeLink): ?></a><?php endif; ?>
                                         </td>

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -125,8 +125,7 @@ $graphContent = $view->render(
                                                 // which does not convert back to date simply print the formatted string.
                                                 if (in_array($cellType, ['date', 'datetime']) && !strtotime($cellVal)) {
                                                     echo $cellVal;
-                                                }
-                                                else {
+                                                } else {
                                                     // For grouping by datetime fields, so we don't get the timestamp on them
                                                     if ('datetime' === $cellType && 10 === strlen($cellVal)) {
                                                         $cellType = 'date';

--- a/app/bundles/ReportBundle/Views/Report/details_data.html.php
+++ b/app/bundles/ReportBundle/Views/Report/details_data.html.php
@@ -125,8 +125,7 @@ $graphContent = $view->render(
                                                     // which does not convert back to date simply print the formatted string.
                                                     if (in_array($cellType, ['date', 'datetime']) && !strtotime($cellVal)) {
                                                         echo $cellVal;
-                                                    }
-                                                    else {
+                                                    } else {
                                                         // For grouping by datetime fields, so we don't get the timestamp on them
                                                         if ('datetime' === $cellType && 10 === strlen($cellVal)) {
                                                             $cellType = 'date';


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ✅ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ :x:]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ]
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->


#### Description:
When working on a custom report, I tried updating the date to be able to use the custom date format. Instead of showing the formatted date, it shows `1970-01-01 00:00:00`.

I subscribed to the `ReportEvents::REPORT_ON_DISPLAY`event and replaced the date fields format.
```php
  $date = new \DateTimeImmutable($datum[$column]);
  $datum[$column] = $date->format('W/Y');
```

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

