### PR TITLE
Fix for non-functional pager on the marketplace overview

### DIFF
--- a/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
@@ -62,9 +62,18 @@ class ListController extends CommonController
             return $this->accessDenied();
         }
 
+        $this->setListFilters();
+
         $request = $this->getCurrentRequest();
         $search  = InputHelper::clean($request->get('search', ''));
-        $limit   = (int) $request->get('limit', 30);
+
+        $session = $request->getSession();
+        if (empty($page)) {
+            $page = $session->get('mautic.marketplace.package.page', 1);
+        }
+
+        // set limits
+        $limit   = $session->get('mautic.marketplace.package.limit', $this->coreParametersHelper->get('default_pagelimit'));
         $route   = $this->routeProvider->buildListRoute($page);
 
         return $this->delegateView(


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When using the pager on the marketplace overview page (`/s/marketplace`), some funkystuff happens:
* you can change the result limit (e.g. 5 instead of 30), but after refreshing the value is the default again
* changing the result limit to 5, going to the next page (as there are 7 in total, there are 2 pages) results in an empty page

This is because the Marketplace ListController doesn't use the default logic (see e.g. in [the `AbstractStandardFormController::indexStandard` method](https://github.com/mautic/mautic/blob/d4ef86f5eee2ae17265fc32e4a44d4b7efb7c8ad/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php#L841-L853)

this PR addresses this

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. go to the  marketplace overview page (`/s/marketplace`)
3. change the result limit to 5, and validate there are 2 pages
4. go to the next page, and verify the number of rows is correct
5. go back to the first page, verify the number of rows is correct
6. change the pager back to 30, and verify the number of results and pager are correct

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
