### PR TITLE
Campaign event timeline fixes after twig refactoring

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
@@ -23,7 +23,7 @@
         <span id="timeline-campaign-event-text-{{ item.event_id }}"{{ cancelled ? ' class="text-warning"' : '' }}>
             <i class="fa fa-clock-o"></i>
             <span class="timeline-campaign-event-scheduled-{{ item.event_id }}{{cancelled ? ' hide' : '' }}">
-                {{ 'mautic.core.timeline.event.scheduled.time'|trans({'%date%' : dateSpan, '%event%' : event.eventLabel}) }}
+                {{ 'mautic.core.timeline.event.scheduled.time'|trans({'%date%' : dateSpan, '%event%' : event.eventLabel})|purify }}
             </span>
             <span class="timeline-campaign-event-cancelled-{{ item.event_id }}{{ cancelled is empty ? ' hide' : '' }}">
                 {{ 'mautic.campaign.event.cancelled.time'|trans({'%date%' : dateSpan, '%event%' : event.eventLabel}) }}
@@ -49,7 +49,7 @@
     {% if (item.isScheduled) %}
     <hr />
     {% endif %}
-    <p class="text-danger mt-0 mb-10"><i class="fa fa-warning"></i> {{ 'mautic.campaign.event.last_error'|trans }}: {{ errors }}</p>
+    <p class="text-danger mt-0 mb-10"><i class="fa fa-warning"></i> {{ 'mautic.campaign.event.last_error'|trans }}:<br/>{{ errors|purify }}</p>
 {% endif %}
 
 {% if (item.metadata.timeline is defined and item.metadata.timeline is not empty or item.campaign_description or item.event_description) %}

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -462,7 +462,7 @@
                         {% for event in upcomingEvents %}
                             {% set metadata = serializerDecode(event.metadata) %}
                             {% set errors = false %}
-                            {% if metadata.errors is not empty %}
+                            {% if metadata.errors is defined and metadata.errors is not empty %}
                                 {% set errors = metadata.errors is iterable ? metadata.errors|join('<br/>') : metadata.errors %}
                             {% endif %}
                             <li class="media">
@@ -473,7 +473,7 @@
                                     {{ 'mautic.lead.lead.upcoming.event.triggered.at'|trans({
                                           '%event%': event.event_name,
                                           '%link%': '<a href="'~path('mautic_campaign_action', {'objectAction': 'view', 'objectId': event.campaign_id})~'" data-toggle="ajax">'~event.campaign_name~'</a>',
-                                    }) }}
+                                    })|purify }}
                                     {% if errors is not empty %}
                                       <i class="fa fa-warning text-danger" data-toggle="tooltip" title="{{ errors|purify }}"></i>
                                     {% endif %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/12082

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

As I was fixing this error:
![Screenshot 2023-10-05 at 10 04 42](https://github.com/mautic/mautic/assets/1235442/02143e18-9a59-4878-822e-96aca5e99db3)
I also noticed that some places needed the Purify Twig filter:
![Screenshot 2023-10-05 at 09 55 53](https://github.com/mautic/mautic/assets/1235442/edefcdc9-25c9-4aff-9751-41d4891fce08)
This is how it looks after the fixes:
![Screenshot 2023-10-05 at 10 02 36](https://github.com/mautic/mautic/assets/1235442/ef657708-2baf-4cfd-9428-83f4bbc1547c)


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a campaign with an event to add a tag next week. It must be scheduled.
3. Add a contact to the campaign and let it execute
4. Visit the contact detail page and see the error.
5. After this PR is applied, there contact detail page loads and there is no visible HTML markup.
6. If you want to test also how it looks like if there are some errors, you can add this value to the respected row in the `campaign_lead_event_log` table, to the `metadata` column: `a:1:{s:6:"errors";a:2:{i:0;s:7:"error 1";i:1;s:7:"error 2";}}`

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
