### PR TITLE
Adding migration that will replace root_dir variable with project_dir

### DIFF
--- a/app/migrations/Version20230627140512.php
+++ b/app/migrations/Version20230627140512.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Configurator\Configurator;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+
+final class Version20230627140512 extends PreUpAssertionMigration
+{
+    protected function preUpAssertions(): void
+    {
+        $configurator = $this->getConfigurator();
+
+        $this->skipAssertion(
+            fn () => !$configurator->isFileWritable(),
+            'The local.php file is not writable. Skipping the migration. Replace the usages of "%kernel.root_dir%" in your local.config file with "%kernel.project_dir%/app".'
+        );
+
+        $this->skipAssertion(
+            fn () => str_contains('%kernel.root_dir%', $configurator->render()),
+            'The deprecated %kernel.root_dir% is unused. Your local.php file is just fine. Skipping the migration.'
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $configurator = $this->getConfigurator();
+
+        $configurator->mergeParameters(
+            array_map(
+                function ($value) {
+                    if (is_string($value) && str_contains($value, '%kernel.root_dir%/..')) {
+                        return str_replace('%kernel.root_dir%/..', '%kernel.project_dir%', $value);
+                    }
+                    if (is_string($value) && str_contains($value, '%kernel.root_dir%')) {
+                        return str_replace('%kernel.root_dir%', '%kernel.project_dir%/app', $value);
+                    }
+
+                    return $value;
+                },
+                $configurator->getParameters()
+            )
+        );
+
+        $configurator->write();
+    }
+
+    private function getConfigurator(): Configurator
+    {
+        return $this->container->get(Configurator::class);
+    }
+}

--- a/app/migrations/Version20230627140512.php
+++ b/app/migrations/Version20230627140512.php
@@ -6,21 +6,21 @@ namespace Mautic\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Configurator\Configurator;
-use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-final class Version20230627140512 extends PreUpAssertionMigration
+final class Version20230627140512 extends AbstractMauticMigration
 {
-    protected function preUpAssertions(): void
+    public function preUp(Schema $schema): void
     {
         $configurator = $this->getConfigurator();
 
-        $this->skipAssertion(
-            fn () => !$configurator->isFileWritable(),
+        $this->skipIf(
+            !$configurator->isFileWritable(),
             'The local.php file is not writable. Skipping the migration. Replace the usages of "%kernel.root_dir%" in your local.config file with "%kernel.project_dir%/app".'
         );
 
-        $this->skipAssertion(
-            fn () => str_contains('%kernel.root_dir%', $configurator->render()),
+        $this->skipIf(
+            !str_contains($configurator->render(), '%kernel.root_dir%'),
             'The deprecated %kernel.root_dir% is unused. Your local.php file is just fine. Skipping the migration.'
         );
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/12516
<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In https://github.com/mautic/mautic/pull/11145 we've changed all values of %root_dir% to %project_dir% but this still must be done in local.php during upgrade from M4 to M5 so users don't have to panic when the Mautic instance will be broken due to this issue.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add these lines to your local.php:
```php
        'testing_path1' => '%kernel.root_dir%/../../var/tmp',
	'testing_path2' => 'some/%kernel.root_dir%/var/tmp',
```
These are the 2 options being replaced in https://github.com/mautic/mautic/pull/11145.
3. Run `bin/console doctrine:migrations:migrate`. You may have to hit the Enter if you are asked some question.
4. Once the migration has run, your local.php values should be changed to:
```php
        'testing_path1' => '%kernel.project_dir%/../var/tmp',
	'testing_path2' => 'some/%kernel.project_dir%/app/var/tmp',
```

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
