### PR TITLE
Update analytics.js to gtag to support ga4

### DIFF
--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This test is breaking other tests, so running it in a separate process.
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
+ */
+final class JsControllerTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['google_analytics_id']                   = 'G-F3825DS9CD';
+        $this->configParams['google_analytics_trackingpage_enabled'] = true;
+        $this->configParams['google_analytics_anonymize_ip']         = 'testIndexActionRendersSuccessfullyWithAnonymizeIp' === $this->getName();
+        parent::setUp();
+    }
+
+    public function testIndexActionRendersSuccessfully(): void
+    {
+        $this->client->request('GET', '/mtc.js');
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('gtag(\'config\',\'G-F3825DS9CD\')', $this->client->getResponse()->getContent());
+    }
+
+    public function testIndexActionRendersSuccessfullyWithAnonymizeIp(): void
+    {
+        $this->client->request('GET', '/mtc.js');
+        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('gtag(\'config\',\'G-F3825DS9CD\',{"anonymize_ip":true})', $this->client->getResponse()->getContent());
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -21,6 +21,7 @@ final class JsControllerTest extends MauticMysqlTestCase
     {
         $this->configParams['google_analytics_id']                   = 'G-F3825DS9CD';
         $this->configParams['google_analytics_trackingpage_enabled'] = true;
+        $this->configParams['site_url']                              = 'https://mautic.test';
         $this->configParams['google_analytics_anonymize_ip']         = 'testIndexActionRendersSuccessfullyWithAnonymizeIp' === $this->getName();
         parent::setUp();
     }

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -495,19 +495,31 @@ JS;
         $lead   = $this->trackingHelper->getLead();
 
         if ($id = $this->trackingHelper->displayInitCode('google_analytics')) {
-            $gaUserId      = ($lead && $lead->getId()) ? 'ga(\'set\', \'userId\', '.$lead->getId().');' : '';
-            $gaAnonymizeIp = $this->trackingHelper->getAnonymizeIp() ? 'ga(\'set\', \'anonymizeIp\', true);' : '';
+            $gtagSettings = [];
+
+            if ($this->trackingHelper->getAnonymizeIp()) {
+                $gtagSettings['anonymize_ip'] = true;
+            }
+
+            if ($lead && $lead->getId()) {
+                $gtagSettings['user_id'] = $lead->getId();
+            }
+
+            if (count($gtagSettings) > 0) {
+                $gtagSettings = ', '.json_encode($gtagSettings);
+            } else {
+                $gtagSettings = '';
+            }
 
             $js .= <<<JS
-            dataLayer = window.dataLayer ? window.dataLayer : [];
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', '{$id}', 'auto');
-  {$gaAnonymizeIp}
-  {$gaUserId}
-  ga('send', 'pageview');
+a = document.createElement('script');
+a.async = 1;
+a.src = 'https://www.googletagmanager.com/gtag/js?id={$id}';
+document.getElementsByTagName('head')[0].appendChild(a);
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '{$id}'{$gtagSettings});
 JS;
         }
 
@@ -566,15 +578,14 @@ MauticJS.setTrackedEvents = function(events) {
                 
                 if (typeof ga  !== 'undefined' && typeof events.google_analytics !== 'undefined') {
                  var e = events.google_analytics; 
-                     for(var i = 0; i < e.length; i++) {
-                         if(typeof e[i]['action']  !== 'undefined' && typeof e[i]['label']  !== 'undefined' )
-                             	ga('send', {
-                                    hitType: 'event',
-                                    eventCategory: e[i]['category'],
-                                    eventAction: e[i]['action'],
-                                    eventLabel: e[i]['label'],
-			                     });
-                     }
+                    for(var i = 0; i < e.length; i++) {
+                        if(typeof e[i]['action']  !== 'undefined' && typeof e[i]['label']  !== 'undefined' ) {
+                            gtag('event', e[i]['action'], {
+                                'event_category': e[i]['category'],
+                                'event_label': e[i]['label']
+                            });
+                        }
+                    }
                 }        
                 
                 if (typeof events.focus_item !== 'undefined') {

--- a/app/bundles/PageBundle/Helper/TrackingHelper.php
+++ b/app/bundles/PageBundle/Helper/TrackingHelper.php
@@ -138,7 +138,7 @@ class TrackingHelper
     protected function isLandingPage()
     {
         $server = $this->requestStack->getCurrentRequest()->server;
-        if (false === strpos($server->get('HTTP_REFERER'), $this->coreParametersHelper->get('site_url'))) {
+        if (false === strpos((string) $server->get('HTTP_REFERER'), $this->coreParametersHelper->get('site_url'))) {
             return false;
         }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✅
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ✅
| Automated tests included?              | ✅ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

This is the same as https://github.com/mautic/mautic/pull/12421 but on the v4 codebase.

#### Description:

Google will turn off universal analytics on July 1st and the new GA4 codes do not work with analytics.js. This PR upgrades the analytics.js code to use the newer gtag code which will work with old UA codes and the newer GA4 codes.

This is a breaking change if the frontend uses analytics.js for goal or ecommerce tracking the end user would need to update that code to gtag or lose that reporting.

#### Steps to test this PR:

Create a new GA4 analytics account and get the code.
In mautic under Configuration > Tracking Settings > Google Analytics
Paste in your Google Analytics ID and enable on tracking page and landing page.
Load a landing page in a private tab.
Check analytics real time you will see your page hit.