### PR TITLE
[DPMMA-2341] Part of the saveprefsbutton template removed

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Default/form_end.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/form_end.html.twig
@@ -1,0 +1,1 @@
+{{ form_end(form, {render_rest:  false}) }}

--- a/app/bundles/CoreBundle/Resources/views/Default/form_end.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/form_end.html.twig
@@ -1,1 +1,2 @@
-{{ form_end(form, {render_rest:  false}) }}
+{{ form_widget(form._token) }}
+{{ form_end(form, {render_rest: false}) }}

--- a/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Slots/saveprefsbutton.html.twig
@@ -14,32 +14,3 @@
         {{ 'mautic.page.form.saveprefs'|trans }}
     </a>
     <div style="clear:both"></div>
-
-{% if form is defined %}
-    unset($form['subscribed_channels'], $form['buttons']['save'], $form['buttons']['cancel']);
-    if (!$showContactCategories) {
-        unset($form['global_categories']);
-    }
-    if (!$showContactSegments) {
-        unset($form['lead_lists']);
-    }
-    if (!$showContactPauseDates) {
-        unset($form['lead_channels']['contact_pause_start_date_email'], $form['lead_channels']['contact_pause_end_date_email']);
-    }
-    if (!$showContactFrequency) {
-        unset($form['lead_channels']['frequency_number_email'], $form['lead_channels']['frequency_time_email']);
-    }
-    if (!$showContactPreferredChannels) {
-        unset($form['lead_channels']['preferred_channel']);
-    }
-    unset($form['lead_channels']);
-    // add close form tag before the custom tag to prevent cascading forms
-    // in case there is already an unsubscribe form on the page
-    // that's why we can't use the bodyclose customdeclaration
-    if (isset($custom_tag)) {
-        echo $custom_tag;
-        $view['assets']->addCustomDeclaration($view['form']->end($form), 'customTag');
-    } else {
-        $view['assets']->addCustomDeclaration($view['form']->end($form), 'bodyClose');
-    }
-{% endif %}

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -236,7 +236,7 @@ class PublicController extends CommonFormController
                             $viewParameters,
                             [
                                 'form'                         => $formView,
-                                'startform'                    => $this->render('@MauticCore/Default/form.html.twig', ['form' => $formView]),
+                                'startform'                    => $this->renderView('@MauticCore/Default/form.html.twig', ['form' => $formView]),
                                 'custom_tag'                   => '<a name="end-'.$formView->vars['id'].'"></a>',
                                 'showContactFrequency'         => str_contains($html, 'data-slot="channelfrequency"') || str_contains($html, BuilderSubscriber::channelfrequency),
                                 'showContactSegments'          => str_contains($html, 'data-slot="segmentlist"') || str_contains($html, BuilderSubscriber::segmentListRegex),


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [❌]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR removes part of saveprefsbutton.html.twig template, which is no longer used in Mautic 5. The script causes an error and is displayed as text if the email has its own preference center (landing page) with the {saveprefsbutton} token:

![save_pref](https://github.com/mautic/mautic/assets/102536220/f41d41be-cf74-443b-9ff6-1a7e7b2e4a00)

However, if part of the deleted script is needed, please let me know.

#### Steps to reproduce the error:
1. Open Mautic 5.x on Gitpod or pull down for testing locally. 
2. Create <b>Landing Page</b> with option <b>preference center page</b> switched to <b>Yes</b>. In the content add token {saveprefsbutton}. 
![lp_prefs](https://github.com/mautic/mautic/assets/102536220/64fa9cc4-a95b-4838-a7fd-2558ac00e429)
3. Save landing page. 
4. Create a new email and include the landing page as <b>Preference center page</b> in email settings.
5. Send the email to some of your test contacts and click the unsubscribe link included in the email you received.
6. Part of the code will be displayed on the page below the <b>Save preferences</b> button.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Follow steps 2-5 in the "Steps to Reproduce the Error" section.
3. The button should be displayed with no additional text/code below.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
