### PR TITLE
[DPMMA-2218] Fix email read concurrency issues

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -536,6 +536,8 @@ class EmailRepository extends CommonRepository
     /**
      * Up the read/sent counts.
      *
+     * @depreacated use upCountSent or upCountRead method
+     *
      * @param int        $id
      * @param string     $type
      * @param int        $increaseBy
@@ -562,7 +564,80 @@ class EmailRepository extends CommonRepository
         $retrialLimit = 3;
         while ($retrialLimit >= 0) {
             try {
-                $q->execute();
+                return;
+            } catch (\Doctrine\DBAL\Exception $e) {
+                --$retrialLimit;
+                if (0 === $retrialLimit) {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    public function upCountSent(int $id, int $increaseBy, bool $variant = false): void
+    {
+        if (!$increaseBy) {
+            return;
+        }
+
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        $q->update(MAUTIC_TABLE_PREFIX.'emails');
+        $q->set('sent_count', 'sent_count + 1'.$increaseBy);
+        $q->where('id = '.$id);
+
+        if ($variant) {
+            $q->set('variant_sent_count', 'variant_sent_count + '.$increaseBy);
+        }
+
+        // Try to execute 3 times before throwing the exception
+        // to increase the chance the update will do its stuff.
+        $retrialLimit = 3;
+        while ($retrialLimit >= 0) {
+            try {
+                $q->executeStatement();
+
+                return;
+            } catch (\Doctrine\DBAL\Exception $e) {
+                --$retrialLimit;
+                if (0 === $retrialLimit) {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    public function incrementRead(int $emailId, int $statId, bool $isVariant = false): void
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        $subQuery = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->select('es.email_id')
+            ->from(MAUTIC_TABLE_PREFIX.'email_stats', 'es')
+            ->where('es.id = :statId')
+            ->andWhere('es.is_read = 1');
+
+        $q->update(MAUTIC_TABLE_PREFIX.'emails', 'e')
+            ->set('read_count', 'read_count + 1')
+            ->where(
+                $q->expr()->and(
+                    $q->expr()->eq('e.id', ':emailId'),
+                    $q->expr()->notIn('e.id', $subQuery->getSQL())
+                )
+            )
+            ->setParameter('emailId', $emailId)
+            ->setParameter('statId', $statId);
+
+        if ($isVariant) {
+            $q->set('variant_read_count', 'variant_read_count + 1');
+        }
+
+        // Try to execute 3 times before throwing the exception
+        // to increase the chance the update will do its stuff.
+        $retrialLimit = 3;
+        while ($retrialLimit >= 0) {
+            try {
+                $q->executeStatement();
 
                 return;
             } catch (\Doctrine\DBAL\Exception $e) {

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -536,7 +536,7 @@ class EmailRepository extends CommonRepository
     /**
      * Up the read/sent counts.
      *
-     * @depreacated use upCountSent or upCountRead method
+     * @depreacated use upCountSent or incrementRead method
      *
      * @param int        $id
      * @param string     $type

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -536,7 +536,7 @@ class EmailRepository extends CommonRepository
     /**
      * Up the read/sent counts.
      *
-     * @depreacated use upCountSent or incrementRead method
+     * @deprecated use upCountSent or incrementRead method
      *
      * @param int        $id
      * @param string     $type

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1560,7 +1560,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $strikes = 3;
             while ($strikes >= 0) {
                 try {
-                    $this->getRepository()->upCount($emailId, 'sent', $count, $emailSettings[$emailId]['isVariant']);
+                    $this->getRepository()->upCountSent($emailId, (int) $count, (bool) $emailSettings[$emailId]['isVariant']);
                     break;
                 } catch (\Exception $exception) {
                     error_log($exception);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -515,15 +515,6 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $firstTime = true;
             $stat->setIsRead(true);
             $stat->setDateRead($readDateTime->getDateTime());
-
-            // Only up counts if associated with both an email and lead
-            if ($email && $lead) {
-                try {
-                    $this->getRepository()->upCount($email->getId(), 'read', 1, $email->isVariant());
-                } catch (\Exception $exception) {
-                    error_log($exception);
-                }
-            }
         }
 
         if ($viaBrowser) {
@@ -547,11 +538,19 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $this->dispatcher->dispatch($event, EmailEvents::EMAIL_ON_OPEN);
         }
 
+        $this->em->persist($stat);
+
+        // Only up counts if associated with both an email and lead
+        if ($firstTime && $email && $lead) {
+            try {
+                $this->getRepository()->incrementRead($email->getId(), $stat->getId(), $email->isVariant());
+            } catch (\Exception $exception) {
+                error_log($exception);
+            }
+        }
         if ($email) {
             $this->em->persist($email);
         }
-
-        $this->em->persist($stat);
 
         // Flush the email stat entity in different transactions than the device stat entity to avoid deadlocks.
         $this->flushAndCatch();

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Entity;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailRepository;
+
+class EmailRepositoryIncrementReadTest extends \PHPUnit\Framework\TestCase
+{
+    use RepositoryConfiguratorTrait;
+
+    private QueryBuilder $queryBuilder;
+
+    private QueryBuilder $subQueryBuilder;
+
+    /**
+     * @var EmailRepository|object
+     */
+    private $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo             = $this->configureRepository(Email::class);
+        $this->queryBuilder     = new QueryBuilder($this->connection);
+        $this->subQueryBuilder  = new QueryBuilder($this->connection);
+        $this->connection->method('createQueryBuilder')->willReturnOnConsecutiveCalls(
+            $this->queryBuilder,
+            $this->subQueryBuilder
+        );
+    }
+
+    public function testIncrementRead(): void
+    {
+        $this->connection
+            ->expects($this->exactly(1))
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $this->repo->incrementRead(11, 21);
+        $generatedSql = $this->queryBuilder->getSQL();
+
+        // Assert that the generated SQL matches our expectations
+        $expectedSql = 'UPDATE test_emails e SET read_count = read_count + 1 WHERE (e.id = :emailId) AND (e.id NOT IN (SELECT es.email_id FROM test_email_stats es WHERE (es.id = :statId) AND (es.is_read = 1)))';
+        $this->assertEquals($expectedSql, $generatedSql);
+    }
+
+    public function testIncrementReadWithVariant(): void
+    {
+        $this->connection
+            ->expects($this->exactly(1))
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $this->repo->incrementRead(11, 21, true);
+        $generatedSql = $this->queryBuilder->getSQL();
+
+        // Assert that the generated SQL matches our expectations
+        $expectedSql = 'UPDATE test_emails e SET read_count = read_count + 1, variant_read_count = variant_read_count + 1 WHERE (e.id = :emailId) AND (e.id NOT IN (SELECT es.email_id FROM test_email_stats es WHERE (es.id = :statId) AND (es.is_read = 1)))';
+        $this->assertEquals($expectedSql, $generatedSql);
+    }
+
+    public function testUpCountWithTwoErrors(): void
+    {
+        $this->connection
+            ->expects($this->exactly(3))
+            ->method('executeStatement')
+                ->will(
+                    $this->onConsecutiveCalls(
+                        $this->throwException(new DBALException()),
+                        $this->throwException(new DBALException()),
+                        1
+                    )
+                );
+
+        $this->repo->incrementRead(45, 616);
+    }
+
+    public function testUpCountWithFourErrors(): void
+    {
+        $this->connection
+            ->expects($this->exactly(3))
+            ->method('executeStatement')
+            ->will($this->throwException(new DBALException()));
+
+        $this->expectException(DBALException::class);
+        $this->repo->incrementRead(45, 616);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountSentTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountSentTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Entity;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class EmailRepositoryUpCountSentTest extends \PHPUnit\Framework\TestCase
+{
+    use RepositoryConfiguratorTrait;
+
+    /**
+     * @var MockObject|QueryBuilder
+     */
+    private $queryBuilderMock;
+
+    private QueryBuilder $queryBuilder;
+
+    private EmailRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo             = $this->configureRepository(Email::class);
+        $this->queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $this->queryBuilder     = new QueryBuilder($this->connection);
+    }
+
+    public function testUpCountSentWithNoIncrease(): void
+    {
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilderMock);
+        $this->queryBuilderMock->expects($this->never())
+            ->method('update');
+
+        $this->repo->upCountSent(45, 0);
+    }
+
+    public function testUpCountSentWithId(): void
+    {
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $this->connection
+            ->expects($this->exactly(1))
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $this->repo->upCountSent(11);
+        $generatedSql = $this->queryBuilder->getSQL();
+
+        // Assert that the generated SQL matches our expectations
+        $expectedSql = 'UPDATE test_emails SET sent_count = sent_count + :increaseBy WHERE id = :id';
+        $this->assertEquals($expectedSql, $generatedSql);
+
+        // Assert parameters are properly set up
+        $this->assertEquals(11, $this->queryBuilder->getParameter('id'));
+        $this->assertEquals(1, $this->queryBuilder->getParameter('increaseBy'));
+    }
+
+    public function testUpCountWithVariant(): void
+    {
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $this->connection
+            ->expects($this->exactly(1))
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $this->repo->upCountSent(11, 2, true);
+        $generatedSql = $this->queryBuilder->getSQL();
+
+        // Assert that the generated SQL matches our expectations
+        $expectedSql = 'UPDATE test_emails SET sent_count = sent_count + :increaseBy, variant_sent_count = variant_sent_count + :increaseBy WHERE id = :id';
+        $this->assertEquals($expectedSql, $generatedSql);
+    }
+
+    public function testUpCountWithTwoErrors(): void
+    {
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+
+        $this->connection
+            ->expects($this->exactly(3))
+            ->method('executeStatement')
+            ->will(
+                $this->onConsecutiveCalls(
+                    $this->throwException(new DBALException()),
+                    $this->throwException(new DBALException()),
+                    1
+                )
+            );
+
+        $this->repo->upCountSent(45);
+    }
+
+    public function testUpCountWithFourErrors(): void
+    {
+        $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
+        $this->connection
+            ->expects($this->exactly(3))
+            ->method('executeStatement')
+            ->will($this->throwException(new DBALException()));
+
+        $this->expectException(DBALException::class);
+        $this->repo->upCountSent(45);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountTest.php
@@ -36,6 +36,7 @@ class EmailRepositoryUpCountTest extends \PHPUnit\Framework\TestCase
         $this->queryBuilderMock->expects($this->never())
             ->method('update');
 
+        /** @phpstan-ignore-next-line */
         $this->repo->upCount(45, 'sent', 0);
     }
 
