### PR TITLE
Replacing HistoryJS with native history browser api

### DIFF
--- a/app/assets/scaffold/files/package-lock.json
+++ b/app/assets/scaffold/files/package-lock.json
@@ -16,7 +16,6 @@
         "ckeditor4": "^4.21.0",
         "codemirror": "^5.65.13",
         "dropzone": "^4.3.0",
-        "historyjs": "^1.8.0-b2",
         "jquery": "^3.7.0",
         "jquery-datetimepicker": "^2.5.21",
         "jquery-form": "^4.3.0",
@@ -61,17 +60,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "node_modules/ambi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.0.0.tgz",
-      "integrity": "sha512-IXzMsvqViCbMwwTykPnHnzbiMjzKocXzxofPEC1ZYSSJTnoBOEsBhEABa8FJ98ADYtxhPdGTEWDeJUGyS8K6Iw==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -107,18 +95,8 @@
     "node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "node_modules/async_testing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async_testing/-/async_testing-0.3.2.tgz",
-      "integrity": "sha512-1M9jJ5JAoExlitLvZGFhUZOYeel3sObdhmacmbHZxWvHOTpNFkypXiJ3+HeGU+3eH1b26YL7a9aqagSdWVtWgg==",
-      "bin": {
-        "node-async-test": "bin/node-async-test.js"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -140,28 +118,11 @@
         "jquery": ">=1.7.0 <4.0.0"
       }
     },
-    "node_modules/bal-util": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.18.0.tgz",
-      "integrity": "sha512-wjVrsaK6K4OM1kgwiw1cf0+7RGjyNsgxc7kjoqfTDAKzdBoG1JQuAXk0VpJOpn5kgB68zjttbu0ghXPDamyc9Q==",
-      "dependencies": {
-        "ambi": "~2.0.0",
-        "eachr": "~2.0.2",
-        "extendr": "~2.0.1",
-        "getsetdeep": "~2.0.0",
-        "safecallback": "~1.0.1",
-        "safefs": "~2.0.3",
-        "taskgroup": "~2.0.0",
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/body": {
       "version": "5.1.0",
@@ -187,6 +148,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -202,63 +164,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buildr": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/buildr/-/buildr-0.8.7.tgz",
-      "integrity": "sha512-VyDsdhqc8wxk84S/NyMiIgOgeRTKu/GNViEkJAE+us3mY4hB5l+dH4tiADbdD5K75rZMJiBvoYNGeDxhffrVSA==",
-      "dependencies": {
-        "bal-util": "1.x",
-        "caterpillar": "1.x",
-        "coffee-script": "1.4.x",
-        "cson": ">=1.4",
-        "csslint": "0.9.x",
-        "jshint": "0.9.x",
-        "less": "1.3.x",
-        "optimist": ">=0.3",
-        "pulverizr": "0.7.x",
-        "rimraf": "2.1.4",
-        "uglify-js": "1.3.x",
-        "watch-tree-maintained": "0.1.x"
-      },
-      "bin": {
-        "buildr": "bin/buildr.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/buildr/node_modules/graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/buildr/node_modules/less": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-1.3.3.tgz",
-      "integrity": "sha512-y9el4KFU/bjCb0IvDoPX9ncwZcIZZtxKlYlNcXXqcfYbqzjfKM+TjLutrE9HwMQ+PqzBAPFI3NI6KRNbMBvc3Q==",
-      "bin": {
-        "lessc": "bin/lessc"
-      },
-      "engines": {
-        "node": ">=0.4.2"
-      },
-      "optionalDependencies": {
-        "ycssmin": ">=1.0.1"
-      }
-    },
-    "node_modules/buildr/node_modules/rimraf": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-      "integrity": "sha512-tzwmX16YQhcFu0T/m0gHBcFKx6yQAg77Z6WWaQSJsUekXYa6yaAmHhrDdmFicgauX/er7GsdN+vRao3mBhA4kQ==",
-      "optionalDependencies": {
-        "graceful-fs": "~1"
       }
     },
     "node_modules/bytes": {
@@ -278,17 +183,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caterpillar": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-1.1.4.tgz",
-      "integrity": "sha512-rocDSXqlhcKlh+5qjhuXZwNeopu5AkN5r9t1dXhhlsKasOqS7rSQBEnjVTLUrw86jEeWl+Sn0s9eslrue0V/TA==",
-      "engines": {
-        "node": ">=0.4"
-      },
-      "optionalDependencies": {
-        "cli-color": "~0.2.2"
       }
     },
     "node_modules/chart.js": {
@@ -355,59 +249,10 @@
       "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.21.0.tgz",
       "integrity": "sha512-OAMw68puJcrKFtsPZwIWVB/upYLgJpFw1yTuBBIhoreY+g/f0SttjQY0I/fUwxevVUHvgmRVNeJwNl8qkJPvyw=="
     },
