### PR TITLE
ensure the elfinder paths are within the default firewall, so rememberme functionality works

### DIFF
--- a/app/config/security.php
+++ b/app/config/security.php
@@ -54,7 +54,7 @@ $firewalls = [
         'http_basic'         => true,
     ],
     'main' => [
-        'pattern'       => '^/s/',
+        'pattern'       => '^/(s/|elfinder|efconnect)',
         'light_saml_sp' => [
             'provider'        => 'user_provider',
             'success_handler' => 'mautic.security.authentication_handler',
@@ -130,8 +130,6 @@ $container->loadFromExtension(
         'firewalls'      => $firewalls,
         'access_control' => [
             ['path' => '^/api', 'roles' => 'IS_AUTHENTICATED_FULLY'],
-            ['path' => '^/efconnect', 'roles' => 'IS_AUTHENTICATED_FULLY'],
-            ['path' => '^/elfinder', 'roles' => 'IS_AUTHENTICATED_FULLY'],
         ],
     ]
 );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12406 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

See #12406, https://forum.mautic.org/t/checkbox-remember-me-cookie-elfinder-401-unauthorized-error/27946


approaches tested:
* switch from `IS_AUTHENTICATED_FULLY` to `IS_AUTHENTICATED_REMEMBERED` in `security.access_control` for the `elfinder` and `efconnect` route.
see https://symfony.com/doc/5.4/security.html#checking-to-see-if-a-user-is-logged-in for the difference between the 2
This approach doesn't work, as these routes are not part of a firewall with support for remember_me, only `main` has support, but only for paths with pattern `'^/s/'` -> NOT WORKING
* Alter the routes in the [helios-ag/fm-elfinder-bundle](https://github.com/helios-ag/FMElfinderBundle/blob/37c3db0cc50b1158d5224acf9da0760881712212/src/Resources/config/routing.yaml#L1-L8) package
this is not the approach we take in ths project -> NOT OK
* alter the existing routes of `helios-ag/fm-elfinder-bundle`
I couldn't get this working -> NOT WORKING
* create a separate firewall special for the `elfinder` routes,
This would create a lot of unneeded duplicate code -> NOT OK
* add the `elfinder` and `efconnect` routes to the `main` firewall
this looked like the most proper and correct solution, and it's implemented in this PR

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
1. For ease of testing, decrease session lifetime to 30 seconds. Paste the following in index.php, before anything else.
    ```
    ini_set('session.gc_maxlifetime', 30);
    session_set_cookie_params(30);
    ```
1. Go to `/s/login` and check `keep me logged in`, log in and wait 40 seconds
1. refresh the dashboard (or don't, makes no difference) and go to /elfinder. You should nog get a 401 error

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
