### PR TITLE
Migration for remove quotes from existing campaign event

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
+++ b/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -189,13 +189,4 @@ abstract class AbstractMauticMigration extends AbstractMigration implements Cont
     {
         $this->addSql('SELECT "This migration did not generate select statements." AS purpose');
     }
-
-    protected function getPrefixedTableName(string $tableName = null): string
-    {
-        if (is_null($tableName)) {
-            $tableName = static::$tableName;
-        }
-
-        return $this->prefix.$tableName;
-    }
 }

--- a/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
+++ b/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -189,4 +189,13 @@ abstract class AbstractMauticMigration extends AbstractMigration implements Cont
     {
         $this->addSql('SELECT "This migration did not generate select statements." AS purpose');
     }
+
+    protected function getPrefixedTableName(string $tableName = null): string
+    {
+        if (is_null($tableName)) {
+            $tableName = static::$tableName;
+        }
+
+        return $this->prefix.$tableName;
+    }
 }

--- a/app/migrations/Version20230606111852.php
+++ b/app/migrations/Version20230606111852.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+
+final class Version20230606111852 extends PreUpAssertionMigration
+{
+    public const OLD_STRING = 'Connect a &quot;Send Email&quot; action to the top of this decision.';
+    public const NEW_STRING = 'Connect a Send Email action to the top of this decision.';
+
+    protected static $tableName = 'campaign_events';
+
+    protected function preUpAssertions(): void
+    {
+        $this->skipAssertion(function (Schema $schema) {
+            $sql  = sprintf("select id from %s where properties like '%s' limit 1", $this->getPrefixedTableName(self::$tableName), '%'.self::OLD_STRING.'%');
+            $recordCount = $this->connection->executeQuery($sql)->fetchAllAssociative();
+
+            return !$recordCount;
+        }, 'Migration is not required.');
+    }
+
+    public function up(Schema $schema): void
+    {
+        $sql            = sprintf("select id, properties from %s where properties like '%s'", $this->getPrefixedTableName(self::$tableName), '%'.self::OLD_STRING.'%');
+        $results        = $this->connection->executeQuery($sql)->fetchAllAssociative();
+        $updatedRecords = 0;
+        foreach ($results as $row) {
+            $propertiesArray                            = unserialize($row['properties']);
+            $propertiesArray['settings']['description'] = str_replace(self::OLD_STRING, self::NEW_STRING, $propertiesArray['settings']['description']);
+            $propertiesString                           = serialize($propertiesArray);
+
+            $sql  = sprintf('UPDATE %s SET properties = :properties where id = :id', $this->getPrefixedTableName(self::$tableName));
+            $stmt = $this->connection->prepare($sql);
+            $stmt->bindParam('properties', $propertiesString, \PDO::PARAM_STR);
+            $stmt->bindParam('id', $row['id'], \PDO::PARAM_INT);
+            $stmt->executeStatement();
+
+            $updatedRecords += $stmt->rowCount();
+        }
+        $this->write(sprintf('<comment>%s record(s) have been updated successfully.</comment>', $updatedRecords));
+    }
+}

--- a/app/migrations/Version20230606111852.php
+++ b/app/migrations/Version20230606111852.php
@@ -17,7 +17,7 @@ final class Version20230606111852 extends PreUpAssertionMigration
     protected function preUpAssertions(): void
     {
         $this->skipAssertion(function (Schema $schema) {
-            $sql  = sprintf("select id from %s where properties like '%s' limit 1", $this->getPrefixedTableName(self::$tableName), '%'.self::OLD_STRING.'%');
+            $sql         = sprintf("select id from %s where properties like '%s' limit 1", $this->getPrefixedTableName(self::$tableName), '%'.self::OLD_STRING.'%');
             $recordCount = $this->connection->executeQuery($sql)->fetchAllAssociative();
 
             return !$recordCount;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | No <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

On my instance there were 2 events with labels with encoded quotes as " and it break the json parsing and preventing campaigns to successfully save. 

The issue was addressed in https://github.com/mautic/mautic/pull/12567 to remove the bad content (") from the strings  but event were there before the fix so the quoted string is there in campaign event payload.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Create a campaign event in old format (it would required to manipulate from db , not possible from UI), which have "Connect a "Send Email" action to the top of this decision." in event detail as following :- 
![image](https://github.com/mautic/mautic/assets/48244990/f0560757-5d64-4a58-a7ad-4dea74021d28)

2. Now execute migration and 'Connect a "Send Email" action to the top of this decision.' should be replaced by 'Connect a Send Email action to the top of this decision.'

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
