### PR TITLE
Adding the Purify filter to the values that can contain simple HTML formatting

### DIFF
--- a/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
+++ b/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
@@ -28,7 +28,7 @@
                 <div class="pr-md pl-md pt-lg pb-lg">
                     <div class="box-layout">
                         <div class="col-xs-10">
-                            <div class="text-muted">{{ item.getDescription() }}</div>
+                            <div class="text-muted">{{ item.getDescription()|purify }}</div>
                         </div>
 
                     </div>

--- a/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
@@ -54,7 +54,7 @@
 
         <div class="code-editor {% if not isCodeMode %}hide{% endif %}">
             <div id="customHtmlContainer"></div>
-            <i class="text-muted">{{ 'mautic.core.code.mode.token.dropdown.hint'|trans|puirfy }}</i>
+            <i class="text-muted">{{ 'mautic.core.code.mode.token.dropdown.hint'|trans|purify }}</i>
         </div>
         <div class="builder-toolbar {% if isCodeMode %}hide{% endif %}">
             <div class="panel panel-default">

--- a/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
@@ -54,7 +54,7 @@
 
         <div class="code-editor {% if not isCodeMode %}hide{% endif %}">
             <div id="customHtmlContainer"></div>
-            <i class="text-muted">{{ 'mautic.core.code.mode.token.dropdown.hint'|trans|raw }}</i>
+            <i class="text-muted">{{ 'mautic.core.code.mode.token.dropdown.hint'|trans|puirfy }}</i>
         </div>
         <div class="builder-toolbar {% if isCodeMode %}hide{% endif %}">
             <div class="panel panel-default">

--- a/app/bundles/CoreBundle/Resources/views/Notification/notification_messages.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Notification/notification_messages.html.twig
@@ -1,6 +1,6 @@
 {% if updateMessage.message is not empty %}
 <div class="media pt-sm pb-sm pr-md pl-md nm bdr-b alert-mautic mautic-update">
-    <h4 class="pull-left">{{ updateMessage.message|raw }}</h4>
+    <h4 class="pull-left">{{ updateMessage.message|purify }}</h4>
     <div class="pull-right">
         <a class="btn btn-danger" href="{{ path('mautic_core_update') }}" data-toggle="ajax">{% trans %}mautic.core.update.now{% endtrans %}</a>
     </div>

--- a/app/bundles/CoreBundle/Resources/views/Standard/list.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Standard/list.html.twig
@@ -198,7 +198,7 @@
                                 </div>
                                 {% if attribute(item, 'getDescription') is defined and item.getDescription() %}
                                     <div class="text-muted mt-4">
-                                        <small>{{ item.getDescription() }}</small>
+                                        <small>{{ item.getDescription()|purify }}</small>
                                     </div>
                                 {% endif %}
                             </td>

--- a/app/bundles/CoreBundle/Resources/views/Update/index.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Update/index.html.twig
@@ -49,11 +49,11 @@
                           </table>
                           {%- if isComposerEnabled %}
                           <div class="alert alert-warning text-center">
-                              <strong>{{ 'mautic.core.update.composer'|trans|raw }}</strong>
+                              <strong>{{ 'mautic.core.update.composer'|trans|purify }}</strong>
                           </div>
                           {%- else %}
                           <div class="alert alert-warning text-center">
-                              <strong>{{ 'mautic.core.update.ui.deprecated'|trans|raw }}</strong>
+                              <strong>{{ 'mautic.core.update.ui.deprecated'|trans|purify }}</strong>
                           </div>
                           <div class="text-right">
                               <button class="btn btn-primary" onclick="Mautic.processUpdate('update-panel', 1, '');">{{ 'mautic.core.update.now'|trans }}</button>

--- a/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
@@ -134,7 +134,7 @@
                         </div>
                         {% if item.getDescription() is not empty %}
                             <div class="text-muted mt-4">
-                                <small>{{ item.getDescription() }}</small>
+                                <small>{{ item.getDescription()|purify }}</small>
                             </div>
                         {% endif %}
                     </td>

--- a/app/bundles/EmailBundle/Resources/views/FormTheme/Config/_config_emailconfig_widget.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/FormTheme/Config/_config_emailconfig_widget.html.twig
@@ -119,7 +119,7 @@
             {% if 'imap_open' is function %}
                 {{ form_widget(form.monitored_email) }}
             {% else %}
-                <div class="alert alert-info">{{ 'mautic.email.imap_extension_missing'|trans|raw }}</div>
+                <div class="alert alert-info">{{ 'mautic.email.imap_extension_missing'|trans|purify }}</div>
             {% endif %}
         </div>
     </div>

--- a/app/bundles/EmailBundle/Resources/views/FormTheme/Config/monitored_email_widget.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/FormTheme/Config/monitored_email_widget.html.twig
@@ -7,7 +7,7 @@
         <div class="panel-body">
             {% set tooltip = translatorHasId(child.vars.label ~ '.tooltip') ? (child.vars.label ~ '.tooltip')|trans : '' %}
             {% if tooltip %}
