### PR TITLE
FEAT: Simplifies form field twig template creation for themes

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
@@ -65,8 +65,10 @@
                       {%- endif -%}
                       {%- set template = '@MauticForm/Field/' ~ f.type ~ '.html.twig' -%}
                   {%- endif %}
-                
+
+                  {# render theme specific form type template file or built-in template #}
                   {{- include([theme ~ f.type ~ '.html.twig', template], {
+                        'theme': theme,
                         'field': f.convertToArray,
                         'id': f.alias,
                         'formName': formName,
@@ -99,7 +101,7 @@
 
 
                   <!-- start: "{{ theme }}{{ template }}" -->
-                  {%- if theme is empty -%}                    
+                  {%- if theme is empty -%}
                   {{- include(theme ~ f.type ~ '.html.twig', {
                           'field': f.convertToArray,
                           'id': f.alias,
@@ -109,7 +111,7 @@
                           'inBuilder': inBuilder,
                           'fields': fields,
                   }) -}}
-                  {%- else -%}                    
+                  {%- else -%}
                   {{- include(template, {
                           'field': f.convertToArray,
                           'id': f.alias,
@@ -119,7 +121,7 @@
                           'inBuilder': inBuilder,
                           'fields': fields,
                   }) -}}
-                {%- endif -%}                    
+                {%- endif -%}
                   <!-- end: "{{ theme }}{{ template }}" -->
                 {%- endif -%}
               {%- endfor -%}

--- a/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
@@ -14,7 +14,15 @@
     {% endif %}
 {% endif %}
 
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -23,4 +31,4 @@
         'required': required,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
@@ -1,5 +1,14 @@
 {% if field.defaultValue is defined and field.defaultValue is not empty %}
-    {{ include('@MauticForm/Field/hidden.html.twig', {
+
+{#
+    This field relies on the `hidden.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/hidden.html.twig`
+    and falls back to the standard template '@MauticForm/Field/hidden.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+    {{- include([theme|default('') ~ 'hidden.html.twig', '@MauticForm/Field/hidden.html.twig'], {
             'field': field,
             'fields': fields|default([]),
             'inForm': inForm|default(false),
@@ -10,9 +19,17 @@
             'mappedFields': mappedFields|default([]),
     })|replace({
             '<input': '<input value="' ~ field.defaultValue ~ '"',
-    }) }}
+    }) -}}
 {% endif %}
-{{ include('@MauticForm/Field/group.html.twig', {
+{#
+    This field relies on the `group.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/group.html.twig`
+    and falls back to the standard template '@MauticForm/Field/group.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'group.html.twig', '@MauticForm/Field/group.html.twig'], {
         'field': field,
         'inForm': inForm|default(false),
         'id': id,
@@ -21,4 +38,4 @@
         'formName': formName|default(''),
         'mappedFields': mappedFields|default([]),
         'fields': fields|default(null),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/country.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/country.html.twig
@@ -1,4 +1,12 @@
-{{- include('@MauticForm/Field/select.html.twig', {
+{#
+    This field relies on the `select.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/select.html.twig`
+    and falls back to the standard template '@MauticForm/Field/select.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'select.html.twig', '@MauticForm/Field/select.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'mappedFields': mappedFields|default([]),

--- a/app/bundles/FormBundle/Resources/views/Field/date.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/date.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/datetime.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/datetime.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/email.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/email.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -7,4 +15,4 @@
         'deleted': deleted is defined,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/file.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/file.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -7,4 +15,4 @@
         'deleted': deleted is defined,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/number.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/number.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/password.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/password.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/radiogrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/radiogrp.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/group.html.twig', {
+{#
+    This field relies on the `group.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/group.html.twig`
+    and falls back to the standard template '@MauticForm/Field/group.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'group.html.twig', '@MauticForm/Field/group.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -7,4 +15,4 @@
         'formName': formName|default(''),
         'type': 'radio',
         'mappedFields': mappedFields|default([]),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/tel.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/tel.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/textarea.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/textarea.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -8,4 +16,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}

--- a/app/bundles/FormBundle/Resources/views/Field/url.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/url.html.twig
@@ -1,4 +1,12 @@
-{{ include('@MauticForm/Field/text.html.twig', {
+{#
+    This field relies on the `text.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`
+    and falls back to the standard template '@MauticForm/Field/text.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+{{- include([theme|default('') ~ 'text.html.twig', '@MauticForm/Field/text.html.twig'], {
         'field': field,
         'fields': fields|default([]),
         'inForm': inForm|default(false),
@@ -6,4 +14,4 @@
         'id': id,
         'formId': formId|default(0),
         'formName': formName|default(''),
-}) }}
+}) -}}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Most twig templates for form fields rely on `text.html.twig`, `group.html.twig` or `select.html.twig`. They simply pass variables to those base templates to render the specific form fields.

Until now a theme had to copy all twig templates; just to change the path to those three base templates.

This change makes this obsolet. 

Mautic passes the `theme` variable to each twig field. The dependent form field templates use this to try to `include()` a theme's base twig template (e.g., `@themes/{{theme}}/html/MauticFormBundle/Field/text.html.twig`) before rendering the built-in template (e.g., `@MauticForm/Field/text.html.twig`).

This changes the rendering logic to:
1. `@MauticForm/Builder/form.html.twig` tries to render `@themes/{{theme}}/html/MauticFormBundle/' ~ f.type ~ '.html.twig`.
2. `@MauticForm/Builder/form.html.twig` tries to render `@MauticForm/Field/' ~ f.type ~ '.html.twig`.
3. If `@MauticForm/Field/' ~ f.type ~ '.html.twig` is dependent on a base template it tries to render 1. `@themes/{{theme}}/html/MauticFormBundle/Field/(BASE).html.twig` (`(BASE)` being `text`, `select` or `group`) 2. `@MauticForm/Field/(BASE).html.twig` (`(BASE)` being `text`, `select` or `group`)

This ensures that:
- A theme and form field specific file takes always precedence.
- A theme specific base template gets applied to dependent fields.
- Mautic uses the built-in templates if a theme doesn't provide form field styling.


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a theme
3. Copy [app/bundles/FormBundle/Resources/views/Field/text.html.twig](https://github.com/mautic/mautic/blob/f1ff3b231ede9b971e47b1cb09b59b62b17997e3/app/bundles/FormBundle/Resources/views/Field/text.html.twig) into your theme and make some adjustments. Add a border color to `containerAttributes` for example.
4. Every text input element should have a border color now, even though you did not copy, e.g. `email.html.twig` or `password.html.twig`, etc.
5. Create a field specific twig template in your theme (e.g., `password.html.twig`) and put this content inside:

```
<input type="password" disabled="true" value="———" />
No password needed
```

6. Add a password field to your theme.
7. Mautic will render the theme twig template (which overrides the input element, but this is for the sake of this demonstration).

### **HINT:** until #13046 is merged you need to use the paths mentioned in this PR.
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
