### PR TITLE
[pre-phpunit-10] Make data providers static

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
@@ -48,7 +48,7 @@ final class EventControllerFunctionalTest extends MauticMysqlTestCase
     /**
      * @return string[][]
      */
-    public function fieldAndValueProvider(): array
+    public static function fieldAndValueProvider(): array
     {
         return [
             'country'  => ['country', 'India'],

--- a/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
@@ -61,7 +61,7 @@ final class VisitedPageConditionControllerFunctionalTest extends MauticMysqlTest
     /**
      * @return array<mixed,mixed>
      */
-    public function fieldAndValueProvider(): array
+    public static function fieldAndValueProvider(): array
     {
         return [
             [

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -142,7 +142,7 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @return array<string, array<mixed>> */
-    public function provideReschedulingData(): array
+    public static function ProvidereschedulingData(): array
     {
         return [
             'test on specified hour'                     => [new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00')],

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -74,7 +74,7 @@ JSON;
      *
      * @return iterable<mixed[]>
      */
-    public function patchProvider(): iterable
+    public static function patchProvider(): iterable
     {
         yield [
             [

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -94,7 +94,7 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
     /**
      * @return iterable<array<?int,int|bool|string|null>>
      */
-    public function boolProvider(): iterable
+    public static function boolProvider(): iterable
     {
         yield [true, '1'];
         yield [true, 1];

--- a/app/bundles/CoreBundle/Tests/Unit/Form/DataTransformer/BarStringTransformerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/DataTransformer/BarStringTransformerTest.php
@@ -24,7 +24,7 @@ final class BarStringTransformerTest extends TestCase
     /**
      * @return \Generator<array<mixed>>
      */
-    public function transformProvider(): \Generator
+    public static function transformProvider(): \Generator
     {
         yield [null, ''];
         yield [[], ''];
@@ -51,7 +51,7 @@ final class BarStringTransformerTest extends TestCase
     /**
      * @return \Generator<array<mixed>>
      */
-    public function reverseTransformProvider(): \Generator
+    public static function reverseTransformProvider(): \Generator
     {
         yield [null, []];
         yield [[], []];

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -180,7 +180,7 @@ class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
             ->validate($filters, new CircularDependency(['message' => 'mautic.core.segment.circular_dependency_exists']));
     }
 
-    public function validateDataProvider()
+    public static function validateDataProvider()
     {
         $constraint = new CircularDependency(['message' => 'mautic.core.segment.circular_dependency_exists']);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ArrayHelperTest.php
@@ -54,7 +54,7 @@ class ArrayHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \Generator<mixed[]>
      */
-    public function removeEmptyValuesProvider(): \Generator
+    public static function removeEmptyValuesProvider(): \Generator
     {
         $object = new \stdClass();
         yield [[null], []];

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
@@ -26,7 +26,7 @@ final class EmailAddressHelperTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function emailProvider(): array
+    public static function emailProvider(): array
     {
         return [
             ['test@example.com', 'test@example.com'],
@@ -52,7 +52,7 @@ final class EmailAddressHelperTest extends TestCase
     /**
      * @return array<int, array<int, array<int, string>|string>>
      */
-    public function variationsProvider(): array
+    public static function variationsProvider(): array
     {
         return [
             ['test@example.com', ['test@example.com']],

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
@@ -20,7 +20,7 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($megabyte, $fileHelper::convertBytesToMegabytes($byte));
     }
 
-    public function bytesToMegabytesProvider()
+    public static function bytesToMegabytesProvider()
     {
         return [
             [0, 0.0],
@@ -44,7 +44,7 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($byte, $fileHelper::convertMegabytesToBytes($megabyte));
     }
 
-    public function megabytesToBytesProvider()
+    public static function megabytesToBytesProvider()
     {
         return [
             [0, 0],
@@ -67,7 +67,7 @@ class FileHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($bytes, $fileHelper::convertPHPSizeToBytes($phpSize));
     }
 
-    public function phpSizeToBytesProvider()
+    public static function phpSizeToBytesProvider()
     {
         return [
             ['3048M', 3196059648],

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -174,7 +174,7 @@ class InputHelperTest extends TestCase
         Assert::assertEquals($cleanedUrl, $outputUrl);
     }
 
-    public function urlProvider(): iterable
+    public static function urlProvider(): iterable
     {
         // valid URL is reconstructed as expected
         yield ['https://www.mautic.org/somewhere/something?foo=bar#abc123', 'https://www.mautic.org/somewhere/something?foo=bar#abc123'];
@@ -232,7 +232,7 @@ class InputHelperTest extends TestCase
     /**
      * @return iterable<array<string>>
      */
-    public function filenameProvider(): iterable
+    public static function filenameProvider(): iterable
     {
         yield [
             'dirname',
@@ -276,7 +276,7 @@ class InputHelperTest extends TestCase
     /**
      * @return array<array<string>>
      */
-    public function minifyHTMLProvider(): array
+    public static function minifyHTMLProvider(): array
     {
         return [
             // Test with a simple HTML string with no whitespace
@@ -310,7 +310,7 @@ class InputHelperTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function underscoreProvider(): array
+    public static function underscoreProvider(): array
     {
         return [
             ['hello', 'hello'],

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
@@ -35,7 +35,7 @@ class PageHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($page, $this->pageHelper->countPage($count));
     }
 
-    public function pageProvider()
+    public static function pageProvider()
     {
         return [
             [0, 10, 1],
@@ -63,7 +63,7 @@ class PageHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($start, $this->pageHelper->countPage($page));
     }
 
-    public function startProvider()
+    public static function startProvider()
     {
         return [
             [0, 10, 1],

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
@@ -27,7 +27,7 @@ final class HtmlExtensionTest extends TestCase
     /**
      * @return array<int, mixed>
      */
-    public function convertStringToArrayProvider(): iterable
+    public static function convertStringToArrayProvider(): iterable
     {
         yield ['id="test-id" class="test-class"', [
             'id'    => 'test-id',

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
@@ -102,7 +102,7 @@ class FormatterHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @return iterable<array<mixed>>
      */
-    public function stringProvider(): iterable
+    public static function stringProvider(): iterable
     {
         // string
         yield ['random string', 'random string'];

--- a/app/bundles/EmailBundle/Tests/Entity/StatTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatTest.php
@@ -38,7 +38,7 @@ class StatTest extends TestCase
     /**
      * Data provider for addOpenDetails.
      */
-    public function addOpenDetailsTestProvider(): array
+    public static function addOpenDetailsTestProvider(): array
     {
         return [
             'no openDetails'            => [0],

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -107,7 +107,7 @@ class MatchFilterForLeadTraitTest extends TestCase
         $this->assertEquals($expect, $this->matchFilterForLeadTrait->match($filters, $lead));
     }
 
-    public function dateMatchTestProvider(): iterable
+    public static function dateMatchTestProvider(): iterable
     {
         $date = '2021-05-01';
 

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -572,7 +572,7 @@ class MailHelperTest extends TestCase
     /**
      * @return array<array<bool|int|string>>
      */
-    public function minifyHtmlDataProvider(): array
+    public static function minifyHtmlDataProvider(): array
     {
         $html = '<!doctype html>
 <html lang=3D"en" xmlns=3D"http://www.w3.org/1999/xhtml" xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-microsoft-com:office:office">

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -102,7 +102,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
     /**
      * @return \Generator<mixed[]>
      */
-    public function provider(): \Generator
+    public static function Provider(): \Generator
     {
         // Test null value.
         yield [

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -109,10 +109,10 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             null,
             0,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function (): void {
-                $this->fail('Null value should not be validated.');
+                self::fail('Null value should not be validated.');
             },
         ];
 
@@ -121,10 +121,10 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             '',
             0,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function (): void {
-                $this->fail('Empty string value should not be validated.');
+                self::fail('Empty string value should not be validated.');
             },
         ];
 
@@ -133,7 +133,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             'somestring',
             1,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function ($message, array $parameters = []): void {
                 Assert::assertSame('mautic.email.email_or_token.not_valid', $message);
@@ -152,10 +152,10 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             'john@doe.com',
             0,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function (): void {
-                $this->fail('Valid email address value should not add violation.');
+                self::fail('Valid email address value should not add violation.');
             },
         ];
 
@@ -164,7 +164,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             'john@doe.com, somestring',
             1,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function ($message, array $parameters = []): void {
                 Assert::assertSame('mautic.email.email_or_token.not_valid', $message);
@@ -182,7 +182,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             'john@doe.com, {contactfield=somefield | invalid-default-email-address}',
             1,
             function (): void {
-                $this->fail('Field should not be fetched');
+                self::fail('Field should not be fetched');
             },
             function ($message, array $parameters = []): void {
                 Assert::assertSame('mautic.email.email_or_token.not_valid', $message);
@@ -256,7 +256,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
                 return $field;
             },
             function (): void {
-                $this->fail('There is no violation');
+                self::fail('There is no violation');
             },
         ];
 

--- a/app/bundles/FormBundle/Tests/Entity/FieldTest.php
+++ b/app/bundles/FormBundle/Tests/Entity/FieldTest.php
@@ -319,7 +319,7 @@ final class FieldTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<int, mixed>
      */
-    public function dataProvider(): iterable
+    public static function dataProvider(): iterable
     {
         yield ['string', [], false];
         yield ['string', ['multiple' => 0], false];

--- a/app/bundles/FormBundle/Tests/Entity/FormTest.php
+++ b/app/bundles/FormBundle/Tests/Entity/FormTest.php
@@ -22,7 +22,7 @@ final class FormTest extends \PHPUnit\Framework\TestCase
         Assert::assertSame($changes, $form->getChanges());
     }
 
-    public function setNoIndexDataProvider(): iterable
+    public static function setNoIndexDataProvider(): iterable
     {
         yield [null, null, []];
         yield [true, true, ['noIndex' => [null, true]]];

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -125,7 +125,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($result, $event->getResult());
     }
 
-    public function valueProvider(): iterable
+    public static function valueProvider(): iterable
     {
         yield [
             'test & test',

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -185,7 +185,7 @@ class FormSubscriberTest extends TestCase
         $this->subscriber->onFormSubmitActionSendEmail($submissionEvent);
     }
 
-    public function toCcBccProvider(): \Generator
+    public static function toCcBccProvider(): \Generator
     {
         yield ['to@email.email, to2@email.email', null, null];
         yield [null, 'cc@email.email, cc2@email.email', null];

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -44,63 +44,63 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
     {
         return [
             [
-                $this->getField('First Name', 'text'),
+                self::getField('First Name', 'text'),
                 '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
                 '<input value="" id="mauticform_input_mautic_firstname" />',
                 '<input id="mauticform_input_mautic_firstname" value="&quot;/&gt;alert(0)" />',
                 'Tags should be stripped from textet field values submitted via GET to prevent XSS.',
             ],
             [
-                $this->getField('First Name', 'text'),
+                self::getField('First Name', 'text'),
                 '%22%20onfocus=%22alert(123)',
                 '<input value="" id="mauticform_input_mautic_firstname" />',
                 '<input id="mauticform_input_mautic_firstname" value="&quot; onfocus=&quot;alert(123)" />',
                 'Inline JS values should not be allowed via GET to prevent XSS.',
             ],
             [
-                $this->getField('Phone', 'tel'),
+                self::getField('Phone', 'tel'),
                 '+41 123 456 7890',
                 '<input value="" id="mauticform_input_mautic_phone" />',
                 '<input id="mauticform_input_mautic_phone" value="+41 123 456 7890" />',
                 'Phone number are populated properly',
             ],
             [
-                $this->getField('Description', 'textarea'),
+                self::getField('Description', 'textarea'),
                 '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
                 '<textarea id="mauticform_input_mautic_description"></textarea>',
                 '<textarea id="mauticform_input_mautic_description">&quot;/&gt;alert(0)</textarea>',
                 'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
             ],
             [
-                $this->getField('Description', 'textarea'),
+                self::getField('Description', 'textarea'),
                 '%22%20onfocus=%22alert(123)',
                 '<textarea id="mauticform_input_mautic_description"></textarea>',
                 '<textarea id="mauticform_input_mautic_description">&quot; onfocus=&quot;alert(123)</textarea>',
                 'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
             ],
             [
-                $this->getField('Checkbox Single', 'checkboxgrp'),
+                self::getField('Checkbox Single', 'checkboxgrp'),
                 'myvalue',
-                '<input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Single').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
-                '<input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Single').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
+                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
+                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
                 'Single value checkbox groups should have their values set appropriately via GET.',
             ],
             [
-                $this->getField('Checkbox Multi', 'checkboxgrp'),
+                self::getField('Checkbox Multi', 'checkboxgrp'),
                 'myvalue%7Calsomyvalue',
-                '<input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'2" value="alsomyvalue"/><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
-                '<input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'2" value="alsomyvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.$this->getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
+                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
+                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
                 'Multi-value checkbox groups should have their values set appropriately via GET.',
             ],
             [
-                $this->getField('Radio Single', 'radiogrp'),
+                self::getField('Radio Single', 'radiogrp'),
                 'myvalue',
-                '<input id="mauticform_radiogrp_radio_'.$this->getAliasFromName('Radio Single').'1" value="myvalue"/><input id="mauticform_radiogrp_radio_'.$this->getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
-                '<input id="mauticform_radiogrp_radio_'.$this->getAliasFromName('Radio Single').'1" value="myvalue" checked /><input id="mauticform_radiogrp_radio_'.$this->getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
+                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
+                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue" checked /><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
                 'Single value radio groups should have their values set appropriately via GET.',
             ],
             [
-                $this->getField('Select', 'select'),
+                self::getField('Select', 'select'),
                 'myvalue',
                 '<select id="mauticform_input_mautic_select"><option value="myvalue">My Value</option></select>',
                 '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
@@ -115,12 +115,12 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return Field
      */
-    protected function getField($name, $type)
+    protected static function getField($name, $type)
     {
         $field = new Field();
 
         $field->setLabel($name);
-        $field->setAlias($this->getAliasFromName($name));
+        $field->setAlias(self::getAliasFromName($name));
         $field->setType($type);
 
         return $field;
@@ -131,7 +131,7 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return string
      */
-    private function getAliasFromName($name)
+    private static function getAliasFromName($name)
     {
         return strtolower(str_replace(' ', '', $name));
     }

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -40,7 +40,7 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function fieldProvider()
+    public static function fieldProvider()
     {
         return [
             [

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -416,7 +416,7 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<string[]>
      */
-    public function fieldTypeProvider(): array
+    public static function fieldTypeProvider(): array
     {
         return [
             ['select'],

--- a/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
@@ -60,7 +60,7 @@ class CreateCustomFieldCommandTest extends TestCase
     /**
      * @return array<int, array<int, bool|int>>
      */
-    public function completeRunMethodProvider(): array
+    public static function completeRunMethodProvider(): array
     {
         return [
             [true, 1],  // `completeRun` should be called once

--- a/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
@@ -75,7 +75,7 @@ final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
     /**
      * @return iterable<array<callable>>
      */
-    public function provider(): iterable
+    public static function Provider(): iterable
     {
         // Test that all segments will be rebuilt with no params set.
         yield [

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -410,7 +410,7 @@ class ListControllerFunctionalTest extends MauticMysqlTestCase
     /**
      * @return array<int, array<int, bool|string|null>>
      */
-    public function dateFieldProvider(): array
+    public static function dateFieldProvider(): array
     {
         return [
             ['Today', true],

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
@@ -165,7 +165,7 @@ final class LeadListTest extends \PHPUnit\Framework\TestCase
         Assert::assertSame($changes, $segment->getChanges());
     }
 
-    public function setIsGlobalDataProvider(): iterable
+    public static function setIsGlobalDataProvider(): iterable
     {
         yield [null, false, ['isGlobal' => [true, false]]];
         yield [true, true, []];
@@ -187,7 +187,7 @@ final class LeadListTest extends \PHPUnit\Framework\TestCase
         Assert::assertSame($changes, $segment->getChanges());
     }
 
-    public function setIsPreferenceCenterDataProvider(): iterable
+    public static function setIsPreferenceCenterDataProvider(): iterable
     {
         yield [null, false, []];
         yield [true, true, ['isPreferenceCenter' => [false, true]]];

--- a/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
@@ -47,7 +47,7 @@ class UtmTagTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<string|array<bool|string|''>>
      */
-    public function utmTagsDataProvider(): array
+    public static function utmTagsDataProvider(): array
     {
         return [
             'All tags are empty'       => ['', '', '', '', '', false],

--- a/app/bundles/LeadBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -38,7 +38,7 @@ class EmailSubscriberTest extends TestCase
     /**
      * @return \Generator<string[]>
      */
-    public function onEmailAddressReplacementProvider(): \Generator
+    public static function onEmailAddressReplacementProvider(): \Generator
     {
         yield ['{contactfield=unicorn}', ''];
         yield ['{contactfield=unicorn|default@value.email}', 'default@value.email'];

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -346,7 +346,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function eventDataProvider(): array
+    public static function eventDataProvider(): array
     {
         return [
             ['leads'],
@@ -362,7 +362,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function reportGraphEventDataProvider(): array
+    public static function reportGraphEventDataProvider(): array
     {
         return [
             ['leads'],

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
@@ -22,7 +22,7 @@ final class LeadRepositoryTest extends MauticMysqlTestCase
     /**
      * @return array<int, array<string, array<string, bool>>>
      */
-    public function joinIpAddressesProvider(): array
+    public static function joinIpAddressesProvider(): array
     {
         return [
             ['' => []],

--- a/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
@@ -94,7 +94,7 @@ class LeadListModelTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $result, $message);
     }
 
-    public function segmentTestDataProvider()
+    public static function segmentTestDataProvider()
     {
         return [
             [

--- a/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -131,7 +131,7 @@ class ListModelTest extends TestCase
         $this->fixture = $mockListModel;
     }
 
-    public function sourceTypeTestDataProvider(): array
+    public static function sourceTypeTestDataProvider(): array
     {
         return [
             [

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
@@ -279,7 +279,7 @@ class ContactSegmentFilterCrateTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($contactSegmentFilterCrate->hasTimeParts());
     }
 
-    public function specialFieldsToConvertToEmptyProvider()
+    public static function specialFieldsToConvertToEmptyProvider()
     {
         return [
             ['page_id'],

--- a/app/bundles/LeadBundle/Tests/Segment/DoNotContact/DoNotContactPartsTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/DoNotContact/DoNotContactPartsTest.php
@@ -22,7 +22,7 @@ class DoNotContactPartsTest extends \PHPUnit\Framework\TestCase
     /**
      * @return iterable<array<string,string|int>>
      */
-    public function dataProvider(): iterable
+    public static function dataProvider(): iterable
     {
         yield [
             'field'   => 'dnc_bounced',

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -37,7 +37,7 @@ class EmailAddressValidatorTest extends AbstractMauticTestCase
     /**
      * @return iterable<mixed[]>
      */
-    public function provider(): iterable
+    public static function Provider(): iterable
     {
         yield [null, 0];
         yield ['', 0];

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -42,7 +42,7 @@ final class DetailControllerTest extends MauticMysqlTestCase
     /**
      * @return iterable<array<string|int>>
      */
-    public function dataProvider(): iterable
+    public static function dataProvider(): iterable
     {
         // Package that do not exist in the allowlist.
         yield [

--- a/app/bundles/PageBundle/Tests/Entity/PageTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/PageTest.php
@@ -21,7 +21,7 @@ class PageTest extends \PHPUnit\Framework\TestCase
         Assert::assertSame($changes, $page->getChanges());
     }
 
-    public function setIsPreferenceCenterDataProvider(): iterable
+    public static function setIsPreferenceCenterDataProvider(): iterable
     {
         yield [null, null, []];
         yield [true, true, ['isPreferenceCenter' => [null, true]]];
@@ -43,7 +43,7 @@ class PageTest extends \PHPUnit\Framework\TestCase
         Assert::assertSame($changes, $page->getChanges());
     }
 
-    public function setNoIndexDataProvider(): iterable
+    public static function setNoIndexDataProvider(): iterable
     {
         yield [null, null, []];
         yield [true, true, ['noIndex' => [null, true]]];

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -802,7 +802,7 @@ CONTENT;
     /**
      * @return array<array<bool|null>> Use null to include both <a> and <map> tags
      */
-    public function trackMapProvider(): array
+    public static function trackMapProvider(): array
     {
         return [
             [true],

--- a/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
@@ -150,7 +150,7 @@ class DetailsTypeTest extends TestCase
         self::assertSame(2, $calls);
     }
 
-    public function authorizedDataProvider(): \Generator
+    public static function authorizedDataProvider(): \Generator
     {
         yield 'authorized' => [true, 'reauthorize'];
         yield 'not authorized' => [false, 'authorize'];
@@ -232,7 +232,7 @@ class DetailsTypeTest extends TestCase
         self::assertSame(2, $calls);
     }
 
-    public function withFeaturesProvider(): \Generator
+    public static function withFeaturesProvider(): \Generator
     {
         yield 'create integration' => [null, ['non-configured']];
         yield 'edit integration' => [1, ['configured']];

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -126,7 +126,7 @@ class AbstractIntegrationTest extends AbstractIntegrationTestCase
     /**
      * @return iterable<mixed[]>
      */
-    public function requestProvider(): iterable
+    public static function requestProvider(): iterable
     {
         // Test with JSON.
         yield [

--- a/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
+++ b/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
@@ -87,7 +87,7 @@ class PointEntityValidationTest extends MauticMysqlTestCase
      *
      * @throws \Exception
      */
-    public function deltaScenariosProvider(): iterable
+    public static function deltaScenariosProvider(): iterable
     {
         yield 'within range positive number' => [3000, ''];
         yield 'within range negative number' => [-7857, ''];

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
@@ -89,7 +89,7 @@ class MessageScheduleTest extends \PHPUnit\Framework\TestCase
         $this->messageSchedule->getMessage($this->report, 'path-to-a-file');
     }
 
-    public function sendFileProvider()
+    public static function sendFileProvider()
     {
         return [
             [10, 100],
@@ -129,7 +129,7 @@ class MessageScheduleTest extends \PHPUnit\Framework\TestCase
         $this->messageSchedule->getMessage($this->report, 'path-to-a-file');
     }
 
-    public function doSendFileProvider()
+    public static function doSendFileProvider()
     {
         return [
             [100, 10],


### PR DESCRIPTION
I thought we can do PHPUnit 10 directly, but we'll need PHP 8.1 min version.

In the meantime, we can get ready by using static data providers :+1: 