### PR TITLE
specify composer version explicitly in tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        tools: composer:2.5
 
     - name: Get tag name
       id: get-mautic-version
@@ -142,6 +143,7 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        tools: composer:2.5
 
     - name: Download full installation package from previous step
       uses: actions/download-artifact@v3
@@ -194,6 +196,7 @@ jobs:
       with:
         php-version: ${{ env.MAUTIC_PHP_MINIMUM_VERSION }}
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        tools: composer:2.5
 
     - name: "Download and install minimum Mautic version: ${{ env.MAUTIC_MINIMUM_VERSION }}"
       env:
@@ -242,6 +245,7 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        tools: composer:2.5
 
     - name: Install dependencies
       working-directory: ./.github/workflows/mautic-asset-upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        tools: composer:2.5
 
     - name: Get tag name
       id: get-mautic-version
@@ -143,7 +142,6 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        tools: composer:2.5
 
     - name: Download full installation package from previous step
       uses: actions/download-artifact@v3
@@ -196,7 +194,6 @@ jobs:
       with:
         php-version: ${{ env.MAUTIC_PHP_MINIMUM_VERSION }}
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        tools: composer:2.5
 
     - name: "Download and install minimum Mautic version: ${{ env.MAUTIC_MINIMUM_VERSION }}"
       env:
@@ -245,7 +242,6 @@ jobs:
       with:
         php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        tools: composer:2.5
 
     - name: Install dependencies
       working-directory: ./.github/workflows/mautic-asset-upload

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,6 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        tools: composer:2.5
         coverage: pcov
         ini-values: pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~"
 
@@ -173,7 +172,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-        tools: composer:2.5
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -244,9 +244,9 @@ jobs:
           ./bin/console cache:clear
         elif [[ "${{ matrix.commands }}" == "composer lock check" ]]; then
           composer update --lock --no-plugins --no-scripts 2> /dev/null
-          git diff composer.lock > /tmp/diff_command_output.txt
+          git diff -I'"plugin-api-version": "[0-9\.]+"' > /tmp/diff_command_output.txt
           if [[ $(wc -l </tmp/diff_command_output.txt) -ge 1 ]]; then
-            echo "The composer.lock file doens't correspond with the changes in the composer.json file"
+            echo "The composer.lock file doesn't correspond with the changes in the composer.json file"
             echo "Please run following command locally"
             echo "composer update --lock"
             echo ""

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        tools: composer:2.5
         coverage: pcov
         ini-values: pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~"
 
@@ -172,6 +173,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        tools: composer:2.5
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

since Composer 2.6.0 was released, the CI pipelines of this repo started failing.
This is because all of us are still on Composer >= 2.3 < 2.6 (explanation below), but CI was automatically using the latest Composer version via the [`Setup PHP` Github Action](https://github.com/shivammathur/setup-php#:~:text=The%20latest%20stable%20version%20of%20composer%20is%20set%20up%20by%20default).

~~This PR addresses this by explicitly specifying the Composer version that should be used. 
A follow-up PR may be needed to enforce the usage of a minimal / maximal Composer version when working on Mautic.~~
_(the approach above was not a good one, as it was not future proof)._

This PR addresses this by ignoring a changed `plugin-api-version` in the `composer.lock` file by using [git diff functionality](https://github.com/git/git/commit/296d4a94e7231a1d57356889f51bff57a1a3c5a1) .

##### Why does a minor composer update matter?

Composer has an API to allow you to write plugins, see [the documentation](https://getcomposer.org/doc/articles/plugins.md#creating-a-plugin).

The last update of the `composer-plugin-api` version happened in [Composer 2.3](https://github.com/composer/composer/blob/main/CHANGELOG.md#:~:text=Bumped%20composer%2Dplugin%2Dapi%20to%202.3.0), where it was updated to `2.3.0`. Composer 2.4 and 2.5 had no update of the `composer-plugin-api` version.
That version is also mentioned on [the documentation pages](https://getcomposer.org/doc/articles/plugins.md#creating-a-plugin:~:text=The%20current%20Composer).

**but** Composer 2.6 also [updated the `composer-plugin-api`](https://github.com/composer/composer/commit/16bdfe4dae0d6ef151d71441849e735f3b0a93c8), without it being mentioned in the [release notes](https://github.com/composer/composer/blob/main/CHANGELOG.md).
This looks like an undocumented change

The version of the `composer-plugin-api`  used during the execution of Composer commands (`require`, `update`, ...) is stored in the `composer.lock` file.
One of the CI tests validates if the `composer.json` file corresponds with the `composer.lock` file.
As the `composer-plugin-api` value changed, that test fails

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
