### PR TITLE
exceptions such as assertions produce code 1, which is not valid exit…

### DIFF
--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -23,7 +23,7 @@ class ExceptionController extends CommonController
         $layout         = 'prod' == MAUTIC_ENV ? 'Error' : 'Exception';
         $code           = $exception->getStatusCode();
 
-        if (0 === $code) {
+        if (0 === $code || 1 === $code) {   // 1 is thrown by e.g. assertions
             // thrown exception that didn't set a code
             $code = 500;
         }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]

### Description:

if exit code of exception is **1** new exception is thrown as a result.

```shell
[2023-11-03 10:52:26] mautic.CRITICAL: Exception thrown when handling an exception (InvalidArgumentException: The HTTP status code "1" is not valid. at /var/www/html/vendor/symfony/http-foundation/Response.php line 470) {"exception":"[object] (InvalidArgumentException(code: 0): The HTTP status code \"1\" is not valid. at /var/www/html/vendor/symfony/http-foundation/Response.php:470)
[stacktrace]
#0 /var/www/html/vendor/symfony/http-foundation/Response.php(219): Symfony\\Component\\HttpFoundation\\Response->setStatusCode(1)
#1 /var/www/html/app/bundles/CoreBundle/Controller/CommonController.php(204): Symfony\\Component\\HttpFoundation\\Response->__construct('', 1)
#2 /var/www/html/app/bundles/CoreBundle/Controller/ExceptionController.php(111): Mautic\\CoreBundle\\Controller\\CommonController->delegateView(Array)
#3 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(163): Mautic\\CoreBundle\\Controller\\ExceptionController->showAction(Object(Symfony\\Component\\HttpFoundation\\Request), Object(Symfony\\Component\\ErrorHandler\\Exception\\FlattenException), Object(Mautic\\CoreBundle\\Helper\\ThemeHelper), Object(Symfony\\Bridge\\Monolog\\Logger))
#4 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(75): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw(Object(Symfony\\Component\\HttpFoundation\\Request), 2)
#5 /var/www/html/app/bundles/CoreBundle/EventListener/ExceptionListener.php(63): Symfony\\Component\\HttpKernel\\HttpKernel->handle(Object(Symfony\\Component\\HttpFoundation\\Request), 2, false)
#6 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(270): Mautic\\CoreBundle\\EventListener\\ExceptionListener->onKernelException(Object(Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\EventDispatcher\\EventDispatcher))
#7 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Symfony\\Component\\EventDispatcher\\EventDispatcher::Symfony\\Component\\EventDispatcher\\{closure}(Object(Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent), 'kernel.exceptio...', Object(Symfony\\Component\\EventDispatcher\\EventDispatcher))
#8 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\\Component\\EventDispatcher\\EventDispatcher->callListeners(Array, 'kernel.exceptio...', Object(Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent))
#9 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(223): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch(Object(Symfony\\Component\\HttpKernel\\Event\\ExceptionEvent), 'kernel.exceptio...')
#10 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(114): Symfony\\Component\\HttpKernel\\HttpKernel->handleThrowable(Object(AssertionError), Object(Symfony\\Component\\HttpFoundation\\Request), 1)
#11 /var/www/html/vendor/symfony/http-kernel/EventListener/DebugHandlersListener.php(131): Symfony\\Component\\HttpKernel\\HttpKernel->terminateWithException(Object(AssertionError), Object(Symfony\\Component\\HttpFoundation\\Request))
#12 /var/www/html/vendor/symfony/error-handler/ErrorHandler.php(607): Symfony\\Component\\HttpKernel\\EventListener\\DebugHandlersListener::Symfony\\Component\\HttpKernel\\EventListener\\{closure}(Object(AssertionError))
#13 [internal function]: Symfony\\Component\\ErrorHandler\\ErrorHandler->handleException(Object(AssertionError))
#14 {main}
"} {"hostname":"a5d391faa085","pid":622}
``` 

#### Steps to test this PR:

 1. assert exception anywhere in the code, take DashboardController for instance. 
 2. apply this PR
 3. verify exception is correctly thrown.

