### PR TITLE
Add two debug logging statements when there is a wrong configuration

### DIFF
--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -380,6 +380,11 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
         if (count(array_diff_key($uniqueLeadFields, $matchedFields)) == count($uniqueLeadFields)) {
             // return if uniqueIdentifiers have no data set to avoid duplicating leads.
+            $this->logger->debug('getMauticLead: No unique identifiers', [
+                'uniqueLeadFields' => $uniqueLeadFields,
+                'matchedFields'    => $matchedFields,
+            ]);
+
             return;
         }
 
@@ -404,6 +409,8 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
             // Use only prioirty fields if updating
             $fieldsToUpdateInMautic = $this->getPriorityFieldsForMautic($config, $object, 'mautic');
             if (empty($fieldsToUpdateInMautic)) {
+                $this->logger->debug('getMauticLead: No fields to update in Mautic', ['config' => $config, 'object' => $object]);
+
                 return;
             }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |  no
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no
| Related user documentation PR URL      | not needed
| Related developer documentation PR URL | not needed
| Issue(s) addressed                     | non created

#### Description:

When there is a misconfiguration of the Mautic fields, the CRM integration (e.g. HubSpot) fails to update the contacts without any hint on why it is failing.

This PR ads two debug level log messages to the log that help to debug this issue for users or system administrators.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Remove the is unique `Is Unique Identifier` from the email (or I guess you can also unpublish it)
3. Sync from a CRM e.g. HubSpot (you need to have a private app with HubSpot, a HubSpot free account is enough).
4. Run the `integration:fetchleads` commands
5. The log shows an entry like this: `getMauticLead: No unique identifiers`

In addition, there is also a debug level entry for when there are no "Priority Fields For Mautic":
getMauticLead: No fields to update in Mautic

Not sure how to achieve that stage for testing. Maybe someone knows? But I guess since it is only a log entry, it is fine without testing.
