### PR TITLE
Fix error 500 for Visits URL within time Point action

### DIFF
--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -217,7 +217,7 @@ class HitRepository extends CommonRepository
      *
      * @param array $options
      */
-    public function getLatestHit($options): \DateTime
+    public function getLatestHit($options): ?\DateTime
     {
         $sq = $this->_em->getConnection()->createQueryBuilder();
         $sq->select('h.date_hit latest_hit')
@@ -242,7 +242,7 @@ class HitRepository extends CommonRepository
         }
         $result = $sq->executeQuery()->fetchAssociative();
 
-        return new \DateTime($result['latest_hit'], new \DateTimeZone('UTC'));
+        return $result ? new \DateTime($result['latest_hit'], new \DateTimeZone('UTC')) : null;
     }
 
     /**

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -3,6 +3,7 @@
 namespace Mautic\PageBundle\Helper;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 
 class PointActionHelper
@@ -64,7 +65,13 @@ class PointActionHelper
             }
         }
         $now       = new \DateTime();
-        $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), $urlWithSqlWC, 'second_to_last' => $eventDetails->getId()]);
+
+        if ($action['properties']['returns_within'] || $action['properties']['returns_after']) {
+            // get the latest hit only when it's needed
+            $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), $urlWithSqlWC, 'second_to_last' => $eventDetails->getId()]);
+        } else {
+            $latestHit = null;
+        }
 
         if ($action['properties']['accumulative_time']) {
             if (!isset($hitStats)) {
@@ -92,14 +99,14 @@ class PointActionHelper
             }
         }
         if ($action['properties']['returns_within']) {
-            if ($now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within']) {
+            if ($latestHit && $now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within']) {
                 $changePoints['returns_within'] = true;
             } else {
                 $changePoints['returns_within'] = false;
             }
         }
         if ($action['properties']['returns_after']) {
-            if ($now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after']) {
+            if ($latestHit && $now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after']) {
                 $changePoints['returns_after'] = true;
             } else {
                 $changePoints['returns_after'] = false;

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -10,258 +10,190 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Helper\PointActionHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PointActionHelperTest extends TestCase
 {
-    public function testValidateUrlPageHitsAction(): void
+    /**
+     * @var MockObject|MauticFactory
+     */
+    private $factory;
+
+    /**
+     * @var MockObject|EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var MockObject|HitRepository
+     */
+    private $hitRepository;
+
+    /**
+     * @var MockObject|Lead
+     */
+    private $lead;
+
+    /**
+     * @var MockObject|Hit
+     */
+    private $eventDetails;
+
+    protected function setUp(): void
     {
-        // Mock the required objects
-        $factory       = $this->createMock(MauticFactory::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $lead          = $this->createMock(Lead::class);
-        $eventDetails  = $this->createMock(Hit::class);
-        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk');
+        /** @phpstan-ignore-next-line */
+        $this->factory       = $this->createMock(MauticFactory::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->hitRepository = $this->createMock(HitRepository::class);
+        $this->lead          = $this->createMock(Lead::class);
+        $this->eventDetails  = $this->createMock(Hit::class);
 
-        // Set the action properties for the test scenario
-        $action = [
-            'id'         => 2,
-            'type'       => 'url.hit',
-            'name'       => 'Hit page',
-            'properties' => [
-                'page_url'               => 'http://localhost:7000/ppk',
-                'page_hits'              => 1,
-                'accumulative_time_unit' => 'H',
-                'accumulative_time'      => 0,
-                'returns_within_unit'    => 'H',
-                'returns_within'         => 0,
-                'returns_after_unit'     => 'H',
-                'returns_after'          => 0,
-            ],
-            'points' => 5,
-        ];
+        $this->factory->method('getEntityManager')->willReturn($this->entityManager);
+        $this->eventDetails->method('getLead')->willReturn($this->lead);
+        $this->entityManager->method('getRepository')->willReturn($this->hitRepository);
+    }
 
-        // Set up the mocks
-        $factory->method('getEntityManager')->willReturn($entityManager);
-        $eventDetails->method('getLead')->willReturn($lead);
-
-        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
-        $hitRepository = $this->createMock(HitRepository::class);
-        $hitRepository->method('getDwellTimesForUrl')->willReturn([
+    /**
+     * @param array<string, mixed> $action
+     *
+     * @dataProvider urlHitsActionDataProvider
+     */
+    public function testValidateUrlPageHitsAction(array $action, bool $expectedResult): void
+    {
+        $this->eventDetails->method('getUrl')->willReturn('https://example.com/ppk');
+        $this->hitRepository->method('getDwellTimesForUrl')->willReturn([
             'sum'     => 0,
             'min'     => 0,
             'max'     => 0,
             'average' => 0.0,
             'count'   => 1,
         ]);
-        $entityManager->method('getRepository')->willReturn($hitRepository);
+        $this->hitRepository->expects($this->never())->method('getLatestHit');
 
-        // Getting the latest Hit is not needed for this action
-        $hitRepository->expects($this->never())->method('getLatestHit');
+        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
 
-        // Test the method
-        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
-
-        // Assert the result is true as the URL matches the pattern and meets the conditions for the first hit
-        $this->assertTrue($result);
+        $this->assertSame($expectedResult, $result);
     }
 
-    public function testValidateUrlReturnWithinAction(): void
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function urlHitsActionDataProvider(): array
     {
-        // Mock the required objects
-        $factory       = $this->createMock(MauticFactory::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $lead          = $this->createMock(Lead::class);
-        $eventDetails  = $this->createMock(Hit::class);
-        $eventDetails->method('getUrl')->willReturn('https://example.com/test/');
-
-        // Set the action properties for the test scenario
-        $action = [
-            'id'         => 1,
-            'type'       => 'url.hit',
-            'name'       => 'Test return within',
-            'properties' => [
-                'page_url'               => 'https://example.com/test/',
-                'page_hits'              => null,
-                'accumulative_time_unit' => 'H',
-                'accumulative_time'      => 0,
-                'returns_within_unit'    => 'H',
-                'returns_within'         => 14400, // 4 hours in seconds
-                'returns_after_unit'     => 'H',
-                'returns_after'          => 0,
+        return [
+            'url_matches_first_hit' => [
+                [
+                    'id'         => 2,
+                    'type'       => 'url.hit',
+                    'name'       => 'Hit page',
+                    'properties' => [
+                        'page_url'               => 'https://example.com/ppk',
+                        'page_hits'              => 1,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 0,
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 5,
+                ],
+                true,
             ],
-            'points' => 3,
+            'url_does_not_match' => [
+                [
+                    'id'         => 3,
+                    'type'       => 'url.hit',
+                    'name'       => 'Invalid URL',
+                    'properties' => [
+                        'page_url'               => 'https://example.com/invalid',
+                        'page_hits'              => 1,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 0,
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 5,
+                ],
+                false,
+            ],
         ];
-
-        // Set up the mocks
-        $factory->method('getEntityManager')->willReturn($entityManager);
-        $eventDetails->method('getLead')->willReturn($lead);
-
-        $hitRepository = $this->createMock(HitRepository::class);
-
-        // Mock the getLatestHit method to return the current time minus 3 hours
-        $currentTimestamp       = time();
-        $threeHoursAgoTimestamp = $currentTimestamp - (3 * 3600);
-        $latestHit              = new \DateTime();
-        $latestHit->setTimestamp($threeHoursAgoTimestamp);
-        $hitRepository->method('getLatestHit')->willReturn($latestHit);
-
-        $entityManager->method('getRepository')->willReturn($hitRepository);
-
-        // Test the method
-        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
-
-        // Assert the result is true as the URL matches the pattern and meets the "returns_within" condition
-        $this->assertTrue($result);
     }
 
-    public function testValidateUrlReturnWithinActionWhenNoLastHitFound(): void
+    /**
+     * @param array<string, mixed> $action
+     *
+     * @dataProvider returnWithinActionDataProvider
+     */
+    public function testValidateUrlReturnWithinAction(array $action, bool $expectedResult): void
     {
-        // Mock the required objects
-        $factory       = $this->createMock(MauticFactory::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $lead          = $this->createMock(Lead::class);
-        $eventDetails  = $this->createMock(Hit::class);
-        $eventDetails->method('getUrl')->willReturn('https://example.com/test/');
-
-        // Set the action properties for the test scenario
-        $action = [
-            'id'         => 1,
-            'type'       => 'url.hit',
-            'name'       => 'Test return within when no last hit found',
-            'properties' => [
-                'page_url'               => 'https://example.com/test/',
-                'page_hits'              => null,
-                'accumulative_time_unit' => 'H',
-                'accumulative_time'      => 0,
-                'returns_within_unit'    => 'H',
-                'returns_within'         => 14400, // 4 hours in seconds
-                'returns_after_unit'     => 'H',
-                'returns_after'          => 0,
-            ],
-            'points' => 3,
-        ];
-
-        // Set up the mocks
-        $factory->method('getEntityManager')->willReturn($entityManager);
-        $eventDetails->method('getLead')->willReturn($lead);
-        $hitRepository = $this->createMock(HitRepository::class);
-        $hitRepository->method('getLatestHit')->willReturn(null);
-        $entityManager->method('getRepository')->willReturn($hitRepository);
-
-        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
-
-        // Assert the result is false as this was the first URL hit
-        $this->assertFalse($result);
-    }
-
-    public function testValidateUrlAccumulativeTimeAction(): void
-    {
-        // Mock the required objects
-        $factory       = $this->createMock(MauticFactory::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $lead          = $this->createMock(Lead::class);
-        $eventDetails  = $this->createMock(Hit::class);
-        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk/');
-
-        // Set the action properties for the test scenario
-        $action = [
-            'id'         => 1,
-            'type'       => 'url.hit',
-            'name'       => 'Test accumulative time',
-            'properties' => [
-                'page_url'               => 'http://localhost:7000/ppk/',
-                'page_hits'              => null,
-                'accumulative_time_unit' => 'H',
-                'accumulative_time'      => 7200, // 2 hours in seconds
-                'returns_within_unit'    => 'H',
-                'returns_within'         => 0,
-                'returns_after_unit'     => 'H',
-                'returns_after'          => 0,
-            ],
-            'points' => 3,
-        ];
-
-        // Set up the mocks
-        $factory->method('getEntityManager')->willReturn($entityManager);
-        $eventDetails->method('getLead')->willReturn($lead);
-
-        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
-        $hitRepository = $this->createMock(HitRepository::class);
-        $hitRepository->method('getDwellTimesForUrl')->willReturn([
-            'sum'     => 14400, // 4 hours in seconds
-            'min'     => 3600, // 1 hour in seconds
-            'max'     => 7200, // 2 hours in seconds
-            'average' => 3600.0, // 1 hour in seconds
-            'count'   => 4, // 4 hits recorded
-        ]);
-
-        // Getting the latest Hit is not needed for this action
-        $hitRepository->expects($this->never())->method('getLatestHit');
-
-        $entityManager->method('getRepository')->willReturn($hitRepository);
-
-        // Test the method
-        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
-
-        // Assert the result is true as the accumulated time exceeds the specified threshold
-        $this->assertTrue($result);
-    }
-
-    public function testValidateUrlReturnsAfterAction(): void
-    {
-        // Mock the required objects
-        $factory       = $this->createMock(MauticFactory::class);
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $lead          = $this->createMock(Lead::class);
-        $eventDetails  = $this->createMock(Hit::class);
-        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk/');
-
-        // Set the action properties for the test scenario
-        $action = [
-            'id'         => 1,
-            'type'       => 'url.hit',
-            'name'       => 'Test returns after',
-            'properties' => [
-                'page_url'               => 'http://localhost:7000/ppk/',
-                'page_hits'              => null,
-                'accumulative_time_unit' => 'H',
-                'accumulative_time'      => 0,
-                'returns_within_unit'    => 'H',
-                'returns_within'         => 0,
-                'returns_after_unit'     => 'H',
-                'returns_after'          => 7200, // 2 hours in seconds
-            ],
-            'points' => 3,
-        ];
-
-        // Set up the mocks
-        $factory->method('getEntityManager')->willReturn($entityManager);
-        $eventDetails->method('getLead')->willReturn($lead);
-
-        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
-        $hitRepository = $this->createMock(HitRepository::class);
-        $hitRepository->method('getDwellTimesForUrl')->willReturn([
+        $this->eventDetails->method('getUrl')->willReturn('https://example.com/test/');
+        $this->hitRepository->method('getDwellTimesForUrl')->willReturn([
             'sum'     => 0,
             'min'     => 0,
             'max'     => 0,
             'average' => 0.0,
-            'count'   => 1, // Only one hit recorded
+            'count'   => 1,
         ]);
 
-        // Mock the getLatestHit method to return a DateTime object representing 3 hours ago
         $currentTimestamp       = time();
         $threeHoursAgoTimestamp = $currentTimestamp - (3 * 3600);
         $latestHit              = new \DateTime();
         $latestHit->setTimestamp($threeHoursAgoTimestamp);
-        $hitRepository->method('getLatestHit')->willReturn($latestHit);
+        $this->hitRepository->method('getLatestHit')->willReturn($latestHit);
 
-        $entityManager->method('getRepository')->willReturn($hitRepository);
+        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
 
-        // Test the method
-        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+        $this->assertSame($expectedResult, $result);
+    }
 
-        // Assert the result is true as the time elapsed since the last hit exceeds the specified threshold
-        $this->assertTrue($result);
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function returnWithinActionDataProvider(): array
+    {
+        return [
+            'valid_return_within' => [
+                [
+                    'id'         => 1,
+                    'type'       => 'url.hit',
+                    'name'       => 'Test return within',
+                    'properties' => [
+                        'page_url'               => 'https://example.com/test/',
+                        'page_hits'              => null,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 14400, // 4 hours in seconds
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 3,
+                ],
+                true,
+            ],
+            'invalid_return_within' => [
+                [
+                    'id'         => 4,
+                    'type'       => 'url.hit',
+                    'name'       => 'Invalid Return Within',
+                    'properties' => [
+                        'page_url'               => 'https://example.com/test/',
+                        'page_hits'              => null,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 3600, // 1 hour in seconds
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 3,
+                ],
+                false,
+            ],
+        ];
     }
 }

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Helper;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Entity\HitRepository;
+use Mautic\PageBundle\Helper\PointActionHelper;
+use PHPUnit\Framework\TestCase;
+
+class PointActionHelperTest extends TestCase
+{
+    public function testValidateUrlPageHitsAction(): void
+    {
+        // Mock the required objects
+        $factory       = $this->createMock(MauticFactory::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $lead          = $this->createMock(Lead::class);
+        $eventDetails  = $this->createMock(Hit::class);
+        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk');
+
+        // Set the action properties for the test scenario
+        $action = [
+            'id'         => 2,
+            'type'       => 'url.hit',
+            'name'       => 'Hit page',
+            'properties' => [
+                'page_url'               => 'http://localhost:7000/ppk',
+                'page_hits'              => 1,
+                'accumulative_time_unit' => 'H',
+                'accumulative_time'      => 0,
+                'returns_within_unit'    => 'H',
+                'returns_within'         => 0,
+                'returns_after_unit'     => 'H',
+                'returns_after'          => 0,
+            ],
+            'points' => 5,
+        ];
+
+        // Set up the mocks
+        $factory->method('getEntityManager')->willReturn($entityManager);
+        $eventDetails->method('getLead')->willReturn($lead);
+
+        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->method('getDwellTimesForUrl')->willReturn([
+            'sum'     => 0,
+            'min'     => 0,
+            'max'     => 0,
+            'average' => 0.0,
+            'count'   => 1,
+        ]);
+        $entityManager->method('getRepository')->willReturn($hitRepository);
+
+        // Getting the latest Hit is not needed for this action
+        $hitRepository->expects($this->never())->method('getLatestHit');
+
+        // Test the method
+        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+
+        // Assert the result is true as the URL matches the pattern and meets the conditions for the first hit
+        $this->assertTrue($result);
+    }
+
+    public function testValidateUrlReturnWithinAction(): void
+    {
+        // Mock the required objects
+        $factory       = $this->createMock(MauticFactory::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $lead          = $this->createMock(Lead::class);
+        $eventDetails  = $this->createMock(Hit::class);
+        $eventDetails->method('getUrl')->willReturn('https://example.com/test/');
+
+        // Set the action properties for the test scenario
+        $action = [
+            'id'         => 1,
+            'type'       => 'url.hit',
+            'name'       => 'Test return within',
+            'properties' => [
+                'page_url'               => 'https://example.com/test/',
+                'page_hits'              => null,
+                'accumulative_time_unit' => 'H',
+                'accumulative_time'      => 0,
+                'returns_within_unit'    => 'H',
+                'returns_within'         => 14400, // 4 hours in seconds
+                'returns_after_unit'     => 'H',
+                'returns_after'          => 0,
+            ],
+            'points' => 3,
+        ];
+
+        // Set up the mocks
+        $factory->method('getEntityManager')->willReturn($entityManager);
+        $eventDetails->method('getLead')->willReturn($lead);
+
+        $hitRepository = $this->createMock(HitRepository::class);
+
+        // Mock the getLatestHit method to return the current time minus 3 hours
+        $currentTimestamp       = time();
+        $threeHoursAgoTimestamp = $currentTimestamp - (3 * 3600);
+        $latestHit              = new \DateTime();
+        $latestHit->setTimestamp($threeHoursAgoTimestamp);
+        $hitRepository->method('getLatestHit')->willReturn($latestHit);
+
+        $entityManager->method('getRepository')->willReturn($hitRepository);
+
+        // Test the method
+        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+
+        // Assert the result is true as the URL matches the pattern and meets the "returns_within" condition
+        $this->assertTrue($result);
+    }
+
+    public function testValidateUrlReturnWithinActionWhenNoLastHitFound(): void
+    {
+        // Mock the required objects
+        $factory       = $this->createMock(MauticFactory::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $lead          = $this->createMock(Lead::class);
+        $eventDetails  = $this->createMock(Hit::class);
+        $eventDetails->method('getUrl')->willReturn('https://example.com/test/');
+
+        // Set the action properties for the test scenario
+        $action = [
+            'id'         => 1,
+            'type'       => 'url.hit',
+            'name'       => 'Test return within when no last hit found',
+            'properties' => [
+                'page_url'               => 'https://example.com/test/',
+                'page_hits'              => null,
+                'accumulative_time_unit' => 'H',
+                'accumulative_time'      => 0,
+                'returns_within_unit'    => 'H',
+                'returns_within'         => 14400, // 4 hours in seconds
+                'returns_after_unit'     => 'H',
+                'returns_after'          => 0,
+            ],
+            'points' => 3,
+        ];
+
+        // Set up the mocks
+        $factory->method('getEntityManager')->willReturn($entityManager);
+        $eventDetails->method('getLead')->willReturn($lead);
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->method('getLatestHit')->willReturn(null);
+        $entityManager->method('getRepository')->willReturn($hitRepository);
+
+        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+
+        // Assert the result is false as this was the first URL hit
+        $this->assertFalse($result);
+    }
+
+    public function testValidateUrlAccumulativeTimeAction(): void
+    {
+        // Mock the required objects
+        $factory       = $this->createMock(MauticFactory::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $lead          = $this->createMock(Lead::class);
+        $eventDetails  = $this->createMock(Hit::class);
+        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk/');
+
+        // Set the action properties for the test scenario
+        $action = [
+            'id'         => 1,
+            'type'       => 'url.hit',
+            'name'       => 'Test accumulative time',
+            'properties' => [
+                'page_url'               => 'http://localhost:7000/ppk/',
+                'page_hits'              => null,
+                'accumulative_time_unit' => 'H',
+                'accumulative_time'      => 7200, // 2 hours in seconds
+                'returns_within_unit'    => 'H',
+                'returns_within'         => 0,
+                'returns_after_unit'     => 'H',
+                'returns_after'          => 0,
+            ],
+            'points' => 3,
+        ];
+
+        // Set up the mocks
+        $factory->method('getEntityManager')->willReturn($entityManager);
+        $eventDetails->method('getLead')->willReturn($lead);
+
+        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->method('getDwellTimesForUrl')->willReturn([
+            'sum'     => 14400, // 4 hours in seconds
+            'min'     => 3600, // 1 hour in seconds
+            'max'     => 7200, // 2 hours in seconds
+            'average' => 3600.0, // 1 hour in seconds
+            'count'   => 4, // 4 hits recorded
+        ]);
+
+        // Getting the latest Hit is not needed for this action
+        $hitRepository->expects($this->never())->method('getLatestHit');
+
+        $entityManager->method('getRepository')->willReturn($hitRepository);
+
+        // Test the method
+        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+
+        // Assert the result is true as the accumulated time exceeds the specified threshold
+        $this->assertTrue($result);
+    }
+
+    public function testValidateUrlReturnsAfterAction(): void
+    {
+        // Mock the required objects
+        $factory       = $this->createMock(MauticFactory::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $lead          = $this->createMock(Lead::class);
+        $eventDetails  = $this->createMock(Hit::class);
+        $eventDetails->method('getUrl')->willReturn('http://localhost:7000/ppk/');
+
+        // Set the action properties for the test scenario
+        $action = [
+            'id'         => 1,
+            'type'       => 'url.hit',
+            'name'       => 'Test returns after',
+            'properties' => [
+                'page_url'               => 'http://localhost:7000/ppk/',
+                'page_hits'              => null,
+                'accumulative_time_unit' => 'H',
+                'accumulative_time'      => 0,
+                'returns_within_unit'    => 'H',
+                'returns_within'         => 0,
+                'returns_after_unit'     => 'H',
+                'returns_after'          => 7200, // 2 hours in seconds
+            ],
+            'points' => 3,
+        ];
+
+        // Set up the mocks
+        $factory->method('getEntityManager')->willReturn($entityManager);
+        $eventDetails->method('getLead')->willReturn($lead);
+
+        // Mock the HitRepository and configure the getDwellTimesForUrl method to return the desired array
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->method('getDwellTimesForUrl')->willReturn([
+            'sum'     => 0,
+            'min'     => 0,
+            'max'     => 0,
+            'average' => 0.0,
+            'count'   => 1, // Only one hit recorded
+        ]);
+
+        // Mock the getLatestHit method to return a DateTime object representing 3 hours ago
+        $currentTimestamp       = time();
+        $threeHoursAgoTimestamp = $currentTimestamp - (3 * 3600);
+        $latestHit              = new \DateTime();
+        $latestHit->setTimestamp($threeHoursAgoTimestamp);
+        $hitRepository->method('getLatestHit')->willReturn($latestHit);
+
+        $entityManager->method('getRepository')->willReturn($hitRepository);
+
+        // Test the method
+        $result = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+
+        // Assert the result is true as the time elapsed since the last hit exceeds the specified threshold
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10316 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
When new contact is created through the tracking script on external website and you have published "Visits specific URL" point action with "Returns within/after" the Mautic respone will return status 500.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:


<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create and publish "Visits specific URL" point action with "Returns within" parameter
![image](https://github.com/mautic/mautic/assets/8580942/9d589b21-f9ef-461d-9f7c-fb38cbcc7888)
3. OPTION 1:Go to website specified in the action as a new visitor (browser private window or new device). The website must have your mtc tracking script.
OPTION 2: Simulate the request from website with curl. You may need to replace URLs in the curl request
```
curl 'https://mautic.ddev.site/mtc/event' -X POST \
  -H 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.5' \
  -H 'Accept-Encoding: gzip, deflate, br' \
  -H 'Referer: https://yourwebsite.example.com' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'X-Requested-With: XMLHttpRequest' \
  -H 'Origin: https://yourwebsite.example.com' \
  -H 'DNT: 1' \
  -H 'Connection: keep-alive' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: cross-site' \
  --data-raw 'page_title=TEST_TITLE&page_language=en-US&preferred_locale=en_US&page_referrer=&page_url=https%3A%2F%2Fyourwebsite.example.com&counter=0&timezone_offset=-120&resolution=1920x1080&platform=UNIX&do_not_track=true&timezone=Europe%2FWarsaw'
```
4. The request should return a success status (200) and an anonymous contact should be created with a page view:
![image](https://github.com/mautic/mautic/assets/8580942/aa862fff-c875-4148-b615-1a6f63ac920b)
5. Points for action should not be assigned at this point, as they will be assigned when the contact returns to the page.
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
