### PR TITLE
The $siteUrl is null on installation. substr() requires string. It fails on PHP 8.1

### DIFF
--- a/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
@@ -734,11 +734,11 @@ final class AssetsHelper
     }
 
     /**
-     * @param string $siteUrl
+     * @param ?string $siteUrl can be null on installation
      */
     public function setSiteUrl($siteUrl): void
     {
-        if ('/' === substr($siteUrl, -1)) {
+        if ($siteUrl && '/' === substr($siteUrl, -1)) {
             $siteUrl = substr($siteUrl, 0, -1);
         }
 


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I'm testing installing Mautic on PHP 8.1 via command:
```
php bin/console mautic:install -f "https://mautic.test" --db_host "mysql" --db_port "3306" --db_name "mautic" --db_user "mautic" --db_password "some_password" --admin_password "Maut1cR0cks!" --admin_firstname "John" --admin_lastname "Doe" --admin_username "admin" --admin_email "john@doe.email"
```
and it goes like this:
```
Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/docroot/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php on line 741
Mautic Install
==============

Parsing options and arguments...
0 - Checking installation requirements...
Ready to Install!
1 - Creating database...
Errors in database configuration/installation:
  - [error] An error occured while attempting to connect to the database: Failed to start the session because headers have already been sent by "/var/www/html/docroot/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php" at line 741.
Install canceled
mautic exited with code 0
```
I tried to set the site URL in an environmental variable in the IntstallCommand but it's too late. The [`setSiteUrl()`](https://github.com/mautic/mautic/blob/5.x/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php#L739) method is called on cache build and the command is called after.

So I think it's OK to let it set an empty site URL for a moment before the local.php file is created. This is resolving the PHP notice which it seems to be halting the installation on PHP 8.1.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. You should get the same issue when running the command from above (adjust for your mysql connection) on PHP 8.1
2. This change do not send a null value to a PHP function that expects a string value, so the PHP notice is gone.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
