### PR TITLE
Fix incorrect twig field checks for contacts and companies

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Company/list_rows_contacts.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/list_rows_contacts.html.twig
@@ -167,7 +167,7 @@
                             }]) %}
                         {% endif %}
 
-                        {% if fields.core.email.value is not empty %}
+                        {% if fields.core.email is defined %}
                             {% set custom = custom|merge([{
                                 'attr': {
                                     'data-toggle': 'ajaxmodal',
@@ -198,17 +198,17 @@
                     </td>
                     <td class="visible-md visible-lg">{{ fields.core.email.value|purify }}</td>
                     <td class="visible-md visible-lg">
-                        {% set flag = fields.core.country is not empty and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
+                        {% set flag = fields.core.country is defined and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
                         {% if flag is not empty %}
                           <img src="{{ flag }}" style="max-height: 24px;" class="mr-sm" />
                         {% endif %}
                         {% set location = [] %}
-                        {% if fields.core.city.value is not empty %}
+                        {% if fields.core.city is defined %}
                             {% set location = location|merge([fields.core.city.value]) %}
                         {% endif %}
-                        {% if fields.core.state.value is not empty %}
+                        {% if fields.core.state is defined %}
                             {% set location = location|merge([fields.core.state.value]) %}
-                        {% elseif fields.core.country.value is not empty %}
+                        {% elseif fields.core.country is defined %}
                             {% set location = location|merge([fields.core.country.value]) %}
                         {% endif %}
                         {{ location|join(', ') }}

--- a/app/bundles/LeadBundle/Resources/views/Lead/_list_column_location.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_list_column_location.html.twig
@@ -1,16 +1,16 @@
 <td class="{{ class }}">
-    {% set flag = fields.core.country.value is not null ? assetGetCountryFlag(fields.core.country.value) : '' %}
+    {% set flag = fields.core.country is defined and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
     {% if flag is not empty %}
         <img src="{{ flag }}" style="max-height: 24px;" class="mr-sm" />
     {% endif %}
 
     {% set location = [] %}
-    {% if fields.core.city.value is not empty %}
+    {% if fields.core.city is defined %}
         {% set location = location|merge([fields.core.city.value]) %}
     {% endif %}
-    {% if fields.core.state.value is not empty %}
+    {% if fields.core.state is defined %}
         {% set location = location|merge([fields.core.state.value]) %}
-    {% elseif fields.core.country.value is not empty %}
+    {% elseif fields.core.country is defined %}
         {% set location = location|merge([fields.core.country.value]) %}
     {% endif %}
     {{ location|join(', ')|purify }}

--- a/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
@@ -32,12 +32,12 @@
                     <div class="text-muted mb-1 ellipsis">
                         <i class="fa fa-fw fa-map-marker mr-xs"></i>
                         {% set location = [] %}
-                        {% if fields.core.city.value is not empty %}
+                        {% if fields.core.city is defined %}
                           {% set location = location|merge([fields.core.city.value]) %}
                         {% endif %}
-                        {% if fields.core.state.value is not empty %}
+                        {% if fields.core.state is defined %}
                           {% set location = location|merge([fields.core.state.value]) %}
-                        {% elseif fields.core.country.value is not empty %}
+                        {% elseif fields.core.country is defined %}
                           {% set location = location|merge([fields.core.country.value]) %}
                         {% endif %}
                         {{ location|join(', ') }}
@@ -45,7 +45,7 @@
                     <div class="text-muted mb-1 ellipsis">
                         <i class="fa fa-fw fa-globe mr-xs"></i>{{ fields.core.country.value|default('') }}
                     </div>
-                    {% set flag = fields.core.country.value is not null ? assetGetCountryFlag(fields.core.country.value) : '' %}
+                    {% set flag = fields.core.country is defined and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
                     {% if flag is not empty %}
                         <div style="position: absolute; right: 30px; bottom: 30px">
                             <img src="{{ flag }}" style="max-height: 24px;" class="ml-sm" />

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -15,7 +15,7 @@
   {% endif %}
 {% endset %}
 
-{% set flag = fields.core.country.value is not null ? assetGetCountryFlag(fields.core.country.value) : '' %}
+{% set flag = fields.core.country is defined and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
 {% set groups = fields|keys %}
 
 {% block headerTitle %}
@@ -28,7 +28,7 @@
     {% set buttons = [] %}
 
     {# Send email button #}
-    {% if fields.core.email.value is not empty %}
+    {% if fields.core.email is defined %}
       {% set buttons = buttons|merge([{
           'attr': {
               'id': 'sendEmailButton',
@@ -428,7 +428,7 @@
                 </h6>
                 <address class="text-muted">
                     {% if fields.core.address1 is defined %}{{ fields.core.address1.value|purify }}<br>{% endif %}
-                    {% if fields.core.address2.value is not empty %}{{ fields.core.address2.value|purify }}<br>{% endif %}
+                    {% if fields.core.address2 is defined %}{{ fields.core.address2.value|purify }}<br>{% endif %}
                     {{ lead.location|purify }}
                     {% if fields.core.zipcode is defined %}{{ fields.core.zipcode.value|purify }}{% endif %}
                     <br>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13197 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

during the phptemplate to thig migration, some checks were not correcty converted, resulting in 500 errors when a field doesn't exist. 
As Mautic allows to disable specific fields via the UI, this is a common usecase.

in PHP this works
```php
if (!empty($fields['core']['city']['value'])):
    $location[] = $fields['core']['city']['value'];
endif;
```

but the equivalent in twig doesn't work, and throws a `Twig\Error\RuntimeError` 

```twig
{% if fields.core.city.value is not empty %}
   {% set location = location|merge([fields.core.city.value]) %}
{% endif %}
```

This PR addresses this, by checking if the parent is defined.

**questions for someone more familiar with twig**

what is the proper way to check this?
is it
* `{% if fields.core.city is defined %}` 
* `{% if fields.core.city is defined and fields.core.city.value is defined %}`
* `{% if fields.core.city is defined and fields.core.city.value is defined and fields.core.city.value is not empty %}`
* another option

This makes me wonder is we should provide a generic `does exist is is not empty` helper, to be able to check properly the whole structure?

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. disable all fields except email, company name
3. create contacts, create companies, add contacts to companies, list company details, ...
4. verify no 500 `Twig\Error\RuntimeError`  errorss are thrown

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
