### PR TITLE
PHP 8.2 support

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,6 +1,6 @@
 type: php
 docroot: ""
-php_version: "8.0"
+php_version: "8.2"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -12,7 +12,7 @@ mysql_version: ""
 provider: default
 use_dns_when_possible: true
 composer_version: "2"
-webimage_extra_packages: [php8.0-imap]
+webimage_extra_packages: [php8.2-imap]
 hooks:
   post-start:
     # Fix line endings on Windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
         db-types: ['mysql', 'mariadb']
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -20,7 +20,9 @@ class ExceptionController extends CommonController
         $layout         = 'prod' == MAUTIC_ENV ? 'Error' : 'Exception';
         $code           = $exception->getStatusCode();
 
-        if (0 === $code) {
+        // All valid status codes are within the range of 100 to 599, inclusive
+        // @see https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
+        if ($code < 100 || $code > 599) {
             // thrown exception that didn't set a code
             $code = 500;
         }

--- a/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
@@ -4,7 +4,6 @@ namespace Mautic\CoreBundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
-use Mautic\CoreBundle\Helper\UTF8Helper;
 
 /**
  * Type that maps a PHP array to a clob SQL type.
@@ -18,14 +17,6 @@ class ArrayType extends \Doctrine\DBAL\Types\ArrayType
         if (!is_array($value)) {
             return (null === $value) ? 'N;' : 'a:0:{}';
         }
-
-        // MySQL will crap out on corrupt UTF8 leading to broken serialized strings
-        array_walk(
-            $value,
-            function (&$entry): void {
-                $entry = UTF8Helper::toUTF8($entry);
-            }
-        );
 
         $serialized = serialize($value);
 

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -417,8 +417,7 @@ class InputHelper
             // Special handling for HTML comments
             $value = str_replace(['<!-->', '<!--', '-->'], ['<mcomment></mcomment>', '<mcomment>', '</mcomment>'], $value, $commentCount);
 
-            // detect if there is any unicode character in the passed string
-            $hasUnicode = strlen($value) != strlen(utf8_decode($value));
+            $hasUnicode = 'UTF-8"' === mb_detect_encoding($value);
 
             $value = self::getFilter(true)->clean($value, $hasUnicode ? 'raw' : 'html');
 

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -417,7 +417,7 @@ class InputHelper
             // Special handling for HTML comments
             $value = str_replace(['<!-->', '<!--', '-->'], ['<mcomment></mcomment>', '<mcomment>', '</mcomment>'], $value, $commentCount);
 
-            $hasUnicode = 'UTF-8"' === mb_detect_encoding($value);
+            $hasUnicode = strlen($value) != strlen(iconv('UTF-8', 'Windows-1252', $value));
 
             $value = self::getFilter(true)->clean($value, $hasUnicode ? 'raw' : 'html');
 

--- a/app/bundles/CoreBundle/Helper/UTF8Helper.php
+++ b/app/bundles/CoreBundle/Helper/UTF8Helper.php
@@ -302,6 +302,9 @@ class UTF8Helper
         return self::toUTF8($text);
     }
 
+    /**
+     * @return string|false
+     */
     protected static function utf8_decode($text, $option)
     {
         return iconv(

--- a/app/bundles/CoreBundle/Helper/UTF8Helper.php
+++ b/app/bundles/CoreBundle/Helper/UTF8Helper.php
@@ -2,6 +2,9 @@
 
 namespace Mautic\CoreBundle\Helper;
 
+/**
+ * @deprecated as unused and unnecessary. To be removed in Mautic 6 without replacement.
+ */
 class UTF8Helper
 {
     public const ICONV_TRANSLIT = 'TRANSLIT';
@@ -301,18 +304,10 @@ class UTF8Helper
 
     protected static function utf8_decode($text, $option)
     {
-        if (self::WITHOUT_ICONV == $option || !function_exists('iconv')) {
-            $o = utf8_decode(
-                str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), self::toUTF8($text))
-            );
-        } else {
-            $o = iconv(
-                'UTF-8',
-                'Windows-1252'.(self::ICONV_TRANSLIT == $option ? '//TRANSLIT' : (self::ICONV_IGNORE == $option ? '//IGNORE' : '')),
-                $text
-            );
-        }
-
-        return $o;
+        return iconv(
+            'UTF-8',
+            'Windows-1252'.(self::ICONV_TRANSLIT == $option ? '//TRANSLIT' : (self::ICONV_IGNORE == $option ? '//IGNORE' : '')),
+            $text
+        );
     }
 }

--- a/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
@@ -2,6 +2,8 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
+use GuzzleHttp\Exception\GuzzleException;
+
 abstract class AbstractRemoteDataLookup extends AbstractLookup
 {
     /**
@@ -59,7 +61,7 @@ abstract class AbstractRemoteDataLookup extends AbstractLookup
                 ]);
 
             $this->parseResponse($response->getBody());
-        } catch (\Exception $exception) {
+        } catch (GuzzleException $exception) {
             if ($this->logger) {
                 $this->logger->warning('IP LOOKUP: '.$exception->getMessage());
             }

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -4,6 +4,17 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class ExtremeIpLookup extends AbstractRemoteDataLookup
 {
+    public string $businessWebsite = '';
+    public string $continent       = '';
+    public string $countryCode     = '';
+    public string $ipName          = '';
+    public string $ipType          = '';
+    public string $lat             = '';
+    public string $lon             = '';
+    public string $org             = '';
+    public string $query           = '';
+    public string $status          = '';
+
     /**
      * Return attribution HTML displayed in the configuration UI.
      */

--- a/app/bundles/CoreBundle/IpLookup/GeobytesLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/GeobytesLookup.php
@@ -4,6 +4,25 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class GeobytesLookup extends AbstractRemoteDataLookup
 {
+    public string $forwarderfor        = '';
+    public string $remoteip            = '';
+    public string $ipaddress           = '';
+    public string $certainty           = '';
+    public string $internet            = '';
+    public string $regionlocationcode  = '';
+    public string $code                = '';
+    public string $locationcode        = '';
+    public string $cityid              = '';
+    public string $fqcn                = '';
+    public string $capital             = '';
+    public string $nationalitysingular = '';
+    public string $population          = '';
+    public string $nationalityplural   = '';
+    public string $mapreference        = '';
+    public string $currency            = '';
+    public string $currencycode        = '';
+    public string $title               = '';
+
     public function getAttribution(): string
     {
         return '<a href="http://geobytes.com/" target="_blank">Geobytes</a> offers both free (16,000 lookups per hour) and VIP (paid) offerings.';

--- a/app/bundles/CoreBundle/IpLookup/GeoipsLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/GeoipsLookup.php
@@ -4,6 +4,12 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class GeoipsLookup extends AbstractRemoteDataLookup
 {
+    public string $continent_name = '';
+    public string $continent_code = '';
+    public string $country_code   = '';
+    public string $region_code    = '';
+    public string $county_name    = '';
+
     public function getAttribution(): string
     {
         return '<a href="http://www.geoips.com/" target="_blank">GeoIPs</a> offers tiered subscriptions for lookups.';

--- a/app/bundles/CoreBundle/IpLookup/IpinfodbLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpinfodbLookup.php
@@ -4,6 +4,11 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class IpinfodbLookup extends AbstractRemoteDataLookup
 {
+    public string $statusCode    = '';
+    public string $statusMessage = '';
+    public string $ipAddress     = '';
+    public string $countryCode   = '';
+
     public function getAttribution(): string
     {
         return '<a href="http://www.ipinfodb.com/" target="_blank">iPInfoDB</a> offers a free service (2 lookups per second) that leverages data from IP2Location. API key required.';

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -4,6 +4,10 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class IpstackLookup extends AbstractRemoteDataLookup
 {
+    public string $country_code = '';
+    public string $region_code  = '';
+    public string $metro_code   = '';
+
     public function getAttribution(): string
     {
         return '<a href="https://ipstack.com/" target="_blank">ipstack.com</a> is a free lookup service that leverages GeoLite2 data created by MaxMind.';

--- a/app/bundles/CoreBundle/IpLookup/TelizeLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/TelizeLookup.php
@@ -4,6 +4,14 @@ namespace Mautic\CoreBundle\IpLookup;
 
 class TelizeLookup extends AbstractRemoteDataLookup
 {
+    public string $offset         = '';
+    public string $area_code      = '';
+    public string $dma_code       = '';
+    public string $country_code3  = '';
+    public string $continent_code = '';
+    public string $country_code   = '';
+    public string $region_code    = '';
+
     public function getAttribution(): string
     {
         return '<a href="https://market.mashape.com/fcambus/telize/" target="_blank">Telize</a> is a paid lookup service.';

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -159,7 +159,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
 
         // replace slots
         $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
         $xpath = new \DOMXPath($dom);
 
         $divContent = $xpath->query('//*[@data-slot="dwc"]');
@@ -174,7 +174,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
             }
 
             $newnode = $dom->createDocumentFragment();
-            $newnode->appendXML('<![CDATA['.mb_encode_numericentity($slotContent, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8').']]>');
+            $newnode->appendXML('<![CDATA['.mb_encode_numericentity($slotContent, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8').']]>');
             $slot->parentNode->replaceChild($newnode, $slot);
         }
 

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -159,7 +159,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
 
         // replace slots
         $dom = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
         $xpath = new \DOMXPath($dom);
 
         $divContent = $xpath->query('//*[@data-slot="dwc"]');
@@ -174,7 +174,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
             }
 
             $newnode = $dom->createDocumentFragment();
-            $newnode->appendXML('<![CDATA['.mb_convert_encoding($slotContent, 'HTML-ENTITIES', 'UTF-8').']]>');
+            $newnode->appendXML('<![CDATA['.mb_encode_numericentity($slotContent, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8').']]>');
             $slot->parentNode->replaceChild($newnode, $slot);
         }
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -54,14 +54,16 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-/**
- * @property LeadDeviceRepository|(LeadDeviceRepository&object&MockObject)|(LeadDeviceRepository&MockObject)|(object&MockObject)|MockObject $leadDeviceRepository
- */
 class EmailModelTest extends \PHPUnit\Framework\TestCase
 {
     public const SEGMENT_A = 'segment A';
 
     public const SEGMENT_B = 'segment B';
+
+    /**
+     * @var Connection|LeadDeviceRepository
+     */
+    private \PHPUnit\Framework\MockObject\MockObject $leadDeviceRepository;
 
     /**
      * @var Connection|MockObject

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -874,9 +874,9 @@ class FormModel extends CommonFormModel
     private function loadHTML(&$dom, $html): void
     {
         if (defined('LIBXML_HTML_NOIMPLIED') && defined('LIBXML_HTML_NODEFDTD')) {
-            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         } else {
-            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'));
+            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'));
         }
     }
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -874,9 +874,9 @@ class FormModel extends CommonFormModel
     private function loadHTML(&$dom, $html): void
     {
         if (defined('LIBXML_HTML_NOIMPLIED') && defined('LIBXML_HTML_NODEFDTD')) {
-            $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         } else {
-            $dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+            $dom->loadHTML(mb_encode_numericentity($html, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'));
         }
     }
 

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -180,7 +180,7 @@ class CheckStep implements StepInterface
             $messages[] = 'mautic.install.function.iconv';
         }
 
-        if (!function_exists('utf8_decode')) {
+        if (!extension_loaded('xml')) {
             $messages[] = 'mautic.install.function.xml';
         }
 

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -22,6 +22,11 @@ class DoctrineStep implements StepInterface
     public $host = 'localhost';
 
     /**
+     * Database host. Read Only Replica.
+     */
+    public $host_ro = 'localhost';
+
+    /**
      * Database table prefix.
      * Required in step.
      *

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -24,7 +24,7 @@ class DoctrineStep implements StepInterface
     /**
      * Database host. Read Only Replica.
      */
-    public $host_ro = 'localhost';
+    public ?string $host_ro = null;
 
     /**
      * Database table prefix.

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO as OrderFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
-use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object as SyncObject;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company as SyncObjectCompany;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\CompanyObjectHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
@@ -66,7 +66,7 @@ class CompanyObjectHelperTest extends MauticMysqlTestCase
 
     private function buildObjectChangeDAO(Company $company, string $name, string $value): ObjectChangeDAO
     {
-        $objectChangeDAO = new ObjectChangeDAO('Test', MauticSyncDataExchange::OBJECT_COMPANY, $company->getId(), SyncObject\Company::NAME, $company->getId(), new \DateTime());
+        $objectChangeDAO = new ObjectChangeDAO('Test', MauticSyncDataExchange::OBJECT_COMPANY, $company->getId(), SyncObjectCompany::NAME, $company->getId(), new \DateTime());
         $objectChangeDAO->addField(new OrderFieldDAO($name, new NormalizedValueDAO(NormalizedValueDAO::PHONE_TYPE, $value)));
 
         return $objectChangeDAO;

--- a/app/bundles/LeadBundle/Entity/Tag.php
+++ b/app/bundles/LeadBundle/Entity/Tag.php
@@ -25,6 +25,8 @@ class Tag
      */
     private $description;
 
+    public ?int $deletedId;
+
     public function __construct(string $tag = null, bool $clean = true)
     {
         $this->tag = $clean && $tag ? $this->validateTag($tag) : $tag;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -50,7 +50,7 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         // Delete:
         $this->client->request('DELETE', "/api/tags/{$tagId}/delete");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Get (ensure it's deleted):
         $this->client->request('GET', "/api/tags/{$tagId}");

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -343,7 +343,7 @@ class BuilderSubscriber implements EventSubscriberInterface
             // replace slots
             if (count($params)) {
                 $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
+                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
                 $xpath = new \DOMXPath($dom);
 
                 $divContent = $xpath->query('//*[@data-slot="segmentlist"]');
@@ -422,7 +422,7 @@ class BuilderSubscriber implements EventSubscriberInterface
             // add form before first block of prefs center
             if (isset($params['startform']) && str_contains($content, 'data-prefs-center')) {
                 $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
+                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
                 $xpath      = new \DOMXPath($dom);
                 // If use slots
                 $divContent = $xpath->query('//*[@data-prefs-center="1"]');

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -343,7 +343,7 @@ class BuilderSubscriber implements EventSubscriberInterface
             // replace slots
             if (count($params)) {
                 $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
                 $xpath = new \DOMXPath($dom);
 
                 $divContent = $xpath->query('//*[@data-slot="segmentlist"]');
@@ -422,7 +422,7 @@ class BuilderSubscriber implements EventSubscriberInterface
             // add form before first block of prefs center
             if (isset($params['startform']) && str_contains($content, 'data-prefs-center')) {
                 $dom = new \DOMDocument('1.0', 'utf-8');
-                $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+                $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
                 $xpath      = new \DOMXPath($dom);
                 // If use slots
                 $divContent = $xpath->query('//*[@data-prefs-center="1"]');

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -159,7 +159,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $result  = [];
         $content = $response->getContent();
         $dom     = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
         $tbody = $dom->getElementById('reportTable')->getElementsByTagName('tbody')[0];
         $rows  = $tbody->getElementsByTagName('tr');
 

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -159,7 +159,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $result  = [];
         $content = $response->getContent();
         $dom     = new \DOMDocument('1.0', 'utf-8');
-        $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10ffff, 0, 0xfffff], 'UTF-8'), LIBXML_NOERROR);
         $tbody = $dom->getElementById('reportTable')->getElementsByTagName('tbody')[0];
         $rows  = $tbody->getElementsByTagName('tr');
 

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -225,7 +225,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         $dom     = new \DOMDocument('1.0', 'utf-8');
 
-        $dom->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_NOERROR);
+        $dom->loadHTML(mb_encode_numericentity($content, [0x80, 0x10FFFF, 0, 0xFFFFF], 'UTF-8'), LIBXML_NOERROR);
         $tbody = $dom->getElementById('reportTable')->getElementsByTagName('tbody')[0];
         $rows  = $tbody->getElementsByTagName('tr');
 

--- a/app/composer.json
+++ b/app/composer.json
@@ -22,6 +22,7 @@
     "ext-zip": "*",
     "ext-imap": "*",
     "ext-pdo": "*",
+    "ext-iconv": "*",
     "symfony/amqp-messenger": "~5.4",
     "symfony/console": "~5.4.0",
     "symfony/form": "~5.4.0",

--- a/app/composer.json
+++ b/app/composer.json
@@ -103,6 +103,7 @@
     "composer/composer": "^2.2",
     "beberlei/doctrineextensions": "^1.3",
     "exercise/htmlpurifier-bundle": "^4.1",
+    "ezyang/htmlpurifier": "^4.16",
     "giggsey/libphonenumber-for-php": "^8.12",
     "symfony/doctrine-messenger": "^5.4",
     "symfony/mailer": "~5.4",

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -2,7 +2,7 @@
   "version": "5.0.2",
   "stability": "stable",
   "minimum_php_version": "8.0.2",
-  "maximum_php_version": "8.1.99",
+  "maximum_php_version": "8.2.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -5993,7 +5993,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "a07982bbc6a6e438f80d365f875825a0ce9c1cfb"
+                "reference": "05f968726cecb5faeae31b348bde65e776e6dbcb"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -6010,6 +6010,7 @@
                 "doctrine/doctrine-migrations-bundle": "^3.2.2",
                 "doctrine/orm": "^2.14.0",
                 "exercise/htmlpurifier-bundle": "^4.1",
+                "ext-iconv": "*",
                 "ext-imap": "*",
                 "ext-pdo": "*",
                 "ext-zip": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -2981,20 +2981,30 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.14.0",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75"
+                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
-                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/523407fb06eb9e5f3d59889b3978d5bfe94299c8",
+                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2"
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
             },
             "type": "library",
             "autoload": {
@@ -3026,9 +3036,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.14.0"
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.16.0"
             },
-            "time": "2021-12-25T01:21:49+00:00"
+            "time": "2022-09-18T07:06:19+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
@@ -6004,6 +6014,7 @@
                 "ext-pdo": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
+                "ezyang/htmlpurifier": "^4.16",
                 "friendsofsymfony/oauth-server-bundle": "dev-upgrade-2",
                 "friendsofsymfony/rest-bundle": "^3.5.0",
                 "gaufrette/aws-s3-adapter": "^0.4.0",

--- a/rector.php
+++ b/rector.php
@@ -34,6 +34,10 @@ return static function (RectorConfig $rectorConfig): void {
         '*/Test/*',
         '*/Tests/*',
         '*.html.php',
+
+        // Remove in M6 once the class is removed.
+        __DIR__.'/app/bundles/CoreBundle/Helper/UTF8Helper.php',
+
         ReturnTypeFromReturnDirectArrayRector::class => [
             // require bit test update
             __DIR__.'/app/bundles/LeadBundle/Model/LeadModel.php',
@@ -77,17 +81,17 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__.'/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php',
         ],
 
-        \Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector::class => [
+        Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector::class => [
             '*/Entity/*',
         ],
 
         // handle later with full PHP 8.0 upgrade
-        \Rector\Php80\Rector\FunctionLike\MixedTypeRector::class,
-        \Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-        \Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector::class,
+        Rector\Php80\Rector\FunctionLike\MixedTypeRector::class,
+        Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
+        Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector::class,
 
         // handle later, case by case as lot of chnaged code
-        \Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector::class => [
+        Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector::class => [
             __DIR__.'/app/bundles/PointBundle/Controller/TriggerController.php',
             __DIR__.'/app/bundles/LeadBundle/Controller/ImportController.php',
             __DIR__.'/app/bundles/FormBundle/Controller/FormController.php',
@@ -106,10 +110,10 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Define what single rules will be applied
     $rectorConfig->rules([
-        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector::class,
-        \Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector::class,
+        Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector::class,
+        Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector::class,
 
-        \Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector::class,
+        Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector::class,
         NumericReturnTypeFromStrictScalarReturnsRector::class,
         ReturnTypeFromReturnNewRector::class,
         ReturnTypeFromStrictNativeCallRector::class,


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR contains the minimal changes to get Mautic working on PHP 8.2 and get the CI green.

The UTF8 conversions aren't necessary since Mautic 3 when we started using UTF8MB4 encoding. I think it's safe to get rid of it. The methods used for it were removed in PHP 8.2.

The `ext-iconv` should be required as we use it in the code without any checks if it is installed or not.

##### Old description:

~~This PR is just to test if there is some BC break required to support PHP 8.2. Based on the PHPUNIT output there doesn't seem to be. Many deprecations and failed tests are due to Swiftmaier which is going to be removed in https://github.com/mautic/mautic/pull/11613. So we can do this any time after that is merged. Even after M5.0.0 release.~~

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Gitpod was updated to PHP 8.2 as well so you can test it on this newer PHP version. There is nothing specific to test. Everything should work as before.
3. One thing I'd recommend to focus on is sending emails with some UTF8 characters like emojis.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