-    "node_modules/cli": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
-      "integrity": "sha512-zPLMXUf13f5JkcgpA6FJim+U1fcsPYymGdEhdNsF5rRf1k+MEyBjmxECSI0lg+i143E6kPTpVN65bNaCvf+avA==",
-      "dependencies": {
-        "glob": ">= 3.1.4"
-      },
-      "engines": {
-        "node": ">=0.2.5"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-      "integrity": "sha512-f4DFHXdoe2rGMwuVO+DTBM6CkSt4m9R4a0vjnq5CJkSCKaXbrHbslCmyjG6cz/o50HP2wkjO3G1mXvc7G3V1LQ==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "memoizee": "~0.2.5"
-      },
-      "engines": {
-        "node": ">=0.1.103"
-      }
-    },
     "node_modules/codemirror": {
       "version": "5.65.13",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
       "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
-    },
-    "node_modules/coffee-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz",
-      "integrity": "sha512-LEn5PkG6XJ3QmqGl3W2LoBMcPhWI0mIRbH+r95THAfeO86+BS4R8Twh9g2F6rCs6iMZBvmPwu6sUZF33+wkUfA==",
-      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -435,38 +280,11 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/coloured": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/coloured/-/coloured-0.2.0.tgz",
-      "integrity": "sha512-d6/mc19iA0+M07wuVeZTmRZmNoaVqoSSvPbEuz8oObDgUDwSolBJhi1v+lPLhNVy8FDthGQ4KSVH8lDPNgmtyQ==",
-      "engines": [
-        "node >=0.1.5"
-      ]
-    },
-    "node_modules/coloured-log": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/coloured-log/-/coloured-log-0.9.7.tgz",
-      "integrity": "sha512-1Ja7MGAwyEXhzmRRWhwMG4Q+QzlVFaR0LJbykXIbm0mexP6l5ec35nM+3Nr/oo6m/6B+pXI7Xz22CWutSV2B1w==",
-      "dependencies": {
-        "coloured": ">= 0.2.0",
-        "log": ">= 1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/continuable-cache": {
       "version": "0.3.1",
@@ -500,101 +318,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cson": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/cson/-/cson-7.20.0.tgz",
-      "integrity": "sha512-K7g/86vC77mJqi6PRFhd3p8U/y0R6SsCeTJb5RpOAaQdApHxCoK5JwfZ8WeJjpOZ6lyyi8tNvh3UuC184H3GWg==",
-      "dependencies": {
-        "cson-parser": "^4.0.5",
-        "extract-opts": "^4.3.0",
-        "requirefresh": "^4.12.0",
-        "safefs": "^6.12.0"
-      },
-      "bin": {
-        "cson2json": "bin.cjs",
-        "json2cson": "bin.cjs"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/cson-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
-      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
-      "dependencies": {
-        "coffeescript": "1.12.7"
-      },
-      "engines": {
-        "node": ">=10.13"
-      }
-    },
-    "node_modules/cson/node_modules/safefs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-6.16.0.tgz",
-      "integrity": "sha512-IUIN5h+r2acNVkbsM5VoBUsRnaSFwQFZnzyvQsiLlgFsncLi7rrtmM4FsEgwv+xDTJzsrp79rd+/GJu2zWcR9w==",
-      "dependencies": {
-        "graceful-fs": "^4.2.6"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/csslint": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.9.10.tgz",
-      "integrity": "sha512-x2q/J6oNpWoPNk+HeI0Y1nc2mgcCK15WGXLrZbGnt2/sokiDeJT4P2A//pVvFt1ot78ZmbowQlkCHuW5Nxn4QQ==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "bin": {
-        "csslint": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
-    "node_modules/d/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/d/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/d/node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -627,45 +350,6 @@
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
       "integrity": "sha512-KAP4sc9wjaU5xLhZ7olSH1ni72IbXk2l9iF9Ai5p3slwDtKTJunKkQpdFg7voyOcUU+6j75xEhHh+yPqd/Z/PA=="
     },
-    "node_modules/duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
-      }
-    },
-    "node_modules/duration/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/duration/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha512-ImdMB5wEdN+M1VNte4NiYmH7FBJ/D27aOeYuqR3zuBRqwMeqtqPJvIqckzQzXT5s9nDMysV3bkE+zB6ezKhphg==",
-      "dependencies": {
-        "typechecker": "^2.0.8"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -688,53 +372,6 @@
         "string-template": "~0.2.1"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-      "integrity": "sha512-wP3OSxZ0L/qK76t6qxPR8gWr2o5F4SzNF9qS5F/mOfVY3Ezcg07v6hSkETDmoekXIzn8xhQbHpp+tVlOE+qOAg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-iterator/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -746,18 +383,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-      "integrity": "sha512-kdjfxF6jYJ5m/OEe3ZNNJzbCEcagF4lNJeuhgrBSRnlitpdxICDKzCel+Z5Wbl7K9UhBN/7k2MzXBvCvSwfzzg==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/eventemitter2": {
@@ -787,70 +412,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
-    },
-    "node_modules/extendr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.0.1.tgz",
-      "integrity": "sha512-HI5RiZxISYYFYZ95L0qt4fAxB/HmrV+oWuMwg03wGGxADNqZHssxGB8aai/NYHNxGrcIRvRqdptMNxmxWHJGEg==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/extract-opts": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-4.3.0.tgz",
-      "integrity": "sha512-Dmssi1tgKJkQsVmbP7TgW/kbdc42SAsNf6h9ClweP+dS7O24YYMTXsNwPelxhx0LF15npiWwY5ahKtyQiNgxWA==",
-      "dependencies": {
-        "eachr": "^4.5.0",
-        "typechecker": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/extract-opts/node_modules/eachr": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
-      "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
-      "dependencies": {
-        "typechecker": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/extract-opts/node_modules/typechecker": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
-      "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
     },
     "node_modules/faye-websocket": {
       "version": "0.10.0",
@@ -964,7 +530,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1007,21 +574,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/getsetdeep": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/getsetdeep/-/getsetdeep-2.0.0.tgz",
-      "integrity": "sha512-tC4ROuyPTxnO8UALLADoDTWQMP4XbIeIUjVw0KmbuUlL8WjUeyDvGPnKFKyz1r4hw3JymD9dSc/gTdc0vLZs3w==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1096,7 +653,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/grunt": {
       "version": "1.6.1",
@@ -1382,14 +940,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/historyjs": {
-      "version": "1.8.0-b2",
-      "resolved": "https://registry.npmjs.org/historyjs/-/historyjs-1.8.0-b2.tgz",
-      "integrity": "sha512-hxT7tZ2XG8hNkR2PObvQXup33ukuR+zrOHBfnoMc9+r0UsHdpnzxt3yv64qnyjlhr/1i+91shtONXArUDKnBQA==",
-      "dependencies": {
-        "buildr": "0.8.x"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -1447,6 +997,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1455,7 +1006,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1686,30 +1238,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jshint": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
-      "integrity": "sha512-W69SwJ3/pBdkwwpNxCOmlJHlsJCzA2xJ4DyWoXezdjBEteBq/R3eX6CaU7SM7mTjdSU1iSI7UG57fl0QqNO4Nw==",
-      "dependencies": {
-        "cli": "0.4.3",
-        "minimatch": "0.0.x"
-      },
-      "bin": {
-        "jshint": "bin/hint"
-      }
-    },
-    "node_modules/jshint/node_modules/minimatch": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
-      "integrity": "sha512-+uV1GoFd1Qme/Evj0R3kXX2sZvLFPPKv3FPBE+Q33Xx+ME1G4i3V1x9q68j6nHfZWsl74fdCfX4SIxjbuKtKXA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "dependencies": {
-        "lru-cache": "~1.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1825,56 +1353,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/log": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.53",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.1",
-        "type": "^2.5.0",
-        "uni-global": "^1.0.0"
-      }
-    },
-    "node_modules/log/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/log/node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "node_modules/log/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/lru-cache": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz",
-      "integrity": "sha512-mM3c2io8llIGu/6WuMhLl5Qu9Flt5io8Epuqk+iIbKwyUwDQI6FdcCDxjAhhxYqgi0U17G89chu/Va1gbKhJbw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -1915,20 +1393,6 @@
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
       "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
-    "node_modules/memoizee": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-      "integrity": "sha512-0VZI0btwyGk6FSDnJGuJtso4M/eSxhVb5ID5AZNWMFFgT2LexCV18hHI764V4ELKlyfnQ5KMQ+q5H3uvFN3MLw==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "event-emitter": "~0.2.2",
-        "next-tick": "0.1.x"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -1959,6 +1423,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1970,19 +1435,9 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/moment": {
@@ -2028,15 +1483,6 @@
       },
       "engines": {
         "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/next-tick": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-      "integrity": "sha512-I44QWeGCHJTx2D3buhnljvSjmPgJua3zdPGtlCQEvA45t9kS/CaHnlVqidTzHwq8LGXhD2SMezjk4hQgP+32Lg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/nopt": {
@@ -2113,6 +1559,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2132,20 +1579,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -2283,6 +1716,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2357,32 +1791,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/pulverizr": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pulverizr/-/pulverizr-0.7.0.tgz",
-      "integrity": "sha512-mzviuxtLbRW1fDHUBccQoLvahrhVIsgaqCf7LKQAv2IfDhzw7Ip1ygNat/Ui55V9j9aTcV2p2l7HZJ/+OY7EEQ==",
-      "dependencies": {
-        "coloured-log": ">= 0.9.7",
-        "commander": ">= 0.6.0",
-        "q": ">= 0.8.5",
-        "temp": ">= 0.4.0"
-      },
-      "bin": {
-        "pulverize": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -2421,17 +1829,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/requirefresh": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-4.13.0.tgz",
-      "integrity": "sha512-APrzWWxqnwE2Bz3ysFepAU0Dc0aYjn8jsDLFIegedn+KVCS9LykAclkf+6YaJXk3ON9l6QAm04rN+bEA89cGIg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/resolve": {
@@ -2501,22 +1898,6 @@
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
-    },
-    "node_modules/safecallback": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safecallback/-/safecallback-1.0.1.tgz",
-      "integrity": "sha512-iwkVkRKejb2X1WshFYVTYsJrrLpq3pRiaeyG4vycyjLrvoxaUZrjR+htwzuN87KvRO5hFCCtwspUKQbO09awRg==",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/safefs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-2.0.3.tgz",
-      "integrity": "sha512-8OTBjnIQYCuGE7A+MzbQjQEeVrjT8p8HAgX7vi53xX6hhCAjiz8eQKWCzFYdlRZ6FozUw143xjvTFqBE/4QptQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2611,33 +1992,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/sprintf-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
-      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
-      "dependencies": {
-        "es5-ext": "^0.10.53"
-      }
-    },
-    "node_modules/sprintf-kit/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/sprintf-kit/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -2660,41 +2014,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/taskgroup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-2.0.0.tgz",
-      "integrity": "sha512-uvL8DQ7cEViBG60xYnyceK1y0pXZD+wHIa5hwnW/JHDCSipzdSRfSX8bUsoqXczxHdRjgAfJQ6LSTHnOyzCHRw==",
-      "dependencies": {
-        "ambi": "~2.0.0",
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/throttleit": {
@@ -2751,34 +2070,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
     "node_modules/typeahead.js": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
       "integrity": "sha512-yGaLzGjVHyryZdNfrWz2NHXUwEO7hrlVmGMGCo5+6mH3nEEhcQ0Te3mK3G60uRnxfERu8twOWSU4WmwScbwhMg==",
       "dependencies": {
         "jquery": ">=1.7"
-      }
-    },
-    "node_modules/typechecker": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-      "integrity": "sha512-7czjA7j/rc9zA/mTzsjD1yc41GIuARzFXIs69cc0PeMRu7uiGpQw4Cs83l/NjJj93PnSxeTZrOc2lDDLUmmpwg==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
       }
     },
     "node_modules/unc-path-regex": {
@@ -2789,11 +2086,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/underscore.string": {
       "version": "3.3.6",
@@ -2813,14 +2105,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
-    },
-    "node_modules/uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "dependencies": {
-        "type": "^2.5.0"
-      }
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -2853,24 +2137,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/vimeo-froogaloop2/-/vimeo-froogaloop2-0.1.1.tgz",
       "integrity": "sha512-sJfpwW23Yzp4Uq1H9HAzVpILiYjXTiN64l6igHCadhi0udh5MUbhMCMVA8DUt/yOzvSiCDdGPYIpv1AvM5D2gw=="
-    },
-    "node_modules/watch-tree-maintained": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/watch-tree-maintained/-/watch-tree-maintained-0.1.2.tgz",
-      "integrity": "sha512-mMsSXfdO1S2g7sY3LxDCYi1G2tX4LNHrLJXkx7E43XGsOFoxcA2XRtlEy4/TqiEt6VxFKHY8VWIdMeY9DES7Iw==",
-      "dependencies": {
-        "async": ">=0.1.7",
-        "async_testing": ">=0.3.2",
-        "coffee-script": ">=1.0.0",
-        "optimist": ">=0.1.2",
-        "underscore": ">=1.1.4"
-      },
-      "bin": {
-        "watch-tree": "bin/watch-tree"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -2910,18 +2176,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.2.2",
@@ -2930,15 +2189,6 @@
       "dev": true,
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ycssmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ycssmin/-/ycssmin-1.0.1.tgz",
-      "integrity": "sha512-nSBxAfGA/RlALXyqijYUnIjMXNXWxYHrQJSYwNqypeULl44J8Z/eN5larw7ZEdYLeUHBgPyilve6hqQtWVVs9g==",
-      "optional": true,
-      "bin": {
-        "ycssmin": "bin/cssmin"
       }
     }
   },
@@ -2960,14 +2210,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "ambi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.0.0.tgz",
-      "integrity": "sha512-IXzMsvqViCbMwwTykPnHnzbiMjzKocXzxofPEC1ZYSSJTnoBOEsBhEABa8FJ98ADYtxhPdGTEWDeJUGyS8K6Iw==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -2998,12 +2240,8 @@
     "async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "async_testing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async_testing/-/async_testing-0.3.2.tgz",
-      "integrity": "sha512-1M9jJ5JAoExlitLvZGFhUZOYeel3sObdhmacmbHZxWvHOTpNFkypXiJ3+HeGU+3eH1b26YL7a9aqagSdWVtWgg=="
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -3017,25 +2255,11 @@
       "integrity": "sha512-G8mgUb/PqShPoH8AyjuxsTGvIr1o716BtQUKDM44C8qN2W615y7KGJ68MlTGamd0J0D/m28emUkzagaHTdrGZw==",
       "requires": {}
     },
