### PR TITLE
Support for Redis UNLINK command for Redis in the cluster mode

### DIFF
--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use Mautic\CoreBundle\Predis\Replication\StrategyConfig;
 use Predis\Client;
 use Predis\Cluster\ClusterStrategy;
+use Predis\Connection\Aggregate\PredisCluster;
 use Predis\Connection\Aggregate\RedisCluster;
 use Predis\Connection\Aggregate\SentinelReplication;
 use Predis\Profile\RedisProfile;
@@ -109,7 +110,7 @@ class PRedisConnectionHelper
 
         $connection = $client->getConnection();
 
-        if ($connection instanceof RedisCluster) {
+        if ($connection instanceof RedisCluster || $connection instanceof PredisCluster) {
             $clusterStrategy = $connection->getClusterStrategy();
 
             if ($clusterStrategy instanceof ClusterStrategy && !in_array(Unlink::ID, $clusterStrategy->getSupportedCommands())) {

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper;
 
+use Mautic\CoreBundle\Predis\Command\Unlink;
 use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use Mautic\CoreBundle\Predis\Replication\StrategyConfig;
 use Predis\Client;
 use Predis\Connection\Aggregate\SentinelReplication;
+use Predis\Profile\RedisProfile;
 
 /**
  * Helper functions for simpler operations with arrays.
@@ -89,6 +91,11 @@ class PRedisConnectionHelper
             );
         }
 
-        return new Client($endpoints, $inputOptions);
+        $client  = new Client($endpoints, $inputOptions);
+        $profile = $client->getProfile();
+        \assert($profile instanceof RedisProfile);
+        $profile->defineCommand(Unlink::ID, Unlink::class);
+
+        return $client;
     }
 }

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -69,6 +69,12 @@ class PRedisConnectionHelper
             $redisOptions['parameters'] = ['password' => $redisConfiguration['password']];
         }
 
+        foreach (['cluster', 'scheme', 'ssl'] as $key) {
+            if (isset($redisConfiguration[$key])) {
+                $redisOptions[$key] = $redisConfiguration[$key];
+            }
+        }
+
         return $redisOptions;
     }
 

--- a/app/bundles/CoreBundle/Predis/Command/Unlink.php
+++ b/app/bundles/CoreBundle/Predis/Command/Unlink.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Predis\Command;
+
+use Predis\Command\Command;
+use Predis\Command\PrefixableCommandInterface;
+
+class Unlink extends Command implements PrefixableCommandInterface
+{
+    public const ID = 'UNLINK';
+
+    public function getId(): string
+    {
+        return self::ID;
+    }
+
+    /**
+     * @param mixed[] $arguments
+     *
+     * @return mixed[]
+     */
+    protected function filterArguments(array $arguments): array
+    {
+        return self::normalizeArguments($arguments);
+    }
+
+    public function prefixKeys($prefix): void
+    {
+        if ($arguments = $this->getArguments()) {
+            foreach ($arguments as &$key) {
+                $key = "$prefix$key";
+            }
+
+            $this->setRawArguments($arguments);
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\PRedisConnectionHelper;
+use Mautic\CoreBundle\Predis\Command\Unlink;
 use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Predis\Command\Processor\KeyPrefixProcessor;
 use Predis\Connection\Aggregate\SentinelReplication;
+use Predis\Profile\RedisProfile;
 
 class PRedisConnectionHelperTest extends TestCase
 {
@@ -72,6 +74,10 @@ class PRedisConnectionHelperTest extends TestCase
         \assert($options->prefix instanceof KeyPrefixProcessor);
         Assert::assertSame($prefix, $options->prefix->getPrefix());
         Assert::assertNull($options->aggregate);
+
+        $profile = $client->getProfile();
+        \assert($profile instanceof RedisProfile);
+        Assert::assertTrue($profile->supportsCommand(Unlink::ID));
     }
 
     public function testCreateClientWithSentinel(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -9,7 +9,10 @@ use Mautic\CoreBundle\Predis\Command\Unlink;
 use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Predis\Cluster\ClusterStrategy;
 use Predis\Command\Processor\KeyPrefixProcessor;
+use Predis\Connection\Aggregate\PredisCluster;
+use Predis\Connection\Aggregate\RedisCluster;
 use Predis\Connection\Aggregate\SentinelReplication;
 use Predis\Profile\RedisProfile;
 
@@ -78,6 +81,15 @@ class PRedisConnectionHelperTest extends TestCase
         $profile = $client->getProfile();
         \assert($profile instanceof RedisProfile);
         Assert::assertTrue($profile->supportsCommand(Unlink::ID));
+
+        $connection = $client->getConnection();
+
+        if ($connection instanceof RedisCluster || $connection instanceof PredisCluster) {
+            $clusterStrategy = $connection->getClusterStrategy();
+            \assert($clusterStrategy instanceof ClusterStrategy);
+
+            Assert::assertContains(Unlink::ID, $clusterStrategy->getSupportedCommands());
+        }
     }
 
     public function testCreateClientWithSentinel(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR adds support of Redis UNLINK command for Redis Cluster setup. This PRs includes https://github.com/mautic/mautic/pull/12836 as it depends on it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This PR cannot be tested as it only adds support for Redis UNLINK command for Redis Cluster setup and this command is not utilized by the mautic core codebase at the moment.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
