### PR TITLE
fix: form result table headers and data in rows do match

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Result/_list.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Result/_list.html.twig
@@ -62,6 +62,7 @@
                 {% set fields = form.fields %}
                 {% set fieldCount = canDelete ? 4 : 3 %}
                 {% for f in fields %}
+                    {# skip values for fields that are not to be displayed, e.g. because they are not saved #}
                     {% if f.type not in viewOnlyFields and true == f.saveResult %}
                       {{ include('@MauticCore/Helper/tableheader.html.twig', {
                           'sessionVar': 'formresult.' ~ formId,
@@ -104,19 +105,24 @@
                   </td>
                   <td>{{ dateToFull(item['dateSubmitted'], 'UTC') }}</td>
                   <td>{{ item['ipAddress']|e }}</td>
-                  {% for key, r in item.results %}
-                      {% set isTextarea = ('textarea' == r.type) %}
-                      <td {% if isTextarea %}class="long-text"{% endif %}>
-                          {% if isTextarea %}
-                              {{ r.value|nl2br|e }}
-                          {% elseif 'file' == r.type %}
-                              <a href="{{ path('mautic_form_file_download', {'submissionId': item['id'], 'field': key}) }}">
-                                  {{ r.value|e }}
-                              </a>
-                          {% else %}
-                              {{ r.value|e }}
-                          {% endif %}
-                      </td>
+                  {% for f in fields %}
+                    {# skip values for fields that are not to be displayed, e.g. because they are not saved #}
+                    {% if f.type not in viewOnlyFields and true == f.saveResult %}
+                        {% set key = f.alias %}
+                        {% set r = item.results[key] %}
+                        {% set isTextarea = ('textarea' == r.type) %}
+                        <td {% if isTextarea %}class="long-text"{% endif %}>
+                            {% if isTextarea %}
+                                {{ r.value|nl2br|e }}
+                            {% elseif 'file' == r.type %}
+                                <a href="{{ path('mautic_form_file_download', {'submissionId': item['id'], 'field': key}) }}">
+                                    {{ r.value|e }}
+                                </a>
+                            {% else %}
+                                {{ r.value|e }}
+                            {% endif %}
+                        </td>
+                    {% endif %}
                   {% endfor %}
               </tr>
           {% endfor %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | no
| Related user documentation PR URL      | no
| Related developer documentation PR URL | no
| Issue(s) addressed                     | no issue opened/found

#### Description:

For some reason in the form result view, the table headers and the corresponding data does not match. I assume it happens when the order of the form fields is changed after the initial creation.

As you can see in the printscreen the alias should be file_upload. But is something else from another field:
<img width="624" alt="image" src="https://github.com/mautic/mautic/assets/13075514/cb5c0a22-fd66-40df-89bc-15aa4c29f2e3">

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new form with a couple of fields
3. Submit some form results (e.g. throught the preview, no need to create a landingpage)
4. Make sure that the header and the values correspond 
5. Rearrange the order of the fields in the form
6. Submit some more form results 
7. Make sure that the header and the values still correspond 


