### PR TITLE
Fix for 500 error when deleting a Marketing message

### DIFF
--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -196,7 +196,7 @@ class MessageController extends AbstractStandardFormController
     /**
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    protected function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId)
     {
         return $this->deleteStandard($request, $objectId);
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

when deleting a marketing message, the ajax call fails and contains a 500 message.

The logs show following error:

```
[2023-10-06 19:21:57] mautic.CRITICAL: Uncaught PHP Exception InvalidArgumentException: "The controller for URI "/s/messages/delete/4" is not callable: Method "deleteAction" on class "Mautic\ChannelBundle\Controller\MessageController" should be public and non-abstract." at /var/www/html/mautic/vendor/symfony/http-kernel/Controller/ControllerResolver.php line 88 {"exception":"[object] (InvalidArgumentException(code: 0): The controller for URI \"/s/messages/delete/4\" is not callable: Method \"deleteAction\" on class \"Mautic\\ChannelBundle\\Controller\\MessageController\" should be public and non-abstract. at /var/www/html/mautic/vendor/symfony/http-kernel/Controller/ControllerResolver.php:88, InvalidArgumentException(code: 0): Method \"deleteAction\" on class \"Mautic\\ChannelBundle\\Controller\\MessageController\" should be public and non-abstract. at /var/www/html/mautic/vendor/symfony/http-kernel/Controller/ControllerResolver.php:134)"} {"hostname":"468118775c20","pid":44}
```

this is caused by the incorrect access modifier (`protected` instead of `public`) for `MessageController::DeleteAction`

This PR addresses this

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. create a Marketing message
3. delete it (without patch, it fails, with patch it succeeds)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
