### PR TITLE
fix incorrect defaults for array input parameters when filtering contact history

### DIFF
--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -31,8 +31,8 @@ class TimelineController extends CommonController
         if ('POST' == $request->getMethod() && $request->request->has('search')) {
             $filters = [
                 'search'        => InputHelper::clean($request->request->get('search')),
-                'includeEvents' => InputHelper::clean($request->request->get('includeEvents')) ?? [],
-                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents')) ?? [],
+                'includeEvents' => InputHelper::clean($request->request->get('includeEvents') ?? []),
+                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents') ?? []),
             ];
             $session->set('mautic.lead.'.$leadId.'.timeline.filters', $filters);
         } else {
@@ -78,8 +78,8 @@ class TimelineController extends CommonController
         if ('POST' === $request->getMethod() && $request->request->has('search')) {
             $filters = [
                 'search'        => InputHelper::clean($request->request->get('search')),
-                'includeEvents' => InputHelper::clean($request->request->get('includeEvents')) ?? [],
-                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents')) ?? [],
+                'includeEvents' => InputHelper::clean($request->request->get('includeEvents') ?? []),
+                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents') ?? []),
             ];
             $session->set('mautic.plugin.timeline.filters', $filters);
         } else {
@@ -142,8 +142,8 @@ class TimelineController extends CommonController
         if ('POST' === $request->getMethod() && $request->request->has('search')) {
             $filters = [
                 'search'        => InputHelper::clean($request->request->get('search')),
-                'includeEvents' => InputHelper::clean($request->request->get('includeEvents')) ?? [],
-                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents')) ?? [],
+                'includeEvents' => InputHelper::clean($request->request->get('includeEvents') ?? []),
+                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents') ?? []),
             ];
             $session->set('mautic.plugin.timeline.'.$leadId.'.filters', $filters);
         } else {
@@ -207,8 +207,8 @@ class TimelineController extends CommonController
         if ('POST' == $request->getMethod() && $request->request->has('search')) {
             $filters = [
                 'search'        => InputHelper::clean($request->request->get('search')),
-                'includeEvents' => InputHelper::clean($request->request->get('includeEvents')) ?? [],
-                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents')) ?? [],
+                'includeEvents' => InputHelper::clean($request->request->get('includeEvents') ?? []),
+                'excludeEvents' => InputHelper::clean($request->request->get('excludeEvents') ?? []),
             ];
             $session->set('mautic.lead.'.$leadId.'.timeline.filters', $filters);
         } else {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12595 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

in https://github.com/mautic/mautic/pull/12213 (and more in detail https://github.com/mautic/mautic/commit/312e11baf98834b30d85549ab53027daca060cfa#diff-d90a48b0ef99945ef404d1d06de449eca708e694834418bedb201504f9b6c891) defaults for NULL request params were set. 

the defaults for `includeEvents` and `excludeEvents` were set at the wrong side, resulting in an empty string instead of an empty array.

I checked the rest of the codebase too, to ensure this error was not added elsewhere, but couldn't find any other occurences.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. see steps in #12595

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
