### PR TITLE
Fix datetime contact value campaign condition

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -7,6 +7,7 @@ use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
@@ -171,6 +172,7 @@ class CampaignSubscriber implements EventSubscriberInterface
             'description' => 'mautic.lead.lead.events.updatelead_descr',
             'formType'    => UpdateLeadActionType::class,
             'formTheme'   => '@MauticLead/FormTheme/ActionUpdateLead/_updatelead_action_widget.html.twig',
+
             'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
         ];
         $event->addAction('lead.updatelead', $action);
@@ -698,16 +700,18 @@ class CampaignSubscriber implements EventSubscriberInterface
 
     /**
      * Function to compare date value.
-     *
-     * @return bool
      */
-    private function compareDateValue(Lead $lead, CampaignExecutionEvent $event, \DateTime $triggerDate)
+    private function compareDateValue(Lead $lead, CampaignExecutionEvent $event, \DateTime $triggerDate): bool
     {
-        return $this->leadFieldModel->getRepository()->compareDateValue(
-            $lead->getId(),
-            $event->getConfig()['field'],
-            $triggerDate->format('Y-m-d')
-        );
+        $fieldValueToCompare  = $event->getLead()->getProfileFields()[$event->getConfig()['field']] ?? null;
+
+        if (empty($fieldValueToCompare)) {
+            return false;
+        }
+
+        $dateTimeHelper = new DateTimeHelper($fieldValueToCompare);
+
+        return $dateTimeHelper->toUtcString('Y-m-d') === $triggerDate->format('Y-m-d');
     }
 
     protected function getFields(Lead $lead): array


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

If you use datetime field to contact value campaign condition it was not compare properly. This PR fixed it

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Change timezone in configuration to Europe/paris
2. Create datetime field 
3. Create contact and set datetime If today is 28.10, then set 27.10. 2021 00:00
4. Create campaign with condition field value with date -1 day

![image](https://user-images.githubusercontent.com/462477/139283015-4cb24f96-3896-4161-97af-a3e7bd038719.png)

5. Trigger campaign
6. Before contact was not true for condition because we compare datetime (yyyy-mm-dd h:i:s) with date (yyy-mm-dd). 
7. After PR should work  properly

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/10560"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>