### PR TITLE
Fix contact dashboard graph only showing own contacts regardless of permission

### DIFF
--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -93,7 +93,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
     public function onWidgetDetailGenerate(WidgetDetailEvent $event)
     {
         $this->checkPermissions($event);
-        $canViewOthers = $event->hasPermission('form:forms:viewother');
+        $canViewOthers = $event->hasPermission('lead:leads:viewother');
 
         if ('created.leads.in.time' == $event->getType()) {
             $widget = $event->getWidget();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ]
| Related user documentation PR URL      | -
| Related developer documentation PR URL | -changes -->
| Issue(s) addressed                     | -

#### Description:

A user with "View Others" access to contacts is unable to see any other contacts but their own on the dashboard widget for contacts created in time.

If you give the user "View Others" to Forms, then they can see the dashboard widget. So the permission is incorrect.
