### PR TITLE
Create field in background without user ID

### DIFF
--- a/app/bundles/LeadBundle/Field/BackgroundService.php
+++ b/app/bundles/LeadBundle/Field/BackgroundService.php
@@ -66,7 +66,7 @@ class BackgroundService
      * @throws SchemaException
      * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
-    public function addColumn(int $leadFieldId, int $userId): void
+    public function addColumn(int $leadFieldId, ?int $userId): void
     {
         $leadField = $this->fieldModel->getEntity($leadFieldId);
         if (null === $leadField) {

--- a/app/bundles/LeadBundle/Field/Notification/CustomFieldNotification.php
+++ b/app/bundles/LeadBundle/Field/Notification/CustomFieldNotification.php
@@ -38,7 +38,7 @@ class CustomFieldNotification
         $this->translator        = $translator;
     }
 
-    public function customFieldWasCreated(LeadField $leadField, int $userId): void
+    public function customFieldWasCreated(LeadField $leadField, ?int $userId): void
     {
         try {
             $user = $this->getUser($userId);
@@ -55,7 +55,7 @@ class CustomFieldNotification
         $this->addToNotificationCenter($user, $message, $header);
     }
 
-    public function customFieldLimitWasHit(LeadField $leadField, int $userId): void
+    public function customFieldLimitWasHit(LeadField $leadField, ?int $userId): void
     {
         try {
             $user = $this->getUser($userId);
@@ -72,7 +72,7 @@ class CustomFieldNotification
         $this->addToNotificationCenter($user, $message, $header);
     }
 
-    public function customFieldCannotBeCreated(LeadField $leadField, int $userId): void
+    public function customFieldCannotBeCreated(LeadField $leadField, ?int $userId): void
     {
         try {
             $user = $this->getUser($userId);
@@ -105,7 +105,7 @@ class CustomFieldNotification
     /**
      * @throws NoUserException
      */
-    private function getUser(int $userId): User
+    private function getUser(?int $userId): User
     {
         if (!$userId || !$user = $this->userModel->getEntity($userId)) {
             throw new NoUserException();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
If you use `create_custom_field_in_background` => true and create field by API . Then `mautic:custom-field:create-colum`  command return error. This PR fixed it

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Enable in local.php in `create_custom_field_in_background` => true
3. Create field by API
4. Run `mautic:custom-field:create-colum`  
5. It failed because createdBy is null on field
6. After PR should work

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
