### PR TITLE
fix incorrect version of the SpBundle dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5314,7 +5314,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mautic/SpBundle.git",
-                "reference": "b73d6b96f651fb2a62ab68cf1ddf76aebf75a6f0"
+                "reference": "91f36a54b223d5405e6e41ea612d640360d35554"
             },
             "require": {
                 "lightsaml/symfony-bridge": "dev-symfony5",
@@ -5348,7 +5348,7 @@
             ],
             "description": "Light SAML2 SP Symfony Bundle",
             "homepage": "http://www.lightsaml.com/SP-Bundle/",
-            "time": "2023-04-06T11:32:19+00:00"
+            "time": "2023-11-24T16:00:46+00:00"
         },
         {
             "name": "lightsaml/symfony-bridge",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13250 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In https://github.com/mautic/mautic/issues/12797 and https://github.com/mautic/SpBundle/pull/1 an Symfony incompatibility issue was fixed.
However, https://github.com/mautic/mautic/issues/12797 didn't fix the needed change in the `composer.lock` file, to link to the new version of the `mautic/SpBundle`.

This PR addresses this.

see https://github.com/mautic/SpBundle/commits/symfony5/
* before this PR `mautic/SpBundle` is pulled is as https://github.com/mautic/SpBundle/commit/b73d6b96f651fb2a62ab68cf1ddf76aebf75a6f0
* after this PR `mautic/SpBundle` is pulled is as https://github.com/mautic/SpBundle/commit/91f36a54b223d5405e6e41ea612d640360d35554

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
