### PR TITLE
test if the composer.lock file is in sync with composer changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        commands: ['PHPSTAN', 'CS Fixer', 'Rector', 'Twig Lint', 'scaffolded files mismatch', 'PHPStan baseline changes', 'composer install']
+        commands: ['PHPSTAN', 'CS Fixer', 'Rector', 'Twig Lint', 'scaffolded files mismatch', 'PHPStan baseline changes', 'composer install', 'composer lock check']
         php-versions: ['8.1']
 
     name: ${{ matrix.commands }} - ${{ matrix.php-versions }}
@@ -245,6 +245,18 @@ jobs:
           test -z "$(comm -23 <(ls ../media/css | sort) <(ls docroot/media/css | sort))"
 
           php ./bin/console cache:clear
+        elif [[ "${{ matrix.commands }}" == "composer lock check" ]]; then
+          composer update --lock --no-plugins --no-scripts 2> /dev/null
+          git diff composer.lock > /tmp/diff_command_output.txt
+          if [[ $(wc -l </tmp/diff_command_output.txt) -ge 1 ]]; then
+            echo "The composer.lock file doens't correspond with the changes in the composer.json file"
+            echo "Please run following command locally"
+            echo "composer update --lock"
+            echo ""
+            echo "verbose diff:"
+            cat /tmp/diff_command_output.txt
+            exit 1
+          fi
         else
           echo "Invalid command"
           exit 1

--- a/composer.lock
+++ b/composer.lock
@@ -5886,7 +5886,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "e355f4c754c87d33488235caab0242ccc58f75c1"
+                "reference": "9126dbd91c8a6cb752037bb5d8066e764f34be03"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5981,6 +5981,9 @@
                 "twilio/sdk": "^5.25",
                 "wikimedia/less.php": "^4.1"
             },
+            "conflict": {
+                "psr/simple-cache": ">=3.0.0"
+            },
             "type": "mautic-core",
             "extra": {
                 "mautic-scaffold": {
@@ -5991,6 +5994,7 @@
                         "[project-root]/package-lock.json": "assets/scaffold/files/package-lock.json",
                         "[project-root]/modernizr-config.json": "assets/scaffold/files/modernizr-config.json",
                         "[project-root]/app/config/bootstrap.php": "assets/scaffold/files/bootstrap.php",
+                        "[project-root]/app/console-application.php": "assets/scaffold/files/console-application.php",
                         "[project-root]/bin/console": "assets/scaffold/files/console",
                         "[project-root]/bin/.htaccess": "assets/scaffold/files/deny.htaccess",
                         "[project-root]/.gitignore": "assets/scaffold/files/example.gitignore",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The current `composer.lock` file on the `5.x` branch is not in sync with the recent composer changes.
If you run `composer update --lock` on checked out 5.x branch, you will get the following diff
```
diff --git a/composer.lock b/composer.lock
index 4efb93736c..3492f7165b 100644
--- a/composer.lock
+++ b/composer.lock
@@ -5886,7 +5886,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "e355f4c754c87d33488235caab0242ccc58f75c1"
+                "reference": "9126dbd91c8a6cb752037bb5d8066e764f34be03"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5981,6 +5981,9 @@
                 "twilio/sdk": "^5.25",
                 "wikimedia/less.php": "^4.1"
             },
+            "conflict": {
+                "psr/simple-cache": ">=3.0.0"
+            },
             "type": "mautic-core",
             "extra": {
                 "mautic-scaffold": {
@@ -5991,6 +5994,7 @@
                         "[project-root]/package-lock.json": "assets/scaffold/files/package-lock.json",
                         "[project-root]/modernizr-config.json": "assets/scaffold/files/modernizr-config.json",
                         "[project-root]/app/config/bootstrap.php": "assets/scaffold/files/bootstrap.php",
+                        "[project-root]/app/console-application.php": "assets/scaffold/files/console-application.php",
                         "[project-root]/bin/console": "assets/scaffold/files/console",
                         "[project-root]/bin/.htaccess": "assets/scaffold/files/deny.htaccess",
                         "[project-root]/.gitignore": "assets/scaffold/files/example.gitignore",
```

This is not ideal, as those changes need to be in the commit / PR that changed the composer.json file.

This PR adds an extra check, and will fail (to proove it's working) until I add the fixed `composer.json` afterwards

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
