### PR TITLE
Pre-Fill the primary company values in the form if they are mapped

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -854,17 +854,19 @@ class FormModel extends CommonFormModel
      */
     public function populateValuesWithLead(Form $form, &$formHtml)
     {
-        $formName       = $form->generateFormName();
-        $fields         = $form->getFields();
-        $autoFillFields = [];
+        $formName          = $form->generateFormName();
+        $fields            = $form->getFields();
+        $autoFillFields    = [];
+        $objectsToAutoFill = ['contact', 'company'];
 
         /** @var \Mautic\FormBundle\Entity\Field $field */
         foreach ($fields as $key => $field) {
-            $leadField  = $field->getLeadField();
-            $isAutoFill = $field->getIsAutoFill();
-
             // we want work just with matched autofill fields
-            if ($field->getMappedField() && 'contact' === $field->getMappedObject() && $field->getIsAutoFill()) {
+            if (
+                $field->getMappedField() &&
+                $field->getIsAutoFill() &&
+                in_array($field->getMappedObject(), $objectsToAutoFill)
+            ) {
                 $autoFillFields[$key] = $field;
             }
         }
@@ -881,8 +883,9 @@ class FormModel extends CommonFormModel
 
         // get the contact (lead) and primary company field values
         $leadArray            = ($lead) ? $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
+
         foreach ($autoFillFields as $field) {
-            $value = $leadArray[$field->getLeadField()];
+            $value = $leadArray[$field->getMappedField()];
             // just skip string empty field
             if ('' !== $value) {
                 $this->fieldHelper->populateField($field, $value, $formName, $formHtml);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -132,7 +132,6 @@ class FormModel extends CommonFormModel
         $this->formActionModel        = $formActionModel;
         $this->formFieldModel         = $formFieldModel;
         $this->fieldHelper            = $fieldHelper;
-        $this->primaryCompanyHelper   = $primaryCompanyHelper;
         $this->leadFieldModel         = $leadFieldModel;
         $this->formUploader           = $formUploader;
         $this->contactTracker         = $contactTracker;

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -882,7 +882,10 @@ class FormModel extends CommonFormModel
         }
 
         // get the contact (lead) and primary company field values
-        $leadArray            = ($lead) ? $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
+        $leadArray = $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
+        if (count($leadArray) <= 0) {
+            return;
+        }
 
         foreach ($autoFillFields as $field) {
             $value = isset($leadArray[$field->getMappedField()]) ? $leadArray[$field->getMappedField()] : '';

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -74,11 +74,6 @@ class FormModel extends CommonFormModel
     protected $fieldHelper;
 
     /**
-     * @var PrimaryCompanyHelper
-     */
-    protected $primaryCompanyHelper;
-
-    /**
      * @var LeadFieldModel
      */
     protected $leadFieldModel;
@@ -115,7 +110,7 @@ class FormModel extends CommonFormModel
         ActionModel $formActionModel,
         FieldModel $formFieldModel,
         FormFieldHelper $fieldHelper,
-        PrimaryCompanyHelper $primaryCompanyHelper,
+        private PrimaryCompanyHelper $primaryCompanyHelper,
         LeadFieldModel $leadFieldModel,
         FormUploader $formUploader,
         ContactTracker $contactTracker,
@@ -888,7 +883,7 @@ class FormModel extends CommonFormModel
         }
 
         foreach ($autoFillFields as $field) {
-            $value = isset($leadArray[$field->getMappedField()]) ? $leadArray[$field->getMappedField()] : '';
+            $value = $leadArray[$field->getMappedField()] ?? '';
             // just skip string empty field
             if ('' !== $value) {
                 $this->fieldHelper->populateField($field, $value, $formName, $formHtml);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -26,6 +26,7 @@ use Mautic\FormBundle\Helper\FormUploader;
 use Mautic\FormBundle\ProgressiveProfiling\DisplayManager;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\FormFieldHelper as ContactFieldHelper;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
@@ -73,6 +74,11 @@ class FormModel extends CommonFormModel
     protected $fieldHelper;
 
     /**
+     * @var PrimaryCompanyHelper
+     */
+    protected $primaryCompanyHelper;
+
+    /**
      * @var LeadFieldModel
      */
     protected $leadFieldModel;
@@ -109,6 +115,7 @@ class FormModel extends CommonFormModel
         ActionModel $formActionModel,
         FieldModel $formFieldModel,
         FormFieldHelper $fieldHelper,
+        PrimaryCompanyHelper $primaryCompanyHelper,
         LeadFieldModel $leadFieldModel,
         FormUploader $formUploader,
         ContactTracker $contactTracker,
@@ -124,18 +131,19 @@ class FormModel extends CommonFormModel
         LoggerInterface $mauticLogger,
         CoreParametersHelper $coreParametersHelper
     ) {
-        $this->requestStack          = $requestStack;
-        $this->twig                  = $twig;
-        $this->themeHelper           = $themeHelper;
-        $this->formActionModel       = $formActionModel;
-        $this->formFieldModel        = $formFieldModel;
-        $this->fieldHelper           = $fieldHelper;
-        $this->leadFieldModel        = $leadFieldModel;
-        $this->formUploader          = $formUploader;
-        $this->contactTracker        = $contactTracker;
-        $this->columnSchemaHelper    = $columnSchemaHelper;
-        $this->tableSchemaHelper     = $tableSchemaHelper;
-        $this->mappedObjectCollector = $mappedObjectCollector;
+        $this->requestStack           = $requestStack;
+        $this->twig                   = $twig;
+        $this->themeHelper            = $themeHelper;
+        $this->formActionModel        = $formActionModel;
+        $this->formFieldModel         = $formFieldModel;
+        $this->fieldHelper            = $fieldHelper;
+        $this->primaryCompanyHelper   = $primaryCompanyHelper;
+        $this->leadFieldModel         = $leadFieldModel;
+        $this->formUploader           = $formUploader;
+        $this->contactTracker         = $contactTracker;
+        $this->columnSchemaHelper     = $columnSchemaHelper;
+        $this->tableSchemaHelper      = $tableSchemaHelper;
+        $this->mappedObjectCollector  = $mappedObjectCollector;
 
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
@@ -871,8 +879,10 @@ class FormModel extends CommonFormModel
             return;
         }
 
+        // get the contact (lead) and primary company field values
+        $leadArray            = ($lead) ? $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
         foreach ($autoFillFields as $field) {
-            $value = $lead->getFieldValue($field->getMappedField());
+            $value = $leadArray[$field->getLeadField()];
             // just skip string empty field
             if ('' !== $value) {
                 $this->fieldHelper->populateField($field, $value, $formName, $formHtml);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -883,7 +883,7 @@ class FormModel extends CommonFormModel
 
         // get the contact (lead) and primary company field values
         $leadArray = $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
-        if (count($leadArray) <= 0) {
+        if (!is_array($leadArray) || count($leadArray) <= 0) {
             return;
         }
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -885,7 +885,7 @@ class FormModel extends CommonFormModel
         $leadArray            = ($lead) ? $this->primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
 
         foreach ($autoFillFields as $field) {
-            $value = $leadArray[$field->getMappedField()];
+            $value = isset($leadArray[$field->getMappedField()]) ? $leadArray[$field->getMappedField()] : '';
             // just skip string empty field
             if ('' !== $value) {
                 $this->fieldHelper->populateField($field, $value, $formName, $formHtml);

--- a/app/bundles/FormBundle/Tests/FormTestAbstract.php
+++ b/app/bundles/FormBundle/Tests/FormTestAbstract.php
@@ -30,6 +30,7 @@ use Mautic\FormBundle\Validator\UploadFieldValidator;
 use Mautic\LeadBundle\Deduplicate\ContactMerger;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -87,6 +88,7 @@ class FormTestAbstract extends TestCase
         $formFieldModel        = $this->createMock(FieldModel::class);
         $this->leadModel       = $this->createMock(LeadModel::class);
         $this->fieldHelper     = $this->createMock(FormFieldHelper::class);
+        $primaryCompanyHelper  = $this->createMock(PrimaryCompanyHelper::class);
         $dispatcher            = $this->createMock(EventDispatcher::class);
         $translator            = $this->createMock(Translator::class);
         $entityManager         = $this->createMock(EntityManager::class);
@@ -123,6 +125,7 @@ class FormTestAbstract extends TestCase
             $formActionModel,
             $formFieldModel,
             $this->fieldHelper,
+            $primaryCompanyHelper,
             $this->leadFieldModel,
             $formUploaderMock,
             $contactTracker,

--- a/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
+++ b/app/bundles/FormBundle/Tests/Model/DeleteFormTest.php
@@ -20,6 +20,7 @@ use Mautic\FormBundle\Helper\FormUploader;
 use Mautic\FormBundle\Model\ActionModel;
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
+use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
@@ -38,6 +39,7 @@ class DeleteFormTest extends \PHPUnit\Framework\TestCase
         $formActionModel       = $this->createMock(ActionModel::class);
         $formFieldModel        = $this->createMock(FieldModel::class);
         $fieldHelper           = $this->createMock(FormFieldHelper::class);
+        $primaryCompanyHelper  = $this->createMock(PrimaryCompanyHelper::class);
         $leadFieldModel        = $this->createMock(LeadFieldModel::class);
         $formUploaderMock      = $this->createMock(FormUploader::class);
         $contactTracker        = $this->createMock(ContactTracker::class);
@@ -55,6 +57,7 @@ class DeleteFormTest extends \PHPUnit\Framework\TestCase
             $formActionModel,
             $formFieldModel,
             $fieldHelper,
+            $primaryCompanyHelper,
             $leadFieldModel,
             $formUploaderMock,
             $contactTracker,

--- a/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/PrimaryCompanyHelper.php
@@ -21,7 +21,7 @@ class PrimaryCompanyHelper
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getProfileFieldsWithPrimaryCompany(Lead $lead)
     {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | no
| New feature/enhancement? (use the a.x branch)      | yes
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | yes
| Related user documentation PR URL      | not needed
| Related developer documentation PR URL | not needed
| Issue(s) addressed                     | Fixes #8400, and forum discussion here https://forum.mautic.org/t/no-auto-fill-of-the-company-fields-in-the-mautic-form/12627/5

#### Description:

In a form, that has company fields mapped, those values are currently not pre-filled.

With this PR also the values from the **primary company** are pre-filled in the form.

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new form that has fields that map to contact and company fields (e.g. firstname, company address)
3. Make sure the pre-fill option is enabled on the field <img width="736" alt="image" src="https://github.com/mautic/mautic/assets/13075514/ea071149-b85a-4fa8-9021-26856e80fff8">
4. Add the form to a landingpage
5. Get a trackable link to this landingpage (so the contact is identified). E.g. by sending a personal email with the link to the landingpage (it has to be a html link, the URL as string in the body of the email does not generate a trackable link)
6. Test it without being logged in with Mautic (e.g. in Incognito)
7. The result should be something like this:
<img width="681" alt="image" src="https://github.com/mautic/mautic/assets/13075514/d30e9145-84e8-4fe3-9eeb-6aa2dd27f013">
