### PR TITLE
Backport adding API serialization event to 4.4

### DIFF
--- a/app/bundles/ApiBundle/ApiEvents.php
+++ b/app/bundles/ApiBundle/ApiEvents.php
@@ -60,4 +60,23 @@ final class ApiEvents
      * @var string
      */
     const API_ON_ENTITY_POST_SAVE = 'mautic.api_on_entity_post_save';
+
+
+    /**
+     * The mautic.api_pre_serialization_context event is dispatched before the serialization context is created for the view.
+     *
+     * The event listener receives a Mautic\ApiBundle\Event\ApiSerializationContextEvent instance.
+     *
+     * @var string
+     */
+    public const API_PRE_SERIALIZATION_CONTEXT = 'mautic.api_pre_serialization_context';
+
+    /**
+     * The mautic.api_post_serialization_context event is dispatched after the serialization context is created for the view.
+     *
+     * The event listener receives a Mautic\ApiBundle\Event\ApiSerializationContextEvent instance.
+     *
+     * @var string
+     */
+    public const API_POST_SERIALIZATION_CONTEXT = 'mautic.api_post_serialization_context';
 }

--- a/app/bundles/ApiBundle/Event/ApiSerializationContextEvent.php
+++ b/app/bundles/ApiBundle/Event/ApiSerializationContextEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mautic\ApiBundle\Event;
+
+use FOS\RestBundle\Context\Context;
+use Mautic\CoreBundle\Event\CommonEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+class ApiSerializationContextEvent extends CommonEvent
+{
+    protected Context $context;
+
+    private Request $request;
+
+    public function __construct(Context $context, Request $request)
+    {
+        $this->context                 = $context;
+        $this->request                 = $request;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
+     * Sets the context.
+     */
+    public function setContext(Context $context): void
+    {
+        $this->context = $context;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ NO]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Backport of https://github.com/mautic/mautic/pull/12734 for mautic 4.4

This PR adds an Event to the API on the moment (before and after) the serialization context is set. This allows event listeners to change the context, and change the existing exclusion groups and / or strategies to alter the output from the API (and limit it for example).

#### Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Implement a listener which can alter the serialization context.


