### PR TITLE
Fixed color picker in 5.x 

### DIFF
--- a/app/bundles/CategoryBundle/Resources/views/Category/list.html.twig
+++ b/app/bundles/CategoryBundle/Resources/views/Category/list.html.twig
@@ -133,7 +133,8 @@
                             }) -}}
 							</td>
 							<td>
-								<span class="label label-default pa-10" style="background: #{{ item.getColor() }};"> </span>
+								{% set color = item.getColor() %}
+								<span class="label label-default pa-10" style="background: {{ '#' not in color ? '#' : ''}}{{ color }};"> </span>
 							</td>
 							<td>
                                 <div>

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -1538,6 +1538,8 @@ Mautic.activateColorPicker = function(el, options) {
     input.minicolors(pickerOptions);
 
     // The previous version of the Minicolors library did not use the # in the value. This is for backwards compatibility.
+    input.val(input.val().replace('#', ''));
+
     input.on('blur', function() {
         input.val(input.val().replace('#', ''));
     });

--- a/app/bundles/PointBundle/Resources/views/Trigger/_list.html.twig
+++ b/app/bundles/PointBundle/Resources/views/Trigger/_list.html.twig
@@ -68,7 +68,7 @@
                         }) }}
                     </td>
                     <td>
-                        <span class="label label-default pa-10" style="background: #{{ item.color }};"> </span>
+                        <span class="label label-default pa-10" style="background: {{ '#' not in item.color ? '#' : ''}}{{ item.color }};"> </span>
                     </td>
                     <td>
                         <div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [❌]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12917 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

This PR removes the "#" from the color value during initialization (for backward compatibility) and prevents printing a double "#" in the color value in category and trigger templates

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Follow steps "How can we reproduce this issue?" - https://github.com/mautic/mautic/issues/12917. The color should be saved and displayed correctly.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
