### PR TITLE
Fixing point translation (M4)

### DIFF
--- a/app/bundles/CoreBundle/Command/PushTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PushTransifexCommand.php
@@ -63,7 +63,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $bundleFilter = $input->getOption('bundle');
-        $files        = $this->languageHelper->getLanguageFiles([$bundleFilter]);
+        $files        = $this->languageHelper->getLanguageFiles($bundleFilter ? [$bundleFilter] : []);
 
         try {
             $transifex = $this->transifexFactory->getTransifex();
@@ -106,7 +106,7 @@ EOT
                     }
 
                     $promise = $transifex->getApiConnector()->createPromise(
-                        $resources->uploadContent($alias, $content)
+                        $resources->uploadContent($alias, $content, true)
                     );
                     $promise->setFilePath($file);
                     $promises->enqueue($promise);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/11522

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We've noticed that some strings in some languages are breaking Mautic's functionality because they are using for example the old `%points%` variable instead of `%count%`. These changes were done in https://github.com/mautic/mautic/pull/11046/files to support newer Symfony versions.

However, in Transifex even the original EN language which is the source for other languages was still using the old `%points%` variable:
<img width="1725" alt="transifex-points" src="https://github.com/mautic/mautic/assets/1235442/87a24c77-ecbc-4a83-8754-b36d81908123">

@dadarya0 dug into that and found that we must pass a third param as `true` to the `uploadContent` method in order to actually update existing translations. I was the only one on the team with admin access to Transifex so I'm pushing it for him as he was right.

I also found another issue that calling the command without any bundle filter did not do anything. So I fixed that too. Now the above translation on Transifex have the `%count%` variable:
![Screenshot 2023-06-19 at 15 13 44](https://github.com/mautic/mautic/assets/1235442/66d2b0a5-cf49-4dd6-a82a-a3ec22ae1631)


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Check https://app.transifex.com/mautic/mautic and see that the variable was fixed.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
