### PR TITLE
[DPMMA-2341] Hide success message before saving the form

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -241,7 +241,7 @@ class PublicController extends CommonFormController
                         $this->dispatcher
                             ->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
                         $html = $event->getContent();
-                        if (!$session->has($successSessionName)) {
+                        if (!$session->has($successSessionName) || empty($session->get($successSessionName))) {
                             $successMessageDataSlots       = [
                                 'data-slot="successmessage"',
                                 'class="pref-successmessage"',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [❌]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

The success message is hidden if $successSessionName has not been set for the session. This PR request also adds message hiding when the value has been set but is evaluated to empty (e.g. 0).

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new landing page and switch "Set as preference center page" to Yes. In content, add at least {successmessage}
and {saveprefsbutton} tokens.
3. Save the landing page and create an email with the page set as preference center.
4. Send a message to your test contact and open the Unsubscribe page.
5. The success message should not be visible immediately after opening the page, before saving the form*.

*Additionally, there is an error with the form: "The CSRF token is invalid. Please try to resubmit the form", but this is a separate problem.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
