### PR TITLE
Notification bundle validation.

### DIFF
--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -179,10 +179,8 @@ class CategoryModel extends FormModel
 
     /**
      * Get list of entities for autopopulate fields.
-     *
-     * @return array
      */
-    public function getLookupResults($bundle, $filter = '', $limit = 10)
+    public function getLookupResults($bundle, $filter = '', $limit = 10): array
     {
         static $results = [];
 

--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -221,6 +221,24 @@ class Notification extends FormEntity
             )
         );
 
+        $metadata->addPropertyConstraint(
+            'heading',
+            new NotBlank(
+                [
+                    'message' => 'mautic.core.title.required',
+                ]
+            )
+        );
+
+        $metadata->addPropertyConstraint(
+            'message',
+            new NotBlank(
+                [
+                    'message' => 'mautic.lead.email.body.required',
+                ]
+            )
+        );
+
         $metadata->addConstraint(new Callback([
             'callback' => function (Notification $notification, ExecutionContextInterface $context) {
                 $type = $notification->getNotificationType();

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
@@ -43,7 +43,11 @@ class MobileNotificationDetailsType extends AbstractType
             ]
         );
 
-        if (in_array('ios', $settings['platforms'])) {
+        if (!isset($settings['platforms'])) {
+            return;
+        }
+
+        if (in_array('ios', $settings['platforms'], true)) {
             $builder->add(
                 'ios_subtitle',
                 TextType::class,
@@ -140,7 +144,7 @@ class MobileNotificationDetailsType extends AbstractType
             );
         }
 
-        if (in_array('android', $settings['platforms'])) {
+        if (in_array('android', $settings['platforms'], true)) {
             $builder->add(
                 'android_sound',
                 TextType::class,

--- a/app/bundles/NotificationBundle/Form/Type/NotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationType.php
@@ -68,7 +68,6 @@ class NotificationType extends AbstractType
                 'label'      => 'mautic.notification.form.heading',
                 'label_attr' => ['class' => 'control-label'],
                 'attr'       => ['class' => 'form-control'],
-                'required'   => false,
             ]
         );
 

--- a/app/bundles/NotificationBundle/Resources/views/MobileNotification/form.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/MobileNotification/form.html.twig
@@ -32,10 +32,10 @@
                   <ul class="bg-auto nav nav-tabs pr-md pl-md">
                       <li class="active"><a href="#notification-container" role="tab" data-toggle="tab">{{ 'mautic.core.details'|trans }}</a></li>
                       <li><a href="#data-notification-container" role="tab" data-toggle="tab">{{ 'mautic.notification.tab.data'|trans }}</a></li>
-                      {% if 'ios' in integrationSettings.platforms %}
+                      {% if integrationSettings.platforms is defined and 'ios' in integrationSettings.platforms %}
                           <li><a href="#ios-notification-container" role="tab" data-toggle="tab">{{ 'mautic.notification.tab.ios'|trans }}</a></li>
                       {% endif %}
-                      {% if 'android' in integrationSettings.platforms %}
+                      {% if integrationSettings.platforms is defined and 'android' in integrationSettings.platforms %}
                           <li><a href="#android-notification-container" role="tab" data-toggle="tab">{{ 'mautic.notification.tab.android'|trans }}</a></li>
                       {% endif %}
                   </ul>
@@ -58,7 +58,9 @@
                               <div class="col-md-6">{{ form_row(form.mobileSettings.additional_data) }}</div>
                           </div>
                       </div>
-                      {{ form_widget(form.mobileSettings, {'integrationSettings': integrationSettings}) }}
+                      {% if form.mobileSettings.ios_sound is defined or form.mobileSettings.android_sound is defined  %}
+                        {{ form_widget(form.mobileSettings, {'integrationSettings': integrationSettings}) }}
+                      {% endif %}
                   </div>
                   <!--/ tabs content -->
 

--- a/app/bundles/NotificationBundle/Tests/Controller/MobileNotificationControllerTest.php
+++ b/app/bundles/NotificationBundle/Tests/Controller/MobileNotificationControllerTest.php
@@ -20,4 +20,12 @@ final class MobileNotificationControllerTest extends MauticMysqlTestCase
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
+
+    public function testCreateRouteSuccessfullyLoads(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/s/mobile_notifications/new');
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
 }

--- a/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\NotificationBundle\Tests\Form\Type;
+
+use Mautic\NotificationBundle\Form\Type\MobileNotificationDetailsType;
+use Mautic\PluginBundle\Entity\Integration;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Integration\AbstractIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+
+class MobileNotificationDetailsTypeTest extends TypeTestCase
+{
+    /**
+     * @var MockObject&Integration
+     */
+    private MockObject $integrationSettings;
+
+    /**
+     * @return array<FormExtensionInterface>
+     */
+    protected function getExtensions(): array
+    {
+        $validatorBuilder = Validation::createValidatorBuilder();
+        $validatorBuilder->addMethodMapping('loadValidatorMetadata');
+
+        $this->integrationSettings = $this->createMock(Integration::class);
+
+        // @phpstan-ignore-next-line
+        $integration = $this->createMock(AbstractIntegration::class);
+        $integration->method('getIntegrationSettings')
+            ->willReturn($this->integrationSettings);
+
+        $integrationHelper = $this->createMock(IntegrationHelper::class);
+        $integrationHelper->method('getIntegrationObject')
+            ->with('OneSignal')
+            ->willReturn($integration);
+
+        return [
+            new ValidatorExtension($validatorBuilder->getValidator()),
+            new PreloadedExtension([
+                new MobileNotificationDetailsType($integrationHelper),
+            ], []),
+        ];
+    }
+
+    public function testNoPlatformsSelected(): void
+    {
+        $this->integrationSettings->method('getFeatureSettings')
+            ->willReturn([]);
+
+        $form = $this->factory->create(MobileNotificationDetailsType::class);
+
+        $view = $form->createView();
+        // test only field is "additional_data"
+        self::assertCount(1, $view->children);
+        self::assertArrayHasKey('additional_data', $view->children);
+    }
+
+    /**
+     * @param array<int, string> $platforms
+     * @param array<int, string> $settings
+     *
+     * @dataProvider platformProvider
+     */
+    public function testPlatformSelected(array $platforms, array $settings): void
+    {
+        $this->integrationSettings->method('getFeatureSettings')
+            ->willReturn(['platforms' => $platforms]);
+
+        $form = $this->factory->create(MobileNotificationDetailsType::class);
+
+        $view = $form->createView();
+        self::assertCount(1 + count($settings), $view->children);
+        self::assertArrayHasKey('additional_data', $view->children);
+
+        foreach ($settings as $settingField) {
+            self::assertArrayHasKey($settingField, $view->children);
+        }
+    }
+
+    public static function platformProvider(): \Generator
+    {
+        $iosSettings = [
+            'ios_subtitle',
+            'ios_sound',
+            'ios_badges',
+            'ios_badgeCount',
+            'ios_contentAvailable',
+            'ios_media',
+            'ios_mutableContent',
+        ];
+
+        $androidSettings = [
+            'android_sound',
+            'android_small_icon',
+            'android_large_icon',
+            'android_big_picture',
+            'android_led_color',
+            'android_accent_color',
+            'android_group_key',
+            'android_lockscreen_visibility',
+        ];
+
+        yield 'ios' => [['ios'], $iosSettings];
+        yield 'android' => [['android'], $androidSettings];
+        yield 'both' => [['android', 'ios'], array_merge($androidSettings, $iosSettings)];
+    }
+}

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\NotificationBundle\Tests\Form\Type;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CategoryBundle\Form\Type\CategoryListType;
+use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\NotificationBundle\Entity\Notification;
+use Mautic\NotificationBundle\Form\Type\NotificationType;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class NotificationTypeTest extends TypeTestCase
+{
+    /**
+     * @return array<FormExtensionInterface>
+     */
+    protected function getExtensions(): array
+    {
+        $validatorBuilder = Validation::createValidatorBuilder();
+        $validatorBuilder->addMethodMapping('loadValidatorMetadata');
+
+        return [
+            new ValidatorExtension($validatorBuilder->getValidator()),
+            new PreloadedExtension([
+                new CategoryListType(
+                    $this->createMock(EntityManager::class),
+                    $this->createMock(TranslatorInterface::class),
+                    $this->createMock(CategoryModel::class),
+                    $this->createMock(RouterInterface::class),
+                ),
+            ], []),
+        ];
+    }
+
+    public function testSubmitInvalidData(): void
+    {
+        $form = $this->factory->create(NotificationType::class);
+
+        $expected = new Notification();
+        $expected->setLanguage(null);
+        $expected->setUtmTags([
+            'utmSource'   => null,
+            'utmMedium'   => null,
+            'utmCampaign' => null,
+            'utmContent'  => null,
+        ]);
+        $expected->setIsPublished(false);
+
+        $form->submit([]);
+
+        Assert::assertTrue($form->isSynchronized());
+
+        $formData = $form->getData();
+        \assert($formData instanceof Notification);
+
+        $expected->setChanges($formData->getChanges());
+        Assert::assertEquals($expected, $formData);
+
+        Assert::assertFalse($form->isValid());
+
+        $view          = $form->createView();
+        $invalidFields = ['name', 'heading', 'message'];
+        $errorCount    = 0;
+        foreach ($view->children as $fieldName => $child) {
+            $errors = $view->children[$fieldName]->vars['errors'];
+            \assert($errors instanceof FormErrorIterator);
+
+            if (in_array($fieldName, $invalidFields, true)) {
+                ++$errorCount;
+                self::assertCount(1, $errors);
+                continue;
+            }
+
+            self::assertCount(0, $errors);
+        }
+
+        self::assertCount($errorCount, $invalidFields);
+        self::assertCount(0, $view->vars['errors']);
+    }
+
+    public function testSubmitValidData(): void
+    {
+        $form = $this->factory->create(NotificationType::class);
+
+        $expected = new Notification();
+        $expected->setLanguage(null);
+        $expected->setName('The name');
+        $expected->setHeading('The heading');
+        $expected->setMessage('The message');
+        $expected->setUtmTags([
+            'utmSource'   => null,
+            'utmMedium'   => null,
+            'utmCampaign' => null,
+            'utmContent'  => null,
+        ]);
+        $expected->setIsPublished(false);
+
+        $form->submit([
+            'name'    => 'The name',
+            'heading' => 'The heading',
+            'message' => 'The message',
+        ]);
+
+        Assert::assertTrue($form->isSynchronized());
+
+        $formData = $form->getData();
+        \assert($formData instanceof Notification);
+
+        $expected->setChanges($formData->getChanges());
+        Assert::assertEquals($expected, $formData);
+
+        Assert::assertTrue($form->isValid());
+
+        $view = $form->createView();
+        foreach ($view->children as $fieldName => $child) {
+            $errors = $view->children[$fieldName]->vars['errors'];
+            \assert($errors instanceof FormErrorIterator);
+            self::assertCount(0, $errors);
+        }
+
+        self::assertCount(0, $view->vars['errors']);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ x ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ x ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #11922  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Added required attribute to "Title" field, because in DB the "heading" field is non-nullable.
Fixed validation for the notifications form.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Without opening "One signal" plugin settings page enter the notifications page: `/s/mobile_notifications` or `/s/notifications` and try to create a notification. The form gets a 500 error.
3. Open "One signal" plugin settings and save, this will add default plugin settings.
4. Try to create a notification without setting "Title" and/or "Message" fields.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