-    "bal-util": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.18.0.tgz",
-      "integrity": "sha512-wjVrsaK6K4OM1kgwiw1cf0+7RGjyNsgxc7kjoqfTDAKzdBoG1JQuAXk0VpJOpn5kgB68zjttbu0ghXPDamyc9Q==",
-      "requires": {
-        "ambi": "~2.0.0",
-        "eachr": "~2.0.2",
-        "extendr": "~2.0.1",
-        "getsetdeep": "~2.0.0",
-        "safecallback": "~1.0.1",
-        "safefs": "~2.0.3",
-        "taskgroup": "~2.0.0",
-        "typechecker": "~2.0.1"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "body": {
       "version": "5.1.0",
@@ -3058,6 +2282,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3070,49 +2295,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "buildr": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/buildr/-/buildr-0.8.7.tgz",
-      "integrity": "sha512-VyDsdhqc8wxk84S/NyMiIgOgeRTKu/GNViEkJAE+us3mY4hB5l+dH4tiADbdD5K75rZMJiBvoYNGeDxhffrVSA==",
-      "requires": {
-        "bal-util": "1.x",
-        "caterpillar": "1.x",
-        "coffee-script": "1.4.x",
-        "cson": ">=1.4",
-        "csslint": "0.9.x",
-        "jshint": "0.9.x",
-        "less": "1.3.x",
-        "optimist": ">=0.3",
-        "pulverizr": "0.7.x",
-        "rimraf": "2.1.4",
-        "uglify-js": "1.3.x",
-        "watch-tree-maintained": "0.1.x"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
-          "optional": true
-        },
-        "less": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/less/-/less-1.3.3.tgz",
-          "integrity": "sha512-y9el4KFU/bjCb0IvDoPX9ncwZcIZZtxKlYlNcXXqcfYbqzjfKM+TjLutrE9HwMQ+PqzBAPFI3NI6KRNbMBvc3Q==",
-          "requires": {
-            "ycssmin": ">=1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-          "integrity": "sha512-tzwmX16YQhcFu0T/m0gHBcFKx6yQAg77Z6WWaQSJsUekXYa6yaAmHhrDdmFicgauX/er7GsdN+vRao3mBhA4kQ==",
-          "requires": {
-            "graceful-fs": "~1"
-          }
-        }
       }
     },
     "bytes": {
@@ -3129,14 +2311,6 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caterpillar": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-1.1.4.tgz",
-      "integrity": "sha512-rocDSXqlhcKlh+5qjhuXZwNeopu5AkN5r9t1dXhhlsKasOqS7rSQBEnjVTLUrw86jEeWl+Sn0s9eslrue0V/TA==",
-      "requires": {
-        "cli-color": "~0.2.2"
       }
     },
     "chart.js": {
@@ -3196,38 +2370,10 @@
       "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.21.0.tgz",
       "integrity": "sha512-OAMw68puJcrKFtsPZwIWVB/upYLgJpFw1yTuBBIhoreY+g/f0SttjQY0I/fUwxevVUHvgmRVNeJwNl8qkJPvyw=="
     },
-    "cli": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
-      "integrity": "sha512-zPLMXUf13f5JkcgpA6FJim+U1fcsPYymGdEhdNsF5rRf1k+MEyBjmxECSI0lg+i143E6kPTpVN65bNaCvf+avA==",
-      "requires": {
-        "glob": ">= 3.1.4"
-      }
-    },
-    "cli-color": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-      "integrity": "sha512-f4DFHXdoe2rGMwuVO+DTBM6CkSt4m9R4a0vjnq5CJkSCKaXbrHbslCmyjG6cz/o50HP2wkjO3G1mXvc7G3V1LQ==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2",
-        "memoizee": "~0.2.5"
-      }
-    },
     "codemirror": {
       "version": "5.65.13",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
       "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
-    },
-    "coffee-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz",
-      "integrity": "sha512-LEn5PkG6XJ3QmqGl3W2LoBMcPhWI0mIRbH+r95THAfeO86+BS4R8Twh9g2F6rCs6iMZBvmPwu6sUZF33+wkUfA=="
-    },
-    "coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -3249,29 +2395,11 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "coloured": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/coloured/-/coloured-0.2.0.tgz",
-      "integrity": "sha512-d6/mc19iA0+M07wuVeZTmRZmNoaVqoSSvPbEuz8oObDgUDwSolBJhi1v+lPLhNVy8FDthGQ4KSVH8lDPNgmtyQ=="
-    },
-    "coloured-log": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/coloured-log/-/coloured-log-0.9.7.tgz",
-      "integrity": "sha512-1Ja7MGAwyEXhzmRRWhwMG4Q+QzlVFaR0LJbykXIbm0mexP6l5ec35nM+3Nr/oo6m/6B+pXI7Xz22CWutSV2B1w==",
-      "requires": {
-        "coloured": ">= 0.2.0",
-        "log": ">= 1.2.0"
-      }
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -3297,71 +2425,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "cson": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/cson/-/cson-7.20.0.tgz",
-      "integrity": "sha512-K7g/86vC77mJqi6PRFhd3p8U/y0R6SsCeTJb5RpOAaQdApHxCoK5JwfZ8WeJjpOZ6lyyi8tNvh3UuC184H3GWg==",
-      "requires": {
-        "cson-parser": "^4.0.5",
-        "extract-opts": "^4.3.0",
-        "requirefresh": "^4.12.0",
-        "safefs": "^6.12.0"
-      },
-      "dependencies": {
-        "safefs": {
-          "version": "6.16.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-6.16.0.tgz",
-          "integrity": "sha512-IUIN5h+r2acNVkbsM5VoBUsRnaSFwQFZnzyvQsiLlgFsncLi7rrtmM4FsEgwv+xDTJzsrp79rd+/GJu2zWcR9w==",
-          "requires": {
-            "graceful-fs": "^4.2.6"
-          }
-        }
-      }
-    },
-    "cson-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
-      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
-      "requires": {
-        "coffeescript": "1.12.7"
-      }
-    },
-    "csslint": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.9.10.tgz",
-      "integrity": "sha512-x2q/J6oNpWoPNk+HeI0Y1nc2mgcCK15WGXLrZbGnt2/sokiDeJT4P2A//pVvFt1ot78ZmbowQlkCHuW5Nxn4QQ=="
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        },
-        "type": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        }
       }
     },
     "dateformat": {
@@ -3390,40 +2453,6 @@
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
       "integrity": "sha512-KAP4sc9wjaU5xLhZ7olSH1ni72IbXk2l9iF9Ai5p3slwDtKTJunKkQpdFg7voyOcUU+6j75xEhHh+yPqd/Z/PA=="
     },
-    "duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha512-ImdMB5wEdN+M1VNte4NiYmH7FBJ/D27aOeYuqR3zuBRqwMeqtqPJvIqckzQzXT5s9nDMysV3bkE+zB6ezKhphg==",
-      "requires": {
-        "typechecker": "^2.0.8"
-      }
-    },
     "errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -3443,62 +2472,11 @@
         "string-template": "~0.2.1"
       }
     },
-    "es5-ext": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-      "integrity": "sha512-wP3OSxZ0L/qK76t6qxPR8gWr2o5F4SzNF9qS5F/mOfVY3Ezcg07v6hSkETDmoekXIzn8xhQbHpp+tVlOE+qOAg==",
-      "optional": true
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-      "integrity": "sha512-kdjfxF6jYJ5m/OEe3ZNNJzbCEcagF4lNJeuhgrBSRnlitpdxICDKzCel+Z5Wbl7K9UhBN/7k2MzXBvCvSwfzzg==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2"
-      }
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -3521,51 +2499,11 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "requires": {
-        "type": "^2.7.2"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
-    },
-    "extendr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.0.1.tgz",
-      "integrity": "sha512-HI5RiZxISYYFYZ95L0qt4fAxB/HmrV+oWuMwg03wGGxADNqZHssxGB8aai/NYHNxGrcIRvRqdptMNxmxWHJGEg==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
-    },
-    "extract-opts": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-4.3.0.tgz",
-      "integrity": "sha512-Dmssi1tgKJkQsVmbP7TgW/kbdc42SAsNf6h9ClweP+dS7O24YYMTXsNwPelxhx0LF15npiWwY5ahKtyQiNgxWA==",
-      "requires": {
-        "eachr": "^4.5.0",
-        "typechecker": "^6.2.0"
-      },
-      "dependencies": {
-        "eachr": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
-          "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
-          "requires": {
-            "typechecker": "^6.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
-          "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A=="
-        }
-      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3655,7 +2593,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3689,18 +2628,11 @@
       "integrity": "sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg==",
       "dev": true
     },
