### PR TITLE
Fixing API error caused by the strict type mismatch

### DIFF
--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -500,7 +500,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
         if (!$event->isEngagementCount()) {
             foreach ($rows['results'] as $row) {
-                $row['reason'] = $this->dncReasonHelper->toText($row['reason']);
+                $row['reason'] = $this->dncReasonHelper->toText((int) $row['reason']);
 
                 $template = '@MauticLead/SubscribedEvents/Timeline/donotcontact.html.twig';
                 $icon     = 'fa-ban';

--- a/app/bundles/LeadBundle/Twig/Helper/DncReasonHelper.php
+++ b/app/bundles/LeadBundle/Twig/Helper/DncReasonHelper.php
@@ -18,13 +18,9 @@ final class DncReasonHelper
     /**
      * Convert DNC reason ID to text.
      *
-     * @param int $reasonId
-     *
-     * @return string
-     *
      * @throws UnknownDncReasonException
      */
-    public function toText($reasonId)
+    public function toText(int $reasonId): string
     {
         $reasonKey = match ($reasonId) {
             DoNotContact::IS_CONTACTABLE => 'mautic.lead.event.donotcontact_contactable',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/api-library/actions/runs/7157054492/job/19506343788

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The API Library tests discovered an issue when the new `match` code is comparing also types so `'3'` was not equal to `3` and the DNC type was not found.

This was the error message:
```
[2023-12-11 09:01:08] mautic.CRITICAL: Uncaught PHP Exception Mautic\LeadBundle\Exception\UnknownDncReasonException: "Unknown DNC reason ID ''" at /var/www/html/app/bundles/LeadBundle/Twig/Helper/DncReasonHelper.php line 34 {"exception":"[object] (Mautic\\LeadBundle\\Exception\\UnknownDncReasonException(code: 0): Unknown DNC reason ID '\u0002' at /var/www/html/app/bundles/LeadBundle/Twig/Helper/DncReasonHelper.php:34)
[stacktrace]
#0 /var/www/html/app/bundles/LeadBundle/EventListener/LeadSubscriber.php(503): Mautic\\LeadBundle\\Twig\\Helper\\DncReasonHelper->toText()
#1 /var/www/html/app/bundles/LeadBundle/EventListener/LeadSubscriber.php(322): Mautic\\LeadBundle\\EventListener\\LeadSubscriber->addTimelineDoNotContactEntries()
#2 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(270): Mautic\\LeadBundle\\EventListener\\LeadSubscriber->onTimelineGenerate()
#3 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Symfony\\Component\\EventDispatcher\\EventDispatcher::Symfony\\Component\\EventDispatcher\\{closure}()
#4 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\\Component\\EventDispatcher\\EventDispatcher->callListeners()
#5 /var/www/html/app/bundles/LeadBundle/Model/LeadModel.php(1954): Symfony\\Component\\EventDispatcher\\EventDispatcher->dispatch()
#6 /var/www/html/app/bundles/LeadBundle/Controller/Api/LeadApiController.php(387): Mautic\\LeadBundle\\Model\\LeadModel->getEngagements()
#7 /var/www/html/app/bundles/LeadBundle/Controller/Api/LeadApiController.php(365): Mautic\\LeadBundle\\Controller\\Api\\LeadApiController->getAllActivityAction()
#8 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(163): Mautic\\LeadBundle\\Controller\\Api\\LeadApiController->getActivityAction()
#9 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(75): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw()
#10 /var/www/html/vendor/symfony/http-kernel/Kernel.php(202): Symfony\\Component\\HttpKernel\\HttpKernel->handle()
#11 /var/www/html/app/AppKernel.php(109): Symfony\\Component\\HttpKernel\\Kernel->handle()
#12 /var/www/html/app/middlewares/CORSMiddleware.php(79): AppKernel->handle()
#13 /var/www/html/app/middlewares/HSTSMiddleware.php(35): Mautic\\Middleware\\CORSMiddleware->handle()
#14 /var/www/html/app/middlewares/CatchExceptionMiddleware.php(31): Mautic\\Middleware\\HSTSMiddleware->handle()
#15 /var/www/html/app/middlewares/VersionCheckMiddleware.php(58): Mautic\\Middleware\\CatchExceptionMiddleware->handle()
#16 /var/www/html/app/middlewares/TrustMiddleware.php(42): Mautic\\Middleware\\VersionCheckMiddleware->handle()
#17 /var/www/html/vendor/stack/builder/src/Stack/StackedHttpKernel.php(23): Mautic\\Middleware\\TrustMiddleware->handle()
#18 /var/www/html/index.php(19): Stack\\StackedHttpKernel->handle()
#19 {main}
"} {"hostname":"fv-az974-886","pid":7906}
```

I checked all usages of this method and it's strict `int` on all places except one. So I retyped that to `int` and I'm enforcing an int to be the param of the method.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Actually no need to test this manually as there is a new functional test covering this scenario. But if you want, create a contact, mark it as DNC and then get all its activities with this endpoint: https://developer.mautic.org/#get-asset

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
