### PR TITLE
ensure the remember me key doesn't change every bootstrap

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -936,7 +936,7 @@ return [
         'dev_hosts'                       => [],
         'trusted_hosts'                   => [],
         'trusted_proxies'                 => [],
-        'rememberme_key'                  => hash('sha1', uniqid(mt_rand())),
+        'rememberme_key'                  => '%mautic.secret_key%',
         'rememberme_lifetime'             => 31536000, // 365 days in seconds
         'rememberme_path'                 => '/',
         'rememberme_domain'               => '',

--- a/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mautic\CoreBundle\Tests\Unit;
+
+use Mautic\CoreBundle\Loader\ParameterLoader;
+use PHPUnit\Framework\TestCase;
+
+class RememberMeTest extends TestCase
+{
+    public function testPersistentRemembermeKey(): void
+    {
+        // Ensure the defaultParameters are not statically cached.
+        $p1             = new ParameterLoader();
+        $reflectedClass = new \ReflectionClass($p1);
+        $reflectedClass->setStaticPropertyValue('defaultParameters', []);
+
+        // Create a kernel and set the parameterLoader to the one created above.
+        $k1             = new \AppKernel('test', false);
+        $reflectedClass = new \ReflectionClass($k1);
+        $prop           = $reflectedClass->getProperty('parameterLoader');
+        $prop->setAccessible(true);
+        $prop->setValue($k1, $p1);
+
+        // Boot the kernel and get the value of the rememberme_key value.
+        $k1->boot();
+        $v1 = $k1->getContainer()->getParameter('mautic.rememberme_key');
+
+        // Ensure the defaultParameters are not statically cached.
+        $p2             = new ParameterLoader();
+        $reflectedClass = new \ReflectionClass($p2);
+        $reflectedClass->setStaticPropertyValue('defaultParameters', []);
+
+        // Create a kernel and set the parameterLoader to the one created above.
+        $k2             = new \AppKernel('test', false);
+        $reflectedClass = new \ReflectionClass($k2);
+        $prop           = $reflectedClass->getProperty('parameterLoader');
+        $prop->setAccessible(true);
+        $prop->setValue($k2, $p2);
+
+        // Boot the kernel and get the value of the rememberme_key value.
+        $k2->boot();
+        $v2 = $k2->getContainer()->getParameter('mautic.rememberme_key');
+
+        $this->assertSame($v1, $v2);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

while working on a fix for #12406, I noticed that after a certain amount of time / closing the browser, the `REMEMBERME` cookie didn't do what is should: ensure a new session was initialised.

The reason is that Symfony's [TokenBasedRememberMeServices](https://github.com/symfony/Security/blob/4.4/Http/RememberMe/TokenBasedRememberMeServices.php#L125) uses a secret to calculate the hash of the cookie to check if it's valid.

That secret is passed tot the remember me service via the [Mautic security config](https://github.com/mautic/mautic/blob/5.x/app/config/security.php#L84), where it uses a Mautic parameter that defaults to [a random value](https://github.com/mautic/mautic/blob/5.x/app/bundles/CoreBundle/Config/config.php#L939).

As this value is random, the `REMEMBERME` cookie validation never succeeds, no new session is initialised, and the user is logged out.

The [Symfony documentation](https://symfony.com/doc/5.4/security/remember_me.html) doesn't mention it explicitly that the secret should be a static value, but the they refer to a key via an env var, which makes sense to be not random.

This PR ensures the remember me secret is a static per install random value by default.

Mautic doesn't use the suggested `%kernel.secret%` parameter, so I used the `%mautic.secret_key%` parameter.

This problem only exists with the default config: once you have save the configuration via the UI, the `rememberme_key` becomes a static value in the `app/config/local.php` file.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
