### PR TITLE
Update security policy (4.4 branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,7 @@ If you have questions, the Mautic Community can help provide the answers.
 Installing and using Mautic
 ============================
 
-## Supported Versions
-
-| Branch | RC Release | Initial Release | Active Support Until | Security Support Until*
-|--|--|--|--|--|
-|2.15  | 27 Sep 2019 | 8 Oct 2019 | 8 Oct 2019 | 8 Oct 2019
-|2.16  | 30 Jan 2020 | 13 Feb 2020 | 15 June 2020 | 15 December 2020
-|3.x   | 27 Jan 2020 | 15 June 2020 | 15 June 2021 | 15 December 2021
-|3.1   | 17 Aug 2020 | 24 Aug 2020 | 23 Nov 2020 | 30 Nov 2020
-|3.2   | 23 Nov 2020 | 30 Nov 2020 | 16 Feb 2021 | 22 Feb 2021
-|3.3   | 16 Feb 2021 | 22 Feb 2021 | 17 May 2021 | 24 May 2021
-|4.x   | 17 May 2021 | 24 May 2021 | 24 May 2022 | 20 Dec 2022
-
-`*`Security support for 2.16 will only be provided for Mautic itself, not for core dependencies that are EOL, such as Symfony 2.8.
+Please check the latest supported versions on the [Mautic Releases](https://www.mautic.org/mautic-releases) page.
 
 ## Software Downloads
 The GitHub version is recommended for both development and testing. The production package (including all libraries) is available at [mautic.org/download][download-mautic].

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,37 +16,22 @@ The Mautic Security Team operates with a limited scope and only directly respond
 Which Releases Get Security Advisories?
 ---------------------------------------
 
-Mautic 3 will receive security advisories until 15 December 2021.
+Check the [Releases page](https://www.mautic.org/mautic-releases) to find which are the currently supported releases.
 
-Starting with the release of Mautic 3.0, one minor versions at a time receives security advisories, the most recent minor release.
+Starting with the release of Mautic 3.0, one minor version at a time receives security advisories, the most recent minor release.
 
-For example, Mautic 3.1 will continue receiving security advisories until the release of Mautic 3.2, and 3.2 will receive security advisories until the release of 3.3.
+For example, Mautic 4.1 will continue receiving security advisories until the release of Mautic 4.2, and 4.2 will receive security advisories until the release of 4.3.
 
-### Supported Versions
-
-| Branch | Beta Release | Initial Release | Active Support Until | Security Support Until *
-|--|--|--|--|--|
-|2.16|30 Jan 2020|13 Feb 2020|15 Jun 2020|15 Dec 2020
-|3.x|27 Jan 2020|15 Jun 2020|15 Jun 2021|15 Dec 2021
-|3.1|17 Aug 2020|24 Aug 2020|23 Nov 2020|30 Nov 2020
-|3.2|23 Nov 2020|30 Nov 2020|16 Feb 2021|22 Feb 2021
-|3.3|16 Feb 2021|22 Feb 2021|17 May 2021|24 May 2021
-|4.x|16 Feb 2021|30 Aug 2021|26 Sept 2022|27 Feb 2023
-|4.0|17 May 2021|30 Aug 2021|29 Nov 2021|29 Nov 2021
-
-\* = Security Support for 2.16 will only be provided for Mautic itself, not for core dependencies that are EOL like Symfony 2.8.
-
-Security advisories are only made for issues affecting stable releases in the supported major version branches. That means there will be no security advisories for development releases (-dev), alphas, betas or release candidates.
-
+Security advisories are only made for issues affecting stable releases in the supported major version branches. That means there will be no security advisories for development releases, alphas, betas or release candidates.
 
 How to report a potential security issue
 ----------------------------------------
 
 If you discover or learn about a potential error, weakness, or threat that can compromise the security of Mautic and is covered by the [Security Advisory Policy](https://www.mautic.org/mautic-security-team/mautic-security-advisory-policy), we ask you to keep it confidential and submit your concern to the Mautic security team.
 
-To make your report please submit it via [https://huntr.dev](https://huntr.dev).
+To make your report please submit it as a private disclosure at [https://github.com/mautic/mautic/security](https://github.com/mautic/mautic/security). You can also create a private fork to provide a fix, if you're able to do so. See the documentation from GitHub on [privately reporting a security issue](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
-Do not post it in Github, the forums, or or discuss it in Slack.
+Do not post it in GitHub as an issue or a Pull Request, on the forums, or or discuss it in Slack.
 
 [Read more: How to report a security issue with Mautic](https://www.mautic.org/mautic-security-team/how-to-report-a-security-issue)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ If you discover or learn about a potential error, weakness, or threat that can c
 
 To make your report please submit it as a private disclosure at [https://github.com/mautic/mautic/security](https://github.com/mautic/mautic/security). You can also create a private fork to provide a fix, if you're able to do so. See the documentation from GitHub on [privately reporting a security issue](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
-Do not post it in GitHub as an issue or a Pull Request, on the forums, or or discuss it in Slack.
+Do not post it in GitHub as an issue or a Pull Request, on the forums, or discuss it in Slack.
 
 [Read more: How to report a security issue with Mautic](https://www.mautic.org/mautic-security-team/how-to-report-a-security-issue)
 


### PR DESCRIPTION
Since huntr.dev are no longer supporting open source projects which are not AI/ML related, we have to change our security reporting workflows.

We've decided to use a beta feature from GitHub which allows the private reporting of security vulnerabilities.

Content on mautic.org is already updated, this PR and the companion for 5.x updates the security.md files for the mautic/mautic repo.

No testing required just review.

Fixes https://github.com/mautic/mautic.org-website/issues/25 