### PR TITLE
WIP: Tprod 457 remove auto detect line endings

### DIFF
--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -499,9 +499,6 @@ final class ImportController extends FormController
      * Decide whether the import will be processed in client's browser.
      *
      * @param FormInterface<FormInterface> $form
-     * @param string                       $object
-     *
-     * @return bool
      */
     protected function importInBrowser(FormInterface $form, string $object): bool
     {
@@ -525,9 +522,6 @@ final class ImportController extends FormController
      * Decide whether the import will be queued to be processed by the CLI command in the background.
      *
      * @param FormInterface<FormInterface> $form
-     * @param string                       $object
-     *
-     * @return bool
      */
     protected function importInCli(FormInterface $form, string $object): bool
     {

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -25,7 +25,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Exception\LogicException;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -124,7 +124,7 @@ final class ImportController extends FormController
     }
 
     /** Cancel and unpublish the import during manual import. */
-    public function cancelAction(Request $request): JsonResponse|RedirectResponse
+    public function cancelAction(Request $request): JsonResponse|RedirectResponse|Response
     {
         $initEvent   = $this->dispatchImportOnInit();
         $object      = $initEvent->objectSingular;
@@ -145,7 +145,7 @@ final class ImportController extends FormController
     }
 
     /** Schedules manual import to background queue. */
-    public function queueAction(Request $request): JsonResponse|RedirectResponse
+    public function queueAction(Request $request): JsonResponse|RedirectResponse|Response
     {
         $initEvent   = $this->dispatchImportOnInit();
         $object      = $initEvent->objectSingular;

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -39,7 +39,7 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class ImportController extends FormController
+final class ImportController extends FormController
 {
     // Steps of the import
     public const STEP_UPLOAD_CSV      = 1;

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -70,7 +70,7 @@ final class ImportController extends FormController
         parent::initialize($event);
     }
 
-    public function indexAction(Request $request, int $page = 1): JsonResponse|RedirectResponse
+    public function indexAction(Request $request, int $page = 1): JsonResponse|RedirectResponse|Response
     {
         $initEvent = $this->dispatchImportOnInit();
         $this->session->set('mautic.import.object', $initEvent->objectSingular);

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Controller;
 
 use function assert;
@@ -189,17 +191,8 @@ class ImportController extends FormController
         return $this->indexAction($request);
     }
 
-    /**
-     * @param int  $objectId
-     * @param bool $ignorePost
-     *
-     * @return JsonResponse|Response
-     */
-    public function newAction(Request $request, $objectId = 0, $ignorePost = false)
+     public function newAction(Request $request, int $objectId = 0, bool $ignorePost = false): Response
     {
-        //Auto detect line endings for the file to work around MS DOS vs Unix new line characters
-        ini_set('auto_detect_line_endings', '1');
-
         $dispatcher = $this->dispatcher;
 
         try {

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -46,20 +46,11 @@ final class ImportController extends FormController
     public const STEP_PROGRESS_BAR    = 3;
     public const STEP_IMPORT_FROM_CSV = 4;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /**
-     * @var SessionInterface
-     */
-    private $session;
+    private SessionInterface $session;
 
-    /**
-     * @var ImportModel
-     */
-    private $importModel;
+    private ImportModel $importModel;
 
     public function __construct(CorePermissions $security, UserHelper $userHelper, FormFactoryInterface $formFactory, FormFieldHelper $fieldHelper, LoggerInterface $mauticLogger, ManagerRegistry $doctrine)
     {
@@ -79,12 +70,7 @@ final class ImportController extends FormController
         parent::initialize($event);
     }
 
-    /**
-     * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse
-     */
-    public function indexAction(Request $request, $page = 1)
+    public function indexAction(Request $request, int $page = 1): JsonResponse|RedirectResponse
     {
         $initEvent = $this->dispatchImportOnInit();
         $this->session->set('mautic.import.object', $initEvent->objectSingular);
@@ -132,22 +118,13 @@ final class ImportController extends FormController
         return [$count, $items];
     }
 
-    /**
-     * @param int $objectId
-     *
-     * @return array|JsonResponse|RedirectResponse|Response
-     */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, int $objectId): array|JsonResponse|RedirectResponse|Response
     {
         return $this->viewStandard($request, $objectId, 'import', 'lead');
     }
 
-    /**
-     * Cancel and unpublish the import during manual import.
-     *
-     * @return array|JsonResponse|RedirectResponse|Response
-     */
-    public function cancelAction(Request $request)
+    /** Cancel and unpublish the import during manual import. */
+    public function cancelAction(Request $request): JsonResponse|RedirectResponse
     {
         $initEvent   = $this->dispatchImportOnInit();
         $object      = $initEvent->objectSingular;
@@ -167,12 +144,8 @@ final class ImportController extends FormController
         return $this->indexAction($request);
     }
 
-    /**
-     * Schedules manual import to background queue.
-     *
-     * @return array|JsonResponse|RedirectResponse|Response
-     */
-    public function queueAction(Request $request)
+    /** Schedules manual import to background queue. */
+    public function queueAction(Request $request): JsonResponse|RedirectResponse
     {
         $initEvent   = $this->dispatchImportOnInit();
         $object      = $initEvent->objectSingular;
@@ -190,7 +163,7 @@ final class ImportController extends FormController
         return $this->indexAction($request);
     }
 
-     public function newAction(Request $request, int $objectId = 0, bool $ignorePost = false): Response
+    public function newAction(Request $request, int $objectId = 0, bool $ignorePost = false): Response
     {
         $dispatcher = $this->dispatcher;
 
@@ -514,14 +487,8 @@ final class ImportController extends FormController
         }
     }
 
-    /**
-     * Returns line count from the session.
-     *
-     * @param string $object
-     *
-     * @return int
-     */
-    protected function getLineCount($object)
+    /** Returns line count from the session. */
+    protected function getLineCount(string $object): int
     {
         $progress = $this->session->get('mautic.'.$object.'.import.progress', [0, 0]);
 
@@ -536,7 +503,7 @@ final class ImportController extends FormController
      *
      * @return bool
      */
-    protected function importInBrowser(FormInterface $form, $object)
+    protected function importInBrowser(FormInterface $form, string $object): bool
     {
         $browserImportLimit = $this->getLineCountLimit();
 
@@ -549,9 +516,9 @@ final class ImportController extends FormController
         return false;
     }
 
-    protected function getLineCountLimit()
+    protected function getLineCountLimit(): int
     {
-        return $this->coreParametersHelper->get('background_import_if_more_rows_than', 0);
+        return (int) $this->coreParametersHelper->get('background_import_if_more_rows_than', 0);
     }
 
     /**
@@ -562,7 +529,7 @@ final class ImportController extends FormController
      *
      * @return bool
      */
-    protected function importInCli(FormInterface $form, $object)
+    protected function importInCli(FormInterface $form, string $object): bool
     {
         $browserImportLimit = $this->getLineCountLimit();
 
@@ -575,12 +542,8 @@ final class ImportController extends FormController
         return false;
     }
 
-    /**
-     * Generates import directory path.
-     *
-     * @return string
-     */
-    protected function getImportDirName()
+    /** Generates import directory path. */
+    protected function getImportDirName(): string
     {
         return $this->importModel->getImportDir();
     }
@@ -588,12 +551,8 @@ final class ImportController extends FormController
     /**
      * Generates unique import directory name inside the cache dir if not stored in the session.
      * If it exists in the session, returns that one.
-     *
-     * @param string $object
-     *
-     * @return string
      */
-    protected function getImportFileName($object)
+    protected function getImportFileName(string $object): string
     {
         // Return the dir path from session if exists
         if ($fileName = $this->session->get('mautic.'.$object.'.import.file')) {
@@ -610,12 +569,8 @@ final class ImportController extends FormController
 
     /**
      * Return full absolute path to the CSV file.
-     *
-     * @param string $object
-     *
-     * @return string
      */
-    protected function getFullCsvPath($object)
+    protected function getFullCsvPath(string $object): string
     {
         return $this->getImportDirName().'/'.$this->getImportFileName($object);
     }
@@ -642,9 +597,9 @@ final class ImportController extends FormController
     }
 
     /**
-     * @param $action
+     * @param array<string, mixed> $args
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getViewArguments(array $args, $action)
     {
@@ -675,11 +630,7 @@ final class ImportController extends FormController
         return $args;
     }
 
-    /**
-     * Support non-index pages such as modal forms.
-     *
-     * @return bool|string
-     */
+    /** Support non-index pages such as modal forms. */
     protected function generateUrl(string $route, array $parameters = [], int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         if (!isset($parameters['object'])) {

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -498,7 +498,7 @@ class ImportModel extends FormModel
     /**
      * Returns a list of failed rows for the import.
      *
-     * @return ?Paginator<Import>
+     * @return ?Paginator<LeadEventLog>
      */
     public function getFailedRows(?int $importId = null, string $object = 'lead'): ?Paginator
     {

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @extends FormModel<Import>
  */
-class ImportModel extends FormModel
+final class ImportModel extends FormModel
 {
     /**
      * @var PathsHelper

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @extends FormModel<Import>
  */
-final class ImportModel extends FormModel
+class ImportModel extends FormModel
 {
     protected PathsHelper $pathsHelper;
 

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Model;
 
 use Doctrine\ORM\ORMException;

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -231,8 +231,6 @@ class ImportModel extends FormModel
      * Import the CSV file from configuration in the $import entity.
      *
      * @param int $limit Number of records to import before delaying the import
-     *
-     * @return bool
      */
     public function process(Import $import, Progress $progress, int $limit = 0): bool
     {
@@ -424,8 +422,6 @@ class ImportModel extends FormModel
      * Decide whether the CSV row is empty.
      *
      * @param mixed $row
-     *
-     * @return bool
      */
     public function isEmptyCsvRow($row): bool
     {
@@ -499,7 +495,11 @@ class ImportModel extends FormModel
         return $chart->render();
     }
 
-    /** Returns a list of failed rows for the import. */
+    /**
+     * Returns a list of failed rows for the import.
+     *
+     * @return ?Paginator<Import>
+     */
     public function getFailedRows(?int $importId = null, string $object = 'lead'): ?Paginator
     {
         if (!$importId) {

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -272,9 +272,6 @@ class ImportModel extends FormModel
      */
     public function process(Import $import, Progress $progress, $limit = 0)
     {
-        //Auto detect line endings for the file to work around MS DOS vs Unix new line characters
-        ini_set('auto_detect_line_endings', '1');
-
         try {
             $file = new \SplFileObject($import->getFilePath());
         } catch (\Exception $e) {

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -377,24 +377,6 @@ class ImportModelTest extends StandardImportTestHelper
         $import->end();
     }
 
-    public function testMacLineEndings(): void
-    {
-        $oldCsv = self::$csvPath;
-
-        // Generate a new CSV
-        self::generateSmallCSV();
-
-        $csv = file_get_contents(self::$csvPath);
-        $csv = str_replace("\n", "\r", $csv);
-        file_put_contents(self::$csvPath, $csv);
-
-        $this->testProcess();
-
-        @unlink(self::$csvPath);
-
-        self::$csvPath = $oldCsv;
-    }
-
     public function testItLogsDBErrorIfTheEntityManagerIsClosed(): void
     {
         $this->generateSmallCSV();


### PR DESCRIPTION
#### Description:

`ini_set('auto_detect_line_endings', '1');` is deprecated in PHP 8.1. PHP detects line endings by default.

```
PHP Deprecated:  auto_detect_line_endings is deprecated in app/bundles/LeadBundle/Controller/ImportController.php on line 199
```

#### BC Changes

Like other PRs related to TPROD 457, moving types to the properties/methods will result in errors if an incorrect type is passed.

Old mac line endings `\r` from OS <=9 are no longer supported.
