### PR TITLE
bump to 4.4.9

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.4.8",
+  "version": "4.4.9",
   "stability": "stable",
   "minimum_php_version": "7.4.0",
   "maximum_php_version": "8.0.99",
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "7.4.0",
   "minimum_mautic_version": "3.2.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.4.8"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/4.4.9"
 }


### PR DESCRIPTION
This PR bumps the version to 4.4.9 in preparation for the release. 

No testing required, just review.