### PR TITLE
Fixing migrations

### DIFF
--- a/app/bundles/ChannelBundle/Entity/Channel.php
+++ b/app/bundles/ChannelBundle/Entity/Channel.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\ChannelBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -57,7 +58,7 @@ class Channel extends CommonEntity
             ->addId()
             ->addField('channel', 'string')
             ->addNamedField('channelId', 'integer', 'channel_id', true)
-            ->addField('properties', 'json')
+            ->addField('properties', Types::JSON)
             ->createField('isEnabled', 'boolean')
                 ->columnName('is_enabled')
                 ->build();

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -312,7 +312,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
             ->fetchExtraLazy()
             ->build();
 
-        $builder->addField('headers', 'json');
+        $builder->addField('headers', Types::JSON);
 
         $builder->addNullableField('publicPreview', Types::BOOLEAN, 'public_preview');
     }

--- a/app/bundles/SmsBundle/Entity/Stat.php
+++ b/app/bundles/SmsBundle/Entity/Stat.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\SmsBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -127,7 +128,7 @@ class Stat
             ->nullable()
             ->build();
 
-        $builder->addField('details', 'json');
+        $builder->addField('details', Types::JSON);
     }
 
     /**

--- a/app/migrations/Migration.template
+++ b/app/migrations/Migration.template
@@ -2,27 +2,28 @@
 
 declare(strict_types=1);
 
-namespace Mautic\Migrations;
+namespace <namespace>;
 
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
 
-final class Version<version> extends PreUpAssertionMigration
+final class <className> extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
         // Please add an assertion for every SQL you define in the `up()` method.
         // The order does matter!
-
         // E.g.:
         /*
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->hasTable("{$this->prefix}table_name");
-        }, sprintf('Table %s already exists', "{$this->prefix}table_name"));
+        $this->skipAssertion(
+            fn (Schema $schema) => $schema->hasTable("{$this->prefix}table_name"),
+            "Table {$this->prefix}table_name already exists"
+        );
 
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}table_name")->hasIndex('index_name');
-        }, sprintf('Index %s already exists', 'index_name'));
+        $this->skipAssertion(
+            fn (Schema $schema) => $schema->getTable("{$this->prefix}table_name")->hasIndex('index_name'),
+            'Index index_name already exists'
+        );
         */
     }
 

--- a/app/migrations/Version020230615115326.php
+++ b/app/migrations/Version020230615115326.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * This migration must run first otherwise the pre-up assertions for other migrations will fail on M5.
+ */
+final class Version020230615115326 extends AbstractMauticMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `{$this->prefix}message_channels` CHANGE `properties` `properties` JSON NOT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}emails` CHANGE `headers` `headers` JSON NOT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}form_fields` CHANGE `conditions` `conditions` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}form_fields` CHANGE `validation` `validation` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}dynamic_content` CHANGE `utm_tags` `utm_tags` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}sms_message_stats` CHANGE `details` `details` JSON NOT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}sync_object_mapping` CHANGE `internal_storage` `internal_storage` JSON NOT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}imports` CHANGE `properties` `properties` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}lead_event_log` CHANGE `properties` `properties` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}reports` CHANGE `settings` `settings` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("ALTER TABLE `{$this->prefix}tweet_stats` CHANGE `response_details` `response_details` JSON DEFAULT NULL COMMENT '(DC2Type:json)'");
+    }
+}

--- a/app/migrations/Version20230321133733.php
+++ b/app/migrations/Version20230321133733.php
@@ -5,10 +5,17 @@ declare(strict_types=1);
 namespace Mautic\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
 
-final class Version20230321133733 extends AbstractMauticMigration
+final class Version20230321133733 extends PreUpAssertionMigration
 {
+    protected function preUpAssertions(): void
+    {
+        foreach (['utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_term'] as $column) {
+            $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}asset_downloads")->hasColumn($column), "Column {$this->prefix}asset_downloads.{$column} already exists");
+        }
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql("ALTER TABLE {$this->prefix}asset_downloads ADD utm_campaign VARCHAR(191) DEFAULT NULL, ADD utm_content VARCHAR(191) DEFAULT NULL, ADD utm_medium VARCHAR(191) DEFAULT NULL, ADD utm_source VARCHAR(191) DEFAULT NULL, ADD utm_term VARCHAR(191) DEFAULT

--- a/plugins/MauticSocialBundle/Entity/TweetStat.php
+++ b/plugins/MauticSocialBundle/Entity/TweetStat.php
@@ -2,6 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -137,7 +138,7 @@ class TweetStat
 
         $builder->addNullableField('favoriteCount', 'integer', 'favorite_count');
         $builder->addNullableField('retweetCount', 'integer', 'retweet_count');
-        $builder->addNullableField('responseDetails', 'json', 'response_details');
+        $builder->addNullableField('responseDetails', Types::JSON, 'response_details');
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Migrations are broken.

I was getting
```
Mautic\Migrations\Version20230522141144 failed during Pre-Checks. Error: "Unknown column type "json_array" requested.
```
And I think it will be due to the comment in the DB column for `dynamic_content.utm_tags` having comment `(DC2Type:json_array)`

There is also another proboem:
```
An exception occurred while executing a query: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'utm_campaign
```

And also the migration class generation is broken too.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `bin/console d:m:m`
3. Run `bin/console d:m:g`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