@@ -56,6 +57,7 @@ class EmailRepositoryUpCountTest extends \PHPUnit\Framework\TestCase
         $this->queryBuilderMock->expects($this->once())
             ->method('execute');
 
+        /** @phpstan-ignore-next-line */
         $this->repo->upCount(45);
     }
 
@@ -78,6 +80,7 @@ class EmailRepositoryUpCountTest extends \PHPUnit\Framework\TestCase
         $this->queryBuilderMock->expects($this->once())
             ->method('execute');
 
+        /** @phpstan-ignore-next-line */
         $this->repo->upCount(45, 'read', 2, true);
     }
 
@@ -90,6 +93,7 @@ class EmailRepositoryUpCountTest extends \PHPUnit\Framework\TestCase
                 $this->throwException(new DBALException())
             );
 
+        /** @phpstan-ignore-next-line */
         $this->repo->upCount(45);
     }
 
@@ -100,6 +104,7 @@ class EmailRepositoryUpCountTest extends \PHPUnit\Framework\TestCase
             ->will($this->throwException(new DBALException()));
 
         $this->expectException(DBALException::class);
+        /** @phpstan-ignore-next-line */
         $this->repo->upCount(45);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ Y ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #10056

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR minimises the risk of the concurrency issue with the email read counter described in #10056.

This issue can be easily replicated using curl and the tracking gif from the email:
```
curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif
```
Result:
![image](https://github.com/mautic/mautic/assets/8580942/5371fe7e-cd79-4d00-972e-950aeeaf87de)


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Send an email to segment
3. Get a tracking hash for each contact that received the email. Do not trigger the email view yet, you can get the tracking hash from the contact history link:
![image](https://github.com/mautic/mautic/assets/8580942/724efc2e-271a-426c-9558-3c8471c18cdc)
4. Send multiple concurrent requests to the email browser view or the tracking pixel. Remember to replace the tracking hash
```
// tracking gif
curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif & curl https://mautic.ddev.site/email/64e5b088335ff092502781.gif

// browser view
curl https://mautic.ddev.site/email/view/64e5b088335ff092502781 & curl https://mautic.ddev.site/email/view/64e5b088335ff092502781 & curl https://mautic.ddev.site/email/view/64e5b088335ff092502781 & curl https://mautic.ddev.site/email/view/64e5b088335ff092502781
```
5. The email views counter should be incremented only once per contact

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
DEPRECATIONS:
EmailRepository::upCount - use upCountSent or incrementRead method