-    "getsetdeep": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/getsetdeep/-/getsetdeep-2.0.0.tgz",
-      "integrity": "sha512-tC4ROuyPTxnO8UALLADoDTWQMP4XbIeIUjVw0KmbuUlL8WjUeyDvGPnKFKyz1r4hw3JymD9dSc/gTdc0vLZs3w==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
-    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3759,7 +2691,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "grunt": {
       "version": "1.6.1",
@@ -3977,14 +2910,6 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
-    "historyjs": {
-      "version": "1.8.0-b2",
-      "resolved": "https://registry.npmjs.org/historyjs/-/historyjs-1.8.0-b2.tgz",
-      "integrity": "sha512-hxT7tZ2XG8hNkR2PObvQXup33ukuR+zrOHBfnoMc9+r0UsHdpnzxt3yv64qnyjlhr/1i+91shtONXArUDKnBQA==",
-      "requires": {
-        "buildr": "0.8.x"
-      }
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -4027,6 +2952,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4035,7 +2961,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -4221,25 +3148,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jshint": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
-      "integrity": "sha512-W69SwJ3/pBdkwwpNxCOmlJHlsJCzA2xJ4DyWoXezdjBEteBq/R3eX6CaU7SM7mTjdSU1iSI7UG57fl0QqNO4Nw==",
-      "requires": {
-        "cli": "0.4.3",
-        "minimatch": "0.0.x"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
-          "integrity": "sha512-+uV1GoFd1Qme/Evj0R3kXX2sZvLFPPKv3FPBE+Q33Xx+ME1G4i3V1x9q68j6nHfZWsl74fdCfX4SIxjbuKtKXA==",
-          "requires": {
-            "lru-cache": "~1.0.2"
-          }
-        }
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4338,51 +3246,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "log": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-      "requires": {
-        "d": "^1.0.1",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.53",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.1",
-        "type": "^2.5.0",
-        "uni-global": "^1.0.0"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "lru-cache": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz",
-      "integrity": "sha512-mM3c2io8llIGu/6WuMhLl5Qu9Flt5io8Epuqk+iIbKwyUwDQI6FdcCDxjAhhxYqgi0U17G89chu/Va1gbKhJbw=="
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4414,17 +3277,6 @@
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
       "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
-    "memoizee": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-      "integrity": "sha512-0VZI0btwyGk6FSDnJGuJtso4M/eSxhVb5ID5AZNWMFFgT2LexCV18hHI764V4ELKlyfnQ5KMQ+q5H3uvFN3MLw==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2",
-        "event-emitter": "~0.2.2",
-        "next-tick": "0.1.x"
-      }
-    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -4446,6 +3298,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4453,15 +3306,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-    },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "moment": {
       "version": "2.29.4",
@@ -4498,12 +3344,6 @@
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       }
-    },
-    "next-tick": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-      "integrity": "sha512-I44QWeGCHJTx2D3buhnljvSjmPgJua3zdPGtlCQEvA45t9kS/CaHnlVqidTzHwq8LGXhD2SMezjk4hQgP+32Lg==",
-      "optional": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -4561,6 +3401,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4573,22 +3414,6 @@
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
-        }
       }
     },
     "os-homedir": {
@@ -4691,7 +3516,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -4745,22 +3571,6 @@
       "dev": true,
       "optional": true
     },
-    "pulverizr": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pulverizr/-/pulverizr-0.7.0.tgz",
-      "integrity": "sha512-mzviuxtLbRW1fDHUBccQoLvahrhVIsgaqCf7LKQAv2IfDhzw7Ip1ygNat/Ui55V9j9aTcV2p2l7HZJ/+OY7EEQ==",
-      "requires": {
-        "coloured-log": ">= 0.9.7",
-        "commander": ">= 0.6.0",
-        "q": ">= 0.8.5",
-        "temp": ">= 0.4.0"
-      }
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
-    },
     "qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -4788,11 +3598,6 @@
       "requires": {
         "resolve": "^1.9.0"
       }
-    },
-    "requirefresh": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-4.13.0.tgz",
-      "integrity": "sha512-APrzWWxqnwE2Bz3ysFepAU0Dc0aYjn8jsDLFIegedn+KVCS9LykAclkf+6YaJXk3ON9l6QAm04rN+bEA89cGIg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -4835,16 +3640,6 @@
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
-    },
-    "safecallback": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safecallback/-/safecallback-1.0.1.tgz",
-      "integrity": "sha512-iwkVkRKejb2X1WshFYVTYsJrrLpq3pRiaeyG4vycyjLrvoxaUZrjR+htwzuN87KvRO5hFCCtwspUKQbO09awRg=="
-    },
-    "safefs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-2.0.3.tgz",
-      "integrity": "sha512-8OTBjnIQYCuGE7A+MzbQjQEeVrjT8p8HAgX7vi53xX6hhCAjiz8eQKWCzFYdlRZ6FozUw143xjvTFqBE/4QptQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4921,31 +3716,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sprintf-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
-      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
-      "requires": {
-        "es5-ext": "^0.10.53"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4963,34 +3733,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "taskgroup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-2.0.0.tgz",
-      "integrity": "sha512-uvL8DQ7cEViBG60xYnyceK1y0pXZD+wHIa5hwnW/JHDCSipzdSRfSX8bUsoqXczxHdRjgAfJQ6LSTHnOyzCHRw==",
-      "requires": {
-        "ambi": "~2.0.0",
-        "typechecker": "~2.0.1"
-      }
-    },
-    "temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "throttleit": {
       "version": "1.0.0",
@@ -5040,11 +3782,6 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
     "typeahead.js": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
@@ -5053,26 +3790,11 @@
         "jquery": ">=1.7"
       }
     },
-    "typechecker": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-      "integrity": "sha512-7czjA7j/rc9zA/mTzsjD1yc41GIuARzFXIs69cc0PeMRu7uiGpQw4Cs83l/NjJj93PnSxeTZrOc2lDDLUmmpwg=="
-    },
-    "uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ=="
-    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "underscore.string": {
       "version": "3.3.6",
@@ -5090,14 +3812,6 @@
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "dev": true
         }
-      }
-    },
-    "uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "requires": {
-        "type": "^2.5.0"
       }
     },
     "universalify": {
@@ -5126,18 +3840,6 @@
       "resolved": "https://registry.npmjs.org/vimeo-froogaloop2/-/vimeo-froogaloop2-0.1.1.tgz",
       "integrity": "sha512-sJfpwW23Yzp4Uq1H9HAzVpILiYjXTiN64l6igHCadhi0udh5MUbhMCMVA8DUt/yOzvSiCDdGPYIpv1AvM5D2gw=="
     },
-    "watch-tree-maintained": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/watch-tree-maintained/-/watch-tree-maintained-0.1.2.tgz",
-      "integrity": "sha512-mMsSXfdO1S2g7sY3LxDCYi1G2tX4LNHrLJXkx7E43XGsOFoxcA2XRtlEy4/TqiEt6VxFKHY8VWIdMeY9DES7Iw==",
-      "requires": {
-        "async": ">=0.1.7",
-        "async_testing": ">=0.3.2",
-        "coffee-script": ">=1.0.0",
-        "optimist": ">=0.1.2",
-        "underscore": ">=1.1.4"
-      }
-    },
     "websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -5164,27 +3866,17 @@
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "yaml": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
       "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true
-    },
-    "ycssmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ycssmin/-/ycssmin-1.0.1.tgz",
-      "integrity": "sha512-nSBxAfGA/RlALXyqijYUnIjMXNXWxYHrQJSYwNqypeULl44J8Z/eN5larw7ZEdYLeUHBgPyilve6hqQtWVVs9g==",
-      "optional": true
     }
   }
 }

--- a/app/assets/scaffold/files/package.json
+++ b/app/assets/scaffold/files/package.json
@@ -17,7 +17,6 @@
     "ckeditor4": "^4.21.0",
     "codemirror": "^5.65.13",
     "dropzone": "^4.3.0",
-    "historyjs": "^1.8.0-b2",
     "jquery": "^3.7.0",
     "jquery-datetimepicker": "^2.5.21",
     "jquery-form": "^4.3.0",

--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -74,16 +74,10 @@ mQuery( document ).ready(function() {
     });
 });
 
