### PR TITLE
fix: the value of a form field of type tel is displayed correctly

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -3,6 +3,7 @@
 namespace Mautic\FormBundle\Helper;
 
 use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Entity\Field;
 use Symfony\Component\Validator\Constraints\Blank;
@@ -195,8 +196,13 @@ class FormFieldHelper extends AbstractFormFieldHelper
             case 'url':
             case 'date':
             case 'datetime':
+                if ('tel' === $field->getType()) {
+                    $sanitizedValue = InputHelper::clean($value);
+                } else {
+                    $sanitizedValue = $this->sanitizeValue($value);
+                }
                 if (preg_match('/<input(.*?)value="(.*?)"(.*?)id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)\/?>/i', $formHtml, $match)) {
-                    $replace = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[3].'value="'.$this->sanitizeValue($value).'"'
+                    $replace = '<input'.$match[1].'id="mauticform_input_'.$formName.'_'.$alias.'"'.$match[3].'value="'.$sanitizedValue.'"'
                         .$match[4].'/>';
                     $formHtml = str_replace($match[0], $replace, $formHtml);
                 }

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -58,6 +58,13 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
                 'Inline JS values should not be allowed via GET to prevent XSS.',
             ],
             [
+                $this->getField('Phone', 'tel'),
+                '+41 123 456 7890',
+                '<input value="" id="mauticform_input_mautic_phone" />',
+                '<input id="mauticform_input_mautic_phone" value="+41 123 456 7890" />',
+                'Phone number are populated properly',
+            ],
+            [
                 $this->getField('Description', 'textarea'),
                 '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
                 '<textarea id="mauticform_input_mautic_description"></textarea>',


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | yes
| New feature/enhancement? (use the a.x branch)      | no
| Deprecations?                          | no
| BC breaks? (use the c.x branch)        | no
| Automated tests included?              | yes
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | non found

#### Description:

If a contact has an existing phone numer saved, and this phone number should be prefilled in a form, the + at the beginning of the international phone number is replaced by an empty character: " "
<img width="661" alt="image" src="https://github.com/mautic/mautic/assets/13075514/fb7f9c71-b404-4144-85c3-a34ab6a6994e">

This PR fixes this problem by adding a separate way to validate form fields with the type "Tel".

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new form that has a field with the type "Phone" and that map to a contacts phone number. 
3. Make sure the pre-fill option is enabled on the field <img width="736" alt="image" src="https://github.com/mautic/mautic/assets/13075514/ea071149-b85a-4fa8-9021-26856e80fff8">
5. Add the form to a landingpage
6. Get a trackable link to this landingpage (so the contact is identified). E.g. by sending a personal email with the link to the landingpage (it has to be a html link, the URL as string in the body of the email does not generate a trackable link)
7. Test it without being logged in with Mautic (e.g. in Incognito)
8. The form field should be prefilled with all the values on the contact. Including the phone number. E.g. 
 
<img width="634" alt="image" src="https://github.com/mautic/mautic/assets/13075514/ed5cd752-eaa0-4ee8-9c9d-471d3e9d4641">

