### PR TITLE
add interface to SubmissionResultLoader to appear in models

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionResultLoader.php
+++ b/app/bundles/FormBundle/Model/SubmissionResultLoader.php
@@ -3,10 +3,11 @@
 namespace Mautic\FormBundle\Model;
 
 use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Model\MauticModelInterface;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
 
-class SubmissionResultLoader
+class SubmissionResultLoader implements MauticModelInterface
 {
     /**
      * @var EntityManager

--- a/app/bundles/FormBundle/Validator/UploadFieldValidator.php
+++ b/app/bundles/FormBundle/Validator/UploadFieldValidator.php
@@ -33,12 +33,11 @@ class UploadFieldValidator
     {
         $files = $request->files->get('mauticform');
 
-        if (!$files || !array_key_exists($field->getAlias(), $files)) {
+        if (!$files || !array_key_exists($field->getAlias(), $files) || !$files[$field->getAlias()] instanceof UploadedFile) {
             throw new NoFileGivenException();
         }
 
         $file = $files[$field->getAlias()];
-        \assert($file instanceof UploadedFile);
 
         $properties = $field->getProperties();
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]
| Issue(s) addressed                     | Fixes #12868

#### Description:

Model is not correctly inheriting interface so it is not available in service locator. this fixes it.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. create a form with file upload and upload a file
3. try to open the file from form submission list

