### PR TITLE
We cannot use node_modules in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@
 /media/js/app.js
 /media/js/libraries.js
 /media/js/mautic-form.js
+/media/js/froogaloop.min.js
+/media/js/jquery.min.js
+/media/js/ckeditor4/ckeditor.js
+/media/js/ckeditor4/adapters/jquery.js
 
 /plugins/*
 !/plugins/GrapesJsBuilderBundle

--- a/app/assets/scaffold/files/example.gitignore
+++ b/app/assets/scaffold/files/example.gitignore
@@ -90,6 +90,10 @@
 /media/js/app.js
 /media/js/libraries.js
 /media/js/mautic-form.js
+/media/js/froogaloop.min.js
+/media/js/jquery.min.js
+/media/js/ckeditor4/ckeditor.js
+/media/js/ckeditor4/adapters/jquery.js
 
 /plugins/*
 !/plugins/GrapesJsBuilderBundle

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -58,6 +58,8 @@ EOT
 
         $assetsDir = $this->pathsHelper->getAssetsPath();
 
+        $this->moveExtraLibraries($nodeModulesDir, $assetsDir);
+
         // Minify Mautic Form SDK
         file_put_contents(
             $assetsDir.'/js/mautic-form-tmp.js',
@@ -82,6 +84,10 @@ EOT
             'js/app.js',
             'js/libraries.js',
             'js/mautic-form.js',
+            'js/ckeditor4/ckeditor.js',
+            'js/ckeditor4/adapters/jquery.js',
+            'js/jquery.min.js',
+            'js/froogaloop.min.js',
         ];
 
         foreach ($productionAssets as $relativePath) {
@@ -103,5 +109,16 @@ EOT
         $command = $this->getApplication()->find('elfinder:install');
 
         $command->run(new ArrayInput(['--docroot' => 'media']), new NullOutput());
+    }
+
+    /**
+     * Following libraries are loaded by public, not administration related features so those cannot be built into one JS file.
+     */
+    private function moveExtraLibraries(string $nodeModulesDir, string $assetsDir): void
+    {
+        $this->filesystem->copy("{$nodeModulesDir}/ckeditor4/ckeditor.js", "{$assetsDir}/js/ckeditor4/ckeditor.js");
+        $this->filesystem->copy("{$nodeModulesDir}/ckeditor4/adapters/jquery.js", "{$assetsDir}/js/ckeditor4/adapters/jquery.js");
+        $this->filesystem->copy("{$nodeModulesDir}/jquery/dist/jquery.min.js", "{$assetsDir}/js/jquery.min.js");
+        $this->filesystem->copy("{$nodeModulesDir}/vimeo-froogaloop2/javascript/froogaloop.min.js", "{$assetsDir}/js/froogaloop.min.js");
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
@@ -152,8 +152,8 @@ class AssetsHelperTest extends TestCase
         $ckEditorScripts = $method->invokeArgs($assetHelper, []);
         Assert::assertEquals(
             [
-                "node_modules/ckeditor4/ckeditor.js?v{$version}",
-                "node_modules/ckeditor4/adapters/jquery.js?v{$version}",
+                "media/js/ckeditor4/ckeditor.js?v{$version}",
+                "media/js/ckeditor4/adapters/jquery.js?v{$version}",
                 "app/bundles/CoreBundle/Assets/js/libraries/ckeditor/mautic-token.js?v{$version}",
             ],
             $ckEditorScripts

--- a/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
@@ -502,7 +502,7 @@ final class AssetsHelper
      */
     private function getCKEditorScripts(): array
     {
-        $base = 'node_modules/ckeditor4/';
+        $base = 'media/js/ckeditor4/';
 
         return [
             $base.'ckeditor.js?v'.$this->version,

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -214,18 +214,8 @@ JS;
         );
         $mauticBaseUrl   = $this->router->generate('mautic_base_index', [], UrlGeneratorInterface::ABSOLUTE_URL);
         $mediaElementCss = $this->assetsHelper->getUrl('media/css/mediaelementplayer.min.css', null, null, true);
-        $jQueryUrl       = $this->assetsHelper->getUrl(
-            'node_modules/jquery/dist/jquery.js',
-            null,
-            null,
-            true
-        );
-        $froogaloop2       = $this->assetsHelper->getUrl(
-            'node_modules/vimeo-froogaloop2/javascript/froogaloop.min.js',
-            null,
-            null,
-            true
-        );
+        $jQueryUrl       = $this->assetsHelper->getUrl('media/js/jquery.min.js', null, null, true);
+        $froogaloop2     = $this->assetsHelper->getUrl('media/js/froogaloop.min.js', null, null, true);
 
         $mediaElementJs = <<<'JS'
 /*!


### PR DESCRIPTION
so we must move 4 specific libraries to the media/js directory during production build

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I noticed during working on another PR that I loaded some production JS libraries from the `node_modules` directory directly. This won't fly in production, especially the Mautic instances installed via Composer as the node_modules directory won't be even publicly accessible.

So I'm moving the 4 libraries from node_modules to the media/js directory on `bin/console m:a:g` command which is automatically executed during `composer install` command so it would work on production as well as during development.

The command itself tests that the files were successfully moved and will fail if not.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `composer install` (runs automatically on GitPod so you can skip this if testing there)
3. Refresh any administration page and check via browser dev tools that all JS files were correctly loaded. The ckeditor.js must be loaded from the media/js directory.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
