### PR TITLE
ensure only leads from a company are shown on a the company detail overview

### DIFF
--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -4,35 +4,51 @@ namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\HttpFoundation\Response;
 
 class CompanyControllerTest extends MauticMysqlTestCase
 {
-    private $id;
+    private int $company1Id;
+
+    private int $company2Id;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $companyData = [
+        $companiesData = [
+          1 => [
             'name'     => 'Amazon',
             'state'    => 'Washington',
             'city'     => 'Seattle',
             'country'  => 'United States',
             'industry' => 'Goods',
+          ],
+          2 => [
+            'name'     => 'Google',
+            'state'    => 'Washington',
+            'city'     => 'Seattle',
+            'country'  => 'United States',
+            'industry' => 'Services',
+          ],
         ];
 
-        /** @var CompanyModel $model */
-        $model      = self::$container->get('mautic.lead.model.company');
-        $company    = new Company();
-        $company->setIsPublished(true)
-            ->setName($companyData['name'])
-            ->setState($companyData['state'])
-            ->setCity($companyData['city'])
-            ->setCountry($companyData['country'])
-            ->setIndustry($companyData['industry']);
-        $model->saveEntity($company);
-        $this->id = $company->getId();
+        /** @var \Mautic\LeadBundle\Model\CompanyModel $model */
+        $model = self::getContainer()->get('mautic.lead.model.company');
+
+        foreach ($companiesData as $i => $companyData) {
+            $company    = new Company();
+            $company->setIsPublished(true)
+              ->setName($companyData['name'])
+              ->setState($companyData['state'])
+              ->setCity($companyData['city'])
+              ->setCountry($companyData['country'])
+              ->setIndustry($companyData['industry']);
+            $model->saveEntity($company);
+
+            $this->{'company'.$i.'Id'} = $company->getId();
+        }
     }
 
     /**
@@ -40,11 +56,11 @@ class CompanyControllerTest extends MauticMysqlTestCase
      */
     public function testViewActionCompany(): void
     {
-        $this->client->request('GET', '/s/companies/view/'.$this->id);
+        $this->client->request('GET', '/s/companies/view/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
-        $model                  = self::$container->get('mautic.lead.model.company');
-        $company                = $model->getEntity($this->id);
+        $model                  = self::getContainer()->get('mautic.lead.model.company');
+        $company                = $model->getEntity($this->company1Id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertStringContainsString($company->getName(), $clientResponseContent, 'The return must contain the name of company');
     }
@@ -54,11 +70,11 @@ class CompanyControllerTest extends MauticMysqlTestCase
      */
     public function testEditActionCompany(): void
     {
-        $this->client->request('GET', '/s/companies/edit/'.$this->id);
+        $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
-        $model                  = self::$container->get('mautic.lead.model.company');
-        $company                = $model->getEntity($this->id);
+        $model                  = self::getContainer()->get('mautic.lead.model.company');
+        $company                = $model->getEntity($this->company1Id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertStringContainsString('Edit Company '.$company->getName(), $clientResponseContent, 'The return must contain \'Edit Company\' text');
     }
@@ -66,12 +82,46 @@ class CompanyControllerTest extends MauticMysqlTestCase
     /* Get company contacts list */
     public function testListCompanyContacts(): void
     {
-        $this->client->request('GET', 's/company/'.$this->id.'/contacts/');
-        $clientResponse         = $this->client->getResponse();
-        $clientResponseContent  = $clientResponse->getContent();
-        $model                  = self::$container->get('mautic.lead.model.company');
-        $company                = $model->getEntity($this->id);
-        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+        /** @var \Mautic\LeadBundle\Model\CompanyModel $companyModel */
+        $companyModel = self::getContainer()->get('mautic.lead.model.company');
+        $leadModel    = self::getContainer()->get('mautic.lead.model.lead');
+        $company1     = $companyModel->getEntity($this->company1Id);
+
+        // Create a lead linked to the first company
+        $lead1    = new Lead();
+        $lead1
+          ->setFirstname('lead')
+          ->setLastname('for '.$company1->getName());
+        $leadModel->saveEntity($lead1);
+
+        $companyModel->addLeadToCompany($company1, $lead1);
+
+        // Create a lead not linked to a company
+        $lead2    = new Lead();
+        $lead2
+          ->setFirstname('lead')
+          ->setLastname('without company');
+        $leadModel->saveEntity($lead2);
+
+        // Create a lead not linked to a company, but with `ids` in it's name (see https://github.com/mautic/mautic/issues/12415)
+        $lead3    = new Lead();
+        $lead3
+          ->setFirstname('lead')
+          ->setLastname('without company')
+          ->setEmail('example@idstart.com');
+        $leadModel->saveEntity($lead3);
+
+        $crawler        = $this->client->request('GET', '/s/company/'.$this->company1Id.'/contacts/');
+        $leadsTableRows = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr");
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals(1, $leadsTableRows->count(), $crawler->html());
+
+        $crawler         = $this->client->request('GET', '/s/company/'.$this->company2Id.'/contacts/');
+        $leadsTableRows  = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr");
+
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals(0, $leadsTableRows->count(), $crawler->html());
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12415 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Fix for #12415
PR for 4.x: https://github.com/mautic/mautic/pull/12466

The logic in [`CompanyController::getCompanyContacts()`](https://github.com/mautic/mautic/blob/5.x/app/bundles/LeadBundle/Controller/CompanyController.php#L620) (and locations calling that method) is flawed.
The [build-up of the filter is error-prone](https://github.com/mautic/mautic/blob/5.x/app/bundles/LeadBundle/Controller/CompanyController.php#L583-L587), as it can't handle companies without contacts.

If a company has no contacts, all contacts matching `%ids%` in their first name, last name, email, ... are shown on the company overview page.

This PR addressed this, by making it a strict filter on lead id instead

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
See also the bug description

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