-//Fix for back/forward buttons not loading ajax content with History.pushState()
-MauticVars.manualStateChange = true;
-
-if (typeof History != 'undefined') {
-    History.Adapter.bind(window, 'statechange', function () {
-        if (MauticVars.manualStateChange == true) {
-            //back/forward button pressed
-            window.location.reload();
-        }
-        MauticVars.manualStateChange = true;
+if (typeof history != 'undefined') {
+    //back/forward button pressed
+    window.addEventListener('popstate', function (event) {
+        window.location.reload();
     });
 }
 
@@ -599,8 +593,7 @@ var Mautic = {
                 mQuery('#app-content .content-body').html(response.newContent);
                 if (response.route && response.route.indexOf("ajax") == -1) {
                     //update URL in address bar
-                    MauticVars.manualStateChange = false;
-                    History.pushState(null, "Mautic", response.route);
+                    history.pushState(null, "Mautic", response.route);
                 }
             } else if (response.newContent && mQuery('.modal.in').length) {
                 //assume a modal was the recipient of the information

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -248,8 +248,7 @@ Mautic.processPageContent = function (response) {
 
         if (response.route) {
             //update URL in address bar
-            MauticVars.manualStateChange = false;
-            History.pushState(null, "Mautic", response.route);
+            history.pushState(null, "Mautic", response.route);
 
             //update Title
             Mautic.generatePageTitle( response.route );

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -11,7 +11,6 @@ class AssetGenerationHelper
     private const NODE_MODULES = [
         'mousetrap/mousetrap.js', // Needed for keyboard shortcuts
         'jquery/dist/jquery.js', // Needed for everything. It's the underlying framework.
-        'historyjs/scripts/bundled-uncompressed/html4+html5/jquery.history.js', // Needed for ajaxyfying the UI.
         'js-cookie/src/js.cookie.js', // Needed for cookies.
         'bootstrap/dist/js/bootstrap.js', // Needed for the UI components like bodal boxes.
         'jquery-form/src/jquery.form.js', // Needed for ajax forms with file attachments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "ckeditor4": "^4.21.0",
         "codemirror": "^5.65.13",
         "dropzone": "^4.3.0",
-        "historyjs": "^1.8.0-b2",
         "jquery": "^3.7.0",
         "jquery-datetimepicker": "^2.5.21",
         "jquery-form": "^4.3.0",
@@ -61,17 +60,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "node_modules/ambi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.0.0.tgz",
-      "integrity": "sha512-IXzMsvqViCbMwwTykPnHnzbiMjzKocXzxofPEC1ZYSSJTnoBOEsBhEABa8FJ98ADYtxhPdGTEWDeJUGyS8K6Iw==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -107,18 +95,8 @@
     "node_modules/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "node_modules/async_testing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async_testing/-/async_testing-0.3.2.tgz",
-      "integrity": "sha512-1M9jJ5JAoExlitLvZGFhUZOYeel3sObdhmacmbHZxWvHOTpNFkypXiJ3+HeGU+3eH1b26YL7a9aqagSdWVtWgg==",
-      "bin": {
-        "node-async-test": "bin/node-async-test.js"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -140,28 +118,11 @@
         "jquery": ">=1.7.0 <4.0.0"
       }
     },
-    "node_modules/bal-util": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.18.0.tgz",
-      "integrity": "sha512-wjVrsaK6K4OM1kgwiw1cf0+7RGjyNsgxc7kjoqfTDAKzdBoG1JQuAXk0VpJOpn5kgB68zjttbu0ghXPDamyc9Q==",
-      "dependencies": {
-        "ambi": "~2.0.0",
-        "eachr": "~2.0.2",
-        "extendr": "~2.0.1",
-        "getsetdeep": "~2.0.0",
-        "safecallback": "~1.0.1",
-        "safefs": "~2.0.3",
-        "taskgroup": "~2.0.0",
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/body": {
       "version": "5.1.0",
@@ -187,6 +148,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -202,63 +164,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buildr": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/buildr/-/buildr-0.8.7.tgz",
-      "integrity": "sha512-VyDsdhqc8wxk84S/NyMiIgOgeRTKu/GNViEkJAE+us3mY4hB5l+dH4tiADbdD5K75rZMJiBvoYNGeDxhffrVSA==",
-      "dependencies": {
-        "bal-util": "1.x",
-        "caterpillar": "1.x",
-        "coffee-script": "1.4.x",
-        "cson": ">=1.4",
-        "csslint": "0.9.x",
-        "jshint": "0.9.x",
-        "less": "1.3.x",
-        "optimist": ">=0.3",
-        "pulverizr": "0.7.x",
-        "rimraf": "2.1.4",
-        "uglify-js": "1.3.x",
-        "watch-tree-maintained": "0.1.x"
-      },
-      "bin": {
-        "buildr": "bin/buildr.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/buildr/node_modules/graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
-      "deprecated": "please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/buildr/node_modules/less": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-1.3.3.tgz",
-      "integrity": "sha512-y9el4KFU/bjCb0IvDoPX9ncwZcIZZtxKlYlNcXXqcfYbqzjfKM+TjLutrE9HwMQ+PqzBAPFI3NI6KRNbMBvc3Q==",
-      "bin": {
-        "lessc": "bin/lessc"
-      },
-      "engines": {
-        "node": ">=0.4.2"
-      },
-      "optionalDependencies": {
-        "ycssmin": ">=1.0.1"
-      }
-    },
-    "node_modules/buildr/node_modules/rimraf": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-      "integrity": "sha512-tzwmX16YQhcFu0T/m0gHBcFKx6yQAg77Z6WWaQSJsUekXYa6yaAmHhrDdmFicgauX/er7GsdN+vRao3mBhA4kQ==",
-      "optionalDependencies": {
-        "graceful-fs": "~1"
       }
     },
     "node_modules/bytes": {
@@ -278,17 +183,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caterpillar": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-1.1.4.tgz",
-      "integrity": "sha512-rocDSXqlhcKlh+5qjhuXZwNeopu5AkN5r9t1dXhhlsKasOqS7rSQBEnjVTLUrw86jEeWl+Sn0s9eslrue0V/TA==",
-      "engines": {
-        "node": ">=0.4"
-      },
-      "optionalDependencies": {
-        "cli-color": "~0.2.2"
       }
     },
     "node_modules/chart.js": {
@@ -355,59 +249,10 @@
       "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.21.0.tgz",
       "integrity": "sha512-OAMw68puJcrKFtsPZwIWVB/upYLgJpFw1yTuBBIhoreY+g/f0SttjQY0I/fUwxevVUHvgmRVNeJwNl8qkJPvyw=="
     },
-    "node_modules/cli": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
-      "integrity": "sha512-zPLMXUf13f5JkcgpA6FJim+U1fcsPYymGdEhdNsF5rRf1k+MEyBjmxECSI0lg+i143E6kPTpVN65bNaCvf+avA==",
-      "dependencies": {
-        "glob": ">= 3.1.4"
-      },
-      "engines": {
-        "node": ">=0.2.5"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-      "integrity": "sha512-f4DFHXdoe2rGMwuVO+DTBM6CkSt4m9R4a0vjnq5CJkSCKaXbrHbslCmyjG6cz/o50HP2wkjO3G1mXvc7G3V1LQ==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "memoizee": "~0.2.5"
-      },
-      "engines": {
-        "node": ">=0.1.103"
-      }
-    },
     "node_modules/codemirror": {
       "version": "5.65.13",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
       "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
-    },
-    "node_modules/coffee-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz",
-      "integrity": "sha512-LEn5PkG6XJ3QmqGl3W2LoBMcPhWI0mIRbH+r95THAfeO86+BS4R8Twh9g2F6rCs6iMZBvmPwu6sUZF33+wkUfA==",
-      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -435,38 +280,11 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/coloured": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/coloured/-/coloured-0.2.0.tgz",
-      "integrity": "sha512-d6/mc19iA0+M07wuVeZTmRZmNoaVqoSSvPbEuz8oObDgUDwSolBJhi1v+lPLhNVy8FDthGQ4KSVH8lDPNgmtyQ==",
-      "engines": [
-        "node >=0.1.5"
-      ]
-    },
-    "node_modules/coloured-log": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/coloured-log/-/coloured-log-0.9.7.tgz",
-      "integrity": "sha512-1Ja7MGAwyEXhzmRRWhwMG4Q+QzlVFaR0LJbykXIbm0mexP6l5ec35nM+3Nr/oo6m/6B+pXI7Xz22CWutSV2B1w==",
-      "dependencies": {
-        "coloured": ">= 0.2.0",
-        "log": ">= 1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/continuable-cache": {
       "version": "0.3.1",
@@ -500,101 +318,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cson": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/cson/-/cson-7.20.0.tgz",
-      "integrity": "sha512-K7g/86vC77mJqi6PRFhd3p8U/y0R6SsCeTJb5RpOAaQdApHxCoK5JwfZ8WeJjpOZ6lyyi8tNvh3UuC184H3GWg==",
-      "dependencies": {
-        "cson-parser": "^4.0.5",
-        "extract-opts": "^4.3.0",
-        "requirefresh": "^4.12.0",
-        "safefs": "^6.12.0"
-      },
-      "bin": {
-        "cson2json": "bin.cjs",
-        "json2cson": "bin.cjs"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/cson-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
-      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
-      "dependencies": {
-        "coffeescript": "1.12.7"
-      },
-      "engines": {
-        "node": ">=10.13"
-      }
-    },
-    "node_modules/cson/node_modules/safefs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-6.16.0.tgz",
-      "integrity": "sha512-IUIN5h+r2acNVkbsM5VoBUsRnaSFwQFZnzyvQsiLlgFsncLi7rrtmM4FsEgwv+xDTJzsrp79rd+/GJu2zWcR9w==",
-      "dependencies": {
-        "graceful-fs": "^4.2.6"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/csslint": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.9.10.tgz",
-      "integrity": "sha512-x2q/J6oNpWoPNk+HeI0Y1nc2mgcCK15WGXLrZbGnt2/sokiDeJT4P2A//pVvFt1ot78ZmbowQlkCHuW5Nxn4QQ==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "bin": {
-        "csslint": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
-    "node_modules/d/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/d/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/d/node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -627,45 +350,6 @@
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
       "integrity": "sha512-KAP4sc9wjaU5xLhZ7olSH1ni72IbXk2l9iF9Ai5p3slwDtKTJunKkQpdFg7voyOcUU+6j75xEhHh+yPqd/Z/PA=="
     },
-    "node_modules/duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
-      }
-    },
-    "node_modules/duration/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/duration/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha512-ImdMB5wEdN+M1VNte4NiYmH7FBJ/D27aOeYuqR3zuBRqwMeqtqPJvIqckzQzXT5s9nDMysV3bkE+zB6ezKhphg==",
-      "dependencies": {
-        "typechecker": "^2.0.8"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -688,53 +372,6 @@
         "string-template": "~0.2.1"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-      "integrity": "sha512-wP3OSxZ0L/qK76t6qxPR8gWr2o5F4SzNF9qS5F/mOfVY3Ezcg07v6hSkETDmoekXIzn8xhQbHpp+tVlOE+qOAg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-iterator/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -746,18 +383,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-      "integrity": "sha512-kdjfxF6jYJ5m/OEe3ZNNJzbCEcagF4lNJeuhgrBSRnlitpdxICDKzCel+Z5Wbl7K9UhBN/7k2MzXBvCvSwfzzg==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2"
-      },
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/eventemitter2": {
@@ -787,70 +412,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
-    },
-    "node_modules/extendr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.0.1.tgz",
-      "integrity": "sha512-HI5RiZxISYYFYZ95L0qt4fAxB/HmrV+oWuMwg03wGGxADNqZHssxGB8aai/NYHNxGrcIRvRqdptMNxmxWHJGEg==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/extract-opts": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-4.3.0.tgz",
-      "integrity": "sha512-Dmssi1tgKJkQsVmbP7TgW/kbdc42SAsNf6h9ClweP+dS7O24YYMTXsNwPelxhx0LF15npiWwY5ahKtyQiNgxWA==",
-      "dependencies": {
-        "eachr": "^4.5.0",
-        "typechecker": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/extract-opts/node_modules/eachr": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
-      "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
-      "dependencies": {
-        "typechecker": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/extract-opts/node_modules/typechecker": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
-      "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
     },
     "node_modules/faye-websocket": {
       "version": "0.10.0",
@@ -964,7 +530,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1007,21 +574,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/getsetdeep": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/getsetdeep/-/getsetdeep-2.0.0.tgz",
-      "integrity": "sha512-tC4ROuyPTxnO8UALLADoDTWQMP4XbIeIUjVw0KmbuUlL8WjUeyDvGPnKFKyz1r4hw3JymD9dSc/gTdc0vLZs3w==",
-      "dependencies": {
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1096,7 +653,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/grunt": {
       "version": "1.6.1",
@@ -1382,14 +940,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/historyjs": {
-      "version": "1.8.0-b2",
-      "resolved": "https://registry.npmjs.org/historyjs/-/historyjs-1.8.0-b2.tgz",
-      "integrity": "sha512-hxT7tZ2XG8hNkR2PObvQXup33ukuR+zrOHBfnoMc9+r0UsHdpnzxt3yv64qnyjlhr/1i+91shtONXArUDKnBQA==",
-      "dependencies": {
-        "buildr": "0.8.x"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -1447,6 +997,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1455,7 +1006,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1686,30 +1238,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jshint": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
-      "integrity": "sha512-W69SwJ3/pBdkwwpNxCOmlJHlsJCzA2xJ4DyWoXezdjBEteBq/R3eX6CaU7SM7mTjdSU1iSI7UG57fl0QqNO4Nw==",
-      "dependencies": {
-        "cli": "0.4.3",
-        "minimatch": "0.0.x"
-      },
-      "bin": {
-        "jshint": "bin/hint"
-      }
-    },
-    "node_modules/jshint/node_modules/minimatch": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
-      "integrity": "sha512-+uV1GoFd1Qme/Evj0R3kXX2sZvLFPPKv3FPBE+Q33Xx+ME1G4i3V1x9q68j6nHfZWsl74fdCfX4SIxjbuKtKXA==",
-      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
-      "dependencies": {
-        "lru-cache": "~1.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1825,56 +1353,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/log": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-      "dependencies": {
-        "d": "^1.0.1",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.53",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.1",
-        "type": "^2.5.0",
-        "uni-global": "^1.0.0"
-      }
-    },
-    "node_modules/log/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/log/node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "node_modules/log/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/lru-cache": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz",
-      "integrity": "sha512-mM3c2io8llIGu/6WuMhLl5Qu9Flt5io8Epuqk+iIbKwyUwDQI6FdcCDxjAhhxYqgi0U17G89chu/Va1gbKhJbw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -1915,20 +1393,6 @@
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
       "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
-    "node_modules/memoizee": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-      "integrity": "sha512-0VZI0btwyGk6FSDnJGuJtso4M/eSxhVb5ID5AZNWMFFgT2LexCV18hHI764V4ELKlyfnQ5KMQ+q5H3uvFN3MLw==",
-      "optional": true,
-      "dependencies": {
-        "es5-ext": "~0.9.2",
-        "event-emitter": "~0.2.2",
-        "next-tick": "0.1.x"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -1959,6 +1423,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1970,19 +1435,9 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/moment": {
@@ -2028,15 +1483,6 @@
       },
       "engines": {
         "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/next-tick": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-      "integrity": "sha512-I44QWeGCHJTx2D3buhnljvSjmPgJua3zdPGtlCQEvA45t9kS/CaHnlVqidTzHwq8LGXhD2SMezjk4hQgP+32Lg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/nopt": {
@@ -2113,6 +1559,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2132,20 +1579,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
@@ -2283,6 +1716,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2357,32 +1791,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/pulverizr": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pulverizr/-/pulverizr-0.7.0.tgz",
-      "integrity": "sha512-mzviuxtLbRW1fDHUBccQoLvahrhVIsgaqCf7LKQAv2IfDhzw7Ip1ygNat/Ui55V9j9aTcV2p2l7HZJ/+OY7EEQ==",
-      "dependencies": {
-        "coloured-log": ">= 0.9.7",
-        "commander": ">= 0.6.0",
-        "q": ">= 0.8.5",
-        "temp": ">= 0.4.0"
-      },
-      "bin": {
-        "pulverize": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -2421,17 +1829,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/requirefresh": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-4.13.0.tgz",
-      "integrity": "sha512-APrzWWxqnwE2Bz3ysFepAU0Dc0aYjn8jsDLFIegedn+KVCS9LykAclkf+6YaJXk3ON9l6QAm04rN+bEA89cGIg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/resolve": {
@@ -2501,22 +1898,6 @@
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
-    },
-    "node_modules/safecallback": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safecallback/-/safecallback-1.0.1.tgz",
-      "integrity": "sha512-iwkVkRKejb2X1WshFYVTYsJrrLpq3pRiaeyG4vycyjLrvoxaUZrjR+htwzuN87KvRO5hFCCtwspUKQbO09awRg==",
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/safefs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-2.0.3.tgz",
-      "integrity": "sha512-8OTBjnIQYCuGE7A+MzbQjQEeVrjT8p8HAgX7vi53xX6hhCAjiz8eQKWCzFYdlRZ6FozUw143xjvTFqBE/4QptQ==",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2611,33 +1992,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "node_modules/sprintf-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
-      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
-      "dependencies": {
-        "es5-ext": "^0.10.53"
-      }
-    },
-    "node_modules/sprintf-kit/node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/sprintf-kit/node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -2660,41 +2014,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/taskgroup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-2.0.0.tgz",
-      "integrity": "sha512-uvL8DQ7cEViBG60xYnyceK1y0pXZD+wHIa5hwnW/JHDCSipzdSRfSX8bUsoqXczxHdRjgAfJQ6LSTHnOyzCHRw==",
-      "dependencies": {
-        "ambi": "~2.0.0",
-        "typechecker": "~2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/throttleit": {
@@ -2751,34 +2070,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
     "node_modules/typeahead.js": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
       "integrity": "sha512-yGaLzGjVHyryZdNfrWz2NHXUwEO7hrlVmGMGCo5+6mH3nEEhcQ0Te3mK3G60uRnxfERu8twOWSU4WmwScbwhMg==",
       "dependencies": {
         "jquery": ">=1.7"
-      }
-    },
-    "node_modules/typechecker": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-      "integrity": "sha512-7czjA7j/rc9zA/mTzsjD1yc41GIuARzFXIs69cc0PeMRu7uiGpQw4Cs83l/NjJj93PnSxeTZrOc2lDDLUmmpwg==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
       }
     },
     "node_modules/unc-path-regex": {
@@ -2789,11 +2086,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/underscore.string": {
       "version": "3.3.6",
@@ -2813,14 +2105,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
-    },
-    "node_modules/uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "dependencies": {
-        "type": "^2.5.0"
-      }
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -2853,24 +2137,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/vimeo-froogaloop2/-/vimeo-froogaloop2-0.1.1.tgz",
       "integrity": "sha512-sJfpwW23Yzp4Uq1H9HAzVpILiYjXTiN64l6igHCadhi0udh5MUbhMCMVA8DUt/yOzvSiCDdGPYIpv1AvM5D2gw=="
-    },
-    "node_modules/watch-tree-maintained": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/watch-tree-maintained/-/watch-tree-maintained-0.1.2.tgz",
-      "integrity": "sha512-mMsSXfdO1S2g7sY3LxDCYi1G2tX4LNHrLJXkx7E43XGsOFoxcA2XRtlEy4/TqiEt6VxFKHY8VWIdMeY9DES7Iw==",
-      "dependencies": {
-        "async": ">=0.1.7",
-        "async_testing": ">=0.3.2",
-        "coffee-script": ">=1.0.0",
-        "optimist": ">=0.1.2",
-        "underscore": ">=1.1.4"
-      },
-      "bin": {
-        "watch-tree": "bin/watch-tree"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -2910,18 +2176,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "2.2.2",
@@ -2930,15 +2189,6 @@
       "dev": true,
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/ycssmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ycssmin/-/ycssmin-1.0.1.tgz",
-      "integrity": "sha512-nSBxAfGA/RlALXyqijYUnIjMXNXWxYHrQJSYwNqypeULl44J8Z/eN5larw7ZEdYLeUHBgPyilve6hqQtWVVs9g==",
-      "optional": true,
-      "bin": {
-        "ycssmin": "bin/cssmin"
       }
     }
   },
@@ -2960,14 +2210,6 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
-    },
-    "ambi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.0.0.tgz",
-      "integrity": "sha512-IXzMsvqViCbMwwTykPnHnzbiMjzKocXzxofPEC1ZYSSJTnoBOEsBhEABa8FJ98ADYtxhPdGTEWDeJUGyS8K6Iw==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -2998,12 +2240,8 @@
     "async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
-    },
-    "async_testing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/async_testing/-/async_testing-0.3.2.tgz",
-      "integrity": "sha512-1M9jJ5JAoExlitLvZGFhUZOYeel3sObdhmacmbHZxWvHOTpNFkypXiJ3+HeGU+3eH1b26YL7a9aqagSdWVtWgg=="
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -3017,25 +2255,11 @@
       "integrity": "sha512-G8mgUb/PqShPoH8AyjuxsTGvIr1o716BtQUKDM44C8qN2W615y7KGJ68MlTGamd0J0D/m28emUkzagaHTdrGZw==",
       "requires": {}
     },
-    "bal-util": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.18.0.tgz",
-      "integrity": "sha512-wjVrsaK6K4OM1kgwiw1cf0+7RGjyNsgxc7kjoqfTDAKzdBoG1JQuAXk0VpJOpn5kgB68zjttbu0ghXPDamyc9Q==",
-      "requires": {
-        "ambi": "~2.0.0",
-        "eachr": "~2.0.2",
-        "extendr": "~2.0.1",
-        "getsetdeep": "~2.0.0",
-        "safecallback": "~1.0.1",
-        "safefs": "~2.0.3",
-        "taskgroup": "~2.0.0",
-        "typechecker": "~2.0.1"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "body": {
       "version": "5.1.0",
@@ -3058,6 +2282,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3070,49 +2295,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "buildr": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/buildr/-/buildr-0.8.7.tgz",
-      "integrity": "sha512-VyDsdhqc8wxk84S/NyMiIgOgeRTKu/GNViEkJAE+us3mY4hB5l+dH4tiADbdD5K75rZMJiBvoYNGeDxhffrVSA==",
-      "requires": {
-        "bal-util": "1.x",
-        "caterpillar": "1.x",
-        "coffee-script": "1.4.x",
-        "cson": ">=1.4",
-        "csslint": "0.9.x",
-        "jshint": "0.9.x",
-        "less": "1.3.x",
-        "optimist": ">=0.3",
-        "pulverizr": "0.7.x",
-        "rimraf": "2.1.4",
-        "uglify-js": "1.3.x",
-        "watch-tree-maintained": "0.1.x"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha512-iiTUZ5vZ+2ZV+h71XAgwCSu6+NAizhFU3Yw8aC/hH5SQ3SnISqEqAek40imAFGtDcwJKNhXvSY+hzIolnLwcdQ==",
-          "optional": true
-        },
-        "less": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/less/-/less-1.3.3.tgz",
-          "integrity": "sha512-y9el4KFU/bjCb0IvDoPX9ncwZcIZZtxKlYlNcXXqcfYbqzjfKM+TjLutrE9HwMQ+PqzBAPFI3NI6KRNbMBvc3Q==",
-          "requires": {
-            "ycssmin": ">=1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-          "integrity": "sha512-tzwmX16YQhcFu0T/m0gHBcFKx6yQAg77Z6WWaQSJsUekXYa6yaAmHhrDdmFicgauX/er7GsdN+vRao3mBhA4kQ==",
-          "requires": {
-            "graceful-fs": "~1"
-          }
-        }
       }
     },
     "bytes": {
@@ -3129,14 +2311,6 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caterpillar": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/caterpillar/-/caterpillar-1.1.4.tgz",
-      "integrity": "sha512-rocDSXqlhcKlh+5qjhuXZwNeopu5AkN5r9t1dXhhlsKasOqS7rSQBEnjVTLUrw86jEeWl+Sn0s9eslrue0V/TA==",
-      "requires": {
-        "cli-color": "~0.2.2"
       }
     },
     "chart.js": {
@@ -3196,38 +2370,10 @@
       "resolved": "https://registry.npmjs.org/ckeditor4/-/ckeditor4-4.21.0.tgz",
       "integrity": "sha512-OAMw68puJcrKFtsPZwIWVB/upYLgJpFw1yTuBBIhoreY+g/f0SttjQY0I/fUwxevVUHvgmRVNeJwNl8qkJPvyw=="
     },
-    "cli": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
-      "integrity": "sha512-zPLMXUf13f5JkcgpA6FJim+U1fcsPYymGdEhdNsF5rRf1k+MEyBjmxECSI0lg+i143E6kPTpVN65bNaCvf+avA==",
-      "requires": {
-        "glob": ">= 3.1.4"
-      }
-    },
-    "cli-color": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-      "integrity": "sha512-f4DFHXdoe2rGMwuVO+DTBM6CkSt4m9R4a0vjnq5CJkSCKaXbrHbslCmyjG6cz/o50HP2wkjO3G1mXvc7G3V1LQ==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2",
-        "memoizee": "~0.2.5"
-      }
-    },
     "codemirror": {
       "version": "5.65.13",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
       "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
-    },
-    "coffee-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz",
-      "integrity": "sha512-LEn5PkG6XJ3QmqGl3W2LoBMcPhWI0mIRbH+r95THAfeO86+BS4R8Twh9g2F6rCs6iMZBvmPwu6sUZF33+wkUfA=="
-    },
-    "coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -3249,29 +2395,11 @@
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
-    "coloured": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/coloured/-/coloured-0.2.0.tgz",
-      "integrity": "sha512-d6/mc19iA0+M07wuVeZTmRZmNoaVqoSSvPbEuz8oObDgUDwSolBJhi1v+lPLhNVy8FDthGQ4KSVH8lDPNgmtyQ=="
-    },
-    "coloured-log": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/coloured-log/-/coloured-log-0.9.7.tgz",
-      "integrity": "sha512-1Ja7MGAwyEXhzmRRWhwMG4Q+QzlVFaR0LJbykXIbm0mexP6l5ec35nM+3Nr/oo6m/6B+pXI7Xz22CWutSV2B1w==",
-      "requires": {
-        "coloured": ">= 0.2.0",
-        "log": ">= 1.2.0"
-      }
-    },
-    "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -3297,71 +2425,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "cson": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/cson/-/cson-7.20.0.tgz",
-      "integrity": "sha512-K7g/86vC77mJqi6PRFhd3p8U/y0R6SsCeTJb5RpOAaQdApHxCoK5JwfZ8WeJjpOZ6lyyi8tNvh3UuC184H3GWg==",
-      "requires": {
-        "cson-parser": "^4.0.5",
-        "extract-opts": "^4.3.0",
-        "requirefresh": "^4.12.0",
-        "safefs": "^6.12.0"
-      },
-      "dependencies": {
-        "safefs": {
-          "version": "6.16.0",
-          "resolved": "https://registry.npmjs.org/safefs/-/safefs-6.16.0.tgz",
-          "integrity": "sha512-IUIN5h+r2acNVkbsM5VoBUsRnaSFwQFZnzyvQsiLlgFsncLi7rrtmM4FsEgwv+xDTJzsrp79rd+/GJu2zWcR9w==",
-          "requires": {
-            "graceful-fs": "^4.2.6"
-          }
-        }
-      }
-    },
-    "cson-parser": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-4.0.9.tgz",
-      "integrity": "sha512-I79SAcCYquWnEfXYj8hBqOOWKj6eH6zX1hhX3yqmS4K3bYp7jME3UFpHPzu3rUew0oyfc0s8T6IlWGXRAheHag==",
-      "requires": {
-        "coffeescript": "1.12.7"
-      }
-    },
-    "csslint": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.9.10.tgz",
-      "integrity": "sha512-x2q/J6oNpWoPNk+HeI0Y1nc2mgcCK15WGXLrZbGnt2/sokiDeJT4P2A//pVvFt1ot78ZmbowQlkCHuW5Nxn4QQ=="
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        },
-        "type": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-          "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-        }
       }
     },
     "dateformat": {
@@ -3390,40 +2453,6 @@
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
       "integrity": "sha512-KAP4sc9wjaU5xLhZ7olSH1ni72IbXk2l9iF9Ai5p3slwDtKTJunKkQpdFg7voyOcUU+6j75xEhHh+yPqd/Z/PA=="
     },