-                <p>{{ tooltip|raw }}</p>
+                <p>{{ tooltip|purify }}</p>
             {% endif %}
             {{ form_widget(child) }}
         </div>

--- a/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
@@ -15,13 +15,13 @@
                 {{ 'mautic.email.timeline.event.failed'|trans }}
             {% endif %}
         {% elseif item.dateRead is empty %}
-            {{ 'mautic.email.timeline.event.not.read'|trans|raw }}
+            {{ 'mautic.email.timeline.event.not.read'|trans|purify }}
         {% else %}
             {{ ('mautic.email.timeline.event.' ~ event['extra']['type'])|trans({
                     '%date%': dateToFull(event.timestamp),
                     '%interval%': dateFormatRange(item.dateSent.diff(event.timestamp)),
                     '%sent%': dateToFull(item.dateSent),
-            })|raw }}
+            })|purify }}
         {% endif %}
 
         {% if item.viewedInBrowser is not empty and item.viewedInBrowser %}

--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -50,7 +50,7 @@
             <div class="pr-md pl-md pt-lg pb-lg">
                 <div class="box-layout">
                     <div class="col-xs-10">
-                        <div class="text-white dark-sm mb-0">{{ list.description }}</div>
+                        <div class="text-white dark-sm mb-0">{{ list.description|purify }}</div>
                     </div>
                 </div>
             </div>

--- a/app/bundles/MarketplaceBundle/Resources/views/Package/install.html.twig
+++ b/app/bundles/MarketplaceBundle/Resources/views/Package/install.html.twig
@@ -1,15 +1,15 @@
 <div class="text-center" id="marketplace-installation-in-progress">
