### PR TITLE
Deprecations needed for removal of the legacy builder in M6

### DIFF
--- a/app/bundles/CoreBundle/Event/BuilderEvent.php
+++ b/app/bundles/CoreBundle/Event/BuilderEvent.php
@@ -11,7 +11,14 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class BuilderEvent extends Event
 {
+    /**
+     * @deprecated to be removed in 6.0
+     */
     protected $slotTypes            = [];
+
+    /**
+     * @deprecated to be removed in 6.0
+     */
     protected $sections             = [];
     protected $tokens               = [];
     protected $abTestWinnerCriteria = [];
@@ -33,6 +40,8 @@ class BuilderEvent extends Event
 
     /**
      * @param int $priority
+     *
+     * @deprecated to be removed in 6.0
      */
     public function addSlotType($key, $header, $icon, $content, $form, $priority = 0, array $params = [])
     {
@@ -50,6 +59,8 @@ class BuilderEvent extends Event
      * Get slot types.
      *
      * @return array
+     *
+     * @deprecated to be removed in 6.0
      */
     public function getSlotTypes()
     {
@@ -70,6 +81,9 @@ class BuilderEvent extends Event
         return $this->slotTypes;
     }
 
+    /**
+     * @deprecated to be removed in 6.0
+     */
     public function addSection($key, $header, $icon, $content, $form, $priority = 0)
     {
         $this->sections[$key] = [
@@ -85,6 +99,8 @@ class BuilderEvent extends Event
      * Get slot types.
      *
      * @return array
+     *
+     * @deprecated to be removed in 6.0
      */
     public function getSections()
     {

--- a/app/bundles/CoreBundle/Form/Type/BuilderSectionType.php
+++ b/app/bundles/CoreBundle/Form/Type/BuilderSectionType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class BuilderSectionType.
+ * @deprecated to be removed in 6.0
  */
 class BuilderSectionType extends AbstractType
 {

--- a/app/bundles/CoreBundle/Form/Type/GatedVideoType.php
+++ b/app/bundles/CoreBundle/Form/Type/GatedVideoType.php
@@ -9,6 +9,9 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class GatedVideoType extends SlotType
 {
     /**

--- a/app/bundles/CoreBundle/Form/Type/SlotButtonType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotButtonType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotButtonType.
+ * @deprecated to be removed in 6.0
  */
 class SlotButtonType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotCategoryListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotCategoryListType.php
@@ -6,6 +6,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotCategoryListType extends SlotType
 {
     /**

--- a/app/bundles/CoreBundle/Form/Type/SlotChannelFrequencyType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotChannelFrequencyType.php
@@ -6,6 +6,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotChannelFrequencyType extends SlotType
 {
     /**

--- a/app/bundles/CoreBundle/Form/Type/SlotCodeModeType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotCodeModeType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotImageType.
+ * @deprecated to be removed in 6.0
  */
 class SlotCodeModeType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotDwcType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotDwcType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotDwcType.
+ * @deprecated to be removed in 6.0
  */
 class SlotDwcType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotImageCaptionType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotImageCaptionType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotImageCaptionType.
+ * @deprecated to be removed in 6.0
  */
 class SlotImageCaptionType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotImageCardType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotImageCardType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotImageCardType.
+ * @deprecated to be removed in 6.0
  */
 class SlotImageCardType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotImageType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotImageType.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Form\Type;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotImageType.
+ * @deprecated to be removed in 6.0
  */
 class SlotImageType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotPreferredChannelType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotPreferredChannelType.php
@@ -6,6 +6,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotPreferredChannelType extends SlotType
 {
     /**

--- a/app/bundles/CoreBundle/Form/Type/SlotSavePrefsButtonType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotSavePrefsButtonType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Class SlotButtonType.
+ * @deprecated to be removed in 6.0
  */
 class SlotSavePrefsButtonType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotSegmentListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotSegmentListType.php
@@ -6,6 +6,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotSegmentListType extends SlotType
 {
     /**

--- a/app/bundles/CoreBundle/Form/Type/SlotSeparatorType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotSeparatorType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotImageType.
+ * @deprecated to be removed in 6.0
  */
 class SlotSeparatorType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotSocialFollowType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotSocialFollowType.php
@@ -5,6 +5,9 @@ namespace Mautic\CoreBundle\Form\Type;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotSocialFollowType extends SlotType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/app/bundles/CoreBundle/Form/Type/SlotSuccessMessageType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotSuccessMessageType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotSuccessMessageType.
+ * @deprecated to be removed in 6.0
  */
 class SlotSuccessMessageType extends SlotType
 {

--- a/app/bundles/CoreBundle/Form/Type/SlotTextType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotTextType.php
@@ -5,6 +5,9 @@ namespace Mautic\CoreBundle\Form\Type;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+/**
+ * @deprecated to be removed in 6.0
+ */
 class SlotTextType extends SlotType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/app/bundles/CoreBundle/Form/Type/SlotType.php
+++ b/app/bundles/CoreBundle/Form/Type/SlotType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Class SlotType.
+ * @deprecated to be removed in 6.0
  */
 class SlotType extends AbstractType
 {

--- a/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/builder.html.twig
@@ -1,4 +1,5 @@
 {#
+@deprecated to be removed in 6.0
   Variables
     - type
     - isCodeMode

--- a/app/bundles/CoreBundle/Resources/views/Sections/one-column.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Sections/one-column.html.twig
@@ -1,3 +1,4 @@
+{# @deprecated to be removed in 6.0 #}
 <div data-section-wrapper="1">
     <center>
         <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" cellpadding="0" cellspacing="0" width="600">

--- a/app/bundles/CoreBundle/Resources/views/Sections/three-column.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Sections/three-column.html.twig
@@ -1,3 +1,4 @@
+{# @deprecated to be removed in 6.0 #}
 <div data-section-wrapper="1">
     <center>
         <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" border="0" cellpadding="0" cellspacing="0" width="600">

--- a/app/bundles/CoreBundle/Resources/views/Sections/two-column.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Sections/two-column.html.twig
@@ -1,3 +1,4 @@
+{# @deprecated to be removed in 6.0 #}
 <div data-section-wrapper="1">
     <center>
         <table data-section="1" style="margin: 0 auto;border-collapse: collapse !important;width: 600px;" class="w320" border="0" cellpadding="0" cellspacing="0" width="600">

--- a/app/bundles/CoreBundle/Twig/Helper/SlotsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/SlotsHelper.php
@@ -3,7 +3,7 @@
 namespace Mautic\CoreBundle\Twig\Helper;
 
 /**
- * final class SlotsHelper.
+ * @deprecated to be removed in 6.0
  */
 final class SlotsHelper
 {

--- a/app/bundles/CoreBundle/Twig/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ThemeHelper.php
@@ -96,6 +96,8 @@ final class ThemeHelper
      * @param string $type
      *
      * @return array<string, mixed>
+     *
+     * @deprecated to be removed in 6.0
      */
     public function getSlots($type)
     {

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1440,6 +1440,8 @@ class EmailController extends FormController
      *
      * @param array $slots
      * @param Email $entity
+     *
+     * @deprecated to be removed in 6.0
      */
     private function processSlots(SlotsHelper $slotsHelper, $slots, $entity)
     {

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -87,6 +87,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     /**
      * @var array
+     *
+     * @deprecated to be removed in 6.0
      */
     private $content = [];
 
@@ -546,6 +548,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     /**
      * @return array
+     *
+     * @deprecated to be removed in 6.0
      */
     public function getContent()
     {
@@ -554,6 +558,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     /**
      * @return $this
+     *
+     * @deprecated to be removed in 6.0
      */
     public function setContent($content)
     {

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -984,6 +984,8 @@ class PageController extends FormController
      *
      * @param array $slots
      * @param Page  $entity
+     *
+     * @deprecated to be removed in 6.0
      */
     private function processSlots(SlotsHelper $slotsHelper, $slots, $entity)
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11115,6 +11115,14 @@ parameters:
 			path: app/bundles/CoreBundle/DependencyInjection/Compiler/TranslationsPass.php
 
 		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/DependencyInjection/Compiler/TwigPass.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\DependencyInjection\\\\Compiler\\\\UpdateStepPass\\:\\:process\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/DependencyInjection/Compiler/UpdateStepPass.php
@@ -14051,11 +14059,6 @@ parameters:
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
 
 		-
-			message: "#^Service \"twig\\.helper\\.slots\" is not registered in the container\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
 			message: "#^Service \"twig\\.helper\\.translator\" is not registered in the container\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -14739,6 +14742,14 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/FormButtonsType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\GatedVideoType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/GatedVideoType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\GatedVideoType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/GatedVideoType.php
@@ -14834,9 +14845,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SelectType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotButtonType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotButtonType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotButtonType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotButtonType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCategoryListType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotCategoryListType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCategoryListType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14844,9 +14871,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotCategoryListType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotChannelFrequencyType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotChannelFrequencyType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotChannelFrequencyType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotChannelFrequencyType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCodeModeType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotCodeModeType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCodeModeType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14854,9 +14897,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotCodeModeType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotDwcType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotDwcType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotDwcType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotDwcType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotDynamicContentType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotDynamicContentType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotDynamicContentType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14864,9 +14923,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotDynamicContentType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCaptionType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotImageCaptionType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCaptionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotImageCaptionType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCardType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotImageCardType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCardType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14874,9 +14949,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotImageCardType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotImageType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotImageType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotPreferredChannelType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotPreferredChannelType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotPreferredChannelType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14884,9 +14975,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotPreferredChannelType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSavePrefsButtonType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSavePrefsButtonType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSavePrefsButtonType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotSavePrefsButtonType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSegmentListType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSegmentListType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSegmentListType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14894,9 +15001,25 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotSegmentListType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSeparatorType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSeparatorType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSeparatorType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotSeparatorType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSocialFollowType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSocialFollowType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSocialFollowType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -14904,9 +15027,33 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/SlotSocialFollowType.php
 
 		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSocialShareType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSocialShareType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSuccessMessageType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotSuccessMessageType.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSuccessMessageType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/SlotSuccessMessageType.php
+
+		-
+			message: """
+				#^Class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotTextType extends deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Form/Type/SlotTextType.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotTextType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
@@ -18140,6 +18287,14 @@ parameters:
 			path: app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
 
 		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\GatedVideoType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Tests/Functional/Type/GatedVideoTypeTest.php
+
+		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Tests\\\\Unit\\\\Command\\\\MaxMindDoNotSellPurgeCommandTest\\:\\:buildMockEntityManager\\(\\) has parameter \\$dataToReturn with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -19598,6 +19753,14 @@ parameters:
 			message: "#^Parameter \\#2 \\$maxUploadSizeMB of method Mautic\\\\CoreBundle\\\\Validator\\\\FileUploadValidator\\:\\:checkFileSize\\(\\) expects string, int given\\.$#"
 			count: 2
 			path: app/bundles/CoreBundle/Tests/Unit/Validator/FileUploadValidatorTest.php
+
+		-
+			message: """
+				#^Parameter \\$slotsHelper of method Mautic\\\\CoreBundle\\\\Twig\\\\Extension\\\\SlotExtension\\:\\:__construct\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/CoreBundle/Twig/Extension/SlotExtension.php
 
 		-
 			message: "#^Call to function is_array\\(\\) with array\\<string, mixed\\> will always evaluate to true\\.$#"
@@ -21696,6 +21859,14 @@ parameters:
 			path: app/bundles/EmailBundle/Controller/EmailController.php
 
 		-
+			message: """
+				#^Call to deprecated method processSlots\\(\\) of class Mautic\\\\EmailBundle\\\\Controller\\\\EmailController\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/Controller/EmailController.php
+
+		-
 			message: "#^Call to function method_exists\\(\\) with \\$this\\(Mautic\\\\EmailBundle\\\\Controller\\\\EmailController\\) and 'getRouteBase' will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/EmailController.php
@@ -21711,6 +21882,14 @@ parameters:
 				2\\.3 \\- to be removed in 3\\.0; use AbstractFormController instead$#
 			"""
 			count: 1
+			path: app/bundles/EmailBundle/Controller/EmailController.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\BuilderSectionType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
 			path: app/bundles/EmailBundle/Controller/EmailController.php
 
 		-
@@ -21829,6 +22008,14 @@ parameters:
 			path: app/bundles/EmailBundle/Controller/EmailController.php
 
 		-
+			message: """
+				#^Parameter \\$slotsHelper of method Mautic\\\\EmailBundle\\\\Controller\\\\EmailController\\:\\:builderAction\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/Controller/EmailController.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between null and Mautic\\\\EmailBundle\\\\Entity\\\\Email will always evaluate to false\\.$#"
 			count: 2
 			path: app/bundles/EmailBundle/Controller/EmailController.php
@@ -21847,6 +22034,14 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between null and Mautic\\\\EmailBundle\\\\Entity\\\\Email will always evaluate to false\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+
+		-
+			message: """
+				#^Call to deprecated method getContent\\(\\) of class Mautic\\\\EmailBundle\\\\Entity\\\\Email\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 3
+			path: app/bundles/EmailBundle/Controller/PublicController.php
 
 		-
 			message: """
@@ -23531,6 +23726,78 @@ parameters:
 			path: app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
 
 		-
+			message: """
+				#^Call to deprecated method addSection\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 3
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Call to deprecated method addSlotType\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 9
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotButtonType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCodeModeType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCaptionType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCardType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSeparatorType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSocialFollowType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotTextType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+
+		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -24391,6 +24658,14 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/EmailValidator.php
 
 		-
+			message: """
+				#^Call to deprecated method getContent\\(\\) of class Mautic\\\\EmailBundle\\\\Entity\\\\Email\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 3
+			path: app/bundles/EmailBundle/Helper/MailHelper.php
+
+		-
 			message: "#^Call to method dispatch\\(\\) on an unknown class Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
@@ -25221,6 +25496,30 @@ parameters:
 			message: """
 				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
 				Use `and\\(\\)` instead\\.$#
+			"""
+			count: 2
+			path: app/bundles/EmailBundle/Model/EmailModel.php
+
+		-
+			message: """
+				#^Call to deprecated method getSections\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
+			path: app/bundles/EmailBundle/Model/EmailModel.php
+
+		-
+			message: """
+				#^Call to deprecated method getSlotTypes\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
+			path: app/bundles/EmailBundle/Model/EmailModel.php
+
+		-
+			message: """
+				#^Call to deprecated method getSlots\\(\\) of class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\ThemeHelper\\:
+				to be removed in 6\\.0$#
 			"""
 			count: 2
 			path: app/bundles/EmailBundle/Model/EmailModel.php
@@ -28717,6 +29016,14 @@ parameters:
 			message: """
 				#^Parameter \\$factory of method Mautic\\\\FormBundle\\\\Controller\\\\FormController\\:\\:__construct\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
+			"""
+			count: 1
+			path: app/bundles/FormBundle/Controller/FormController.php
+
+		-
+			message: """
+				#^Parameter \\$slotsHelper of method Mautic\\\\FormBundle\\\\Controller\\\\FormController\\:\\:previewAction\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
 			"""
 			count: 1
 			path: app/bundles/FormBundle/Controller/FormController.php
@@ -45775,14 +46082,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
-
-		-
-			message: """
 				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
 				use testSymfonyCommand\\(\\) instead$#
 			"""
@@ -48639,11 +48938,6 @@ parameters:
 			path: app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: app/bundles/MessengerBundle/DependencyInjection/Compiler/MessengerTransportPass.php
-
-		-
 			message: "#^Class Mautic\\\\MessengerBundle\\\\Form\\\\Type\\\\ConfigType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/MessengerBundle/Form/Type/ConfigType.php
@@ -49834,6 +50128,14 @@ parameters:
 			path: app/bundles/PageBundle/Controller/Api/PageApiController.php
 
 		-
+			message: """
+				#^Call to deprecated method processSlots\\(\\) of class Mautic\\\\PageBundle\\\\Controller\\\\PageController\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/Controller/PageController.php
+
+		-
 			message: "#^Cannot use array destructuring on array\\|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Controller/PageController.php
@@ -49844,6 +50146,14 @@ parameters:
 				2\\.3 \\- to be removed in 3\\.0; use AbstractFormController instead$#
 			"""
 			count: 1
+			path: app/bundles/PageBundle/Controller/PageController.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\BuilderSectionType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
 			path: app/bundles/PageBundle/Controller/PageController.php
 
 		-
@@ -49888,6 +50198,14 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$unit of method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:getHitsLineChartData\\(\\) expects Mautic\\\\PageBundle\\\\Model\\\\char, null given\\.$#"
+			count: 1
+			path: app/bundles/PageBundle/Controller/PageController.php
+
+		-
+			message: """
+				#^Parameter \\$slotsHelper of method Mautic\\\\PageBundle\\\\Controller\\\\PageController\\:\\:builderAction\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
+			"""
 			count: 1
 			path: app/bundles/PageBundle/Controller/PageController.php
 
@@ -51113,8 +51431,152 @@ parameters:
 
 		-
 			message: """
+				#^Call to deprecated method addSection\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 3
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Call to deprecated method addSlotType\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 17
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
 				#^Call to deprecated method getExpressionBuilder\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see createExpressionBuilder\\(\\)\\} instead\\.$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\GatedVideoType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotButtonType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCategoryListType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotChannelFrequencyType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotCodeModeType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotDwcType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCaptionType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageCardType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotImageType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotPreferredChannelType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSavePrefsButtonType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSegmentListType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSeparatorType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSocialFollowType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotSuccessMessageType\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\SlotTextType\\:
+				to be removed in 6\\.0$#
 			"""
 			count: 1
 			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -51813,6 +52275,22 @@ parameters:
 				Use \\{@see executeQuery\\(\\)\\} or \\{@see executeStatement\\(\\)\\} instead\\.$#
 			"""
 			count: 1
+			path: app/bundles/PageBundle/Model/PageModel.php
+
+		-
+			message: """
+				#^Call to deprecated method getSections\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
+			path: app/bundles/PageBundle/Model/PageModel.php
+
+		-
+			message: """
+				#^Call to deprecated method getSlotTypes\\(\\) of class Mautic\\\\CoreBundle\\\\Event\\\\BuilderEvent\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 2
 			path: app/bundles/PageBundle/Model/PageModel.php
 
 		-
@@ -59993,16 +60471,6 @@ parameters:
 			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
 
 		-
-			message: "#^Property Mautic\\\\SmsBundle\\\\Integration\\\\Twilio\\\\TwilioTransport\\:\\:\\$configuration is never read, only written\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
-			message: "#^Property Mautic\\\\SmsBundle\\\\Integration\\\\Twilio\\\\TwilioTransport\\:\\:\\$sendingPhoneNumber is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
@@ -60350,11 +60818,6 @@ parameters:
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
 
 		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testConfigurationExceptionThrownWithoutSendingNumber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
-
-		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testConfigurationExceptionThrownWithoutUsername\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
@@ -60366,11 +60829,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testGetAuthToken\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testGetSendingNumber\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
 
@@ -64126,6 +64584,46 @@ parameters:
 			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
 
 		-
+			message: """
+				#^Call to deprecated method getContent\\(\\) of class Mautic\\\\EmailBundle\\\\Entity\\\\Email\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
+			message: """
+				#^Call to deprecated method getSlots\\(\\) of class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\ThemeHelper\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
+			message: """
+				#^Call to deprecated method processEmailSlots\\(\\) of class MauticPlugin\\\\GrapesJsBuilderBundle\\\\Controller\\\\GrapesJsController\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
+			message: """
+				#^Call to deprecated method processPageSlots\\(\\) of class MauticPlugin\\\\GrapesJsBuilderBundle\\\\Controller\\\\GrapesJsController\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
+			message: """
+				#^Call to deprecated method setContent\\(\\) of class Mautic\\\\EmailBundle\\\\Entity\\\\Email\\:
+				to be removed in 6\\.0$#
+			"""
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
 			message: "#^Method MauticPlugin\\\\GrapesJsBuilderBundle\\\\Controller\\\\GrapesJsController\\:\\:checkForMjmlTemplate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
@@ -64157,6 +64655,14 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, int given\\.$#"
+			count: 1
+			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+
+		-
+			message: """
+				#^Parameter \\$slotsHelper of method MauticPlugin\\\\GrapesJsBuilderBundle\\\\Controller\\\\GrapesJsController\\:\\:builderAction\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Twig\\\\Helper\\\\SlotsHelper\\:
+				to be removed in 6\\.0$#
+			"""
 			count: 1
 			path: plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
 
@@ -72494,11 +73000,6 @@ parameters:
 			message: "#^Property MauticPlugin\\\\MauticSocialBundle\\\\Helper\\\\CampaignEventHelper\\:\\:\\$clickthrough type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
-
-		-
-			message: "#^Instanceof between DateTime and DateTimeInterface will always evaluate to true\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
 
 		-
 			message: "#^Instanceof between Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface and Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface will always evaluate to true\\.$#"

--- a/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+++ b/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
@@ -149,6 +149,8 @@ class GrapesJsController extends CommonController
      *
      * @param array $slots
      * @param Email $entity
+     *
+     * @deprecated to be removed in 6.0
      */
     private function processEmailSlots(SlotsHelper $slotsHelper, $slots, $entity)
     {
@@ -178,6 +180,8 @@ class GrapesJsController extends CommonController
      *
      * @param array $slots
      * @param Page  $entity
+     *
+     * @deprecated to be removed in 6.0
      */
     private function processPageSlots(AssetsHelper $assetsHelper, SlotsHelper $slotsHelper, FormFactoryInterface $formFactory, $slots, $entity)
     {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [y]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This is marking the code used for the legacy builder as deprecated so it could be removed in Mautic 6 and it would be clear to all developers.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No need to test. Only comments were added.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
