### PR TITLE
Fix date time conditions in request trait

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -130,7 +130,7 @@ trait RequestTrait
                         break;
                     }
 
-                    switch ($type) {
+                    switch (get_class($type)) {
                         case DateTimeType::class:
                             $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i');
                             break;
@@ -141,7 +141,6 @@ trait RequestTrait
                             $params[$name] = (new \DateTime(date('H:i:s', $timestamp)))->format('H:i:s');
                             break;
                     }
-
                     break;
             }
         }

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -6,6 +6,7 @@ use Mautic\CoreBundle\Form\RequestTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\FormFactoryBuilder;
@@ -210,5 +211,36 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
         $expectedValues = ['fieldEmail' => 'email@domain.com'];
         $this->cleanFields($fieldData, $leadField);
         $this->assertSame($expectedValues, $fieldData);
+    }
+
+    public function testDatTimePrepareParametersFromRequest(): void
+    {
+        $params = [
+            'datetime'  => '',
+            'datetime2' => '2023-01-01 21:00:00',
+        ];
+
+        $expectedValues =
+            [
+                'datetime2' => '2023-01-01 21:00',
+            ];
+
+        foreach ($params as $alias => $value) {
+            $this->form->add(
+                $alias,
+                DateTimeType::class,
+                [
+                    'label'    => false,
+                    'attr'     => [
+                        'class' => 'form-control',
+                    ],
+                    'required' => false,
+                ]
+            );
+        }
+
+        $this->prepareParametersFromRequest($this->form, $params);
+
+        $this->assertSame($expectedValues, $params);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Noticed wrong condition in Requestrait. DO not have idea what affected, but never triggered before

<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Just code review from release leader