### PR TITLE
Fix date empty/notEmpty companies segment filters

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -59,19 +59,31 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
 
         switch ($filterOperator) {
             case 'empty':
+                $parts      = [
+                    $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField()),
+                ];
+                if ($filter->doesColumnSupportEmptyValue()) {
+                    $parts[] = $queryBuilder->expr()->eq(
+                        $tableAlias.'.'.$filter->getField(),
+                        $queryBuilder->expr()->literal('')
+                    );
+                }
                 $expression = new CompositeExpression(CompositeExpression::TYPE_OR,
-                    [
-                        $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField()),
-                        $queryBuilder->expr()->eq($tableAlias.'.'.$filter->getField(), $queryBuilder->expr()->literal('')),
-                    ]
+                    $parts
                 );
                 break;
             case 'notEmpty':
+                $parts     = [
+                    $queryBuilder->expr()->isNotNull($tableAlias.'.'.$filter->getField()),
+                ];
+                if ($filter->doesColumnSupportEmptyValue()) {
+                    $parts[] = $queryBuilder->expr()->neq(
+                        $tableAlias.'.'.$filter->getField(),
+                        $queryBuilder->expr()->literal('')
+                    );
+                }
                 $expression = new CompositeExpression(CompositeExpression::TYPE_AND,
-                    [
-                        $queryBuilder->expr()->isNotNull($tableAlias.'.'.$filter->getField()),
-                        $queryBuilder->expr()->neq($tableAlias.'.'.$filter->getField(), $queryBuilder->expr()->literal('')),
-                    ]
+                    $parts
                 );
 
                 break;

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -18,6 +18,8 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
      */
     private $leads = [];
 
+    protected $useCleanupRollback = false;
+
     /**
      * Test creates: contacts, segment
      * Test rebuilds segment
@@ -25,14 +27,7 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
      */
     public function testSegments(): void
     {
-        $field = new LeadField();
-        $field->setType('datetime');
-        $field->setObject('company');
-        $field->setAlias('companydatetime');
-        $field->setName('Company datetime');
-        $fieldModel = self::getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
-        $fieldModel->saveEntity($field);
+        $this->createCustomCompanyDateField();
 
         foreach ($this->getSegmentsProvider() as $scenario) {
             $this->runTestSegments($scenario['contacts'], $scenario['segment']);
@@ -191,5 +186,16 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
                 ['field' => 'companydatetime', 'object' => 'company',  'operator' => 'empty', 'value' => null, 'glue' => 'and', 'type' => 'datetime'],
             ],
         ];
+    }
+
+    protected function createCustomCompanyDateField(): void
+    {
+        $field = new LeadField();
+        $field->setType('datetime');
+        $field->setObject('company');
+        $field->setAlias('companydatetime');
+        $field->setName('Company datetime');
+        $fieldModel = self::getContainer()->get(FieldModel::class);
+        $fieldModel->saveEntity($field);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\LeadBundle\Tests\Segment;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Segment\ContactSegmentService;
 
 class SegmentFilterFunctionalTest extends MauticMysqlTestCase
@@ -23,6 +25,15 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
      */
     public function testSegments(): void
     {
+        $field = new LeadField();
+        $field->setType('datetime');
+        $field->setObject('company');
+        $field->setAlias('companydatetime');
+        $field->setName('Company datetime');
+        $fieldModel = self::getContainer()->get(FieldModel::class);
+        \assert($fieldModel instanceof FieldModel);
+        $fieldModel->saveEntity($field);
+
         foreach ($this->getSegmentsProvider() as $scenario) {
             $this->runTestSegments($scenario['contacts'], $scenario['segment']);
         }
@@ -83,7 +94,7 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
         $filters = [];
         foreach ($segmentFilters as $segmentFilter) {
             $filters[] = [
-                'object'     => 'lead',
+                'object'     => $segmentFilter['object'] ?? 'lead',
                 'glue'       => $segmentFilter['glue'],
                 'field'      => $segmentFilter['field'],
                 'type'       => $segmentFilter['type'],
@@ -169,6 +180,15 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
             ],
             'segment' => [
                 ['field' => 'points', 'operator' => 'gte', 'value' => 20, 'glue' => 'and', 'type' => 'text'],
+            ],
+        ];
+
+        yield [
+            'contacts' => [
+                ['email' => 'lukas@mautic.com', 'in_segment' => true],
+            ],
+            'segment' => [
+                ['field' => 'companydatetime', 'object' => 'company',  'operator' => 'empty', 'value' => null, 'glue' => 'and', 'type' => 'datetime'],
             ],
         ];
     }

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentDateValidator.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentDateValidator.php
@@ -29,7 +29,7 @@ final class SegmentDateValidator extends ConstraintValidator
                     continue;
                 }
 
-                if (in_array($filter['operator'] ?? '', ['regexp', '!regexp', 'like', '!like', 'startsWith', 'endsWith', 'contains'])) {
+                if (in_array($filter['operator'] ?? '', ['empty', '!empty', 'regexp', '!regexp', 'like', '!like', 'startsWith', 'endsWith', 'contains'])) {
                     continue;
                 }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->
#### Description:
The PR https://github.com/mautic/mautic/pull/11126 fixed MySQL8 empty/notEmpty filter for contact fields. But company date/datetime fields return error as well. This PR fix it

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Be sure you are on mysql8 - to do this in Gitpod follow these steps:

- Start the Gitpod instance and immediately stop the installation process by pressing command+c / ctrl+c when in the console
- Delete anything that has already been started with the command `ddev delete --omit-snapshot --yes && rm -rf var/cache && rm app/config/local.php`
- Edit the file in .ddev/config.yaml and change the DB from mariaDB 10.3 to mysql8 - remember to save the file!

```
mariadb_version: ""
mysql_version: "8.0"
```

- Type ddev start in the console to continue with installation
- Run the installer in the UI or command line as preferred
- Check you are using MySQL in the database config screen under system information
- Remember to make sure you are using dev mode (index_dev.php on the end of the URL)
- If you make a mistake, open your Gitpod dashboard and delete the instance and start again.

3. Create company date/datetime field
4. Add field to segment filter
5. Rebuild segment filter
6. You should see error
`Incorrect DATE value: ''`

7. After PR should work properly
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11411"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>