### PR TITLE
Add mock http_client

### DIFF
--- a/app/bundles/CoreBundle/Tests/Functional/Service/MockHttpClientTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/MockHttpClientTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional\Service;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class MockHttpClientTest extends MauticMysqlTestCase
+{
+    public function testHttpClient(): void
+    {
+        $expectedResponses = [
+            function ($method, $url, $options): MockResponse {
+                Assert::assertSame(Request::METHOD_GET, $method);
+                Assert::assertSame('https://example.com/get', $url);
+                $body = '{"get_method": true}';
+
+                return new MockResponse($body);
+            },
+            function ($method, $url, $options): MockResponse {
+                Assert::assertSame(Request::METHOD_POST, $method);
+                Assert::assertSame('https://example.com/post', $url);
+                $body = '{"post_method": true}';
+
+                return new MockResponse($body);
+            },
+        ];
+        $mockHttpClient = self::getContainer()->get('http_client');
+        $mockHttpClient->setResponseFactory($expectedResponses);
+
+        $response = $mockHttpClient->request(Request::METHOD_GET, 'https://example.com/get');
+        Assert::assertSame('{"get_method": true}', $response->getContent());
+
+        $mockHttpClient = self::getContainer()->get('http_client');
+        $response = $mockHttpClient->request(Request::METHOD_POST, 'https://example.com/post');
+        Assert::assertSame('{"post_method": true}', $response->getContent());
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Functional/Service/MockHttpClientTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/MockHttpClientTest.php
@@ -36,7 +36,7 @@ class MockHttpClientTest extends MauticMysqlTestCase
         Assert::assertSame('{"get_method": true}', $response->getContent());
 
         $mockHttpClient = self::getContainer()->get('http_client');
-        $response = $mockHttpClient->request(Request::METHOD_POST, 'https://example.com/post');
+        $response       = $mockHttpClient->request(Request::METHOD_POST, 'https://example.com/post');
         Assert::assertSame('{"post_method": true}', $response->getContent());
     }
 }

--- a/app/config/config_test.php
+++ b/app/config/config_test.php
@@ -139,3 +139,6 @@ $container->register('security.csrf.token_manager', \Symfony\Component\Security\
 
 // HTTP client mock handler providing response queue
 $container->register(\GuzzleHttp\Handler\MockHandler::class)->setPublic(true);
+
+$container->register('http_client', \Symfony\Component\HttpClient\MockHttpClient::class)
+    ->setPublic(true);


### PR DESCRIPTION
We do not want to request the actual third party URL when we run Functional tests in Mautic.  The solution is to use `Symfony\Component\HttpClient\MockHttpClient` as `http_client` service.

This simple PR enables this by registering the service in `config_test.php`.