### PR TITLE
[bugfix] Check is_array on passed value in FieldsTypeTrait

### DIFF
--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -39,7 +39,7 @@ trait FieldsTypeTrait
                 $fieldData      = $event->getData();
 
                 foreach ($mauticFields as $key => $value) {
-                    if (is_array($mauticFields)) {
+                    if (is_array($value)) {
                         $mauticFields[$key] = array_flip($value);
                     }
                 }


### PR DESCRIPTION
I've found this weird case while working on Rector dead-code removal. I think this method is unused, it would crash with simple array:
https://3v4l.org/tGXXu

![Screenshot from 2023-09-05 21-01-45](https://github.com/mautic/mautic/assets/924196/2af9f3ce-3889-4a25-b149-f76bd42700d1)


<br>

Also, the `is_array()` is always true.

<br>

What do you think? :slightly_smiling_face: 
