### PR TITLE
Replacing deprecated cache helper with cache provider in the RequestStorageHelper

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -184,12 +184,6 @@ return [
                     'mautic.email.repository.stat',
                 ],
             ],
-            'mautic.email.helper.request.storage' => [
-                'class'     => \Mautic\EmailBundle\Helper\RequestStorageHelper::class,
-                'arguments' => [
-                    'mautic.cache.provider',
-                ],
-            ],
             'mautic.email.helper.stats_collection' => [
                 'class'     => \Mautic\EmailBundle\Helper\StatsCollectionHelper::class,
                 'arguments' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -187,7 +187,7 @@ return [
             'mautic.email.helper.request.storage' => [
                 'class'     => \Mautic\EmailBundle\Helper\RequestStorageHelper::class,
                 'arguments' => [
-                    'mautic.helper.cache_storage',
+                    'mautic.cache.provider',
                 ],
             ],
             'mautic.email.helper.stats_collection' => [

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -33,5 +33,5 @@ return function (ContainerConfigurator $configurator) {
     $services->alias('mautic.email.model.send_email_to_user', \Mautic\EmailBundle\Model\SendEmailToUser::class);
     $services->alias('mautic.email.model.send_email_to_contacts', \Mautic\EmailBundle\Model\SendEmailToContact::class);
     $services->alias('mautic.email.model.transport_callback', \Mautic\EmailBundle\Model\TransportCallback::class);
-    $services->alias('mautic.email.helper.request.storage', \Mautic\EmailBundle\Helper\RequestStorageHelper::class);
+    $services->alias('mautic.email.helper.request.storage', \Mautic\EmailBundle\Helper\RequestStorageHelper::class);  /** @phpstan-ignore-line as the service is deprecated */
 };

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -33,4 +33,5 @@ return function (ContainerConfigurator $configurator) {
     $services->alias('mautic.email.model.send_email_to_user', \Mautic\EmailBundle\Model\SendEmailToUser::class);
     $services->alias('mautic.email.model.send_email_to_contacts', \Mautic\EmailBundle\Model\SendEmailToContact::class);
     $services->alias('mautic.email.model.transport_callback', \Mautic\EmailBundle\Model\TransportCallback::class);
+    $services->alias('mautic.email.helper.request.storage', \Mautic\EmailBundle\Helper\RequestStorageHelper::class);
 };

--- a/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
+++ b/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
@@ -8,6 +8,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Helper class for storing request payload to a cache location and retrieving it back as a Request.
+ *
+ * @deprecated as unused. To be removed in Mautic 6.0.
  */
 class RequestStorageHelper
 {

--- a/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
+++ b/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
@@ -51,9 +51,8 @@ class RequestStorageHelper
      */
     public function getRequest($key)
     {
-        $key     = $this->removeCachePrefix($key);
-        $adapter = get_class($this->cacheStorage);
-        $error   = "Request with key '{$key}' was not found in the cache store '{$adapter}'.";
+        $error = "Request with key '{$key}' was not found.";
+        $key   = $this->removeCachePrefix($key);
 
         try {
             $item = $this->cacheStorage->getItem($key);

--- a/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
+++ b/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
@@ -14,7 +14,7 @@ class RequestStorageHelper
     /**
      * Separator between the transport class name and random hash.
      */
-    public const KEY_SEPARATOR = ':webhook_request:';
+    public const KEY_SEPARATOR = ';webhook_request;';
 
     private CacheProviderInterface $cacheStorage;
 

--- a/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
+++ b/app/bundles/EmailBundle/Helper/RequestStorageHelper.php
@@ -51,13 +51,18 @@ class RequestStorageHelper
      */
     public function getRequest($key)
     {
-        $key = $this->removeCachePrefix($key);
+        $key     = $this->removeCachePrefix($key);
+        $adapter = get_class($this->cacheStorage);
+        $error   = "Request with key '{$key}' was not found in the cache store '{$adapter}'.";
 
         try {
             $item = $this->cacheStorage->getItem($key);
         } catch (InvalidArgumentException $e) {
-            $adapter = get_class($this->cacheStorage);
-            throw new \UnexpectedValueException("Request with key '{$key}' was not found in the cache store '{$adapter}'.");
+            throw new \UnexpectedValueException($error);
+        }
+
+        if (!$item->isHit()) {
+            throw new \UnexpectedValueException($error);
         }
 
         return new Request([], $item->get());

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -9,6 +9,9 @@ use Mautic\EmailBundle\Helper\RequestStorageHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Transport\NullTransport;
 
+/**
+ * @deprecated as unused. To be removed in Mautic 6.0.
+ */
 class RequestStorageHelperTest extends MauticMysqlTestCase
 {
     private RequestStorageHelper $helper;

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -30,6 +30,20 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
         $this->assertEquals(['some' => 'values'], $request->request->all());
     }
 
+    public function testDeleteRequest(): void
+    {
+        $key = $this->helper->storeRequest(NullTransport::class, new Request([], ['some' => 'values']));
+
+        $request = $this->helper->getRequest($key);
+        $this->assertEquals(['some' => 'values'], $request->request->all());
+
+        $this->helper->deleteCachedRequest($key);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage("Request with key '{$key}' was not found.");
+        $request = $this->helper->getRequest($key);
+    }
+
     public function testGetRequestIfNotFound(): void
     {
         $key = NullTransport::class.';webhook_request;5b43832134cfb0.36545510';

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -17,15 +17,14 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->helper = $this->getContainer()->get('mautic.email.helper.request.storage');
+        $this->helper = $this->getContainer()->get(RequestStorageHelper::class);
     }
 
     public function testStoreRequest(): void
     {
-        $key = $this->helper->storeRequest(MomentumTransport::class, new Request([], ['some' => 'values']));
+        $key = $this->helper->storeRequest(NullTransport::class, new Request([], ['some' => 'values']));
 
-        $this->assertStringStartsWith('Mautic|EmailBundle|Swiftmailer|Transport|MomentumTransport', $key);
-        $this->assertEquals(98, strlen($key));
+        $this->assertStringStartsWith('Symfony|Component|Mailer|Transport|NullTransport', $key);
 
         $request = $this->helper->getRequest($key);
         $this->assertInstanceOf(Request::class, $request);
@@ -34,8 +33,7 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
 
     public function testGetRequestIfNotFound(): void
     {
-        $payload = ['some' => 'values'];
-        $key     = NullTransport::class.':webhook_request:5b43832134cfb0.36545510';
+        $key = NullTransport::class.';webhook_request;5b43832134cfb0.36545510';
 
         $this->expectException(\UnexpectedValueException::class);
         $this->helper->getRequest($key);
@@ -43,7 +41,7 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
 
     public function testGetTransportNameFromKey(): void
     {
-        $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey(NullTransport::class.':webhook_request:5b43832134cfb0.36545510'));
+        $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey(NullTransport::class.';webhook_request;5b43832134cfb0.36545510'));
     }
 
     /**
@@ -51,6 +49,6 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
      */
     public function testGetTransportNameFromKeyWithGlobalPrefix(): void
     {
-        $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey('mautic:Symfony|Component|Mailer|Transport|NullTransport:webhook_request:5bfbe8ce671198.00044461'));
+        $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey('mautic:Symfony|Component|Mailer|Transport|NullTransport;webhook_request;5bfbe8ce671198.00044461'));
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -27,7 +27,6 @@ class RequestStorageHelperTest extends MauticMysqlTestCase
         $this->assertStringStartsWith('Symfony|Component|Mailer|Transport|NullTransport', $key);
 
         $request = $this->helper->getRequest($key);
-        $this->assertInstanceOf(Request::class, $request);
         $this->assertEquals(['some' => 'values'], $request->request->all());
     }
 

--- a/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
@@ -1,86 +1,47 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Helper;
 
-use Mautic\CoreBundle\Helper\CacheStorageHelper;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Helper\RequestStorageHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Transport\NullTransport;
 
-class RequestStorageHelperTest extends \PHPUnit\Framework\TestCase
+class RequestStorageHelperTest extends MauticMysqlTestCase
 {
-    private $cacheStorageMock;
-    private $helper;
+    private RequestStorageHelper $helper;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->cacheStorageMock = $this->createMock(CacheStorageHelper::class);
-        $this->helper           = new RequestStorageHelper($this->cacheStorageMock);
+        $this->helper = $this->getContainer()->get('mautic.email.helper.request.storage');
     }
 
-    public function testStoreRequest()
+    public function testStoreRequest(): void
     {
-        $payload = ['some' => 'values'];
+        $key = $this->helper->storeRequest(MomentumTransport::class, new Request([], ['some' => 'values']));
 
-        $this->cacheStorageMock->expects($this->once())
-            ->method('set')
-            ->with($this->anything(), $payload);
-
-        $key = $this->helper->storeRequest(NullTransport::class, new Request([], $payload));
-
-        $this->assertStringStartsWith(NullTransport::class, $key);
-        $this->assertEquals(88, strlen($key));
-    }
-
-    public function testStoreRequestWithLongTansportName()
-    {
-        $payload           = ['some' => 'values'];
-        $longTransportName = '';
-
-        for ($i = 0; $i < 5; ++$i) {
-            $longTransportName .= NullTransport::class;
-        }
-
-        $this->cacheStorageMock->expects($this->never())
-            ->method('set');
-
-        $this->expectException(\LengthException::class);
-        $key = $this->helper->storeRequest($longTransportName, new Request([], $payload));
-    }
-
-    public function testGetRequest()
-    {
-        $payload = ['some' => 'values'];
-        $key     = NullTransport::class.':webhook_request:5b43832134cfb0.36545510';
-
-        $this->cacheStorageMock->expects($this->once())
-            ->method('get')
-            ->with($key)
-            ->willReturn($payload);
+        $this->assertStringStartsWith('Mautic|EmailBundle|Swiftmailer|Transport|MomentumTransport', $key);
+        $this->assertEquals(98, strlen($key));
 
         $request = $this->helper->getRequest($key);
-
         $this->assertInstanceOf(Request::class, $request);
-        $this->assertEquals($payload, $request->request->all());
+        $this->assertEquals(['some' => 'values'], $request->request->all());
     }
 
-    public function testGetRequestIfNotFound()
+    public function testGetRequestIfNotFound(): void
     {
         $payload = ['some' => 'values'];
         $key     = NullTransport::class.':webhook_request:5b43832134cfb0.36545510';
-
-        $this->cacheStorageMock->expects($this->once())
-            ->method('get')
-            ->with($key)
-            ->willReturn(false);
 
         $this->expectException(\UnexpectedValueException::class);
         $this->helper->getRequest($key);
     }
 
-    public function testGetTransportNameFromKey()
+    public function testGetTransportNameFromKey(): void
     {
         $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey(NullTransport::class.':webhook_request:5b43832134cfb0.36545510'));
     }
@@ -88,7 +49,7 @@ class RequestStorageHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * The StorageHelper will add '%mautic.db_table_prefix%' as a prefix to each cache key.
      */
-    public function testGetTransportNameFromKeyWithGlobalPrefix()
+    public function testGetTransportNameFromKeyWithGlobalPrefix(): void
     {
         $this->assertEquals(NullTransport::class, $this->helper->getTransportNameFromKey('mautic:Symfony|Component|Mailer|Transport|NullTransport:webhook_request:5bfbe8ce671198.00044461'));
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [enhancement]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is replacing the deprecated CacheHelper with its suggested replacement - CacheProvider in one service called RequestStorageHelper.

The reason why we needed this change apart from moving from deprecated services is to use Redis instead of MySql to cache requests as it's faster and helps the overloaded MySql.

#### Steps to test this PR:
1. This cannot be tested by the community as I don't see anything using this service. Internally, it's used by our plugin so I guess it was historically created in the EmailBundle as an idea that it will be used in the core in the future, but the idea was never implemented. On the other hand, this change cannot break anything :)
2. And the service itself is automatically tested by a functional test.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
