### PR TITLE
Avoid replacing the whole 'extra' field in the log processor

### DIFF
--- a/app/bundles/CoreBundle/Monolog/LogProcessor.php
+++ b/app/bundles/CoreBundle/Monolog/LogProcessor.php
@@ -13,10 +13,8 @@ class LogProcessor
      */
     public function __invoke(array $record): array
     {
-        $record['extra'] = [
-            'hostname' => gethostname(),
-            'pid'      => getmypid(),
-        ];
+        $record['extra']['hostname'] = gethostname();
+        $record['extra']['pid']      = getmypid();
 
         return $record;
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Monolog/LogProcessorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Monolog/LogProcessorTest.php
@@ -20,7 +20,9 @@ class LogProcessorTest extends TestCase
             'level_name' => 'DEBUG',
             'channel'    => 'mautic',
             'datetime'   => new \DateTime(),
-            'extra'      => [],
+            'extra'      => [
+                'existing' => 'value',
+            ],
         ];
         $outputRecord = $logProcessor($record);
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR improves the `\Mautic\CoreBundle\Monolog\LogProcessor`, so it does not overwrite all the previous values in the `extra` key. Now it does not cause any issues as we have only one log processor in place. There would be an issue if we introduced another log processor.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure the instance is configured using the following environmental variables (using `.env.local` file):
    ```env
    APP_ENV=dev
    APP_DEBUG=1
    ```
3. Navigate to any mautic section (e.g. `/s/contacts`)
4. Check that log messages still contain the extra keys `hostname` and `pid` like
    ```
    [2023-10-27 12:31:23] event.DEBUG: Notified event "kernel.terminate" to listener "Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelTerminate". {"event":"kernel.terminate","listener":"Symfony\\Component\\HttpKernel\\EventListener\\ProfilerListener::onKernelTerminate"} {"hostname":"2757a4a91302","pid":17}
    ```
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
