### PR TITLE
Api bundle config cleanup

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -55,43 +55,6 @@ return [
         ],
     ],
 
-    'services' => [
-        'helpers' => [
-            'mautic.api.helper.entity_result' => [
-                'class' => \Mautic\ApiBundle\Helper\EntityResultHelper::class,
-            ],
-        ],
-        'other' => [
-            'mautic.api.oauth.event_listener' => [
-                'class'     => \Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class,
-                'arguments' => [
-                    'doctrine.orm.entity_manager',
-                    'mautic.security',
-                    'translator',
-                ],
-                'tags' => [
-                    'kernel.event_listener',
-                    'kernel.event_listener',
-                ],
-                'tagArguments' => [
-                    [
-                        'event'  => 'fos_oauth_server.pre_authorization_process',
-                        'method' => 'onPreAuthorizationProcess',
-                    ],
-                    [
-                        'event'  => 'fos_oauth_server.post_authorization_process',
-                        'method' => 'onPostAuthorizationProcess',
-                    ],
-                ],
-            ],
-            'fos_oauth_server.security.authentication.listener.class' => \Mautic\ApiBundle\Security\OAuth2\Firewall\OAuthListener::class,
-            'mautic.validator.oauthcallback'                          => [
-                'class' => \Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class,
-                'tag'   => 'validator.constraint_validator',
-            ],
-        ],
-    ],
-
     'parameters' => [
         'api_enabled'                       => false,
         'api_enable_basic_auth'             => false,

--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
+use Mautic\CoreBundle\Helper\ServiceDeprecator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -50,10 +51,9 @@ return function (ContainerConfigurator $configurator): void {
     $services->get(Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class)
         ->tag('validator.constraint_validator');
 
-    $services->get(Mautic\ApiBundle\Helper\EntityResultHelper::class)
-        ->deprecate('mautic/mautic', '5.1.0', 'Use as `new EntityResultHelper()` instead of a service.');
-
-    $services->alias('mautic.api.model.client', Mautic\ApiBundle\Model\ClientModel::class);
-    $services->alias('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
-    $services->alias('mautic.validator.oauthcallback', Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class);
+    $deprecator = new ServiceDeprecator($services);
+    $deprecator->setDeprecatedService(Mautic\ApiBundle\Helper\EntityResultHelper::class, 'Use as `new EntityResultHelper()` instead of a service.');
+    $deprecator->setDeprecatedAlias('mautic.api.model.client', Mautic\ApiBundle\Model\ClientModel::class);
+    $deprecator->setDeprecatedAlias('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
+    $deprecator->setDeprecatedAlias('mautic.validator.oauthcallback', Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class);
 };

--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -31,5 +31,29 @@ return function (ContainerConfigurator $configurator): void {
         ->arg('$oAuth2Server', service('fos_oauth_server.server'))
         ->arg('$clientManager', service('fos_oauth_server.client_manager.default'));
 
-    $services->alias('mautic.api.model.client', \Mautic\ApiBundle\Model\ClientModel::class);
+    $services->get(Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class)
+        ->tag(
+            'kernel.event_listener',
+            [
+                'event'  => 'fos_oauth_server.pre_authorization_process',
+                'method' => 'onPreAuthorizationProcess',
+            ]
+        )
+        ->tag(
+            'kernel.event_listener',
+            [
+                'event'  => 'fos_oauth_server.post_authorization_process',
+                'method' => 'onPostAuthorizationProcess',
+            ]
+        );
+
+    $services->get(Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class)
+        ->tag('validator.constraint_validator');
+
+    $services->get(Mautic\ApiBundle\Helper\EntityResultHelper::class)
+        ->deprecate('mautic/mautic', '5.1.0', 'Use as `new EntityResultHelper()` instead of a service.');
+
+    $services->alias('mautic.api.model.client', Mautic\ApiBundle\Model\ClientModel::class);
+    $services->alias('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
+    $services->alias('mautic.validator.oauthcallback', Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class);
 };

--- a/app/bundles/ApiBundle/Security/OAuth2/Firewall/OAuthListener.php
+++ b/app/bundles/ApiBundle/Security/OAuth2/Firewall/OAuthListener.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Mautic\ApiBundle\Security\OAuth2\Firewall;
-
-class OAuthListener extends \FOS\OAuthServerBundle\Security\Firewall\OAuthListener
-{
-}

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -33,6 +33,7 @@ return function (ContainerConfigurator $configurator): void {
         'Twig/Helper/ThemeHelper.php',
         'Translation/TranslatorLoader.php',
         'Helper/Dsn/Dsn.php',
+        'Helper/ServiceDeprecator.php',
         'Cache/ResultCacheOptions.php',
     ];
 

--- a/app/bundles/CoreBundle/Helper/ServiceDeprecator.php
+++ b/app/bundles/CoreBundle/Helper/ServiceDeprecator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Helper;
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\DefaultsConfigurator;
+
+final class ServiceDeprecator
+{
+    private const PACKAGE = 'mautic/mautic';
+
+    public function __construct(private DefaultsConfigurator $configurator)
+    {
+    }
+
+    public function setDeprecatedService(string $fcqn, string $message = '', string $version = '5.1'): void
+    {
+        $this->configurator->get($fcqn)
+            ->deprecate(self::PACKAGE, $version, 'The "%service_id%" service is deprecated. '.$message);
+    }
+
+    public function setDeprecatedAlias(string $alias, string $fqcn, $message = '', string $version = '5.1'): void
+    {
+        $this->configurator->alias($alias, $fqcn)
+            ->deprecate(self::PACKAGE, $version, 'The "%alias_id%" service alias is deprecated. Use FQCN instead. '.$message);
+    }
+}

--- a/app/bundles/CoreBundle/Helper/ServiceDeprecator.php
+++ b/app/bundles/CoreBundle/Helper/ServiceDeprecator.php
@@ -20,7 +20,7 @@ final class ServiceDeprecator
             ->deprecate(self::PACKAGE, $version, 'The "%service_id%" service is deprecated. '.$message);
     }
 
-    public function setDeprecatedAlias(string $alias, string $fqcn, $message = '', string $version = '5.1'): void
+    public function setDeprecatedAlias(string $alias, string $fqcn, string $message = '', string $version = '5.1'): void
     {
         $this->configurator->alias($alias, $fqcn)
             ->deprecate(self::PACKAGE, $version, 'The "%alias_id%" service alias is deprecated. Use FQCN instead. '.$message);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [n]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [y]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In M5, all PHP services should be either autowired or defined in services.php instead of config.php as per Symfony standards.

I'm still keeping BC by defining aliases. Those will be removed in M6.

I found that the `OAuthListener` was just an empty class. It wasn't always that way:

https://github.com/mautic/mautic/commit/ba4945a509a5ccc455346344825dd2e3806da7a0#diff-636359ff4ce6461e2b82cc27ec624cf46cc24102f289e19e4b002621ede39172R39

It used to be use for oauth1. But since that was removed, it became an empty class extending the original service that it was overwriting. So we can simply remove this class and do not overwrite it.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test accessing any API endpoint with Oauth2.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
