### PR TITLE
Adding wrongly removed migration back

### DIFF
--- a/app/migrations/Version20200415135706.php
+++ b/app/migrations/Version20200415135706.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20200415135706 extends AbstractMauticMigration
+{
+    public function preUp(Schema $schema): void
+    {
+        if ($schema->getTable("{$this->prefix}form_fields")->hasColumn('mapped_object')) {
+            throw new SkipMigration('Schema includes this migration');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}form_fields 
+            ADD mapped_object VARCHAR(191) DEFAULT NULL,
+            ADD mapped_field VARCHAR(191) DEFAULT NULL");
+
+        // All field that starts with company belongs to the company object.
+        // Except the company field itself that belongs to the contact (lead) object.
+        $this->addSql("UPDATE {$this->prefix}form_fields 
+            SET mapped_object = CASE
+                WHEN lead_field LIKE 'company%' AND lead_field != 'company' THEN 'company'
+                ELSE 'contact'
+            END, mapped_field = lead_field 
+            WHERE lead_field IS NOT NULL");
+    }
+}

--- a/app/migrations/Version20200513162918.php
+++ b/app/migrations/Version20200513162918.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Migration for removing online status.
+ */
+class Version20200513162918 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigration
+     * @throws SchemaException
+     */
+    public function preUp(Schema $schema): void
+    {
+        if ($schema->getTable("{$this->prefix}email_copies")->hasColumn('body_text')) {
+            throw new SkipMigration("The body_text column has already been added to the {$this->prefix}email_copies table.");
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}email_copies ADD COLUMN `body_text` LONGTEXT NULL DEFAULT NULL AFTER `body`");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE {$this->prefix}email_copies DROP COLUMN `body_text`");
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/upgrade-from-v4-4-10-to-5-renders-forms-not-accessable-schema-issues/30415/4

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There was a migration added in https://github.com/mautic/mautic/pull/11905/files#diff-77db4abc4be5950896e8ba8200e42c2fe9abdd165eabb3f1cc27d7a0805d022dR1 which was merged into m5-alpha. Later on I made this PR that cleaned old migrations for M5:

https://github.com/mautic/mautic/pull/12441/files#diff-77db4abc4be5950896e8ba8200e42c2fe9abdd165eabb3f1cc27d7a0805d022dL1

And I removed also this new migration. I was pretty sure that I removed only the old ones. Clearly, I was wrong.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Test migration from M4.4 to M5 and then access the forms. More details in the linked forum thread.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
