### PR TITLE
Focus items fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,7 @@
 /media/js/mautic-form.js
 /media/js/froogaloop.min.js
 /media/js/jquery.min.js
-/media/js/ckeditor4/ckeditor.js
-/media/js/ckeditor4/adapters/jquery.js
+/media/js/ckeditor4/*
 
 /plugins/*
 !/plugins/GrapesJsBuilderBundle

--- a/app/assets/scaffold/files/example.gitignore
+++ b/app/assets/scaffold/files/example.gitignore
@@ -92,8 +92,7 @@
 /media/js/mautic-form.js
 /media/js/froogaloop.min.js
 /media/js/jquery.min.js
-/media/js/ckeditor4/ckeditor.js
-/media/js/ckeditor4/adapters/jquery.js
+/media/js/ckeditor4/*
 
 /plugins/*
 !/plugins/GrapesJsBuilderBundle

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -116,8 +116,7 @@ EOT
      */
     private function moveExtraLibraries(string $nodeModulesDir, string $assetsDir): void
     {
-        $this->filesystem->copy("{$nodeModulesDir}/ckeditor4/ckeditor.js", "{$assetsDir}/js/ckeditor4/ckeditor.js");
-        $this->filesystem->copy("{$nodeModulesDir}/ckeditor4/adapters/jquery.js", "{$assetsDir}/js/ckeditor4/adapters/jquery.js");
+        $this->filesystem->mirror("{$nodeModulesDir}/ckeditor4", "{$assetsDir}/js/ckeditor4");
         $this->filesystem->copy("{$nodeModulesDir}/jquery/dist/jquery.min.js", "{$assetsDir}/js/jquery.min.js");
         $this->filesystem->copy("{$nodeModulesDir}/vimeo-froogaloop2/javascript/froogaloop.min.js", "{$assetsDir}/js/froogaloop.min.js");
     }

--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -14,14 +14,14 @@ class AjaxController extends CommonAjaxController
     /**
      * This method produces HTTP request checking headers which are blocking availability for iframe inheritance for other pages.
      */
-    protected function checkIframeAvailabilityAction(Request $request, IframeAvailabilityChecker $availabilityChecker): JsonResponse
+    public function checkIframeAvailabilityAction(Request $request, IframeAvailabilityChecker $availabilityChecker): JsonResponse
     {
         $url = $request->query->get('website');
 
         return $availabilityChecker->check($url, $request->getScheme());
     }
 
-    protected function generatePreviewAction(Request $request): JsonResponse
+    public function generatePreviewAction(Request $request): JsonResponse
     {
         $responseContent  = ['html' => '', 'style' => ''];
         $focus            = $request->request->all();

--- a/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
@@ -13,7 +13,6 @@
 {% endblock %}
 
 {% block content %}
-  {{ includeScript('plugins/MauticFocusBundle/Assets/js/focus.js') }}
   {{ includeStylesheet('plugins/MauticFocusBundle/Assets/css/focus.css') }}
   {{ form_start(form) }}
     <!-- start: box layout -->
@@ -380,4 +379,5 @@
     </div>
 
   {{ form_end(form) }}
+{{ includeScript('plugins/MauticFocusBundle/Assets/js/focus.js') }}
 {% endblock %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.slack.com/archives/C02HV76BW/p1685938242415359

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There were 3 independent bugs in the Focus Items builder that we did not catch during the various refactoring stages:
1. The CK Editor must have its plugins, themes and languages accessible as it's loading them asynchronously as it needs them. So the whole folder must be in the media directory. Not just some specific files.
2. The ajax controller actions must be public after the controller refactorings in M5. This was missed. I can't find other places that were missed.
3. Not sure what caused this but the JS events were attached before the HTML elements were in DOM. Perhaps the JS is now loaded faster after all the refactoring and cleaning. This took me a while to discover. All I had to do was to move the JS file loading bellow the HTML content instead of loading it at the top.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
4. Check that the Focus builder works in Mautic 4

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
