### PR TITLE
[dead-code] Remove unused var annotations

### DIFF
--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -148,12 +148,6 @@ class FormSubscriber implements EventSubscriberInterface
          */
         $event->stopPropagation();
 
-        /**
-         * @var Form
-         * @var Asset  $asset
-         * @var string $message
-         * @var bool   $messengerMode
-         */
         [
             'form'          => $form,
             'asset'         => $asset,

--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -148,6 +148,12 @@ class FormSubscriber implements EventSubscriberInterface
          */
         $event->stopPropagation();
 
+        /**
+         * @var Form   $form
+         * @var Asset  $asset
+         * @var string $message
+         * @var bool   $messengerMode
+         */
         [
             'form'          => $form,
             'asset'         => $asset,

--- a/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
@@ -60,7 +60,6 @@ class ActionExecutioner implements EventInterface
         // Execute to process the batch of contacts
         $pendingEvent = $this->dispatcher->dispatchEvent($config, $event, $logs);
 
-        /** @var ArrayCollection $contacts */
         $passed = $this->eventLogger->extractContactsFromLogs($pendingEvent->getSuccessful());
         $failed = $this->eventLogger->extractContactsFromLogs($pendingEvent->getFailures());
 

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -383,10 +383,6 @@ class EventExecutioner
 
     private function checkForRemovedContacts(ArrayCollection $logs)
     {
-        /**
-         * @var int
-         * @var LeadEventLog $log
-         */
         foreach ($logs as $key => $log) {
             // Use the deleted ID if the contact was removed by the delete contact action
             $contact    = $log->getLead();

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -383,6 +383,10 @@ class EventExecutioner
 
     private function checkForRemovedContacts(ArrayCollection $logs)
     {
+        /**
+         * @var int          $key
+         * @var LeadEventLog $log
+         */
         foreach ($logs as $key => $log) {
             // Use the deleted ID if the contact was removed by the delete contact action
             $contact    = $log->getLead();

--- a/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
@@ -45,9 +45,6 @@ class InactiveHelper
      */
     private $earliestInactiveDate;
 
-    /**
-     * InactiveHelper constructor.
-     */
     public function __construct(
         EventScheduler $scheduler,
         InactiveContactFinder $inactiveContactFinder,
@@ -65,10 +62,14 @@ class InactiveHelper
     }
 
     /**
-     * @param ArrayCollection|Event[] $decisions
+     * @param ArrayCollection<int, Event> $decisions
      */
-    public function removeDecisionsWithoutNegativeChildren(ArrayCollection $decisions)
+    public function removeDecisionsWithoutNegativeChildren(ArrayCollection $decisions): void
     {
+        /**
+         * @var int   $key
+         * @var Event $decision
+         */
         foreach ($decisions as $key => $decision) {
             $negativeChildren = $decision->getNegativeChildren();
             if (!$negativeChildren->count()) {

--- a/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
@@ -69,10 +69,6 @@ class InactiveHelper
      */
     public function removeDecisionsWithoutNegativeChildren(ArrayCollection $decisions)
     {
-        /**
-         * @var int
-         * @var Event $decision
-         */
         foreach ($decisions as $key => $decision) {
             $negativeChildren = $decision->getNegativeChildren();
             if (!$negativeChildren->count()) {

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -150,10 +150,7 @@ class EventLogger
         return $logs;
     }
 
-    /**
-     * @return $this
-     */
-    public function persistCollection(ArrayCollection $collection)
+    public function persistCollection(ArrayCollection $collection): self
     {
         if (!$collection->count()) {
             return $this;
@@ -165,20 +162,14 @@ class EventLogger
         return $this;
     }
 
-    /**
-     * @return $this
-     */
-    public function clearCollection(ArrayCollection $collection)
+    public function clearCollection(ArrayCollection $collection): self
     {
         $this->leadEventLogRepository->detachEntities($collection->getValues());
 
         return $this;
     }
 
-    /**
-     * @return ArrayCollection
-     */
-    public function extractContactsFromLogs(ArrayCollection $logs)
+    public function extractContactsFromLogs(ArrayCollection $logs): ArrayCollection
     {
         $contacts = new ArrayCollection();
 

--- a/app/bundles/ChannelBundle/Form/Type/ChannelType.php
+++ b/app/bundles/ChannelBundle/Form/Type/ChannelType.php
@@ -21,7 +21,6 @@ class ChannelType extends AbstractType
         $formModifier = function (FormEvent $event) use ($options) {
             $form = $event->getForm();
 
-            /** @var Channel $channel */
             $data = $event->getData();
             if (is_array($data)) {
                 $channelName = $data['channel'];

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -68,6 +68,9 @@ class ChannelPreferences
      */
     public function removeLog(LeadEventLog $log)
     {
+        /**
+         * @var ArrayCollection|LeadEventLog[] $logs
+         */
         foreach ($this->organizedByPriority as $logs) {
             $logs->remove($log->getId());
         }

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -68,10 +68,6 @@ class ChannelPreferences
      */
     public function removeLog(LeadEventLog $log)
     {
-        /**
-         * @var int
-         * @var ArrayCollection|LeadEventLog[] $logs
-         */
         foreach ($this->organizedByPriority as $logs) {
             $logs->remove($log->getId());
         }

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -68,10 +68,8 @@ class ChannelPreferences
      */
     public function removeLog(LeadEventLog $log)
     {
-        /**
-         * @var ArrayCollection|LeadEventLog[] $logs
-         */
         foreach ($this->organizedByPriority as $logs) {
+            /** @var ArrayCollection<int, LeadEventLog> $logs */
             $logs->remove($log->getId());
         }
 

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -263,7 +263,6 @@ class ConfigController extends FormController
         // Import the current local configuration, $parameters is defined in this file
 
         $parameters = [];
-        /** @var array $parameters */
         include $localConfigFile;
 
         $localParams = $parameters;

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -265,6 +265,7 @@ class ConfigController extends FormController
         $parameters = [];
         include $localConfigFile;
 
+        /** @var mixed[] $parameters */
         $localParams = $parameters;
 
         foreach ($forms as &$form) {

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -180,6 +180,7 @@ class ParameterLoader
         $localParametersFile = $this->getLocalParametersFile();
         if (file_exists($localParametersFile)) {
             include $localParametersFile;
+            /** @var array<string, mixed> $parameters */
 
             // override default with forced
             $compiledParameters = array_merge($compiledParameters, $parameters);

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -179,7 +179,6 @@ class ParameterLoader
         // Force local specific params
         $localParametersFile = $this->getLocalParametersFile();
         if (file_exists($localParametersFile)) {
-            /** @var array<string, mixed> $parameters */
             include $localParametersFile;
 
             // override default with forced

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -178,6 +178,10 @@ class DynamicContentSubscriber implements EventSubscriberInterface
                 $utmTags = $dwc->getUtmTags();
             }
 
+            /**
+             * @var string    $token
+             * @var Trackable $trackable
+             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, false, $utmTags);
             }

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -178,10 +178,6 @@ class DynamicContentSubscriber implements EventSubscriberInterface
                 $utmTags = $dwc->getUtmTags();
             }
 
-            /**
-             * @var string
-             * @var Trackable $trackable
-             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, false, $utmTags);
             }

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -357,10 +357,6 @@ class CampaignSubscriber implements EventSubscriberInterface
         $contacts = $event->getContacts();
         $pending  = $event->getPending();
 
-        /**
-         * @var int
-         * @var Lead $contact
-         */
         foreach ($contacts as $logId => $contact) {
             try {
                 $this->sendEmailToUser->sendEmailToUsers($config, $contact);

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -357,6 +357,10 @@ class CampaignSubscriber implements EventSubscriberInterface
         $contacts = $event->getContacts();
         $pending  = $event->getPending();
 
+        /**
+         * @var int  $logId
+         * @var Lead $contact
+         */
         foreach ($contacts as $logId => $contact) {
             try {
                 $this->sendEmailToUser->sendEmailToUsers($config, $contact);

--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -49,7 +49,6 @@ class PointEventHelper
         if (null != $email && $email->isPublished()) {
             $leadFields = $lead->getFields();
             if (isset($leadFields['core']['email']['value']) && $leadFields['core']['email']['value']) {
-                /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
                 $leadCredentials       = $lead->getProfileFields();
                 $leadCredentials['id'] = $lead->getId();
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
@@ -40,10 +40,6 @@ class MailboxOrganizer
         $criteriaRequested      = $this->event->getCriteriaRequests();
         $markAsSeenInstructions = $this->event->getMarkAsSeenInstructions();
 
-        /**
-         * @var string
-         * @var ConfigAccessor $config
-         */
         foreach ($this->mailboxes as $name => $config) {
             // Switch mailbox to get information
             if (!$config->isConfigured()) {

--- a/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
@@ -40,6 +40,10 @@ class MailboxOrganizer
         $criteriaRequested      = $this->event->getCriteriaRequests();
         $markAsSeenInstructions = $this->event->getMarkAsSeenInstructions();
 
+        /**
+         * @var string         $name
+         * @var ConfigAccessor $config
+         */
         foreach ($this->mailboxes as $name => $config) {
             // Switch mailbox to get information
             if (!$config->isConfigured()) {

--- a/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
+++ b/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
@@ -64,7 +64,6 @@ class DisplayManager
      */
     private function shouldDisplayNotAlwaysDisplayField(Field $field)
     {
-        /** @var Field $fieldFromArray */
         $fields = $this->form->getFields()->toArray();
         foreach ($fields as $fieldFromArray) {
             if (in_array($field->getType(), $this->viewOnlyFields)) {

--- a/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
+++ b/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
@@ -66,6 +66,7 @@ class DisplayManager
     {
         $fields = $this->form->getFields()->toArray();
         foreach ($fields as $fieldFromArray) {
+            /** @var Field $fieldFromArray */
             if (in_array($field->getType(), $this->viewOnlyFields)) {
                 continue;
             }

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -150,7 +150,6 @@ class InstallService
             return false;
         }
 
-        /** @var \Mautic\CoreBundle\Configurator\Configurator $configurator */
         $params = $this->configurator->getParameters();
 
         // if db_driver and site_url are present then it is assumed all the steps of the installation have been

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -345,11 +345,13 @@ trait LeadDetailsTrait
         $engagements = [0, 0, 0, 0, 0, 0];
         $points      = [0, 0, 0, 0, 0, 0];
         foreach ($contacts as $contact) {
+            /** @var LeadModel $model */
             $model = $this->getModel('lead.lead');
 
             if (!isset($contact['lead_id'])) {
                 continue;
             }
+
             $lead = $model->getEntity($contact['lead_id']);
             $model->getRepository()->refetchEntity($lead);
             if (!$lead instanceof Lead) {

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -347,7 +347,6 @@ trait LeadDetailsTrait
         foreach ($contacts as $contact) {
             $model = $this->getModel('lead.lead');
 
-            /** @var \Mautic\LeadBundle\Entity\Lead $lead */
             if (!isset($contact['lead_id'])) {
                 continue;
             }

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -539,7 +539,6 @@ class LeadSubscriber implements EventSubscriberInterface
         /** @var \Mautic\LeadBundle\Entity\DoNotContactRepository $dncRepo */
         $dncRepo = $this->entityManager->getRepository(DoNotContact::class);
 
-        /** @var \Mautic\LeadBundle\Entity\DoNotContact[] $entries */
         $rows = $dncRepo->getTimelineStats($event->getLeadId(), $event->getQueryOptions());
 
         // Add to counter
@@ -603,7 +602,6 @@ class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineImportedEntries(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
-        /** @var LeadEventLogRepository */
         $eventLogRepo = $this->entityManager->getRepository(LeadEventLog::class);
         $imports      = $eventLogRepo->getEvents(
             $event->getLead(),
@@ -660,7 +658,6 @@ class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineApiCreatedEntries(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
-        /** @var LeadEventLogRepository */
         $eventLogRepo    = $this->entityManager->getRepository(LeadEventLog::class);
         $apiSingleEvents = $eventLogRepo->getEvents(
             $event->getLead(),

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -602,6 +602,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineImportedEntries(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
+        /** @var LeadEventLogRepository $eventLogRepo */
         $eventLogRepo = $this->entityManager->getRepository(LeadEventLog::class);
         $imports      = $eventLogRepo->getEvents(
             $event->getLead(),
@@ -658,6 +659,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineApiCreatedEntries(Events\LeadTimelineEvent $event, $eventTypeKey, $eventTypeName)
     {
+        /** @var LeadEventLogRepository $eventLogRepo */
         $eventLogRepo    = $this->entityManager->getRepository(LeadEventLog::class);
         $apiSingleEvents = $eventLogRepo->getEvents(
             $event->getLead(),

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -412,7 +412,6 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 $lead->addUpdatedField('company', $companyName)
                     ->setDateModified(new \DateTime());
 
-                /** @var LeadRepository */
                 $leadRepository = $this->em->getRepository(Lead::class);
                 $leadRepository->saveEntity($lead);
             }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -412,6 +412,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 $lead->addUpdatedField('company', $companyName)
                     ->setDateModified(new \DateTime());
 
+                /** @var LeadRepository $leadRepository */
                 $leadRepository = $this->em->getRepository(Lead::class);
                 $leadRepository->saveEntity($lead);
             }

--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -12,7 +12,6 @@ trait DefaultValueTrait
     protected function setEntityDefaultValues(CustomFieldEntityInterface $entity, $object = 'lead')
     {
         if (!$entity->getId()) {
-            /** @var FieldModel $fieldModel */
             $fields = $this->leadFieldModel->getFieldListWithProperties($object);
             foreach ($fields as $alias => $field) {
                 // Prevent defaults from overwriting values already set

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2356,7 +2356,6 @@ class LeadModel extends FormModel
         /** @var \Mautic\LeadBundle\Entity\DoNotContactRepository $dncRepo */
         $dncRepo = $this->em->getRepository(\Mautic\LeadBundle\Entity\DoNotContact::class);
 
-        /** @var \Mautic\LeadBundle\Entity\DoNotContact[] $entries */
         $dncEntries = $dncRepo->getEntriesByLeadAndChannel($lead, $channel);
 
         // If the lead has no entries in the DNC table, we're good to go

--- a/app/bundles/LeadBundle/Validator/CustomFieldValidator.php
+++ b/app/bundles/LeadBundle/Validator/CustomFieldValidator.php
@@ -57,7 +57,6 @@ class CustomFieldValidator
      */
     private function getFieldByAlias(string $alias): LeadField
     {
-        /** @var LeadField|null */
         $field = $this->fieldModel->getEntityByAlias($alias);
 
         if (!$field) {

--- a/app/bundles/LeadBundle/Validator/CustomFieldValidator.php
+++ b/app/bundles/LeadBundle/Validator/CustomFieldValidator.php
@@ -59,7 +59,7 @@ class CustomFieldValidator
     {
         $field = $this->fieldModel->getEntityByAlias($alias);
 
-        if (!$field) {
+        if (!$field instanceof LeadField) {
             throw new RecordNotFoundException($this->translator->trans('mautic.lead.contact.field.not.found', ['%alias%' => $alias], 'validators'));
         }
 

--- a/app/bundles/MarketplaceBundle/Service/PluginCollector.php
+++ b/app/bundles/MarketplaceBundle/Service/PluginCollector.php
@@ -95,7 +95,6 @@ class PluginCollector
             ];
         }
 
-        /** @var array<int,AllowlistEntry[]> */
         $chunks = array_chunk($this->allowlistedPackages, $limit);
         // Array keys start at 0 but page numbers start at 1
         $pageChunk = $page - 1;

--- a/app/bundles/MarketplaceBundle/Service/PluginCollector.php
+++ b/app/bundles/MarketplaceBundle/Service/PluginCollector.php
@@ -95,6 +95,7 @@ class PluginCollector
             ];
         }
 
+        /** @var array<int, AllowlistEntry[]> $chunks */
         $chunks = array_chunk($this->allowlistedPackages, $limit);
         // Array keys start at 0 but page numbers start at 1
         $pageChunk = $page - 1;

--- a/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
@@ -111,10 +111,6 @@ class NotificationSubscriber implements EventSubscriberInterface
                 $clickthrough['channel'][1]
             );
 
-            /**
-             * @var string
-             * @var Trackable $trackable
-             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough);
             }

--- a/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
@@ -111,6 +111,10 @@ class NotificationSubscriber implements EventSubscriberInterface
                 $clickthrough['channel'][1]
             );
 
+            /**
+             * @var string    $token
+             * @var Trackable $trackable
+             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough);
             }

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -54,10 +54,6 @@ trait PushToIntegrationTrait
         $services = static::$integrationHelper->getIntegrationObjects($integration);
         $success  = true;
 
-        /**
-         * @var string
-         * @var AbstractIntegration $s
-         */
         foreach ($services as $s) {
             $settings = $s->getIntegrationSettings();
             if (!$settings->isPublished()) {

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -54,10 +54,8 @@ trait PushToIntegrationTrait
         $services = static::$integrationHelper->getIntegrationObjects($integration);
         $success  = true;
 
-        /**
-         * @var AbstractIntegration $s
-         */
         foreach ($services as $s) {
+            /** @var AbstractIntegration $s */
             $settings = $s->getIntegrationSettings();
             if (!$settings->isPublished()) {
                 continue;

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -54,6 +54,9 @@ trait PushToIntegrationTrait
         $services = static::$integrationHelper->getIntegrationObjects($integration);
         $success  = true;
 
+        /**
+         * @var AbstractIntegration $s
+         */
         foreach ($services as $s) {
             $settings = $s->getIntegrationSettings();
             if (!$settings->isPublished()) {

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -539,6 +539,10 @@ class IntegrationHelper
         if (empty($shareBtns)) {
             $socialIntegrations = $this->getIntegrationObjects(null, ['share_button'], true);
 
+            /**
+             * @var string                                               $integration
+             * @var \Mautic\PluginBundle\Integration\AbstractIntegration $details
+             */
             foreach ($socialIntegrations as $integration => $details) {
                 /** @var \Mautic\PluginBundle\Entity\Integration $settings */
                 $settings = $details->getIntegrationSettings();

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -539,10 +539,6 @@ class IntegrationHelper
         if (empty($shareBtns)) {
             $socialIntegrations = $this->getIntegrationObjects(null, ['share_button'], true);
 
-            /**
-             * @var string
-             * @var \Mautic\PluginBundle\Integration\AbstractIntegration $details
-             */
             foreach ($socialIntegrations as $integration => $details) {
                 /** @var \Mautic\PluginBundle\Entity\Integration $settings */
                 $settings = $details->getIntegrationSettings();

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -386,7 +386,6 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      */
     public function encryptAndSetApiKeys(array $keys, Integration $entity)
     {
-        /** @var PluginIntegrationKeyEvent $event */
         $keys = $this->dispatchIntegrationKeyEvent(
             PluginEvents::PLUGIN_ON_INTEGRATION_KEYS_ENCRYPT,
             $keys

--- a/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
@@ -128,10 +128,6 @@ class SmsSubscriber implements EventSubscriberInterface
                 );
 
                 $shortenEnabled = $this->coreParametersHelper->get('shortener_sms_enable', false);
-                /**
-                 * @var string
-                 * @var Trackable $trackable
-                 */
                 foreach ($trackables as $token => $trackable) {
                     $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, $shortenEnabled);
                 }

--- a/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
@@ -128,6 +128,11 @@ class SmsSubscriber implements EventSubscriberInterface
                 );
 
                 $shortenEnabled = $this->coreParametersHelper->get('shortener_sms_enable', false);
+
+                /**
+                 * @var string    $token
+                 * @var Trackable $trackable
+                 */
                 foreach ($trackables as $token => $trackable) {
                     $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, $shortenEnabled);
                 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -518,11 +518,6 @@ parameters:
 			path: app/bundles/ApiBundle/Form/Type/ClientType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/ApiBundle/Form/Type/ClientType.php
-
-		-
 			message: "#^Variable \\$errors in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -971,11 +966,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormBuilderInterface\\:\\:expects\\(\\)\\.$#"
 			count: 2
-			path: app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
 			path: app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
 
 		-
@@ -1461,11 +1451,6 @@ parameters:
 			path: app/bundles/AssetBundle/Entity/Download.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
-
-		-
 			message: "#^Call to method execute\\(\\) on an unknown class Mautic\\\\AssetBundle\\\\Entity\\\\QueryBuilder\\.$#"
 			count: 3
 			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -1502,26 +1487,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\DownloadRepository\\:\\:getMostDownloaded\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\DownloadRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\DownloadRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\DownloadRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\DownloadRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/AssetBundle/Entity/DownloadRepository.php
 
@@ -1787,11 +1752,6 @@ parameters:
 			path: app/bundles/AssetBundle/EventListener/FormSubscriber.php
 
 		-
-			message: "#^PHPDoc tag @var above assignment does not specify variable name\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/EventListener/FormSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\AssetBundle\\\\EventListener\\\\LeadSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -1938,11 +1898,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\AssetBundle\\\\Form\\\\Type\\\\AssetType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Form/Type/AssetType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/AssetBundle/Form/Type/AssetType.php
 
@@ -3934,11 +3889,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Entity/LeadEventLog.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
 			message: "#^Method Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:isNull\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -4000,26 +3950,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getScheduledCounts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
 
@@ -4270,31 +4200,6 @@ parameters:
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\Summary\\:\\:loadMetadata\\(\\) has parameter \\$metadata with generic class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata but does not specify its types\\: T$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/Summary.php
-
-		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/CampaignBundle/Entity/SummaryRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\SummaryRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/SummaryRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\SummaryRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/SummaryRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\SummaryRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/SummaryRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\SummaryRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/SummaryRepository.php
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\SummaryRepository\\:\\:updateOrmQueryFromContactLimiter\\(\\) has no return type specified\\.$#"
@@ -5636,16 +5541,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$contacts contains generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
-
-		-
-			message: "#^Variable \\$contacts in PHPDoc tag @var does not match assigned variable \\$passed\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
-
-		-
 			message: "#^Variable \\$firstLog in PHPDoc tag @var does not exist\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
@@ -5681,18 +5576,8 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/Event/EventInterface.php
 
 		-
-			message: "#^Argument of an invalid type int supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
-
-		-
 			message: "#^Call to an undefined method Mautic\\\\CampaignBundle\\\\Executioner\\\\Logger\\\\EventLogger\\:\\:clear\\(\\)\\.$#"
 			count: 2
-			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
-
-		-
-			message: "#^Cannot call method remove\\(\\) on int\\.$#"
-			count: 1
 			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
 
 		-
@@ -5861,24 +5746,9 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
 
 		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
-
-		-
 			message: "#^Strict comparison using \\!\\=\\= between null and Mautic\\\\CampaignBundle\\\\Entity\\\\Event will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Helper/DecisionHelper.php
-
-		-
-			message: "#^Argument of an invalid type int supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^Cannot call method remove\\(\\) on int\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:getCollectionByDecisionId\\(\\) has parameter \\$decisionId with no type specified\\.$#"
@@ -5932,21 +5802,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:removeContactsThatAreNotApplicable\\(\\) has parameter \\$negativeChildren with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:removeDecisionsWithoutNegativeChildren\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:removeDecisionsWithoutNegativeChildren\\(\\) has parameter \\$decisions with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
 
@@ -6406,11 +6261,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between null and Mautic\\\\CampaignBundle\\\\Entity\\\\Event will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
-
-		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Scheduler\\\\Mode\\\\DAO\\\\GroupExecutionDateDAO\\:\\:addContact\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/DAO/GroupExecutionDateDAO.php
@@ -6552,11 +6402,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Form\\\\Type\\\\CampaignType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Form/Type/CampaignType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Form/Type/CampaignType.php
 
@@ -8255,11 +8100,6 @@ parameters:
 			path: app/bundles/CategoryBundle/Form/Type/CategoryType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/CategoryBundle/Form/Type/CategoryType.php
-
-		-
 			message: "#^Method Mautic\\\\CategoryBundle\\\\Model\\\\CategoryModel\\:\\:createForm\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -8413,11 +8253,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$threadId of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setThreadId\\(\\) expects int\\|null, string\\|null given\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\AjaxController\\:\\:cancelQueuedMessageEventAction\\(\\) has invalid return type Mautic\\\\ChannelBundle\\\\Controller\\\\LeadEventLog\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/AjaxController.php
 
 		-
 			message: """
@@ -8727,11 +8562,6 @@ parameters:
 			path: app/bundles/ChannelBundle/Entity/MessageQueue.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 2
 			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
@@ -8788,26 +8618,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Entity\\\\MessageQueueRepository\\:\\:getQueuedMessages\\(\\) has parameter \\$processStarted with no type specified\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Entity\\\\MessageQueueRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Entity\\\\MessageQueueRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Entity\\\\MessageQueueRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Entity\\\\MessageQueueRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
 
@@ -9078,11 +8888,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Form\\\\Type\\\\ChannelType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Form/Type/ChannelType.php
-
-		-
-			message: "#^Variable \\$channel in PHPDoc tag @var does not match assigned variable \\$data\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Form/Type/ChannelType.php
 
@@ -9437,11 +9242,6 @@ parameters:
 			path: app/bundles/ChannelBundle/Model/MessageQueueModel.php
 
 		-
-			message: "#^Cannot call method remove\\(\\) on int\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
-
-		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\PreferenceBuilder\\\\ChannelPreferences\\:\\:getLogsByPriority\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
 			count: 1
 			path: app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -9675,11 +9475,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ConfigBundle\\\\Controller\\\\ConfigController\\:\\:removeAction\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ConfigBundle/Controller/ConfigController.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$parameters has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/ConfigBundle/Controller/ConfigController.php
 
@@ -11398,7 +11193,7 @@ parameters:
 
 		-
 			message: "#^If condition is always false\\.$#"
-			count: 2
+			count: 1
 			path: app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
 
 		-
@@ -11576,11 +11371,6 @@ parameters:
 			path: app/bundles/CoreBundle/Entity/AuditLog.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 2
 			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -11646,26 +11436,6 @@ parameters:
 			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\AuditLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\AuditLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\AuditLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\AuditLogRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/AuditLogRepository.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\Cache\\:\\:loadMetadata\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/Cache.php
@@ -11701,16 +11471,6 @@ parameters:
 			path: app/bundles/CoreBundle/Entity/CommonEntity.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonEntity\\:\\:getChanges\\(\\) has parameter \\$includePast with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonEntity.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonEntity\\:\\:getChanges\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonEntity.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonEntity\\:\\:isChanged\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonEntity.php
@@ -11722,11 +11482,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonEntity\\:\\:loadMetadata\\(\\) has parameter \\$metadata with generic class Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata but does not specify its types\\: T$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonEntity.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonEntity\\:\\:resetChanges\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonEntity.php
 
@@ -11809,7 +11564,7 @@ parameters:
 				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
 			"""
-			count: 2
+			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonRepository.php
 
 		-
@@ -12309,11 +12064,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Entity\\\\FormEntity\\:\\:\\$changes type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/FormEntity.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Entity\\\\FormEntity\\:\\:\\$modifiedBy has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/FormEntity.php
 
@@ -12979,11 +12729,6 @@ parameters:
 
 		-
 			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Event/CommonEvent.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Event\\\\CommonEvent\\:\\:getLead\\(\\) should return Mautic\\\\LeadBundle\\\\Entity\\\\Lead but returns null\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Event/CommonEvent.php
 
@@ -13939,11 +13684,6 @@ parameters:
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
 
 		-
-			message: "#^Service \"twig\\.helper\\.slots\" is not registered in the container\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
 			message: "#^Service \"twig\\.helper\\.translator\" is not registered in the container\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -14269,16 +14009,6 @@ parameters:
 			path: app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
 
 		-
-			message: "#^Parameter \\$model of method Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber\\:\\:__construct\\(\\) has invalid type Mautic\\\\CoreBundle\\\\Model\\\\CommonModel\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber\\:\\:\\$model has unknown class Mautic\\\\CoreBundle\\\\Model\\\\CommonModel as its type\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
-
-		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
@@ -14369,11 +14099,6 @@ parameters:
 			path: app/bundles/CoreBundle/Form/Type/ConfigType.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\ConfigType\\:\\:__construct\\(\\) has parameter \\$ipLookupServices with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/Type/ConfigType.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\ConfigType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -14390,11 +14115,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\ConfigType\\:\\:getLanguageChoices\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/Type/ConfigType.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Form\\\\Type\\\\ConfigType\\:\\:\\$ipLookupServices type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/Type/ConfigType.php
 
@@ -16632,11 +16352,6 @@ parameters:
 			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\UpdateHelper\\:\\:sendStats\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/UpdateHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\UrlHelper\\:\\:buildShortUrl\\(\\) has parameter \\$url with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/UrlHelper.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\UrlHelper\\:\\:getUrlsFromPlaintext\\(\\) has parameter \\$contactUrlFields with no value type specified in iterable type array\\.$#"
@@ -19555,11 +19270,6 @@ parameters:
 			path: app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
-
-		-
 			message: """
 				#^Call to deprecated method get\\(\\) of class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:
 				since Symfony 5\\.4, use method or constructor injection in your controller instead$#
@@ -20718,11 +20428,6 @@ parameters:
 			path: app/bundles/DynamicContentBundle/Entity/Stat.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
-
-		-
 			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:deleteStat\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -20764,26 +20469,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:getSentStats\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Entity/StatRepository.php
 
@@ -20867,11 +20552,6 @@ parameters:
 			path: app/bundles/DynamicContentBundle/EventListener/ChannelSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
-
-		-
 			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -20913,11 +20593,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\DynamicContentBundle\\\\EventListener\\\\DynamicContentSubscriber\\:\\:onTokenReplacement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
 
@@ -21053,11 +20728,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Form\\\\Type\\\\DynamicContentType\\:\\:filterFieldChoices\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
 
@@ -21730,11 +21400,6 @@ parameters:
 			path: app/bundles/EmailBundle/Controller/PublicController.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\PublicController\\:\\:addStat\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Controller/PublicController.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\PublicController\\:\\:addStat\\(\\) has parameter \\$email with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/PublicController.php
@@ -21866,11 +21531,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\PublicController\\:\\:resubscribeAction\\(\\) has parameter \\$idHash with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Controller/PublicController.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\PublicController\\:\\:trackingImageAction\\(\\) has parameter \\$idHash with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/PublicController.php
 
@@ -22413,37 +22073,12 @@ parameters:
 			path: app/bundles/EmailBundle/Entity/EmailReply.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getByLeadIdForTimeline\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getByLeadIdForTimeline\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailReplyRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/EmailReplyRepository.php
 
@@ -22791,11 +22426,6 @@ parameters:
 			path: app/bundles/EmailBundle/Entity/StatDeviceRepository.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
 			message: "#^Call to method execute\\(\\) on an unknown class Mautic\\\\EmailBundle\\\\Entity\\\\QueryBuilder\\.$#"
 			count: 2
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
@@ -22964,26 +22594,6 @@ parameters:
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getUniqueClickedLinksPerContactAndEmail\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
@@ -23010,11 +22620,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$y of method Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:in\\(\\) expects array\\<string\\>\\|string, array\\<int\\> given\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Parameter \\#7 \\$resultsParserCallback of method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) expects null, Closure given\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
 
@@ -23334,11 +22939,6 @@ parameters:
 			path: app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
 
 		-
-			message: "#^Parameter \\#4 \\$batch of method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:sendEmailToLists\\(\\) expects bool, int given\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -23377,22 +22977,12 @@ parameters:
 			path: app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type int supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
-
-		-
 			message: "#^Call to an undefined method Mautic\\\\EmailBundle\\\\Entity\\\\Email\\:\\:getEmail\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\CampaignSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
 
@@ -23741,16 +23331,6 @@ parameters:
 			path: app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\QueueSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/QueueSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\QueueSubscriber\\:\\:onEmailHit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/QueueSubscriber.php
-
-		-
 			message: """
 				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
@@ -24095,11 +23675,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Form\\\\Type\\\\EmailType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Form/Type/EmailType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Form/Type/EmailType.php
 
@@ -24778,7 +24353,7 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and null will always evaluate to true\\.$#"
-			count: 2
+			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
@@ -24938,24 +24513,6 @@ parameters:
 			"""
 			count: 1
 			path: app/bundles/EmailBundle/Helper/PointEventHelper.php
-
-		-
-			message: "#^Variable \\$leadModel in PHPDoc tag @var does not match assigned variable \\$leadCredentials\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/PointEventHelper.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\RequestStorageHelper\\:\\:deleteCachedRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/RequestStorageHelper.php
-
-		-
-			message: """
-				#^Parameter \\$cacheStorage of method Mautic\\\\EmailBundle\\\\Helper\\\\RequestStorageHelper\\:\\:__construct\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Helper\\\\CacheStorageHelper\\:
-				This helper is deprecated in favor of CacheBundle$#
-			"""
-			count: 1
-			path: app/bundles/EmailBundle/Helper/RequestStorageHelper.php
 
 		-
 			message: """
@@ -25399,26 +24956,6 @@ parameters:
 			path: app/bundles/EmailBundle/Model/EmailModel.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:hitEmail\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:hitEmail\\(\\) has parameter \\$activeRequest with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:hitEmail\\(\\) has parameter \\$request with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:hitEmail\\(\\) has parameter \\$stat with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Model\\\\EmailModel\\:\\:limitQueryToCreator\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Model/EmailModel.php
@@ -25581,11 +25118,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$details of method Mautic\\\\EmailBundle\\\\Entity\\\\Stat\\:\\:addOpenDetails\\(\\) expects string, array\\<string, mixed\\> given\\.$#"
 			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
-			message: "#^Parameter \\#1 \\$idHash of method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:setIdHash\\(\\) expects null, string given\\.$#"
-			count: 3
 			path: app/bundles/EmailBundle/Model/EmailModel.php
 
 		-
@@ -26363,11 +25895,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\MonitoredEmail\\\\Organizer\\\\MailboxOrganizer\\:\\:organize\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
 
@@ -27155,26 +26682,6 @@ parameters:
 			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:getMockFactory\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:getMockFactory\\(\\) has parameter \\$mailIsOwner with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:getMockFactory\\(\\) has parameter \\$parameterMap with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:mockEmptyMailHelper\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testArrayOfAddressesAreRemappedIntoEmailToNameKeyValuePair\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -27215,51 +26722,6 @@ parameters:
 			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithAmpersandInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithApostropheInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithCaretInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithPercentInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithSemicolonInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithSpaceInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithStarInIt\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateEmailWithoutTld\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:testValidateValidEmails\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:\\$contacts type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -27281,54 +26743,6 @@ parameters:
 			message: "#^Parameter \\#3 \\$factory of method Mautic\\\\EmailBundle\\\\Helper\\\\PointEventHelper\\:\\:sendEmail\\(\\) expects Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory, PHPUnit\\\\Framework\\\\MockObject\\\\MockObject given\\.$#"
 			count: 4
 			path: app/bundles/EmailBundle/Tests/Helper/PointEventHelperTest.php
-
-		-
-			message: """
-				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Helper\\\\CacheStorageHelper\\:
-				This helper is deprecated in favor of CacheBundle$#
-			"""
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testGetRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testGetRequestIfNotFound\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testGetTransportNameFromKey\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testGetTransportNameFromKeyWithGlobalPrefix\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testStoreRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:testStoreRequestWithLongTansportName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:\\$cacheStorageMock has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\RequestStorageHelperTest\\:\\:\\$helper has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/RequestStorageHelperTest.php
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BatchTransport\\:\\:getMetadatas\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -28530,11 +27944,6 @@ parameters:
 			path: app/bundles/FormBundle/Controller/PublicController.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Controller/PublicController.php
-
-		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Controller\\\\PublicController\\:\\:replacePostSubmitTokens\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Controller/PublicController.php
@@ -29071,11 +28480,6 @@ parameters:
 			path: app/bundles/FormBundle/Entity/Submission.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getDefaultOrder\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -29127,26 +28531,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getSubmissions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
 
@@ -30132,11 +29516,6 @@ parameters:
 			path: app/bundles/FormBundle/Form/Type/FormType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Form/Type/FormType.php
-
-		-
 			message: "#^Class Mautic\\\\FormBundle\\\\Form\\\\Type\\\\PointActionFormSubmitType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/FormBundle/Form/Type/PointActionFormSubmitType.php
@@ -30426,7 +29805,7 @@ parameters:
 				#^Call to deprecated method getLeadField\\(\\) of class Mautic\\\\FormBundle\\\\Entity\\\\Field\\:
 				, to be removed in Mautic 4\\. Use mappedObject and mappedField instead\\.$#
 			"""
-			count: 6
+			count: 5
 			path: app/bundles/FormBundle/Model/FormModel.php
 
 		-
@@ -30797,11 +30176,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\FormBundle\\\\ProgressiveProfiling\\\\DisplayManager\\:\\:\\$viewOnlyFields type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
-
-		-
-			message: "#^Variable \\$fieldFromArray in PHPDoc tag @var does not match assigned variable \\$fields\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
 
@@ -31546,11 +30920,6 @@ parameters:
 			path: app/bundles/InstallBundle/Install/InstallService.php
 
 		-
-			message: "#^Variable \\$configurator in PHPDoc tag @var does not match assigned variable \\$params\\.$#"
-			count: 1
-			path: app/bundles/InstallBundle/Install/InstallService.php
-
-		-
 			message: "#^Method Mautic\\\\InstallBundle\\\\InstallFixtures\\\\ORM\\\\LeadFieldData\\:\\:load\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -32251,16 +31620,6 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Event/MauticSyncFieldsLoadEvent.php
 
 		-
-			message: "#^Method Mautic\\\\IntegrationsBundle\\\\EventListener\\\\CompanyObjectSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/EventListener/CompanyObjectSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\IntegrationsBundle\\\\EventListener\\\\ContactObjectSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/EventListener/ContactObjectSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\EventListener\\\\ControllerSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/EventListener/ControllerSubscriber.php
@@ -32479,16 +31838,6 @@ parameters:
 			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Helper\\\\IntegrationsHelper\\:\\:\\$decryptedIntegrationConfigurations type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Helper/IntegrationsHelper.php
-
-		-
-			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Helper\\\\SyncIntegrationsHelper\\:\\:getEnabledIntegrations\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Helper\\\\SyncIntegrationsHelper\\:\\:\\$enabled type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
 
 		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Helper\\\\TokenParser\\:\\:buildTokenWithDefaultOptions\\(\\) has parameter \\$baseURL with no type specified\\.$#"
@@ -33504,57 +32853,12 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Tests/Unit/Event/ConfigSaveEventTest.php
 
 		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:buildCompanyRoute\\(\\)\\.$#"
-			count: 2
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:collectInternalObjects\\(\\)\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:createCompanies\\(\\)\\.$#"
-			count: 2
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:findCompaniesByDateRange\\(\\)\\.$#"
-			count: 3
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:findCompaniesByFieldValues\\(\\)\\.$#"
-			count: 3
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:findCompaniesByIds\\(\\)\\.$#"
-			count: 3
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:findOwnerIdsForCompanies\\(\\)\\.$#"
-			count: 2
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:updateCompanies\\(\\)\\.$#"
-			count: 2
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\{array\\{'object_mapping_1'\\}\\} and array\\<Mautic\\\\IntegrationsBundle\\\\Entity\\\\ObjectMapping\\> will always evaluate to false\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\{array\\{'object_mapping_1'\\}\\} and array\\<Mautic\\\\IntegrationsBundle\\\\Sync\\\\DAO\\\\Mapping\\\\UpdatedObjectMappingDAO\\> will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Tests\\\\Unit\\\\EventListener\\\\CompanyObjectSubscriberTest\\:\\:\\$subscriber \\(Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\) does not accept Mautic\\\\IntegrationsBundle\\\\EventListener\\\\CompanyObjectSubscriber\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
 
@@ -35952,11 +35256,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/Company.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Company\\:\\:isChanged\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Company.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Company\\:\\:loadApiMetadata\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/Company.php
@@ -36083,11 +35382,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Entity\\\\Company\\:\\:\\$zipcode has no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Company.php
-
-		-
-			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/Company.php
 
@@ -36617,11 +35911,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/DoNotContact.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
-
-		-
 			message: """
 				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
@@ -36651,26 +35940,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getCount\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
 
@@ -36972,31 +36241,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addFrequencyRule\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addPointsChangeLogEntry\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addPointsChangeLogEntry\\(\\) has parameter \\$action with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addPointsChangeLogEntry\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addPointsChangeLogEntry\\(\\) has parameter \\$pointChanges with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:addPointsChangeLogEntry\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/Lead.php
 
@@ -37657,11 +36901,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadEventLog.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
 			message: """
 				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
@@ -37716,26 +36955,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getSpecificRows\\(\\) return type with generic class Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator does not specify its types\\: T$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
 
@@ -38853,11 +38072,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/PointsChangeLog.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:getLeadTimelineEvents\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -38898,26 +38112,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\PointsChangeLogRepository\\:\\:updateLead\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -38951,37 +38145,12 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/StagesChangeLog.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getLeadTimelineEvents\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getLeadTimelineEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\StagesChangeLogRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
 
@@ -39108,31 +38277,6 @@ parameters:
 			message: "#^Property Mautic\\\\LeadBundle\\\\Entity\\\\UtmTag\\:\\:\\$url has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/UtmTag.php
-
-		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\UtmTagRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\UtmTagRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\UtmTagRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\UtmTagRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\UtmTagRepository\\:\\:getUtmTagsByLead\\(\\) has parameter \\$options with no type specified\\.$#"
@@ -40409,11 +39553,6 @@ parameters:
 			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
 
 		-
-			message: "#^Variable \\$entries in PHPDoc tag @var does not match assigned variable \\$rows\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\EventListener\\\\MaintenanceSubscriber\\:\\:onDataCleanup\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -40793,11 +39932,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\EventListener\\\\SetContactAvatarFormSubscriber\\:\\:onFormSubmit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
 
@@ -41613,11 +40747,6 @@ parameters:
 			path: app/bundles/LeadBundle/Form/Type/EmailType.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\Type\\\\EmailType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/EmailType.php
-
-		-
 			message: "#^Class Mautic\\\\LeadBundle\\\\Form\\\\Type\\\\FieldType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -41629,11 +40758,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\Type\\\\FieldType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/FieldType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/Type/FieldType.php
 
@@ -41841,11 +40965,6 @@ parameters:
 			path: app/bundles/LeadBundle/Form/Type/LeadType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/LeadType.php
-
-		-
 			message: "#^Parameter \\#2 \\$fromFormat of class Mautic\\\\CoreBundle\\\\Helper\\\\DateTimeHelper constructor expects string, null given\\.$#"
 			count: 2
 			path: app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -41877,11 +40996,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\Type\\\\ListType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/ListType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/Type/ListType.php
 
@@ -41927,11 +41041,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\Type\\\\NoteType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/NoteType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/Type/NoteType.php
 
@@ -42762,11 +41871,6 @@ parameters:
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
 
 		-
-			message: "#^Offset int on array\\{\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Model\\\\CompanyModel\\:\\:\\$companyFields type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
@@ -42783,11 +41887,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between 0 and 0 will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Variable \\$fieldModel in PHPDoc tag @var does not match assigned variable \\$fields\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
 
@@ -43323,11 +42422,6 @@ parameters:
 			path: app/bundles/LeadBundle/Model/LeadModel.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\LeadModel\\:\\:createForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\<mixed\\>\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/LeadModel.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\LeadModel\\:\\:deleteEntity\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/LeadModel.php
@@ -43754,16 +42848,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and mixed will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/LeadModel.php
-
-		-
-			message: "#^Variable \\$entries in PHPDoc tag @var does not match assigned variable \\$dncEntries\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/LeadModel.php
-
-		-
-			message: "#^Variable \\$fieldModel in PHPDoc tag @var does not match assigned variable \\$fields\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/LeadModel.php
 
@@ -44489,14 +43573,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Decorator/FilterDecoratorInterface.php
 
 		-
-			message: """
-				#^Call to deprecated method getConnection\\(\\) of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:
-				Use the connection used to instantiate the builder instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\ContactSegmentQueryBuilder\\:\\:dispatchPluginFilteringEvent\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -44537,31 +43613,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
 
 		-
-			message: "#^Instanceof between array\\|float\\|int\\|string\\|false\\|null and Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\CompositeExpression will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/CompositeExpression.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\CompositeExpression\\:\\:__construct\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/CompositeExpression.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\CompositeExpression\\:\\:addMultiple\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/CompositeExpression.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\CompositeExpression\\:\\:\\$parts type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/CompositeExpression.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/CompositeExpression.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:between\\(\\) has parameter \\$arr with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
@@ -44582,11 +43633,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:in\\(\\) has parameter \\$y with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:notBetween\\(\\) has parameter \\$arr with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
@@ -44602,19 +43648,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:notIn\\(\\) has parameter \\$y with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Expression/ExpressionBuilder.php
-
-		-
-			message: """
-				#^Call to deprecated method getConnection\\(\\) of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:
-				Use the connection used to instantiate the builder instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
-
-		-
 			message: "#^Call to function is_null\\(\\) with Mautic\\\\LeadBundle\\\\Segment\\\\ContactSegmentFilter will always evaluate to false\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -44625,38 +43658,9 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
 
 		-
-			message: """
-				#^Call to deprecated method getConnection\\(\\) of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:
-				Use the connection used to instantiate the builder instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
-
-		-
-			message: """
-				#^Call to deprecated method getConnection\\(\\) of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:
-				Use the connection used to instantiate the builder instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
-
-		-
-			message: """
-				#^Call to deprecated method getConnection\\(\\) of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:
-				Use the connection used to instantiate the builder instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
 			message: "#^Call to function is_null\\(\\) with Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder will always evaluate to false\\.$#"
@@ -44669,45 +43673,10 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
-			message: "#^Fetching deprecated class constant DELETE of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant INSERT of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: """
 				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
 				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
 			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant SELECT of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 4
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant STATE_CLEAN of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 3
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant STATE_DIRTY of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 5
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant UPDATE of class Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Left side of && is always false\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
@@ -44742,42 +43711,12 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getFromClauses\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getJoinCondition\\(\\) has parameter \\$alias with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getLogicStack\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getParameterTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getQueryParts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getSQLForJoins\\(\\) has parameter \\$fromAlias with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:getSQLForJoins\\(\\) has parameter \\$knownAliases with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
@@ -44822,21 +43761,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:resetQueryParts\\(\\) has parameter \\$queryPartNames with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setParameters\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setParameters\\(\\) has parameter \\$types with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setParametersPairs\\(\\) has parameter \\$filterParameters with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -44847,87 +43771,12 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setQueryPart\\(\\) has parameter \\$queryPartName with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setQueryPart\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:values\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:verifyAllAliasesAreKnown\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:verifyAllAliasesAreKnown\\(\\) has parameter \\$knownAliases with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$sqlPart of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:add\\(\\) expects string, array given\\.$#"
-			count: 5
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$sqlPart of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:add\\(\\) expects string, array\\<string, array\\<string, string\\|null\\>\\> given\\.$#"
-			count: 3
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$sqlPart of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:add\\(\\) expects string, array\\<string, string\\> given\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$sqlPart of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:add\\(\\) expects string, array\\<string, string\\|null\\> given\\.$#"
-			count: 3
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#3 \\$type of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:setParameter\\(\\) expects string\\|null, int given\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$_expr is never written, only read\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$logicStack type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$paramTypes type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$params type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$sqlParts type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Return type \\(Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder\\) of method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:expr\\(\\) should be compatible with return type \\(Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\) of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:expr\\(\\)$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
@@ -45268,14 +44117,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\Controller\\\\Api\\\\TagApiControllerFunctionalTest\\:\\:testWhitespaceBeforeAndAfterNameNotCreatingDuplicates\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
 
 		-
 			message: """
@@ -47853,11 +46694,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tracker/ContactTracker.php
 
 		-
-			message: "#^Variable \\$fieldModel in PHPDoc tag @var does not match assigned variable \\$fields\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tracker/ContactTracker.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tracker\\\\DeviceTracker\\:\\:clearTrackingCookies\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tracker/DeviceTracker.php
@@ -48117,11 +46953,6 @@ parameters:
 			"""
 			count: 1
 			path: app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: app/bundles/MessengerBundle/DependencyInjection/Compiler/MessengerTransportPass.php
 
 		-
 			message: "#^Class Mautic\\\\MessengerBundle\\\\Form\\\\Type\\\\ConfigType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
@@ -48892,11 +47723,6 @@ parameters:
 			path: app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\NotificationBundle\\\\EventListener\\\\NotificationSubscriber\\:\\:onDelete\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
@@ -48908,11 +47734,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\NotificationBundle\\\\EventListener\\\\NotificationSubscriber\\:\\:onTokenReplacement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
 
@@ -49027,11 +47848,6 @@ parameters:
 			path: app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
-
-		-
 			message: "#^Class Mautic\\\\NotificationBundle\\\\Form\\\\Type\\\\NotificationConfigType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/NotificationBundle/Form/Type/NotificationConfigType.php
@@ -49073,11 +47889,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\NotificationBundle\\\\Form\\\\Type\\\\NotificationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/NotificationBundle/Form/Type/NotificationType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/NotificationBundle/Form/Type/NotificationType.php
 
@@ -49415,22 +48226,12 @@ parameters:
 			path: app/bundles/PageBundle/Controller/PublicController.php
 
 		-
-			message: "#^Parameter \\#1 \\$page of method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:hitPage\\(\\) expects Mautic\\\\PageBundle\\\\Entity\\\\Page\\|Mautic\\\\PageBundle\\\\Entity\\\\Redirect, null given\\.$#"
-			count: 2
-			path: app/bundles/PageBundle/Controller/PublicController.php
-
-		-
 			message: "#^Parameter \\#5 \\$query of method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:hitPage\\(\\) expects array, string\\|null given\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Controller/PublicController.php
 
 		-
 			message: "#^Strict comparison using \\!\\=\\= between non\\-falsy\\-string and int will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Controller/PublicController.php
-
-		-
-			message: "#^Variable \\$entity in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Controller/PublicController.php
 
@@ -49515,11 +48316,6 @@ parameters:
 		-
 			message: "#^Call to function is_array\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
 			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
 			path: app/bundles/PageBundle/Entity/HitRepository.php
 
 		-
@@ -49624,26 +48420,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getReferers\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/HitRepository.php
 
@@ -50286,11 +49062,6 @@ parameters:
 			path: app/bundles/PageBundle/Entity/VideoHit.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:countStats\\(\\) has parameter \\$times with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
@@ -50312,26 +49083,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:getReferers\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\VideoHitRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/VideoHitRepository.php
 
@@ -50844,31 +49595,6 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 2
-			path: app/bundles/PageBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\PageSubscriber\\:\\:onPageDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\PageSubscriber\\:\\:onPageDisplay\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\PageSubscriber\\:\\:onPageHit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\PageSubscriber\\:\\:onPagePostSave\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/EventListener/PointSubscriber.php
 
@@ -51023,11 +49749,6 @@ parameters:
 			path: app/bundles/PageBundle/Form/Type/PagePublishDatesType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Form/Type/PagePublishDatesType.php
-
-		-
 			message: "#^Class Mautic\\\\PageBundle\\\\Form\\\\Type\\\\PageType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/PageBundle/Form/Type/PageType.php
@@ -51039,11 +49760,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Form\\\\Type\\\\PageType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Form/Type/PageType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Form/Type/PageType.php
 
@@ -51235,7 +49951,7 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 2
+			count: 1
 			path: app/bundles/PageBundle/Model/PageModel.php
 
 		-
@@ -51449,11 +50165,6 @@ parameters:
 			path: app/bundles/PageBundle/Model/PageModel.php
 
 		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:processPageHit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Model/PageModel.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:resetVariants\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Model/PageModel.php
@@ -51551,11 +50262,6 @@ parameters:
 		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 1
-			path: app/bundles/PageBundle/Model/PageModel.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 2
 			path: app/bundles/PageBundle/Model/PageModel.php
 
 		-
@@ -51992,27 +50698,7 @@ parameters:
 			path: app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
 
 		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\EventListener\\\\PageSubscriberTest\\:\\:getEmptyPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\EventListener\\\\PageSubscriberTest\\:\\:getNonEmptyPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\EventListener\\\\PageSubscriberTest\\:\\:testGetTokensWhenCalledReturnsValidTokens\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\EventListener\\\\PageSubscriberTest\\:\\:testOnPageHitWhenCalledAcknowledgesHit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\EventListener\\\\PageSubscriberTest\\:\\:testOnPageHitWhenCalledRejectsBadHit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
 
@@ -53077,23 +51763,13 @@ parameters:
 			path: app/bundles/PluginBundle/Event/PluginIntegrationRequestEvent.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLead' will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
 		-
-			message: "#^Cannot call method getIntegrationSettings\\(\\) on string\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLeadToCampaign' will always evaluate to true\\.$#"
 			count: 1
-			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
-
-		-
-			message: "#^Cannot call method getLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
-			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
-
-		-
-			message: "#^Cannot call method resetLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
 		-
@@ -53147,7 +51823,7 @@ parameters:
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
 		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
+			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:pushLeadToCampaign\\(\\) invoked with 4 parameters, 3 required\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
@@ -53160,23 +51836,13 @@ parameters:
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLead' will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
 		-
-			message: "#^Cannot call method getIntegrationSettings\\(\\) on string\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLeadToCampaign' will always evaluate to true\\.$#"
 			count: 1
-			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
-
-		-
-			message: "#^Cannot call method getLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
-			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
-
-		-
-			message: "#^Cannot call method resetLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
 		-
@@ -53225,12 +51891,12 @@ parameters:
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
 		-
-			message: "#^PHPDoc tag @return with type mixed is not subtype of native type void\\.$#"
+			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:pushLeadToCampaign\\(\\) invoked with 4 parameters, 3 required\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
 		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type void\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
@@ -53303,11 +51969,6 @@ parameters:
 			message: "#^Property Mautic\\\\PluginBundle\\\\Facade\\\\ReloadFacade\\:\\:\\$translator has no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Facade/ReloadFacade.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with non\\-empty\\-array will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Form/Type/CompanyFieldsType.php
 
 		-
 			message: "#^Class Mautic\\\\PluginBundle\\\\Form\\\\Type\\\\CompanyFieldsType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
@@ -53426,11 +52087,6 @@ parameters:
 			message: "#^Variable \\$integrationCompanyFields in empty\\(\\) is never defined\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with non\\-empty\\-array will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Form/Type/FieldsType.php
 
 		-
 			message: "#^Class Mautic\\\\PluginBundle\\\\Form\\\\Type\\\\FieldsType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
@@ -53578,23 +52234,13 @@ parameters:
 			path: app/bundles/PluginBundle/Helper/Cleaner.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLead' will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
 
 		-
-			message: "#^Cannot call method getIntegrationSettings\\(\\) on string\\.$#"
+			message: "#^Call to function method_exists\\(\\) with Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration and 'pushLeadToCampaign' will always evaluate to true\\.$#"
 			count: 1
-			path: app/bundles/PluginBundle/Helper/EventHelper.php
-
-		-
-			message: "#^Cannot call method getLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
-			path: app/bundles/PluginBundle/Helper/EventHelper.php
-
-		-
-			message: "#^Cannot call method resetLastIntegrationError\\(\\) on string\\.$#"
-			count: 2
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
 
 		-
@@ -53653,7 +52299,7 @@ parameters:
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
 
 		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
+			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:pushLeadToCampaign\\(\\) invoked with 4 parameters, 3 required\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
 
@@ -53664,11 +52310,6 @@ parameters:
 			"""
 			count: 1
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
-
-		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
 
 		-
 			message: "#^Call to an undefined method Mautic\\\\PluginBundle\\\\Integration\\\\UnifiedIntegrationInterface\\:\\:getIcon\\(\\)\\.$#"
@@ -53747,11 +52388,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:getUserProfiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
 
@@ -54030,21 +52666,6 @@ parameters:
 			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
 
 		-
-			message: "#^Loose comparison using \\=\\= between 'company' and 'lead' will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: "#^Loose comparison using \\=\\= between 'lead' and 'lead' will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: "#^Loose comparison using \\=\\= between null and null will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:appendToForm\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -54121,11 +52742,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:convertLeadFieldKey\\(\\) has parameter \\$key with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:createIntegrationEntity\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
 
@@ -54661,11 +53277,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between true and int will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: "#^Variable \\$event in PHPDoc tag @var does not match assigned variable \\$keys\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
 
@@ -56001,11 +54612,6 @@ parameters:
 			path: app/bundles/PointBundle/Form/Type/PointType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Form/Type/PointType.php
-
-		-
 			message: "#^Class Mautic\\\\PointBundle\\\\Form\\\\Type\\\\TriggerEventType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/PointBundle/Form/Type/TriggerEventType.php
@@ -56032,11 +54638,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PointBundle\\\\Form\\\\Type\\\\TriggerType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Form/Type/TriggerType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/PointBundle/Form/Type/TriggerType.php
 
@@ -56223,212 +54824,12 @@ parameters:
 			path: app/bundles/PointBundle/Security/Permissions/PointPermissions.php
 
 		-
-			message: "#^Parameter \\#1 \\$permissionNames of method Mautic\\\\CoreBundle\\\\Security\\\\Permissions\\\\AbstractPermissions\\:\\:addStandardPermissions\\(\\) expects array, string given\\.$#"
-			count: 3
-			path: app/bundles/PointBundle/Security/Permissions/PointPermissions.php
-
-		-
 			message: """
 				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
 			"""
 			count: 1
 			path: app/bundles/PointBundle/Tests/Unit/Model/TriggerModelTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Command\\\\ConsumeQueueCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
-
-		-
-			message: "#^Parameter \\#2 \\$messages of method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:consumeFromQueue\\(\\) expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
-
-		-
-			message: "#^Parameter \\#3 \\$timeout of method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:consumeFromQueue\\(\\) expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Command/ConsumeQueueCommand.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueConsumerEvent\\:\\:__construct\\(\\) has parameter \\$payload with no type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueConsumerEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueConsumerEvent\\:\\:getPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueConsumerEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueConsumerEvent\\:\\:setResult\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueConsumerEvent.php
-
-		-
-			message: "#^Property Mautic\\\\QueueBundle\\\\Event\\\\QueueConsumerEvent\\:\\:\\$payload type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueConsumerEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueEvent\\:\\:__construct\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueEvent\\:\\:getPayload\\(\\) has parameter \\$returnArray with no type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Event\\\\QueueEvent\\:\\:getPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueEvent.php
-
-		-
-			message: "#^Property Mautic\\\\QueueBundle\\\\Event\\\\QueueEvent\\:\\:\\$payload type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Event/QueueEvent.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:consumeMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:getSubscribedEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:onConsumeMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:onPublishMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:publishMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:\\$protocol has no type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\QueueBundle\\\\EventListener\\\\AbstractQueueSubscriber\\:\\:\\$protocolUiTranslation has no type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/AbstractQueueSubscriber.php
-
-		-
-			message: "#^Service \"leezy\\.pheanstalk\" is not registered in the container\\.$#"
-			count: 2
-			path: app/bundles/QueueBundle/EventListener/BeanstalkdSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\RabbitMqSubscriber\\:\\:consumeMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\EventListener\\\\RabbitMqSubscriber\\:\\:publishMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
-
-		-
-			message: "#^Service \"old_sound_rabbit_mq\\.mautic_consumer\" is not registered in the container\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
-
-		-
-			message: "#^Service \"old_sound_rabbit_mq\\.mautic_producer\" is not registered in the container\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/EventListener/RabbitMqSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Helper\\\\QueueRequestHelper\\:\\:buildRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Helper/QueueRequestHelper.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Helper\\\\QueueRequestHelper\\:\\:buildRequest\\(\\) has parameter \\$request with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Helper/QueueRequestHelper.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Helper\\\\QueueRequestHelper\\:\\:flattenRequest\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Helper/QueueRequestHelper.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Helper\\\\RabbitMqProducer\\:\\:setQueue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Helper/RabbitMqProducer.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:consumeFromQueue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Queue/QueueService.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:dispatchConsumerEventFromPayload\\(\\) has parameter \\$payload with no type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Queue/QueueService.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:publishToQueue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Queue/QueueService.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Queue\\\\QueueService\\:\\:publishToQueue\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Queue/QueueService.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\Event\\\\QueueConsumerEventTest\\:\\:testCheckTransportIfCorrectTransport\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/Event/QueueConsumerEventTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\Event\\\\QueueConsumerEventTest\\:\\:testCheckTransportIfNoTransport\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/Event/QueueConsumerEventTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\Event\\\\QueueConsumerEventTest\\:\\:testCheckTransportIfWrongTransport\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/Event/QueueConsumerEventTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\EventListener\\\\BeanstalkdSubscriberTest\\:\\:testPublishMessage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/EventListener/BeanstalkdSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\MauticQueueBundleTest\\:\\:testBeanstalkdIsLoaded\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/MauticQueueBundleTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\MauticQueueBundleTest\\:\\:testCompilerPassIgnoredIfQueueIsDisabled\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/MauticQueueBundleTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\MauticQueueBundleTest\\:\\:testNothingIsLoadedIfQueueIsNotRecongized\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/MauticQueueBundleTest.php
-
-		-
-			message: "#^Method Mautic\\\\QueueBundle\\\\Tests\\\\MauticQueueBundleTest\\:\\:testRabbitMqIsLoaded\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/QueueBundle/Tests/MauticQueueBundleTest.php
 
 		-
 			message: "#^Method Mautic\\\\ReportBundle\\\\Adapter\\\\ReportDataAdapter\\:\\:getReportData\\(\\) has no return type specified\\.$#"
@@ -57431,11 +55832,6 @@ parameters:
 			path: app/bundles/ReportBundle/Form/Type/ReportType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/ReportBundle/Form/Type/ReportType.php
-
-		-
 			message: "#^Class Mautic\\\\ReportBundle\\\\Form\\\\Type\\\\ReportWidgetType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/ReportBundle/Form/Type/ReportWidgetType.php
@@ -57568,11 +55964,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method DateTimeInterface\\:\\:sub\\(\\)\\.$#"
 			count: 5
-			path: app/bundles/ReportBundle/Model/ReportExporter.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with DateTimeInterface will always evaluate to false\\.$#"
-			count: 1
 			path: app/bundles/ReportBundle/Model/ReportExporter.php
 
 		-
@@ -58807,11 +57198,6 @@ parameters:
 			path: app/bundles/SmsBundle/Entity/Stat.php
 
 		-
-			message: "#^Call to function is_callable\\(\\) with null will always evaluate to false\\.$#"
-			count: 2
-			path: app/bundles/SmsBundle/Entity/StatRepository.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Entity/StatRepository.php
@@ -58853,26 +57239,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\StatRepository\\:\\:getSmsStatus\\(\\) has parameter \\$trackingHash with no type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$dateTimeColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) has parameter \\$serializedColumns with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/StatRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\StatRepository\\:\\:getTimelineResults\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Entity/StatRepository.php
 
@@ -59115,11 +57481,6 @@ parameters:
 			path: app/bundles/SmsBundle/EventListener/ReplySubscriber.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/EventListener/SmsSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\EventListener\\\\SmsSubscriber\\:\\:onDelete\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/EventListener/SmsSubscriber.php
@@ -59131,11 +57492,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\EventListener\\\\SmsSubscriber\\:\\:onTokenReplacement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/EventListener/SmsSubscriber.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/EventListener/SmsSubscriber.php
 
@@ -59240,11 +57596,6 @@ parameters:
 			path: app/bundles/SmsBundle/Form/Type/SmsType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Form/Type/SmsType.php
-
-		-
 			message: "#^Call to method getId\\(\\) on an unknown class Mautic\\\\SmsBundle\\\\Helper\\\\Lead\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Helper/ContactHelper.php
@@ -59313,28 +57664,18 @@ parameters:
 			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
 
 		-
-			message: "#^Property Mautic\\\\SmsBundle\\\\Integration\\\\Twilio\\\\TwilioTransport\\:\\:\\$configuration is never read, only written\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
-			message: "#^Property Mautic\\\\SmsBundle\\\\Integration\\\\Twilio\\\\TwilioTransport\\:\\:\\$sendingPhoneNumber is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
 
 		-
 			message: "#^Call to method add\\(\\) on an unknown class Mautic\\\\PluginBundle\\\\Integration\\\\Form\\.$#"
-			count: 4
+			count: 3
 			path: app/bundles/SmsBundle/Integration/TwilioIntegration.php
 
 		-
 			message: "#^Call to method add\\(\\) on an unknown class Mautic\\\\SmsBundle\\\\Integration\\\\FormBuilder\\.$#"
-			count: 4
+			count: 3
 			path: app/bundles/SmsBundle/Integration/TwilioIntegration.php
 
 		-
@@ -59670,11 +58011,6 @@ parameters:
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
 
 		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testConfigurationExceptionThrownWithoutSendingNumber\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
-
-		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testConfigurationExceptionThrownWithoutUsername\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
@@ -59686,11 +58022,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testGetAuthToken\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Tests\\\\Integration\\\\Twilio\\\\ConfigurationTest\\:\\:testGetSendingNumber\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
 
@@ -60230,11 +58561,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Form\\\\Type\\\\StageType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Form/Type/StageType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Form/Type/StageType.php
 
@@ -61720,11 +60046,6 @@ parameters:
 			path: app/bundles/UserBundle/Form/Type/RoleType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Form/Type/RoleType.php
-
-		-
 			message: "#^Class Mautic\\\\UserBundle\\\\Form\\\\Type\\\\UserListType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: app/bundles/UserBundle/Form/Type/UserListType.php
@@ -61761,11 +60082,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Model\\\\UserModel\\:\\:getLookupResults\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Form/Type/UserType.php
-
-		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Form/Type/UserType.php
 
@@ -62000,16 +60316,6 @@ parameters:
 				#^Call to deprecated method isAuthenticated\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\AbstractToken\\:
 				since Symfony 5\\.4$#
 			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and Psr\\\\Log\\\\LoggerInterface will always evaluate to true\\.$#"
-			count: 2
-			path: app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
 
@@ -63212,27 +61518,7 @@ parameters:
 			path: app/bundles/WebhookBundle/Model/WebhookModel.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
-
-		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Notificator\\\\WebhookKillNotificator\\:\\:send\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
-
-		-
-			message: "#^Result of && is always true\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between int and Mautic\\\\UserBundle\\\\Entity\\\\User will always evaluate to true\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and Mautic\\\\UserBundle\\\\Entity\\\\User will always evaluate to true\\.$#"
 			count: 1
 			path: app/bundles/WebhookBundle/Notificator/WebhookKillNotificator.php
 
@@ -65151,11 +63437,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
 
 		-
-			message: "#^Variable \\$integrationEntities in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
-
-		-
 			message: "#^Call to an undefined method MauticPlugin\\\\MauticCrmBundle\\\\Api\\\\CrmApi\\:\\:createLead\\(\\)\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -65485,11 +63766,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
 
 		-
-			message: "#^Parameter \\#3 \\$object of method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:populateMauticLeadData\\(\\) expects null, string given\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
-
-		-
 			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\CrmAbstractIntegration\\:\\:\\$auth has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -65763,11 +64039,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$opts has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
-
-		-
 			message: "#^Parameter \\#10 \\$integrationEntityIds of method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) expects null, string given\\.$#"
 			count: 3
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -65788,22 +64059,12 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
 
 		-
-			message: "#^Parameter \\#3 \\$object of method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:populateMauticLeadData\\(\\) expects null, string given\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
-
-		-
 			message: "#^Return type \\(bool\\) of method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\DynamicsIntegration\\:\\:getDataPriority\\(\\) should be compatible with return type \\(string\\) of method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:getDataPriority\\(\\)$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
 
 		-
 			message: "#^Variable \\$integrationId in empty\\(\\) always exists and is always falsy\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
-
-		-
-			message: "#^Variable \\$opts in PHPDoc tag @var does not match assigned variable \\$fields\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
 
@@ -65999,11 +64260,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\HubspotIntegration\\:\\:pushLead\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
-
-		-
-			message: "#^Offset 'results' on array\\{results\\: array\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
 
@@ -67376,11 +65632,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 
 		-
-			message: "#^Variable \\$request in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
 			message: "#^Call to an undefined method MauticPlugin\\\\MauticCrmBundle\\\\Api\\\\CrmApi\\:\\:createLead\\(\\)\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -67427,11 +65678,6 @@ parameters:
 
 		-
 			message: "#^If condition is always false\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
-			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
 
@@ -68084,11 +66330,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
 
 		-
-			message: "#^Call to function array_key_exists\\(\\) with 'page' and array\\{fields\\: string, per_page\\: 200, lastModifiedTime\\?\\: non\\-falsy\\-string\\} will always evaluate to false\\.$#"
-			count: 2
-			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -68344,11 +66585,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$rows has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
-
-		-
 			message: "#^Parameter \\#10 \\$integrationEntityIds of method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) expects null, array\\<int, mixed\\> given\\.$#"
 			count: 3
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -68370,11 +66606,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between 'company' and null will always evaluate to false\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
-
-		-
-			message: "#^Variable \\$rows in PHPDoc tag @var does not match assigned variable \\$integrationEntities\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
 
@@ -69578,32 +67809,12 @@ parameters:
 			path: plugins/MauticFocusBundle/Controller/FocusController.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Controller/PublicController.php
-
-		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Controller/PublicController.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\Controller\\\\PublicController\\:\\:generateAction\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Controller/PublicController.php
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\Controller\\\\PublicController\\:\\:generateAction\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Controller/PublicController.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of method MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\FocusModel\\:\\:getEntity\\(\\) expects null, mixed given\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Controller/PublicController.php
-
-		-
-			message: "#^Parameter \\#3 \\$data of method MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\FocusModel\\:\\:addStat\\(\\) expects null, Symfony\\\\Component\\\\HttpFoundation\\\\Request given\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Controller/PublicController.php
 
@@ -69751,11 +67962,6 @@ parameters:
 			path: plugins/MauticFocusBundle/Entity/Stat.php
 
 		-
-			message: "#^Property MauticPlugin\\\\MauticFocusBundle\\\\Entity\\\\Stat\\:\\:\\$lead has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Entity/Stat.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Entity/StatRepository.php
@@ -69794,11 +68000,6 @@ parameters:
 			path: plugins/MauticFocusBundle/EventListener/CampaignSubscriber.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
-
-		-
 			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -69820,11 +68021,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\EventListener\\\\FocusSubscriber\\:\\:onTokenReplacement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
 
@@ -69859,37 +68055,12 @@ parameters:
 			path: plugins/MauticFocusBundle/EventListener/PageSubscriber.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between null and MauticPlugin\\\\MauticFocusBundle\\\\Entity\\\\Focus will always evaluate to true\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/PageSubscriber.php
-
-		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 2
-			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\EventListener\\\\StatSubscriber\\:\\:onFormSubmit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\EventListener\\\\StatSubscriber\\:\\:onPageHit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of method MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\FocusModel\\:\\:getEntity\\(\\) expects null, int given\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
-
-		-
-			message: "#^Parameter \\#3 \\$data of method MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\FocusModel\\:\\:addStat\\(\\) expects null, Mautic\\\\FormBundle\\\\Entity\\\\Submission given\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
-
-		-
-			message: "#^Parameter \\#3 \\$data of method MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\FocusModel\\:\\:addStat\\(\\) expects null, Mautic\\\\PageBundle\\\\Entity\\\\Hit given\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/EventListener/StatSubscriber.php
 
@@ -69979,11 +68150,6 @@ parameters:
 			path: plugins/MauticFocusBundle/Form/Type/FocusType.php
 
 		-
-			message: "#^Parameter \\#1 \\$model of class Mautic\\\\CoreBundle\\\\Form\\\\EventListener\\\\FormExitSubscriber constructor expects Mautic\\\\CoreBundle\\\\Model\\\\CommonModel, string given\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Form/Type/FocusType.php
-
-		-
 			message: "#^Class MauticPlugin\\\\MauticFocusBundle\\\\Form\\\\Type\\\\PropertiesType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Form/Type/PropertiesType.php
@@ -70020,11 +68186,6 @@ parameters:
 
 		-
 			message: "#^Property MauticPlugin\\\\MauticFocusBundle\\\\Helper\\\\TokenHelper\\:\\:\\$regex has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Helper/TokenHelper.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and MauticPlugin\\\\MauticFocusBundle\\\\Entity\\\\Focus will always evaluate to true\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Helper/TokenHelper.php
 
@@ -70095,16 +68256,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @throws with type MauticPlugin\\\\MauticFocusBundle\\\\Model\\\\NotFoundHttpException is not subtype of Throwable$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Model/FocusModel.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and null will always evaluate to true\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Model/FocusModel.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Model/FocusModel.php
 
@@ -71736,11 +69887,6 @@ parameters:
 			path: plugins/MauticSocialBundle/Form/Type/TwitterType.php
 
 		-
-			message: "#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Helper\\\\CampaignEventHelper\\:\\:parseTweetText\\(\\) has parameter \\$lead with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
@@ -71752,11 +69898,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Helper\\\\CampaignEventHelper\\:\\:sendTweetAction\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
-
-		-
-			message: "#^PHPDoc tag @var above foreach loop does not specify variable name\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
 
@@ -71774,11 +69915,6 @@ parameters:
 			message: "#^Property MauticPlugin\\\\MauticSocialBundle\\\\Helper\\\\CampaignEventHelper\\:\\:\\$clickthrough type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
-
-		-
-			message: "#^Instanceof between DateTime and DateTimeInterface will always evaluate to true\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
 
 		-
 			message: "#^Instanceof between Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface and Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface will always evaluate to true\\.$#"
@@ -72438,11 +70574,6 @@ parameters:
 			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticTagManagerBundle\\\\Entity\\\\TagRepository\\:\\:getDefaultOrder\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
-
-		-
 			message: "#^Class MauticPlugin\\\\MauticTagManagerBundle\\\\Form\\\\Type\\\\TagEntityType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#"
 			count: 1
 			path: plugins/MauticTagManagerBundle/Form/Type/TagEntityType.php
@@ -72492,11 +70623,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\:\\:saveEntity\\(\\)\\.$#"
-			count: 1
-			path: plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticTagManagerBundle\\\\Tests\\\\Functional\\\\Entity\\\\TagRepositoryTest\\:\\:\\$tagModel \\(MauticPlugin\\\\MauticTagManagerBundle\\\\Model\\\\TagModel\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\.$#"
 			count: 1
 			path: plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
 

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -276,7 +276,6 @@ class DynamicsIntegration extends CrmAbstractIntegration
                         if (null === $leadObject || !array_key_exists('value', $leadObject)) {
                             return [];
                         }
-                        /** @var array $opts */
                         $fields = $leadObject['value'];
                         foreach ($fields as $field) {
                             $type      = 'string';

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -181,7 +181,7 @@ class ZohoIntegration extends CrmAbstractIntegration
             /** @var IntegrationEntityRepository $integrationEntityRepo */
             $integrationEntityRepo = $this->em->getRepository(\Mautic\PluginBundle\Entity\IntegrationEntity::class);
             $objects               = $data['data'];
-            $integrationEntities = [];
+            $integrationEntities   = [];
             /** @var array $objects */
             foreach ($objects as $recordId => $entityData) {
                 $isModified = false;

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -181,7 +181,6 @@ class ZohoIntegration extends CrmAbstractIntegration
             /** @var IntegrationEntityRepository $integrationEntityRepo */
             $integrationEntityRepo = $this->em->getRepository(\Mautic\PluginBundle\Entity\IntegrationEntity::class);
             $objects               = $data['data'];
-            /** @var array $rows */
             $integrationEntities = [];
             /** @var array $objects */
             foreach ($objects as $recordId => $entityData) {

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -183,10 +183,6 @@ class FocusSubscriber implements EventSubscriberInterface
 
             $focus = $this->focusModel->getEntity($clickthrough['focus_id']);
 
-            /**
-             * @var string
-             * @var Trackable $trackable
-             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, false, $focus->getUtmTags());
             }

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -183,6 +183,10 @@ class FocusSubscriber implements EventSubscriberInterface
 
             $focus = $this->focusModel->getEntity($clickthrough['focus_id']);
 
+            /**
+             * @var string    $token
+             * @var Trackable $trackable
+             */
             foreach ($trackables as $token => $trackable) {
                 $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $clickthrough, false, $focus->getUtmTags());
             }

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -356,7 +356,6 @@ class FocusModel extends FormModel
                 $typeId = $data->getId();
                 break;
             case Stat::TYPE_NOTIFICATION:
-                /** @var Request $data */
                 $typeId = null;
                 break;
             case Stat::TYPE_CLICK:

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -27,7 +27,6 @@ use MauticPlugin\MauticFocusBundle\Form\Type\FocusType;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;

--- a/plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
+++ b/plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
@@ -145,10 +145,6 @@ class CampaignEventHelper
             $channelId
         );
 
-        /**
-         * @var string
-         * @var Trackable $trackable
-         */
         foreach ($trackables as $token => $trackable) {
             $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $this->clickthrough);
         }

--- a/plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
+++ b/plugins/MauticSocialBundle/Helper/CampaignEventHelper.php
@@ -145,6 +145,10 @@ class CampaignEventHelper
             $channelId
         );
 
+        /**
+         * @var string    $token
+         * @var Trackable $trackable
+         */
         foreach ($trackables as $token => $trackable) {
             $tokens[$token] = $this->trackableModel->generateTrackableUrl($trackable, $this->clickthrough);
         }


### PR DESCRIPTION
Hey, I got a generous note on Twitter, thank you for that :pray:  :hugs: 

I realized I'd still love to push the dead code Rector set forward. Kicking of with next rule removing unused `@var` annotations :+1: 