### PR TITLE
Support for Redis UNLINK command

### DIFF
--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper;
 
+use Mautic\CoreBundle\Predis\Command\Unlink;
 use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use Mautic\CoreBundle\Predis\Replication\StrategyConfig;
 use Predis\Client;
 use Predis\Connection\Aggregate\SentinelReplication;
+use Predis\Profile\RedisProfile;
 
 /**
  * Helper functions for simpler operations with arrays.
@@ -89,6 +91,11 @@ class PRedisConnectionHelper
             );
         }
 
-        return new Client($endpoints, $inputOptions);
+        $client  = new Client($endpoints, $inputOptions);
+        $profile = $client->getProfile();
+        \assert($profile instanceof RedisProfile);
+        $profile->defineCommand(Unlink::ID, Unlink::class);
+
+        return $client;
     }
 }

--- a/app/bundles/CoreBundle/Predis/Command/Unlink.php
+++ b/app/bundles/CoreBundle/Predis/Command/Unlink.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Predis\Command;
+
+use Predis\Command\Command;
+use Predis\Command\PrefixableCommandInterface;
+
+class Unlink extends Command implements PrefixableCommandInterface
+{
+    public const ID = 'UNLINK';
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+    /**
+     * @param mixed[] $arguments
+     *
+     * @return mixed[]
+     */
+    protected function filterArguments(array $arguments): array
+    {
+        return self::normalizeArguments($arguments);
+    }
+
+    public function prefixKeys($prefix): void
+    {
+        if ($arguments = $this->getArguments()) {
+            foreach ($arguments as &$key) {
+                $key = "$prefix$key";
+            }
+
+            $this->setRawArguments($arguments);
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\PRedisConnectionHelper;
+use Mautic\CoreBundle\Predis\Command\Unlink;
 use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Predis\Command\Processor\KeyPrefixProcessor;
 use Predis\Connection\Aggregate\SentinelReplication;
+use Predis\Profile\RedisProfile;
 
 class PRedisConnectionHelperTest extends TestCase
 {
@@ -72,6 +74,10 @@ class PRedisConnectionHelperTest extends TestCase
         \assert($options->prefix instanceof KeyPrefixProcessor);
         Assert::assertSame($prefix, $options->prefix->getPrefix());
         Assert::assertNull($options->aggregate);
+
+        $profile = $client->getProfile();
+        \assert($profile instanceof RedisProfile);
+        Assert::assertTrue($profile->supportsCommand(Unlink::ID));
     }
 
     public function testCreateClientWithSentinel(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR just adds support for Redis [UNLINK](https://redis.io/commands/unlink/) command. It should be used instead of the DEL command. From the docs:

> This command is very similar to [DEL](https://redis.io/commands/del): it removes the specified keys. Just like [DEL](https://redis.io/commands/del) a key is ignored if it does not exist. However the command performs the actual memory reclaiming in a different thread, so it is not blocking, while [DEL](https://redis.io/commands/del) is.

Please use this command in the new Redis implementations going forward.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This PR cannot be tested as it only adds support for Redis UNLINK command and this command is not utilized by the mautic core codebase at the moment.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
