### PR TITLE
Allow for preconfigured cache & log directories [backport]

### DIFF
--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -257,6 +257,10 @@ class CheckStep implements StepInterface
             }
         }
 
+        if (-1 !== (int) ini_get('zend.assertions')) {
+            $messages[] = 'mautic.install.zend_assertions';
+        }
+
         return $messages;
     }
 

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -5,6 +5,7 @@ namespace Mautic\InstallBundle\Configurator\Step;
 use Mautic\CoreBundle\Configurator\Configurator;
 use Mautic\CoreBundle\Configurator\Step\StepInterface;
 use Mautic\CoreBundle\Helper\FileHelper;
+use Mautic\CoreBundle\Loader\ParameterLoader;
 use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher;
 use Mautic\InstallBundle\Configurator\Form\CheckStepType;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -31,7 +32,13 @@ class CheckStep implements StepInterface
     private $openSSLCipher;
 
     /**
-     * Absolute path to cache directory.
+     * @var ParameterLoader|null
+     */
+    private $parameterLoader;
+
+    /**
+     * Default absolute path to cache directory.
+     * Used when no cache path is defined in configuration.
      * Required in step.
      *
      * @var string
@@ -39,7 +46,8 @@ class CheckStep implements StepInterface
     public $cache_path = '%kernel.root_dir%/../var/cache';
 
     /**
-     * Absolute path to log directory.
+     * Default absolute path to log directory.
+     * Used when no log path is defined in configuration.
      * Required in step.
      *
      * @var string
@@ -110,11 +118,11 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.config.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->cache_path))) {
+        if (!is_writable($this->getCacheDir())) {
             $messages[] = 'mautic.install.cache.unwritable';
         }
 
-        if (!is_writable(str_replace('%kernel.root_dir%', $this->kernelRoot, $this->log_path))) {
+        if (!is_writable($this->getLogDir())) {
             $messages[] = 'mautic.install.logs.unwritable';
         }
 
@@ -249,10 +257,6 @@ class CheckStep implements StepInterface
             }
         }
 
-        if (-1 !== (int) ini_get('zend.assertions')) {
-            $messages[] = 'mautic.install.zend_assertions';
-        }
-
         return $messages;
     }
 
@@ -279,5 +283,26 @@ class CheckStep implements StepInterface
         }
 
         return $parameters;
+    }
+
+    private function getParameterLoader(): ParameterLoader
+    {
+        if (!$this->parameterLoader) {
+            $this->parameterLoader = new ParameterLoader();
+        }
+
+        return $this->parameterLoader;
+    }
+
+    public function getCacheDir(): string
+    {
+        $cachePath = $this->getParameterLoader()->getLocalParameterBag()->get('cache_path') ?? $this->cache_path;
+        return str_replace('%kernel.root_dir%', $this->kernelRoot, $cachePath);
+    }
+
+    public function getLogDir(): string
+    {
+        $logPath = $this->getParameterLoader()->getLocalParameterBag()->get('log_path') ?? $this->log_path;
+        return str_replace('%kernel.root_dir%', $this->kernelRoot, $logPath);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ x ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

*copied from [PR](https://github.com/mautic/mautic/pull/10296)*

> Currently the checkstep takes a very biased approach where logs and cache are placed. This allows for these configurations to be overridden in local parameters and be loaded in before installation time.
> 
> Without this change, installing Mautic is not possible without first setting these folders to the "biased" location and only afterwards they can be moved.

This is the backport for PR #12300, which itself is an update to PR #10296. Reason for a backport, when the original PR still exists is because the original PR causes undefined variable notices

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
*copied from [PR](https://github.com/mautic/mautic/pull/10296)*

> 1. Create a new mautic project using mautic/recommended-project
> 2. Set a file parameters_local.php in app/config before installing mautic with the following content
> 
> ```
> <?php
> $parameters = [
>   'cache_path' => '%kernel.root_dir%/../../var/cache',
>   'log_path' => '%kernel.root_dir%/../../var/logs',
>   'mailer_spool_path' => '%kernel.root_dir%/../../var/spool',
>   'tmp_path' => '%kernel.root_dir%/../../var/tmp',
>   'db_server_version' => '5.7.32',
> ];
> ```
> 
> 2. Make sure you remove the docroot/var folder
> 3. Try installing mautic
> 4. Without this patch, installing mautic will fail because it thinks the folder is not writeable. In reality it actually
> 5. with this patch the installation will be able to continue
