### PR TITLE
Fix set boolean properties on form field

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -1142,7 +1142,7 @@ class FormModel extends CommonFormModel
                 $list = $contactFieldProps['list'] ?? [];
                 break;
             case 'boolean':
-                $list = [$contactFieldProps['no'], $contactFieldProps['yes']];
+                $list = [['label'=> $contactFieldProps['no'], 'value' => 0], ['label'=>  $contactFieldProps['yes'], 'value' => 1]];
                 break;
             case 'country':
                 $list = ContactFieldHelper::getCountryChoices();

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -20,8 +20,7 @@
 {% set inputAttributes = htmlAttributesStringToArray(field.inputAttributes|default('')) %}
 {% set labelAttributes = htmlAttributesStringToArray(field.labelAttributes|default('')) %}
 {% set containerAttributes = htmlAttributesStringToArray(field.containerAttributes|default('')) %}
-{%
-    if ignoreName is not defined or (ignoreName is defined and ignoreName is empty) %}
+{% if ignoreName is not defined or (ignoreName is defined and ignoreName is empty) %}
   {% set inputName = 'mauticform[' ~ field.alias ~ ']' %}
   {% if field.properties.multiple is defined %}
     {% set inputName = inputName ~ '[]' %}

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -20,6 +20,7 @@
 {% set inputAttributes = htmlAttributesStringToArray(field.inputAttributes|default('')) %}
 {% set labelAttributes = htmlAttributesStringToArray(field.labelAttributes|default('')) %}
 {% set containerAttributes = htmlAttributesStringToArray(field.containerAttributes|default('')) %}
+
 {% if ignoreName is not defined or (ignoreName is defined and ignoreName is empty) %}
   {% set inputName = 'mauticform[' ~ field.alias ~ ']' %}
   {% if field.properties.multiple is defined %}
@@ -123,6 +124,7 @@
           ]),
   }) %}
 {% endif %}
+
 {# Setup list parsing #}
 {%- if list is defined or field.properties.syncList is defined or field.properties.list is defined or field.properties.optionList is defined -%}
   {%- set parseList = [] -%}

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -20,8 +20,8 @@
 {% set inputAttributes = htmlAttributesStringToArray(field.inputAttributes|default('')) %}
 {% set labelAttributes = htmlAttributesStringToArray(field.labelAttributes|default('')) %}
 {% set containerAttributes = htmlAttributesStringToArray(field.containerAttributes|default('')) %}
-
-{% if ignoreName is not defined or (ignoreName is defined and ignoreName is empty) %}
+{%
+    if ignoreName is not defined or (ignoreName is defined and ignoreName is empty) %}
   {% set inputName = 'mauticform[' ~ field.alias ~ ']' %}
   {% if field.properties.multiple is defined %}
     {% set inputName = inputName ~ '[]' %}
@@ -124,7 +124,6 @@
           ]),
   }) %}
 {% endif %}
-
 {# Setup list parsing #}
 {%- if list is defined or field.properties.syncList is defined or field.properties.list is defined or field.properties.optionList is defined -%}
   {%- set parseList = [] -%}
@@ -149,6 +148,7 @@
                 '0': mappedField.properties.no,
                 '1': mappedField.properties.yes,
         }-%}
+        {%- set isBooleanList = true -%}
       {%- elseif 'country' == mappedFieldType -%}
         {%- set list = leadFieldCountryChoices() -%}
       {%- elseif 'region' == mappedFieldType -%}
@@ -235,7 +235,7 @@
             'type': type,
             'value': listValue|e,
     }) %}
-    {% if field.defaultValue == listValue %}
+    {% if field.defaultValue != '' and field.defaultValue == listValue %}
       {% set inputAttributes = inputAttributes|merge({
               'checked': 'checked',
       }) %}

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -382,7 +382,7 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
 
         $this->formModel->getEntity(5);
 
-        $this->assertSame(['lunch?', 'dinner?'], $formField->getProperties()['list']['list']);
+        $this->assertSame([['label' => 'lunch?', 'value' => 0], ['label' => 'dinner?', 'value' => 1]], $formField->getProperties()['list']['list']);
     }
 
     public function testGetEntityForSyncedCountryField(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->


#### Description:

M5 version of https://github.com/mautic/mautic/pull/11171

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Properties for bolean fields are set as `yes => Yes` to properties. It make issue for some cases. This PR fixed it.

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create form with email and boolean and checkbox group with boolean contact field mapping and enabled **Use assigned contact/company field's list choices.**
![image](https://user-images.githubusercontent.com/462477/174253835-efb36637-f1d5-46cd-82b7-2e90be7c5b9b.png)
3. Submit form with Yes option
4. Go to campaign and create campaign with `form field condition` for checkboxgroup field  with preselected option Yes
5. Run campaign. 
6. See like condition go to false path, even we expect true
7. Condition compare `'yes' === true`, after PR should go to true


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->


<a href="https://gitpod.io/#https://github.com/mautic/mautic/pull/11171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
