### PR TITLE
Updating simshaun/recurr from v3 to v5 to support php 8.1

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -81,7 +81,7 @@
     "sparkpost/sparkpost": "^2.3",
     "lightsaml/sp-bundle": "dev-symfony5",
     "php-amqplib/rabbitmq-bundle": "^2.5.1",
-    "simshaun/recurr": "^3.0",
+    "simshaun/recurr": "^5.0",
     "ramsey/uuid": "^4.7",
     "sendgrid/sendgrid": "~6.0",
     "noxlogic/ratelimit-bundle": "^1.19",

--- a/composer.lock
+++ b/composer.lock
@@ -5777,7 +5777,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "061b48f2b0897bf414b32056f1d71a0fb3bf1301"
+                "reference": "7dcbb23cd0d48577a9df709090fdadfa03c3f9ba"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5825,7 +5825,7 @@
                 "predis/predis": "^1.1",
                 "ramsey/uuid": "^4.7",
                 "sendgrid/sendgrid": "~6.0",
-                "simshaun/recurr": "^3.0",
+                "simshaun/recurr": "^5.0",
                 "sparkpost/sparkpost": "^2.3",
                 "stack/builder": "^1.0",
                 "symfony/asset": "~5.4.0",
@@ -8670,24 +8670,25 @@
         },
         {
             "name": "simshaun/recurr",
-            "version": "v3.1.1",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simshaun/recurr.git",
-                "reference": "2702aedc996d4c6520731a1661ab4dc2501799a4"
+                "reference": "6887b7bd7075de97c8c69835e0939ff68d23c47e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simshaun/recurr/zipball/2702aedc996d4c6520731a1661ab4dc2501799a4",
-                "reference": "2702aedc996d4c6520731a1661ab4dc2501799a4",
+                "url": "https://api.github.com/repos/simshaun/recurr/zipball/6887b7bd7075de97c8c69835e0939ff68d23c47e",
+                "reference": "6887b7bd7075de97c8c69835e0939ff68d23c47e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/collections": "~1.3",
-                "php": ">=5.5.0"
+                "doctrine/collections": "~1.6",
+                "php": "^7.2||^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5"
+                "phpunit/phpunit": "^8.5.16",
+                "symfony/yaml": "^5.3"
             },
             "type": "library",
             "extra": {
@@ -8697,8 +8698,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Recurr\\": "src/Recurr/",
-                    "Recurr\\Test\\": "tests/"
+                    "Recurr\\": "src/Recurr/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -8708,8 +8708,8 @@
             "authors": [
                 {
                     "name": "Shaun Simmons",
-                    "email": "shaun@envysphere.com",
-                    "homepage": "http://envysphere.com"
+                    "email": "shaun@shaun.pub",
+                    "homepage": "https://shaun.pub"
                 }
             ],
             "description": "PHP library for working with recurrence rules",
@@ -8723,9 +8723,9 @@
             ],
             "support": {
                 "issues": "https://github.com/simshaun/recurr/issues",
-                "source": "https://github.com/simshaun/recurr/tree/master"
+                "source": "https://github.com/simshaun/recurr/tree/v5.0.1"
             },
-            "time": "2019-01-03T18:08:41+00:00"
+            "time": "2022-09-09T05:37:22+00:00"
         },
         {
             "name": "sparkpost/sparkpost",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This is needed for https://github.com/mautic/mautic/pull/12382

There do not seem to be any BC breaking changes other than bumping PHP min version between the v3 and v5:

https://github.com/simshaun/recurr/releases

This is hopefully fixing this deprecation for PHP 8.1:
```
PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /home/runner/work/mautic/mautic/vendor/simshaun/recurr/src/Recurr/Rule.php on line 201
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. The updated library is being used when scheduling report sends.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
