### PR TITLE
Datetimeimmutable doctrine mapping

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Doctrine\Type;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+
+class UTCDateTimeImmutableType extends DateTimeImmutableType
+{
+    /**
+     * Persist the date in UTC.
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof DateTimeImmutable) {
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    /**
+     * Convert the UTC persisted date to the current timezone (determined by date_default_timezone_get()).
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTimeImmutable
+    {
+        $value = parent::convertToPHPValue($value, $platform);
+
+        if (!$value instanceof DateTimeImmutable) {
+            return null;
+        }
+
+        $value = new DateTimeImmutable($value->format($platform->getDateTimeFormatString()), new DateTimeZone('UTC'));
+
+        return $value->setTimezone(new DateTimeZone(date_default_timezone_get()));
+    }
+}

--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Doctrine\Type;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 
@@ -16,8 +14,8 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
-        if ($value instanceof DateTimeImmutable) {
-            $value = $value->setTimezone(new DateTimeZone('UTC'));
+        if ($value instanceof \DateTimeImmutable) {
+            $value = $value->setTimezone(new \DateTimeZone('UTC'));
         }
 
         return parent::convertToDatabaseValue($value, $platform);
@@ -26,16 +24,16 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
     /**
      * Convert the UTC persisted date to the current timezone (determined by date_default_timezone_get()).
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTimeImmutable
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?\DateTimeImmutable
     {
         $value = parent::convertToPHPValue($value, $platform);
 
-        if (!$value instanceof DateTimeImmutable) {
+        if (!$value instanceof \DateTimeImmutable) {
             return null;
         }
 
-        $value = new DateTimeImmutable($value->format($platform->getDateTimeFormatString()), new DateTimeZone('UTC'));
+        $value = new \DateTimeImmutable($value->format($platform->getDateTimeFormatString()), new \DateTimeZone('UTC'));
 
-        return $value->setTimezone(new DateTimeZone(date_default_timezone_get()));
+        return $value->setTimezone(new \DateTimeZone(date_default_timezone_get()));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeImmutableTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeImmutableTypeTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Unit\Type;
 
-use DateTimeImmutable;
-use DateTimeZone;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Mautic\CoreBundle\Doctrine\Type\UTCDateTimeImmutableType;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
@@ -42,7 +40,7 @@ class UTCDateTimeImmutableTypeTest extends TestCase
     {
         date_default_timezone_set($timezone);
 
-        $databaseValue = $this->type->convertToDatabaseValue(new DateTimeImmutable($date), $this->platform);
+        $databaseValue = $this->type->convertToDatabaseValue(new \DateTimeImmutable($date), $this->platform);
 
         Assert::assertIsString($databaseValue);
         Assert::assertSame($this->convertDateTimezone($date, $timezone, 'UTC'), $databaseValue, 'Database value should be converted to UTC.');
@@ -62,7 +60,7 @@ class UTCDateTimeImmutableTypeTest extends TestCase
 
         $phpValue = $this->type->convertToPHPValue($date, $this->platform);
 
-        Assert::assertInstanceOf(DateTimeImmutable::class, $phpValue);
+        Assert::assertInstanceOf(\DateTimeImmutable::class, $phpValue);
         Assert::assertSame($this->convertDateTimezone($date, 'UTC', $timezone), $phpValue->format(DateTimeHelper::FORMAT_DB), sprintf('PHP value should be converted to %s.', $timezone));
     }
 
@@ -79,8 +77,8 @@ class UTCDateTimeImmutableTypeTest extends TestCase
 
     private function convertDateTimezone(string $date, string $timezoneFrom, string $timezoneTo): string
     {
-        return (new DateTimeImmutable($date, new DateTimeZone($timezoneFrom)))
-            ->setTimezone(new DateTimeZone($timezoneTo))
+        return (new \DateTimeImmutable($date, new \DateTimeZone($timezoneFrom)))
+            ->setTimezone(new \DateTimeZone($timezoneTo))
             ->format(DateTimeHelper::FORMAT_DB);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeImmutableTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeImmutableTypeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Type;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Mautic\CoreBundle\Doctrine\Type\UTCDateTimeImmutableType;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class UTCDateTimeImmutableTypeTest extends TestCase
+{
+    private string $previousTimeZone;
+    private UTCDateTimeImmutableType $type;
+    private MySQL80Platform $platform;
+
+    protected function setUp(): void
+    {
+        $this->previousTimeZone = date_default_timezone_get();
+        $this->type             = new UTCDateTimeImmutableType();
+        $this->platform         = new MySQL80Platform();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->previousTimeZone);
+    }
+
+    public function testConvertToDatabaseValueWithNull(): void
+    {
+        Assert::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     */
+    public function testConvertToDatabaseValueWithDate(string $timezone, string $date): void
+    {
+        date_default_timezone_set($timezone);
+
+        $databaseValue = $this->type->convertToDatabaseValue(new DateTimeImmutable($date), $this->platform);
+
+        Assert::assertIsString($databaseValue);
+        Assert::assertSame($this->convertDateTimezone($date, $timezone, 'UTC'), $databaseValue, 'Database value should be converted to UTC.');
+    }
+
+    public function testConvertToPHPValueWithNull(): void
+    {
+        Assert::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    /**
+     * @dataProvider timezoneProvider
+     */
+    public function testConvertToPHPValueWithDate(string $timezone, string $date): void
+    {
+        date_default_timezone_set($timezone);
+
+        $phpValue = $this->type->convertToPHPValue($date, $this->platform);
+
+        Assert::assertInstanceOf(DateTimeImmutable::class, $phpValue);
+        Assert::assertSame($this->convertDateTimezone($date, 'UTC', $timezone), $phpValue->format(DateTimeHelper::FORMAT_DB), sprintf('PHP value should be converted to %s.', $timezone));
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public function timezoneProvider(): iterable
+    {
+        yield ['America/Cayman', '2023-12-14 10:39:25'];
+        yield ['Europe/Prague', '2022-11-18 18:32:27'];
+        yield ['Indian/Maldives', '2018-01-01 02:02:55'];
+        yield ['Asia/Taipei', '2019-03-01 13:09:45'];
+    }
+
+    private function convertDateTimezone(string $date, string $timezoneFrom, string $timezoneTo): string
+    {
+        return (new DateTimeImmutable($date, new DateTimeZone($timezoneFrom)))
+            ->setTimezone(new DateTimeZone($timezoneTo))
+            ->format(DateTimeHelper::FORMAT_DB);
+    }
+}

--- a/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
+++ b/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
@@ -130,7 +130,7 @@ class ContactExportSchedulerModel extends AbstractCommonModel
         $contactExportScheduler = new ContactExportScheduler();
         $contactExportScheduler
             ->setUser($this->userHelper->getUser())
-            ->setScheduledDateTime(new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+            ->setScheduledDateTime(new \DateTimeImmutable())
             ->setData($data);
 
         $this->em->persist($contactExportScheduler);

--- a/app/bundles/LeadBundle/Tests/Entity/ContactExportSchedulerTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ContactExportSchedulerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\ContactExportScheduler;
+use PHPUnit\Framework\Assert;
+
+class ContactExportSchedulerTest extends MauticMysqlTestCase
+{
+    private string $previousTimeZone;
+
+    protected function setUp(): void
+    {
+        $this->previousTimeZone = date_default_timezone_get();
+        parent::setUp();
+    }
+
+    protected function beforeTearDown(): void
+    {
+        date_default_timezone_set($this->previousTimeZone);
+    }
+
+    public function testScheduledDateTimeIsPersistedAndHydratedProperly(): void
+    {
+        $timezone = 'Asia/Taipei';
+        date_default_timezone_set($timezone);
+
+        $exportScheduler = new ContactExportScheduler();
+        $exportScheduler->setScheduledDateTime(new \DateTimeImmutable());
+        $this->em->persist($exportScheduler);
+        $this->em->flush();
+
+        $id        = $exportScheduler->getId();
+        $localDate = $exportScheduler->getScheduledDateTime()->format(DateTimeHelper::FORMAT_DB);
+        $utcDate   = $this->convertDateTimezone($localDate, $timezone, 'UTC');
+        Assert::assertSame($timezone, $exportScheduler->getScheduledDateTime()->getTimezone()->getName(), sprintf('Timezone should be %s.', $timezone));
+        Assert::assertSame($utcDate, $this->fetchScheduledDate($id), 'Database value should be converted to UTC.');
+
+        $this->em->clear();
+
+        $timezone = 'America/Cayman';
+        date_default_timezone_set($timezone);
+
+        $exportScheduler = $this->em->find(ContactExportScheduler::class, $id);
+        $localDate       = $this->convertDateTimezone($this->fetchScheduledDate($id), 'UTC', $timezone);
+        Assert::assertSame($timezone, $exportScheduler->getScheduledDateTime()->getTimezone()->getName(), sprintf('Timezone should be %s.', $timezone));
+        Assert::assertSame($localDate, $exportScheduler->getScheduledDateTime()->format(DateTimeHelper::FORMAT_DB), sprintf('PHP value should be converted to %s.', $timezone));
+    }
+
+    private function convertDateTimezone(string $date, string $timezoneFrom, string $timezoneTo): string
+    {
+        return (new \DateTimeImmutable($date, new \DateTimeZone($timezoneFrom)))
+            ->setTimezone(new \DateTimeZone($timezoneTo))
+            ->format(DateTimeHelper::FORMAT_DB);
+    }
+
+    private function fetchScheduledDate(int $id): string
+    {
+        $tablePrefix   = self::getContainer()->getParameter('mautic.db_table_prefix');
+        $connection    = $this->em->getConnection();
+        $query         = sprintf('SELECT scheduled_datetime FROM %scontact_export_scheduler WHERE id = :id', $tablePrefix);
+
+        return $connection->executeQuery($query, ['id' => $id])
+            ->fetchOne();
+    }
+}

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -1,5 +1,7 @@
 <?php
 
+use Doctrine\DBAL\Types\Types;
+use Mautic\CoreBundle\Doctrine\Type;
 use Mautic\CoreBundle\EventListener\ConsoleErrorListener;
 use Mautic\CoreBundle\EventListener\ConsoleTerminateListener;
 use Symfony\Component\DependencyInjection\Definition;
@@ -164,9 +166,10 @@ $container->loadFromExtension('doctrine', [
             ]),
         ],
         'types'    => [
-            'array'     => \Mautic\CoreBundle\Doctrine\Type\ArrayType::class,
-            'datetime'  => \Mautic\CoreBundle\Doctrine\Type\UTCDateTimeType::class,
-            'generated' => \Mautic\CoreBundle\Doctrine\Type\GeneratedType::class,
+            Types::ARRAY                  => Type\ArrayType::class,
+            Types::DATETIME_MUTABLE       => Type\UTCDateTimeType::class,
+            Types::DATETIME_IMMUTABLE     => Type\UTCDateTimeImmutableType::class,
+            Type\GeneratedType::GENERATED => Type\GeneratedType::class,
         ],
     ],
     'orm'  => [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR makes DateTimeImmutable entity field types work the same way as DateTime. It implements the same timezone conversions like we have for DateTime types in [UTCDateTimeType.php](https://github.com/mautic/mautic/blob/5.1/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php).

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Make sure your user has a **non-UTC timezone** set at `/s/account` page. Choose `America / New York` for example.
2. At `/s/contacts` page click `Export to CSV` it the top right corner menu.
3. Check that the value of `contact_export_scheduler.scheduled_datetime` column of the latest row is saved in the UTC timezone.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
