### PR TITLE
Contact import made interruptible via the signals

### DIFF
--- a/app/bundles/CoreBundle/ProcessSignal/Exception/SignalCaughtException.php
+++ b/app/bundles/CoreBundle/ProcessSignal/Exception/SignalCaughtException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\ProcessSignal\Exception;
+
+use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
+
+class SignalCaughtException extends \Exception
+{
+    public function __construct(int $signal = ProcessSignalService::SIGTERM)
+    {
+        parent::__construct(sprintf('Signal received: "%d"', $signal), $signal);
+    }
+}

--- a/app/bundles/CoreBundle/ProcessSignal/ProcessSignalService.php
+++ b/app/bundles/CoreBundle/ProcessSignal/ProcessSignalService.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\ProcessSignal;
+
+use Mautic\CoreBundle\ProcessSignal\Exception\SignalCaughtException;
+
+class ProcessSignalService
+{
+    public const SIGTERM  = 15;
+    public const SIGINT   = 2;
+    private const SIGNALS = [self::SIGTERM, self::SIGINT];
+    private ?int $signal  = null;
+
+    /**
+     * @param int[] $signals
+     */
+    public function registerSignalHandler(callable $beforeCallback = null, array $signals = self::SIGNALS): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+
+        $handler = function (int $signal) use ($beforeCallback) {
+            if ($beforeCallback) {
+                call_user_func($beforeCallback, $signal);
+            }
+
+            $this->signal = $signal;
+        };
+
+        foreach ($signals as $signal) {
+            pcntl_signal($signal, $handler);
+        }
+    }
+
+    /**
+     * @param int[] $signals
+     */
+    public function restoreSignalHandler(array $signals = self::SIGNALS): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+
+        foreach ($signals as $signal) {
+            pcntl_signal($signal, SIG_DFL);
+        }
+    }
+
+    public function isSignalCaught(): bool
+    {
+        if (!function_exists('pcntl_signal_dispatch')) {
+            return false;
+        }
+
+        pcntl_signal_dispatch();
+
+        return null !== $this->signal;
+    }
+
+    /**
+     * @throws SignalCaughtException
+     */
+    public function throwExceptionIfSignalIsCaught(): void
+    {
+        if (!$this->isSignalCaught()) {
+            return;
+        }
+
+        throw new SignalCaughtException($this->signal);
+    }
+}

--- a/app/bundles/CoreBundle/Test/ProcessSignal/ProcessSignalServiceTest.php
+++ b/app/bundles/CoreBundle/Test/ProcessSignal/ProcessSignalServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Test\ProcessSignal;
+
+use Mautic\CoreBundle\ProcessSignal\Exception\SignalCaughtException;
+use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class ProcessSignalServiceTest extends TestCase
+{
+    private ProcessSignalService $processSignalService;
+
+    protected function setUp(): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            $this->markTestSkipped('PCNTL extension is required.');
+        }
+
+        if (!function_exists('posix_kill')) {
+            $this->markTestSkipped('POSIX extension is required.');
+        }
+
+        $this->processSignalService = new ProcessSignalService();
+    }
+
+    protected function tearDown(): void
+    {
+        if (!function_exists('pcntl_signal')) {
+            return;
+        }
+
+        pcntl_signal(SIGUSR1, SIG_DFL);
+        pcntl_signal(SIGUSR2, SIG_DFL);
+    }
+
+    /**
+     * @return iterable<string, array{int, int[]}>
+     */
+    public function dataSignals(): iterable
+    {
+        yield 'SIGUSR1' => [SIGUSR1, [SIGUSR1, SIGUSR2]];
+        yield 'SIGUSR2' => [SIGUSR2, [SIGUSR1, SIGUSR2]];
+    }
+
+    /**
+     * @dataProvider dataSignals
+     *
+     * @param int[] $signals
+     */
+    public function testRegisterSignalHandler(int $signal, array $signals): void
+    {
+        $beforeCallbackCalled = false;
+
+        $this->processSignalService->registerSignalHandler(function () use (&$beforeCallbackCalled) {
+            $beforeCallbackCalled = true;
+        }, $signals);
+
+        posix_kill(posix_getpid(), $signal);
+
+        Assert::assertTrue($this->processSignalService->isSignalCaught());
+        Assert::assertTrue($beforeCallbackCalled);
+    }
+
+    /**
+     * @dataProvider dataSignals
+     *
+     * @param int[] $signals
+     */
+    public function testRestoreSignalHandler(int $signal, array $signals): void
+    {
+        $this->processSignalService->registerSignalHandler(null, $signals);
+        Assert::assertIsCallable(pcntl_signal_get_handler($signal));
+
+        $this->processSignalService->restoreSignalHandler($signals);
+        Assert::assertSame(SIG_DFL, pcntl_signal_get_handler($signal));
+    }
+
+    /**
+     * @dataProvider dataSignals
+     *
+     * @param int[] $signals
+     */
+    public function testIsSignalCaught(int $signal, array $signals): void
+    {
+        Assert::assertFalse($this->processSignalService->isSignalCaught());
+
+        $this->processSignalService->registerSignalHandler(null, $signals);
+
+        posix_kill(posix_getpid(), $signal);
+
+        Assert::assertTrue($this->processSignalService->isSignalCaught());
+    }
+
+    /**
+     * @dataProvider dataSignals
+     *
+     * @param int[] $signals
+     */
+    public function testThrowExceptionIfSignalIsCaught(int $signal, array $signals): void
+    {
+        $this->processSignalService->registerSignalHandler(null, $signals);
+
+        posix_kill(posix_getpid(), $signal);
+
+        $this->expectException(SignalCaughtException::class);
+        $this->expectExceptionCode($signal);
+        $this->expectExceptionMessage(sprintf('Signal received: "%d"', $signal));
+
+        $this->processSignalService->throwExceptionIfSignalIsCaught();
+    }
+}

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Command;
 
