### PR TITLE
Show scrollbar for menu bars only if some items are bellow the fold

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -1313,7 +1313,7 @@ blockquote > p:after {
 }
 .touchevents .scroll-content {
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   -webkit-overflow-scrolling: touch;
 }

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/scrollbar.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/scrollbar.less
@@ -6,7 +6,7 @@
 .touchevents {
   .scroll-content {
     height: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
     -webkit-overflow-scrolling: touch;
   }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I noticed that there is a scroll bar visible in the menu bars now:
<img width="282" alt="Screenshot 2023-05-30 at 14 52 01" src="https://github.com/mautic/mautic/assets/1235442/eb3d156b-3b3f-4613-9393-949be83b0291">

It was caused by https://github.com/mautic/mautic/pull/12402 and that the `touch`/`no-touch` feature was replaced in Modernizr 3 with `touchevents`/`no-touchevents` however, this feature does not detect if the device use touch instead of cursor to navigate. It only detects if the device supports touch events. Which many do nowadays even if they are not touch devices. More on this topic: https://github.com/Modernizr/Modernizr/issues/2430

As I couldn't find a better way, I just changed `overflow-y: scroll;` to `overflow-y: auto;` so the scrollbar is visible only if the menu is too long for the browser window. This is a good compromise in between and it allows touch devices that have often small screens to scroll through the menu.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test that the scroll bar is visible only if the browser window is too small.
3. You can also test that small touch devices can scroll through the menu columns by emulating a small touch device in the dev tools:
<img width="210" alt="Screenshot 2023-05-30 at 14 57 29" src="https://github.com/mautic/mautic/assets/1235442/c6ac8997-41f7-44f0-934a-2dda21e0fdb9">


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
