### PR TITLE
Allow multiple lookup fields for same type in same form

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
+++ b/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
@@ -94,13 +94,13 @@ class EntityLookupType extends AbstractType
                 'choice_loader'          => function (Options $options) {
                     // This class is defined as a service therefore the choice loader has to be unique per field that inherits this class as a parent
                     // if you have multiple lookup fields with same type then use different - 2 'key' for all fields
-                    $model = $this->getModelName($options);
+                    $model                       = $this->getModelName($options);
                     $this->choiceLoaders[$model] = new EntityLookupChoiceLoader(
-                            $this->modelFactory,
-                            $this->translator,
-                            $this->connection,
-                            $options
-                        );
+                        $this->modelFactory,
+                        $this->translator,
+                        $this->connection,
+                        $options
+                    );
 
                     return $this->choiceLoaders[$model];
                 },
@@ -149,7 +149,7 @@ class EntityLookupType extends AbstractType
     }
 
     /**
-     * @param Options|array<mixed> $options
+     * @param Options<mixed[]>|array<mixed> $options
      */
     private function getModelName($options): string
     {

--- a/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
+++ b/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
@@ -82,7 +82,7 @@ class EntityLookupType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(['model', 'ajax_lookup_action']);
-        $resolver->setDefined(['model_lookup_method', 'repo_lookup_method', 'lookup_arguments']);
+        $resolver->setDefined(['model_lookup_method', 'repo_lookup_method', 'lookup_arguments', 'model_key']);
         $resolver->setDefaults(
             [
                 'modal_route'            => false,
@@ -153,7 +153,7 @@ class EntityLookupType extends AbstractType
      */
     private function getModelName($options): string
     {
-        $key = $options['key'] ?? null;
+        $key = $options['model_key'] ?? null;
         if (!$key) {
             return $options['model'];
         }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | No
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | No <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
If any form have 2 or more lookup fields with same type then it does not works properly, it shows only last field as selected on edit.

**If using multiple field of same type in same form then add 1 extra key "model_key" in field config.**
**Ex.** 
```

'label_attr'  => ['class' => 'control-label'],
  'attr'        => [
      'class'   => 'form-control',
  ],
  'multiple'    => false,
  'required'    => true,
  'constraints' => [
      new NotBlank(
          ['message' => 'Template 1 required']
      ),
  ],
  'model_key'   => 'template1',
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. In mautic, I don't know any form where we are using multiple look up fields in same form but In my application there is a plugin which have this type of case.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
