### PR TITLE
Improve SlowTestExtension

### DIFF
--- a/app/bundles/CoreBundle/Test/Hooks/SlowTestExtension.php
+++ b/app/bundles/CoreBundle/Test/Hooks/SlowTestExtension.php
@@ -31,10 +31,16 @@ class SlowTestExtension implements AfterTestHook, AfterLastTestHook
      */
     private $classes = [];
 
+    /**
+     * @var float
+     */
+    private $started;
+
     public function __construct()
     {
         $this->enabled   = (bool) getenv('MAUTIC_TEST_LOG_SLOW_TESTS');
         $this->threshold = (float) (getenv('MAUTIC_TEST_SLOW_TESTS_THRESHOLD') ?: 2);
+        $this->started   = microtime(true);
     }
 
     public function executeAfterTest(string $test, float $time): void
@@ -42,6 +48,9 @@ class SlowTestExtension implements AfterTestHook, AfterLastTestHook
         if (!$this->enabled) {
             return;
         }
+
+        $time            = microtime(true) - $this->started;
+        $this->started   = microtime(true);
 
         if ($time <= $this->threshold) {
             return;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When I was debugging some slow tests, I noticed that the `\Mautic\CoreBundle\Test\Hooks\SlowTestExtension` was not reporting the slow test correctly. This PR improves the extensions, so it reports slow test accurately.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This PR only touches the tests, so there is nothing to test when it comes to the Mautic's functionality.
2. You can check that the slow test reporting works as expected by running the following:
```bash
MAUTIC_TEST_LOG_SLOW_TESTS=1 MAUTIC_TEST_SLOW_TESTS_THRESHOLD=0.0001 composer test -- app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
```
3. You should see the output containing the slow test report as follows:
```
PHPUnit 9.5.20 #StandWithUkraine

using db prefix "test_"
..                                                                  2 / 2 (100%)
Slow test classes:
array (
  'Mautic\\CoreBundle\\Tests\\Unit\\Model\\IteratorExportDataModelTest' => 0.04778885841369629,
)

Time: 00:00.042, Memory: 8.00 MB

OK (2 tests, 6 assertions)
```

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
