### PR TITLE
Add DDEV config.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@
 !/themes/blank-big.png
 
 /translations
+.ddev/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !.htaccess
 !.gitkeep
 !.ddev
+.ddev/config.yaml
 !.php-cs-fixer.php
 !.github/ci-files/.my.cnf
 .ddev/mautic-preference
@@ -141,4 +142,3 @@
 !/themes/blank-big.png
 
 /translations
-.ddev/config.yaml

--- a/app/assets/scaffold/files/example.gitignore
+++ b/app/assets/scaffold/files/example.gitignore
@@ -4,6 +4,7 @@
 !.htaccess
 !.gitkeep
 !.ddev
+.ddev/config.yaml
 !.php-cs-fixer.php
 !.github/ci-files/.my.cnf
 .ddev/mautic-preference


### PR DESCRIPTION
#### Description:

Add ddev config file to gitignore

#### Steps to test this PR:

1. Do a development install with DDEV and see config.yaml disappear from changed files history