-    "duration": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.46"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha512-ImdMB5wEdN+M1VNte4NiYmH7FBJ/D27aOeYuqR3zuBRqwMeqtqPJvIqckzQzXT5s9nDMysV3bkE+zB6ezKhphg==",
-      "requires": {
-        "typechecker": "^2.0.8"
-      }
-    },
     "errno": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
@@ -3443,62 +2472,11 @@
         "string-template": "~0.2.1"
       }
     },
-    "es5-ext": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-      "integrity": "sha512-wP3OSxZ0L/qK76t6qxPR8gWr2o5F4SzNF9qS5F/mOfVY3Ezcg07v6hSkETDmoekXIzn8xhQbHpp+tVlOE+qOAg==",
-      "optional": true
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-      "integrity": "sha512-kdjfxF6jYJ5m/OEe3ZNNJzbCEcagF4lNJeuhgrBSRnlitpdxICDKzCel+Z5Wbl7K9UhBN/7k2MzXBvCvSwfzzg==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2"
-      }
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -3521,51 +2499,11 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "requires": {
-        "type": "^2.7.2"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
-    },
-    "extendr": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.0.1.tgz",
-      "integrity": "sha512-HI5RiZxISYYFYZ95L0qt4fAxB/HmrV+oWuMwg03wGGxADNqZHssxGB8aai/NYHNxGrcIRvRqdptMNxmxWHJGEg==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
-    },
-    "extract-opts": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-4.3.0.tgz",
-      "integrity": "sha512-Dmssi1tgKJkQsVmbP7TgW/kbdc42SAsNf6h9ClweP+dS7O24YYMTXsNwPelxhx0LF15npiWwY5ahKtyQiNgxWA==",
-      "requires": {
-        "eachr": "^4.5.0",
-        "typechecker": "^6.2.0"
-      },
-      "dependencies": {
-        "eachr": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
-          "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
-          "requires": {
-            "typechecker": "^6.2.0"
-          }
-        },
-        "typechecker": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
-          "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A=="
-        }
-      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3655,7 +2593,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3689,18 +2628,11 @@
       "integrity": "sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg==",
       "dev": true
     },
