### PR TITLE
Adding VIEW_INJECT_CUSTOM_TEMPLATE back even in the Twig world

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -3,6 +3,8 @@
 namespace Mautic\CoreBundle\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -202,6 +204,16 @@ class CommonController extends AbstractController implements MauticController
 
         $code     = (isset($args['responseCode'])) ? $args['responseCode'] : 200;
         $response = new Response('', $code);
+
+        if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
+            $event = $this->dispatcher->dispatch(
+                new CustomTemplateEvent($request, $template, $parameters),
+                CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
+            );
+
+            $template   = $event->getTemplate();
+            $parameters = $event->getVars();
+        }
 
         return $this->render($template, $parameters, $response);
     }

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\Tests\Functional\EventListener;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\IntegrationsBundle\Entity\ObjectMapping;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+final class UIContactIntegrationsTabSubscriberTest extends MauticMysqlTestCase
+{
+    public function testIntegrationMappingIsShown(): void
+    {
+        $contact = new Lead();
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $objectMapping = new ObjectMapping();
+        $objectMapping->setIntegration('testintegration');
+        $objectMapping->setIntegrationObjectName('testobject');
+        $objectMapping->setIntegrationObjectId('testid');
+        $objectMapping->setInternalObjectName(Contact::NAME);
+        $objectMapping->setInternalObjectId($contact->getId());
+
+        $this->em->persist($objectMapping);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->request('GET', "/s/contacts/view/{$contact->getId()}");
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('<dt>Object</dt><dd>testobject</dd>', $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('<dt>Object ID</dt><dd>testid</dd>', $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('testintegration', $this->client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/what-is-mautic-5-way-of-injecting-custom-templates/29846/2

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The `CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE` event used to be in the [PhpEngine](https://github.com/mautic/mautic/blob/4.4/app/bundles/CoreBundle/Templating/Engine/PhpEngine.php#L103) but was removed together with it.

I found another place to put it to work as before even with the twig templates.

The IntegrationBundle actually used that event to display object mapping on the contact detail page, so that was broken.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This cannot be easily tested. You'd need a plugin built on top of the IntegrationsBundle and then have a Mautic contact mapped to some integration object. But I've added a functional test that confirms the mapping object is visible on the contact detail page if some mapping exists. Since the `CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE` event was removed together with the PhpEngine, this functionality stopped working.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
