### PR TITLE
Fix: Company Fields variables are not rendered when used in Dynamic Web Content

### DIFF
--- a/app/bundles/DynamicContentBundle/Config/config.php
+++ b/app/bundles/DynamicContentBundle/Config/config.php
@@ -75,6 +75,7 @@ return [
                     'mautic.dynamicContent.model.dynamicContent',
                     'mautic.security',
                     'mautic.tracker.contact',
+                    'mautic.lead.model.company',
                 ],
             ],
             'mautic.dynamicContent.subscriber.channel' => [

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -161,15 +161,11 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         $content      = $event->getContent();
         $clickthrough = $event->getClickthrough();
 
-        if ($lead instanceof Lead) {
+        if ($lead instanceof Lead && $content) {
+            /** @var Lead $lead */
             $leadArray              = $this->dynamicContentHelper->convertLeadToArray($lead);
             $leadArray['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($leadArray['id']);
-        } else {
-            /** @var Lead $lead */
-            $leadArray = $lead->getProfileFields();
-        }
 
-        if ($content) {
             $tokens = array_merge(
                 TokenHelper::findLeadTokens($content, $leadArray),
                 $this->pageTokenHelper->findPageTokens($content, $clickthrough),

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -80,6 +80,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
      * @var ContactTracker
      */
     private $contactTracker;
+    private CompanyModel $companyModel;
 
     public function __construct(
         TrackableModel $trackableModel,
@@ -92,7 +93,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         DynamicContentModel $dynamicContentModel,
         CorePermissions $security,
         ContactTracker $contactTracker,
-        private CompanyModel $companyModel
+        CompanyModel $companyModel
     ) {
         $this->trackableModel       = $trackableModel;
         $this->pageTokenHelper      = $pageTokenHelper;
@@ -104,6 +105,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         $this->dynamicContentModel  = $dynamicContentModel;
         $this->security             = $security;
         $this->contactTracker       = $contactTracker;
+        $this->companyModel         = $companyModel;
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -80,7 +80,6 @@ class DynamicContentSubscriber implements EventSubscriberInterface
      * @var ContactTracker
      */
     private $contactTracker;
-    private CompanyModel $companyModel;
 
     public function __construct(
         TrackableModel $trackableModel,
@@ -93,7 +92,7 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         DynamicContentModel $dynamicContentModel,
         CorePermissions $security,
         ContactTracker $contactTracker,
-        CompanyModel $companyModel
+        private CompanyModel $companyModel
     ) {
         $this->trackableModel       = $trackableModel;
         $this->pageTokenHelper      = $pageTokenHelper;
@@ -105,7 +104,6 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         $this->dynamicContentModel  = $dynamicContentModel;
         $this->security             = $security;
         $this->contactTracker       = $contactTracker;
-        $this->companyModel         = $companyModel;
     }
 
     /**
@@ -162,7 +160,6 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         $clickthrough = $event->getClickthrough();
 
         if ($lead instanceof Lead && $content) {
-            /** @var Lead $lead */
             $leadArray              = $this->dynamicContentHelper->convertLeadToArray($lead);
             $leadArray['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($leadArray['id']);
 

--- a/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -3,12 +3,15 @@
 namespace Mautic\DynamicContentBundle\Tests\EventListener;
 
 use Mautic\AssetBundle\Helper\TokenHelper as AssetTokenHelper;
+use Mautic\CoreBundle\Event\TokenReplacementEvent;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\DynamicContentBundle\EventListener\DynamicContentSubscriber;
 use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Mautic\FormBundle\Helper\TokenHelper as FormTokenHelper;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -195,5 +198,119 @@ HTML;
             ->with($expected);
 
         $this->subscriber->decodeTokens($event);
+    }
+
+    public function testOnTokenReplacement(): void
+    {
+        $content = <<< HTML
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <h2>Hello there!</h2>
+        Company name    : {contactfield=companyname}
+        Company Country : {contactfield=companycountry}
+        Company website : {contactfield=companywebsite}
+    </body>
+</html>
+
+HTML;
+        $expected = <<< HTML
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <h2>Hello there!</h2>
+        Company name    : Doe Corp
+        Company Country : India
+        Company website : https://www.doe.corp
+    </body>
+</html>
+
+HTML;
+        $contact = new Lead();
+        $event   = $this->createMock(TokenReplacementEvent::class);
+
+        $event
+            ->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content);
+
+        $event
+            ->expects($this->once())
+            ->method('getLead')
+            ->willReturn($contact);
+
+        $event
+            ->expects($this->once())
+            ->method('getClickthrough')
+            ->willReturn([
+                'slot'               => 'slotOne',
+                'dynamic_content_id' => 1,
+                'lead'               => 1,
+            ]);
+
+        $this->dynamicContentHelper
+            ->expects($this->once())
+            ->method('convertLeadToArray')
+            ->willReturn([
+                'id'        => 1,
+                'firstname' => 'John',
+                'lastname'  => 'Doe',
+                'company'   => 'Doe Corp',
+                'email'     => 'john@doe.com',
+            ]);
+
+        $repo = $this->createMock(CompanyRepository::class);
+        $repo->expects($this->once())
+            ->method('getCompaniesByLeadId')
+            ->willReturn([
+                [
+                  'id'             => 1,
+                  'companyname'    => 'Doe Corp',
+                  'companycountry' => 'India',
+                  'companywebsite' => 'https://www.doe.corp',
+                  'is_primary'     => true,
+                ],
+            ]);
+
+        $this->companyModel
+            ->expects($this->once())
+            ->method('getRepository')
+            ->willReturn($repo);
+
+        $this->pageTokenHelper
+            ->method('findPageTokens')
+            ->willReturn([]);
+        $this->assetTokenHelper
+            ->method('findAssetTokens')
+            ->willReturn([]);
+        $this->formTokenHelper
+            ->method('findFormTokens')
+            ->willReturn([]);
+        $this->focusTokenHelper
+            ->method('findFocusTokens')
+            ->willReturn([]);
+
+        $this->trackableModel
+            ->method('parseContentForTrackables')
+            ->willReturn([
+               $content,
+               [],
+            ]);
+
+        $dwc = new DynamicContent();
+        $dwc->setContent($content);
+
+        $this->dynamicContentModel
+            ->expects($this->once())
+            ->method('getEntity')
+            ->willReturn($dwc);
+
+        $event->expects($this->once())
+            ->method('setContent')
+            ->with($expected);
+
+        $this->subscriber->onTokenReplacement($event);
     }
 }

--- a/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -10,6 +10,7 @@ use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Mautic\FormBundle\Helper\TokenHelper as FormTokenHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Event\PageDisplayEvent;
@@ -79,6 +80,10 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
      * @var DynamicContentSubscriber
      */
     private $subscriber;
+    /**
+     * @var CompanyModel|MockObject
+     */
+    private $companyModel;
 
     protected function setUp(): void
     {
@@ -95,6 +100,7 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->dynamicContentModel  = $this->createMock(DynamicContentModel::class);
         $this->security             = $this->createMock(CorePermissions::class);
         $this->contactTracker       = $this->createMock(ContactTracker::class);
+        $this->companyModel         = $this->createMock(CompanyModel::class);
         $this->subscriber           = new DynamicContentSubscriber(
             $this->trackableModel,
             $this->pageTokenHelper,
@@ -105,7 +111,8 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->dynamicContentHelper,
             $this->dynamicContentModel,
             $this->security,
-            $this->contactTracker
+            $this->contactTracker,
+            $this->companyModel
         );
     }
 

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -134,7 +134,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $q->select('*')
+        $q->select('comp.*, cl.is_primary')
             ->from(MAUTIC_TABLE_PREFIX.'companies', 'comp')
             ->leftJoin('comp', MAUTIC_TABLE_PREFIX.'companies_leads', 'cl', 'cl.company_id = comp.id')
             ->where('cl.lead_id = :leadId')

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Entity;
 
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\ORM\QueryBuilder;
 use Mautic\CoreBundle\Entity\CommonRepository;
@@ -126,12 +127,14 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
      * @param $leadId
      *
      * @return array
+     *
+     * @throws Exception
      */
     public function getCompaniesByLeadId($leadId, $companyId = null)
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $q->select('comp.id, comp.companyname, comp.companycity, comp.companycountry, cl.is_primary')
+        $q->select('*')
             ->from(MAUTIC_TABLE_PREFIX.'companies', 'comp')
             ->leftJoin('comp', MAUTIC_TABLE_PREFIX.'companies_leads', 'cl', 'cl.company_id = comp.id')
             ->where('cl.lead_id = :leadId')
@@ -142,7 +145,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
             $q->andWhere('comp.id = :companyId')->setParameter('companyId', $companyId);
         }
 
-        return $q->execute()->fetchAll();
+        return $q->execute()->fetchAllAssociative();
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 4.4
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13084


#### Description:

M5 version: https://github.com/mautic/mautic/pull/13198
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
How can we reproduce this issue?
2. Create a Company and fill out fields like phone, website etc.
3. Create a contact and add the contact to the company
4. Create a non-campaign-based DWC with a variable for a company field, e.g. {contactfield=companyphone} in the content. Add a filter that is fulfilled by the contact form Step 2 eg. Email = not empty
5. Create a landing page and add the DWC to the LP
6. Open the Landing page for the contact from Step 2 and see that no content is rendered.