-    "getsetdeep": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/getsetdeep/-/getsetdeep-2.0.0.tgz",
-      "integrity": "sha512-tC4ROuyPTxnO8UALLADoDTWQMP4XbIeIUjVw0KmbuUlL8WjUeyDvGPnKFKyz1r4hw3JymD9dSc/gTdc0vLZs3w==",
-      "requires": {
-        "typechecker": "~2.0.1"
-      }
-    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3759,7 +2691,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "grunt": {
       "version": "1.6.1",
@@ -3977,14 +2910,6 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
-    "historyjs": {
-      "version": "1.8.0-b2",
-      "resolved": "https://registry.npmjs.org/historyjs/-/historyjs-1.8.0-b2.tgz",
-      "integrity": "sha512-hxT7tZ2XG8hNkR2PObvQXup33ukuR+zrOHBfnoMc9+r0UsHdpnzxt3yv64qnyjlhr/1i+91shtONXArUDKnBQA==",
-      "requires": {
-        "buildr": "0.8.x"
-      }
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -4027,6 +2952,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4035,7 +2961,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -4221,25 +3148,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jshint": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-0.9.1.tgz",
-      "integrity": "sha512-W69SwJ3/pBdkwwpNxCOmlJHlsJCzA2xJ4DyWoXezdjBEteBq/R3eX6CaU7SM7mTjdSU1iSI7UG57fl0QqNO4Nw==",
-      "requires": {
-        "cli": "0.4.3",
-        "minimatch": "0.0.x"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.0.5.tgz",
-          "integrity": "sha512-+uV1GoFd1Qme/Evj0R3kXX2sZvLFPPKv3FPBE+Q33Xx+ME1G4i3V1x9q68j6nHfZWsl74fdCfX4SIxjbuKtKXA==",
-          "requires": {
-            "lru-cache": "~1.0.2"
-          }
-        }
-      }
-    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4338,51 +3246,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "log": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/log/-/log-6.3.1.tgz",
-      "integrity": "sha512-McG47rJEWOkXTDioZzQNydAVvZNeEkSyLJ1VWkFwfW+o1knW+QSi8D1KjPn/TnctV+q99lkvJNe1f0E1IjfY2A==",
-      "requires": {
-        "d": "^1.0.1",
-        "duration": "^0.2.2",
-        "es5-ext": "^0.10.53",
-        "event-emitter": "^0.3.5",
-        "sprintf-kit": "^2.0.1",
-        "type": "^2.5.0",
-        "uni-global": "^1.0.0"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "event-emitter": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-          "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-          "requires": {
-            "d": "1",
-            "es5-ext": "~0.10.14"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
-    "lru-cache": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.0.6.tgz",
-      "integrity": "sha512-mM3c2io8llIGu/6WuMhLl5Qu9Flt5io8Epuqk+iIbKwyUwDQI6FdcCDxjAhhxYqgi0U17G89chu/Va1gbKhJbw=="
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4414,17 +3277,6 @@
       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
       "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
     },
-    "memoizee": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-      "integrity": "sha512-0VZI0btwyGk6FSDnJGuJtso4M/eSxhVb5ID5AZNWMFFgT2LexCV18hHI764V4ELKlyfnQ5KMQ+q5H3uvFN3MLw==",
-      "optional": true,
-      "requires": {
-        "es5-ext": "~0.9.2",
-        "event-emitter": "~0.2.2",
-        "next-tick": "0.1.x"
-      }
-    },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -4446,6 +3298,7 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4453,15 +3306,8 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-    },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
     },
     "moment": {
       "version": "2.29.4",
@@ -4498,12 +3344,6 @@
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       }
-    },
-    "next-tick": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-      "integrity": "sha512-I44QWeGCHJTx2D3buhnljvSjmPgJua3zdPGtlCQEvA45t9kS/CaHnlVqidTzHwq8LGXhD2SMezjk4hQgP+32Lg==",
-      "optional": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -4561,6 +3401,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4573,22 +3414,6 @@
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw=="
-        }
       }
     },
     "os-homedir": {
@@ -4691,7 +3516,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -4745,22 +3571,6 @@
       "dev": true,
       "optional": true
     },
