### PR TITLE
[ci] remove phpstan baseline changes check as counter productive and will be removed soon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,9 @@ jobs:
           --shm-size=2gb
           --name=${{ matrix.db-types }}
           --tmpfs=/var/lib/mysql
-          --health-cmd="mysqladmin ping" 
-          --health-interval=10s 
-          --health-timeout=5s 
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
           --health-retries=3
 
     steps:
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        commands: ['PHPSTAN', 'CS Fixer', 'Rector', 'Twig Lint', 'scaffolded files mismatch', 'PHPStan baseline changes', 'composer install', 'composer lock check']
+        commands: ['PHPSTAN', 'CS Fixer', 'Rector', 'Twig Lint', 'scaffolded files mismatch', 'composer install', 'composer lock check']
         php-versions: ['8.1']
 
     name: ${{ matrix.commands }} - ${{ matrix.php-versions }}
@@ -223,17 +223,6 @@ jobs:
             bash diff_commands_verbose.sh
             exit 1
           fi
-        elif [[ "${{ matrix.commands }}" == "PHPStan baseline changes" ]]; then
-          if [[ "${{ steps.changed-files.outputs.modified_files }}" == *"phpstan-baseline.neon"* ]]; then
-            stat=$(git diff --shortstat "origin/${{ github.base_ref }}" ${{ github.sha }} -- phpstan-baseline.neon)
-            echo $stat
-            regex="[0-9]+[[:space:]]insertion"
-            if [[ $stat =~ $regex ]]; then
-              echo "There are modifications (added or changed lines) to the phpstan-baseline.neon"
-              echo "Please fix the PHPStan errors instead of altering the baseline file"
-              exit 1
-            fi
-          fi
         elif [[ "${{ matrix.commands }}" == "composer install" ]]; then
           # create a temp dir and mimic a composer install via mautic/recommended-project
           mkdir test_composer
@@ -244,7 +233,7 @@ jobs:
           # test if media/css and media/js folder contain the same files as the tarball releases
           test -z "$(comm -23 <(ls ../media/js  | sort) <(ls docroot/media/js  | sort))"
           test -z "$(comm -23 <(ls ../media/css | sort) <(ls docroot/media/css | sort))"
-          
+
           # test if console is executable
           ./bin/console cache:clear
         elif [[ "${{ matrix.commands }}" == "composer lock check" ]]; then


### PR DESCRIPTION
I'm aiming at removing phpstan baselines completely, as it it's been hiding few errors and creating false sense of high quality.

This check hasn't been helpful, yet is being triggered everytime type coverage improves, 100 % yielding false postive.
It gives error on success, which goes agains CI idea.

That's why I suggest removing this check, and rather focus on sole PHPStan run and it's report :+1: 
