### PR TITLE
DPMMA-2537 RFC 8058 one-click unsubscribe

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -59,11 +59,6 @@ return [
                 'path'       => '/email/view/{idHash}',
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::indexAction',
             ],
-            'mautic_email_oneclick_unsubscribe' => [
-                'path'       => '/email/unsubscribe/{idHash}',
-                'controller' => 'Mautic\EmailBundle\Controller\PublicController::oneClickUnsubscribeAction',
-                'method'     => 'POST',
-            ],
             'mautic_email_unsubscribe' => [
                 'path'       => '/email/unsubscribe/{idHash}',
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::unsubscribeAction',

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -59,6 +59,11 @@ return [
                 'path'       => '/email/view/{idHash}',
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::indexAction',
             ],
+            'mautic_email_oneclick_unsubscribe' => [
+                'path'       => '/email/unsubscribe/{idHash}',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::oneClickUnsubscribeAction',
+                'method'     => 'POST',
+            ],
             'mautic_email_unsubscribe' => [
                 'path'       => '/email/unsubscribe/{idHash}',
                 'controller' => 'Mautic\EmailBundle\Controller\PublicController::unsubscribeAction',

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -108,6 +108,25 @@ class PublicController extends CommonFormController
     }
 
     /**
+     * One-Click unsubscribe - RFC 8058.
+     */
+    public function oneClickUnsubscribeAction(EmailModel $emailModel, string $idHash): Response
+    {
+        $stat = $emailModel->getEmailStatus($idHash);
+        if (!empty($stat)) {
+            $unsubscribeComment = $this->translator->trans('mautic.email.dnc.unsubscribed');
+            $emailModel->setDoNotContact($stat, $unsubscribeComment, DoNotContact::UNSUBSCRIBED);
+        } else {
+            $content = $this->translator->trans('mautic.email.stat_record.not_found');
+
+            return new Response($content, Response::HTTP_NOT_FOUND);
+        }
+        $content = $this->translator->trans('mautic.lead.do.not.contact_unsubscribed');
+
+        return new Response($content);
+    }
+
+    /**
      * @return Response
      *
      * @throws \Exception

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1380,6 +1380,7 @@ class MailHelper
             } else {
                 $headers['List-Unsubscribe'] = $listUnsubscribeHeader;
             }
+            $headers['List-Unsubscribe-Post'] = 'List-Unsubscribe=One-Click';
         }
 
         return $headers;

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -126,7 +126,9 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $lead = $this->createLead();
         $stat = $this->getStat(null, $lead);
         $this->em->flush();
-        $this->client->request('POST', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $this->client->request('POST', '/email/unsubscribe/'.$stat->getTrackingHash(), [
+            'List-Unsubscribe' => 'One-Click',
+        ]);
         $this->assertTrue($this->client->getResponse()->isOk());
         $dncCollection = $stat->getLead()->getDoNotContact();
         $this->assertEquals(1, $dncCollection->count());

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\TransportWebhookEvent;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
@@ -118,6 +119,18 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         self::assertStringNotContainsString('form/submit?formId=', $crawler->html());
         $this->assertTrue($this->client->getResponse()->isOk());
+    }
+
+    public function testOneClickUnsubscribeAction(): void
+    {
+        $lead = $this->createLead();
+        $stat = $this->getStat(null, $lead);
+        $this->em->flush();
+        $this->client->request('POST', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $this->assertTrue($this->client->getResponse()->isOk());
+        $dncCollection = $stat->getLead()->getDoNotContact();
+        $this->assertEquals(1, $dncCollection->count());
+        $this->assertEquals(DoNotContact::UNSUBSCRIBED, $dncCollection->first()->getReason());
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -376,13 +376,12 @@ class MailHelperTest extends TestCase
     public function testUnsubscribeHeader(): void
     {
         $mockRouter  = $this->createMock(Router::class);
-        $emailSecret = hash_hmac('sha256', 'someemail@email.test', 'secret');
         $mockRouter->expects($this->once())
             ->method('generate')
             ->with('mautic_email_unsubscribe',
                 ['idHash' => 'hash'],
                 UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('http://www.somedomain.cz/email/unsubscribe/hash/someemail@email.test/'.$emailSecret);
+            ->willReturn('https://example.com/email/unsubscribe/65842d012b5b5772172137');
 
         $parameterMap = [
             ['mailer_custom_headers', [], ['X-Mautic-Test' => 'test', 'X-Mautic-Test2' => 'test']],
@@ -410,12 +409,14 @@ class MailHelperTest extends TestCase
 
         $mailer->setEmailType(MailHelper::EMAIL_TYPE_MARKETING);
         $headers = $mailer->getCustomHeaders();
-        $this->assertSame('<http://www.somedomain.cz/email/unsubscribe/hash/someemail@email.test/'.$emailSecret.'>', $headers['List-Unsubscribe']);
+        $this->assertSame('<https://example.com/email/unsubscribe/65842d012b5b5772172137>', $headers['List-Unsubscribe']);
+        $this->assertSame('List-Unsubscribe=One-Click', $headers['List-Unsubscribe-Post']);
 
         // There are no unsubscribe headers in transactional emails.
         $mailer->setEmailType(MailHelper::EMAIL_TYPE_TRANSACTIONAL);
         $headers = $mailer->getCustomHeaders();
         $this->assertNull($headers['List-Unsubscribe'] ?? null);
+        $this->assertNull($headers['List-Unsubscribe-Post'] ?? null);
     }
 
     protected function mockEmptyMailHelper(): MailHelper


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ N ]
| New feature/enhancement? (use the a.x branch)      | [ Y ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12880 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR implements the RFC 8058 one-click unsubscribe feature in Mautic.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create and send a marketing e-mail to a contact(s)
3. Check if the email has the headers required by the RFC 8058:
```
List-Unsubscribe: <https://example.com/email/unsubscribe/xxxxxxxxxxxzz>
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```
4. Send a POST request to the URL from List-Unsubscribe header with param:
```
List-Unsubscribe=One-Click
```
5. Check if the contact is unsubscribed

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
