### PR TITLE
Fix PHP warning when error page is shown

### DIFF
--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -3,6 +3,7 @@
 namespace Mautic\CoreBundle\ErrorHandler {
     use Mautic\CoreBundle\Exception\DatabaseConnectionException;
     use Mautic\CoreBundle\Exception\ErrorHandlerException;
+    use Mautic\CoreBundle\Loader\ParameterLoader;
     use Psr\Log\LoggerInterface;
     use Psr\Log\LogLevel;
     use Symfony\Component\ErrorHandler\Debug;
@@ -482,7 +483,8 @@ namespace Mautic\CoreBundle\ErrorHandler {
                 $base  = str_replace(['index.php'], '', $_SERVER['SCRIPT_NAME']);
 
                 // Determine if there is an asset prefix
-                $root = self::$root;
+                $root          = self::$root;
+                $projectRoot   = ParameterLoader::getProjectDirByRoot($root.'/app');
 
                 /** @var array<string, mixed> $paths */
                 $paths = [];


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When an error occurs in Mautic that needs to be handled by the `ErrorHandler::generateResponse` method, a PHP warning is shown:
```
PHP Warning: Undefined variable $projectRoot in /var/www/html/mautic/app/config/paths.php on line 15
```

this is because the change in https://github.com/mautic/mautic/pull/11561 (more in detail https://github.com/mautic/mautic/pull/11561/files#diff-5ecc7692bcfd4d761a9389c2494ec4b7d0898038b443a33b5ee315da8cf50cf2) didn't take into account this location of including the paths.

This PR fixes this.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. change on purpose the db connection information (e.g. the host) to be incorrect
3. verify the `The site is currently offline due to encountering an error. If the problem persists, please contact the system administrator.` message is shown, and there is no php warning shown or logged

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