-    "pulverizr": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pulverizr/-/pulverizr-0.7.0.tgz",
-      "integrity": "sha512-mzviuxtLbRW1fDHUBccQoLvahrhVIsgaqCf7LKQAv2IfDhzw7Ip1ygNat/Ui55V9j9aTcV2p2l7HZJ/+OY7EEQ==",
-      "requires": {
-        "coloured-log": ">= 0.9.7",
-        "commander": ">= 0.6.0",
-        "q": ">= 0.8.5",
-        "temp": ">= 0.4.0"
-      }
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
-    },
     "qs": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
@@ -4788,11 +3598,6 @@
       "requires": {
         "resolve": "^1.9.0"
       }
-    },
-    "requirefresh": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-4.13.0.tgz",
-      "integrity": "sha512-APrzWWxqnwE2Bz3ysFepAU0Dc0aYjn8jsDLFIegedn+KVCS9LykAclkf+6YaJXk3ON9l6QAm04rN+bEA89cGIg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -4835,16 +3640,6 @@
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
-    },
-    "safecallback": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safecallback/-/safecallback-1.0.1.tgz",
-      "integrity": "sha512-iwkVkRKejb2X1WshFYVTYsJrrLpq3pRiaeyG4vycyjLrvoxaUZrjR+htwzuN87KvRO5hFCCtwspUKQbO09awRg=="
-    },
-    "safefs": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-2.0.3.tgz",
-      "integrity": "sha512-8OTBjnIQYCuGE7A+MzbQjQEeVrjT8p8HAgX7vi53xX6hhCAjiz8eQKWCzFYdlRZ6FozUw143xjvTFqBE/4QptQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4921,31 +3716,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sprintf-kit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.1.tgz",
-      "integrity": "sha512-2PNlcs3j5JflQKcg4wpdqpZ+AjhQJ2OZEo34NXDtlB0tIPG84xaaXhpA8XFacFiwjKA4m49UOYG83y3hbMn/gQ==",
-      "requires": {
-        "es5-ext": "^0.10.53"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.62",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-          "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-          "requires": {
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.3",
-            "next-tick": "^1.1.0"
-          }
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
-      }
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -4963,34 +3733,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "taskgroup": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-2.0.0.tgz",
-      "integrity": "sha512-uvL8DQ7cEViBG60xYnyceK1y0pXZD+wHIa5hwnW/JHDCSipzdSRfSX8bUsoqXczxHdRjgAfJQ6LSTHnOyzCHRw==",
-      "requires": {
-        "ambi": "~2.0.0",
-        "typechecker": "~2.0.1"
-      }
-    },
-    "temp": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "rimraf": "~2.6.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "throttleit": {
       "version": "1.0.0",
@@ -5040,11 +3782,6 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
-    },
     "typeahead.js": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
@@ -5053,26 +3790,11 @@
         "jquery": ">=1.7"
       }
     },
-    "typechecker": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-      "integrity": "sha512-7czjA7j/rc9zA/mTzsjD1yc41GIuARzFXIs69cc0PeMRu7uiGpQw4Cs83l/NjJj93PnSxeTZrOc2lDDLUmmpwg=="
-    },
-    "uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ=="
-    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "underscore.string": {
       "version": "3.3.6",
@@ -5090,14 +3812,6 @@
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
           "dev": true
         }
-      }
-    },
-    "uni-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uni-global/-/uni-global-1.0.0.tgz",
-      "integrity": "sha512-WWM3HP+siTxzIWPNUg7hZ4XO8clKi6NoCAJJWnuRL+BAqyFXF8gC03WNyTefGoUXYc47uYgXxpKLIEvo65PEHw==",
-      "requires": {
-        "type": "^2.5.0"
       }
     },
     "universalify": {
@@ -5126,18 +3840,6 @@
       "resolved": "https://registry.npmjs.org/vimeo-froogaloop2/-/vimeo-froogaloop2-0.1.1.tgz",
       "integrity": "sha512-sJfpwW23Yzp4Uq1H9HAzVpILiYjXTiN64l6igHCadhi0udh5MUbhMCMVA8DUt/yOzvSiCDdGPYIpv1AvM5D2gw=="
     },
-    "watch-tree-maintained": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/watch-tree-maintained/-/watch-tree-maintained-0.1.2.tgz",
-      "integrity": "sha512-mMsSXfdO1S2g7sY3LxDCYi1G2tX4LNHrLJXkx7E43XGsOFoxcA2XRtlEy4/TqiEt6VxFKHY8VWIdMeY9DES7Iw==",
-      "requires": {
-        "async": ">=0.1.7",
-        "async_testing": ">=0.3.2",
-        "coffee-script": ">=1.0.0",
-        "optimist": ">=0.1.2",
-        "underscore": ">=1.1.4"
-      }
-    },
     "websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -5164,27 +3866,17 @@
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "yaml": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
       "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "dev": true
-    },
-    "ycssmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ycssmin/-/ycssmin-1.0.1.tgz",
-      "integrity": "sha512-nSBxAfGA/RlALXyqijYUnIjMXNXWxYHrQJSYwNqypeULl44J8Z/eN5larw7ZEdYLeUHBgPyilve6hqQtWVVs9g==",
-      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "ckeditor4": "^4.21.0",
     "codemirror": "^5.65.13",
     "dropzone": "^4.3.0",
-    "historyjs": "^1.8.0-b2",
     "jquery": "^3.7.0",
     "jquery-datetimepicker": "^2.5.21",
     "jquery-form": "^4.3.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

~~⚠️ this PR is built on top of https://github.com/mautic/mautic/pull/12374 so that should be merged first.~~

The [HistoryJS](https://www.npmjs.com/package/historyjs?activeTab=readme) library was updated 10 years ago. It has a dependency on a `Buildr` JS library that should have been a dev-dependency IMHO but it's not. So when we install NPM dependencies we get this warning:
```
10 vulnerabilities (1 low, 4 high, 5 critical)
```
It turned out all of these were reported in the Buildr dependencies. So when we remove the HistoryJS library from Mautic then we get clean sheet:
```
found 0 vulnerabilities
```
I suppose the reason that the HistoryJS library was not updated in 10 years and there are no replacement libraries is that the native [History browser API is stable enough](https://caniuse.com/?search=history) then there is no need for a specific library.

I tried that by using these 2 native browser APIs instead of the HistoryJS polyfil:
https://developer.mozilla.org/en-US/docs/Web/API/History_API
https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event

And it seem to be that it's working just fine.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Click through the UI. The content is being loaded via JS. There are no refreshes of the whole page.
3. Click the browser's back button. You should be redirected to the previous page. Not the first page you hard-reloaded.
4. Click the browser's forward button. You should be redirected back to the previous page before you clicked the back button.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