+use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
 use Mautic\LeadBundle\Exception\ImportDelayedException;
 use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Helper\Progress;
@@ -20,13 +21,15 @@ class ImportCommand extends Command
     public const COMMAND_NAME = 'mautic:import';
     private TranslatorInterface $translator;
     private ImportModel $importModel;
+    private ProcessSignalService $processSignalService;
 
-    public function __construct(TranslatorInterface $translator, ImportModel $importModel)
+    public function __construct(TranslatorInterface $translator, ImportModel $importModel, ProcessSignalService $processSignalService)
     {
         parent::__construct();
 
-        $this->translator  = $translator;
-        $this->importModel = $importModel;
+        $this->translator           = $translator;
+        $this->importModel          = $importModel;
+        $this->processSignalService = $processSignalService;
     }
 
     protected function configure()
@@ -49,6 +52,8 @@ EOT
         $progress = new Progress($output);
         $id       = (int) $input->getOption('id');
         $limit    = (int) $input->getOption('limit');
+
+        $this->processSignalService->registerSignalHandler(fn (int $signal) => $output->writeln(sprintf('Signal %d caught.', $signal)));
 
         if ($id) {
             $import = $this->importModel->getEntity($id);

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -5,6 +5,7 @@ namespace Mautic\LeadBundle\Tests;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\NotificationModel;
+use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Tests\CommonMocks;
 use Mautic\LeadBundle\Entity\Import;
@@ -200,7 +201,8 @@ abstract class StandardImportTestHelper extends CommonMocks
             $this->createMock(UrlGeneratorInterface::class),
             $translator,
             $userHelper,
-            $this->createMock(LoggerInterface::class)
+            $this->createMock(LoggerInterface::class),
+            new ProcessSignalService()
         );
 
         return $importModel;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR makes the `bin/console mautic:import` command interruptible via the signals SIGTERM and SIGINT. If the command is interrupted by one of the signals and executed again, it continues from the place where it left off. This functionality requires the PCNTL PHP extensions. If the extension is not available, the signals are not handled gracefully. In  other words the behavior of the command remains the same as before introducing this PR.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Make sure you have the [PCNTL](https://www.php.net/manual/en/book.pcntl.php) php extension installed.
2. Create a new contact import via the UI.
3. Run the command with the given import ID (e.g. `bin/console mautic:import -i1` for import with ID = 1)
4. Hit `Ctrl+C` during the command execution.
5. You should see `Signal 2 caught.` in the terminal output as follows:
```
$ bin/console mautic:import -i1   
Import 1 with 346 rows is starting.
  70/346 [=====>----------------------]  20%^CSignal 2 caught.
70 lines were processed, 70 items created, 0 items updated, 0 items ignored in 1.44 s
```
6. Run the same command again. You should see that the command started the import from the position where it left off. You can hit `Ctrl+C` and start the command again as shown below.
```
$ bin/console mautic:import -i1
Import 1 with 346 rows is starting.
 173/346 [==============>-------------]  50%^CSignal 2 caught.
198 lines were processed, 198 items created, 0 items updated, 0 items ignored in 2.07 s
$ bin/console mautic:import -i1
Import 1 with 346 rows is starting.
 346/346 [============================] 100%
346 lines were processed, 345 items created, 0 items updated, 1 items ignored in 2.45 s
```
7. The import should be completed at this point.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