-    <p>{{ 'marketplace.package.install.html.in.progress'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.install.html.in.progress'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <div class="spinner">
         <i class="fa fa-spin fa-spinner"></i>
     </div>
 </div>
 <div style="display: none" class="text-center" id="marketplace-installation-failed">
-    <p>{{ 'marketplace.package.install.html.failed'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.install.html.failed'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <textarea class="form-control" readonly id="marketplace-installation-failed-details"></textarea>
 </div>
 <div style="display: none" class="text-center" id="marketplace-installation-success">
-    <p>{{ 'marketplace.package.install.html.success'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.install.html.success'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <p><a class="btn btn-primary" href="{{ path('mautic_plugin_reload') }}">{% trans %}marketplace.package.install.html.success.continue{% endtrans %}</a></p>
 </div>
 

--- a/app/bundles/MarketplaceBundle/Resources/views/Package/list.html.twig
+++ b/app/bundles/MarketplaceBundle/Resources/views/Package/list.html.twig
@@ -116,7 +116,7 @@
                         </div>
                         {% if item.description %}
                             <div class="text-muted mt-4">
-                                <small>{{ item.description }}</small>
+                                <small>{{ item.description|purify }}</small>
                             </div>
                         {% endif %}
                     </td>

--- a/app/bundles/MarketplaceBundle/Resources/views/Package/remove.html.twig
+++ b/app/bundles/MarketplaceBundle/Resources/views/Package/remove.html.twig
@@ -1,15 +1,15 @@
 <div class="text-center" id="marketplace-removal-in-progress">
-    <p>{{ 'marketplace.package.remove.html.in.progress'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.remove.html.in.progress'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <div class="spinner">
         <i class="fa fa-spin fa-spinner"></i>
     </div>
 </div>
 <div style="display: none" class="text-center" id="marketplace-removal-failed">
-    <p>{{ 'marketplace.package.remove.html.failed'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.remove.html.failed'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <textarea class="form-control" readonly id="marketplace-removal-failed-details"></textarea>
 </div>
 <div style="display: none" class="text-center" id="marketplace-removal-success">
-    <p>{{ 'marketplace.package.remove.html.success'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()|escape}) }}</p>
+    <p>{{ 'marketplace.package.remove.html.success'|trans({'%packagename%' : packageDetail.packageBase.getHumanPackageName()})|purify }}</p>
     <p><a class="btn btn-primary" href="{{ path(constant('Mautic\\MarketplaceBundle\\Service\\RouteProvider::ROUTE_LIST')) }}">
     {% trans %}marketplace.package.remove.html.success.continue{% endtrans %}</a></p>
 </div>

--- a/app/bundles/PluginBundle/Resources/views/Integration/info.html.twig
+++ b/app/bundles/PluginBundle/Resources/views/Integration/info.html.twig
@@ -16,7 +16,7 @@
 {% if bundle.hasSecondaryDescription %}
 <div class="row mt-lg">
     <div class="col-xs-12">
-        {{ bundle.secondaryDescription|raw }}
+        {{ bundle.secondaryDescription|purify }}
     </div>
 </div>
 {% endif %}

--- a/app/bundles/UserBundle/Resources/views/FormTheme/Config/_config_userconfig_widget.html.twig
+++ b/app/bundles/UserBundle/Resources/views/FormTheme/Config/_config_userconfig_widget.html.twig
@@ -8,7 +8,7 @@
           <h3 class="panel-title">{{ 'mautic.user.config.header.saml'|trans }}</h3>
       </div>
       <div class="panel-body">
-          <div class="alert alert-info">{{ 'mautic.user.config.form.saml.idp_entity_id'|trans({'%entityId%': entityId})|raw }}</div>
+          <div class="alert alert-info">{{ 'mautic.user.config.form.saml.idp_entity_id'|trans({'%entityId%': entityId})|purify }}</div>
 
           <div class="row">
               <div class="col-md-6">

--- a/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
+++ b/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
@@ -34,7 +34,7 @@
             <div class="pr-md pl-md pt-lg pb-lg">
                 <div class="box-layout">
                     <div class="col-xs-10">
-                        <div class="text-muted">{{ item.getDescription() }}</div>
+                        <div class="text-muted">{{ item.getDescription()|purify }}</div>
                     </div>
                     <div class="col-xs-2 text-right">
                         {{- include(

--- a/app/bundles/WebhookBundle/Resources/views/Webhook/list.html.twig
+++ b/app/bundles/WebhookBundle/Resources/views/Webhook/list.html.twig
@@ -113,7 +113,7 @@
                             </a>
                             {% if item.getDescription() is defined and item.getDescription() is not empty %}
                             <div class="text-muted mt-4">
-                                <small>{{ item.getDescription() }}</small>
+                                <small>{{ item.getDescription()|purify }}</small>
                             </div>
                             {% endif %}
                         </div>

--- a/plugins/MauticClearbitBundle/Resources/views/Integration/form.html.twig
+++ b/plugins/MauticClearbitBundle/Resources/views/Integration/form.html.twig
@@ -1,9 +1,9 @@
 <div class="well well-sm" style="margin-bottom:0 !important;">
     <p>
-        {{ 'mautic.plugin.clearbit.webhook_info'|trans|raw }}
+        {{ 'mautic.plugin.clearbit.webhook_info'|trans|purify }}
     </p>
     <div class="alert alert-warning">
-        {{ 'mautic.plugin.clearbit.public_info'|trans|raw }}
+        {{ 'mautic.plugin.clearbit.public_info'|trans|purify }}
     </div>
     <input type="text" readonly="" onclick="this.setSelectionRange(0, this.value.length);" value="{{ mauticUrl }}" class="form-control">
 </div>

--- a/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
@@ -355,7 +355,7 @@
                             <div class="focus-hide visible-focus-type-form">
                                 <div class="col-sm-12" id="focusFormAlert" data-hide-on='{"focus_html_mode_0":"checked"}'>
                                     <div class="alert alert-info">
-                                        {{ 'mautic.focus.form_token.instructions'|trans|raw }}
+                                        {{ 'mautic.focus.form_token.instructions'|trans|purify }}
                                     </div>
                                 </div>
                                 {{ form_row(form.form) }}

--- a/plugins/MauticFullContactBundle/Resources/views/Integration/form.html.twig
+++ b/plugins/MauticFullContactBundle/Resources/views/Integration/form.html.twig
@@ -2,7 +2,7 @@
 <div class="well well-sm" style="margin-bottom:0 !important;">
     <p>{{ 'mautic.plugin.fullcontact.webhook'|trans }}</p>
     <div class="alert alert-warning">
-        {{ 'mautic.plugin.fullcontact.public_info'|trans|raw }}
+        {{ 'mautic.plugin.fullcontact.public_info'|trans|purify }}
     </div>
     <input type="text" readonly="readonly" value="{{ mauticUrl }}" class="form-control" title="url"/>
 </div>

--- a/plugins/MauticOutlookBundle/Resources/views/Integration/form.html.twig
+++ b/plugins/MauticOutlookBundle/Resources/views/Integration/form.html.twig
@@ -1,7 +1,7 @@
 <div class="well well-sm" style="margin-bottom:0 !important;">
     <p>{{ 'mautic.plugin.outlook.url'|trans }}</p>
     <div class="alert alert-warning">
-        {{ 'mautic.plugin.outlook.public_info'|trans|raw }}
+        {{ 'mautic.plugin.outlook.public_info'|trans|purify }}
     </div>
     <input type="text" readonly="readonly" onclick="this.setSelectionRange(0, this.value.length);" value="{{ mauticUrl }}" class="form-control">
 </div>


### PR DESCRIPTION
…ormatting

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):

 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I noticed by browsing through the UI that some places show HTML markup. Like:

![Screenshot 2023-06-28 at 16 51 17](https://github.com/mautic/mautic/assets/1235442/614fb0e1-69bd-45cf-8a0b-1cee33739d4d)


And in several places where the description can contain HTML markup. This PR is adding the `|purify` twig filter for those places so the basic HTML markup shows up and potential XSS attack is disabled.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Try to install a plugin via Marketplace UI (you'll have to approve that you've installed Mautic via Composer to get that option). Check that the modal box has well-formatted text.
3. Create a segment with a description that contain bold text. Check that the description renders correctly on the detail page as well as on the list page.
4. Do the same for Marketing Message description, email description and webhook description

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
