### PR TITLE
Fix user password complexity for sample data users

### DIFF
--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractMauticTestCase extends WebTestCase
 
     protected array $clientServer  = [
         'PHP_AUTH_USER' => 'admin',
-        'PHP_AUTH_PW'   => 'mautic',
+        'PHP_AUTH_PW'   => 'Maut1cR0cks!',
     ];
 
     protected array $configParams = [

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -28,7 +28,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
         $user->setLastName('User');
         $user->setUsername('admin');
         $user->setEmail('admin@yoursite.com');
-        $user->setPassword($this->hasher->hashPassword($user, 'mautic'));
+        $user->setPassword($this->hasher->hashPassword($user, 'Maut1cR0cks!'));
         $user->setRole($this->getReference('admin-role'));
         $manager->persist($user);
         $manager->flush();
@@ -40,7 +40,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
         $user->setLastName('User');
         $user->setUsername('sales');
         $user->setEmail('sales@yoursite.com');
-        $user->setPassword($this->hasher->hashPassword($user, 'mautic'));
+        $user->setPassword($this->hasher->hashPassword($user, 'Maut1cR0cks!'));
         $user->setRole($this->getReference('sales-role'));
         $manager->persist($user);
         $manager->flush();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | Community handbook: https://github.com/mautic/mautic-community-handbook/pull/178; User docs: https://github.com/mautic/user-documentation/pull/217; Dev docs: https://github.com/mautic/developer-documentation-new/pull/156
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13104  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

When we merged #12826 we missed updating the data fixtures which are used when testing Mautic. This means that you get a warning when you try to log in, because the password 'mautic' is insecure.

This PR updates the password to 'Maut1cR0cks!' which is used in the config file and DDEV instructions.

PRs to follow for updating the contribution guidelines / docs / dev docs.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Try to log into the admin panel using mautic / Maut1cR0cks! and sales / Maut1cR0cks! and ensure you're able to log in
