### PR TITLE
DPMMA-903 Change campaign trigger order

### DIFF
--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -234,7 +234,11 @@ class TriggerCampaignCommand extends ModeratedCommand
 
         // All published campaigns
         /** @var \Doctrine\ORM\Internal\Hydration\IterableResult $campaigns */
-        $campaigns = $this->campaignRepository->getEntities(['iterator_mode' => true]);
+        $campaigns = $this->campaignRepository->getEntities([
+            'iterator_mode' => true,
+            'orderBy'       => 'c.dateAdded',
+            'orderByDir'    => 'DESC',
+        ]);
 
         while (false !== ($next = $campaigns->next())) {
             // Key is ID and not 0

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -597,7 +597,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertLessThan(10, $tDiff, 'The campaign rebuild takes more than 10 seconds, probably an infinite loop.');
     }
 
-    public function testCampaignExecuteOrderByPriority(): void
+    public function testCampaignExecuteOrderByDateCreatedDesc(): void
     {
         $oldCampaign = $this->createCampaign('Some old campaign');
         $oldCampaign->setDateAdded(new \DateTime('2019-01-03 03:54:25'));
@@ -616,7 +616,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
             }
         }
 
-        // check if the first processed campaign is the campaign with high priority
+        // check if the new campaign processed first
         $this->assertEquals("Triggering events for campaign {$newCampaign->getId()}", $campaignStartLines[0]);
     }
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -597,6 +597,29 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertLessThan(10, $tDiff, 'The campaign rebuild takes more than 10 seconds, probably an infinite loop.');
     }
 
+    public function testCampaignExecuteOrderByPriority(): void
+    {
+        $oldCampaign = $this->createCampaign('Some old campaign');
+        $oldCampaign->setDateAdded(new \DateTime('2019-01-03 03:54:25'));
+        $newCampaign = $this->createCampaign('New campaign');
+        $newCampaign->setDateAdded(new \DateTime());
+        $this->em->flush();
+
+        $commandTester = $this->testSymfonyCommand('mautic:campaigns:trigger');
+        $commandTester->assertCommandIsSuccessful();
+        $lines = preg_split('/\r\n|\r|\n/', $commandTester->getDisplay());
+
+        $campaignStartLines = [];
+        foreach ($lines as $line) {
+            if (str_starts_with($line, 'Triggering events for campaign')) {
+                $campaignStartLines[] = $line;
+            }
+        }
+
+        // check if the first processed campaign is the campaign with high priority
+        $this->assertEquals("Triggering events for campaign {$newCampaign->getId()}", $campaignStartLines[0]);
+    }
+
     /**
      * @throws \Exception
      */


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ N ]
| New feature/enhancement? (use the a.x branch)      | [ Y ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
This PR changes the order of the campaigns processed by the `mautic:campaigns:trigger` command. The campaigns will be processed from the newest to the oldest.

With this change the most recent campaigns would be processed faster.

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add two campaigns
4. Run the trigger command `ddev exec bin/console mautic:campaigns:trigger`
5. The second  campaign should be processed first
```
Triggering events for campaign 2
Triggering events for newly added contacts
0 total events(s) to be processed in batches of 100 contacts
....
Triggering events for campaign 1
Triggering events for newly added contacts
0 total events(s) to be processed in batches of 100 contacts
```

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
