### PR TITLE
Fix using messenger DSN with special characters

### DIFF
--- a/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
+++ b/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\DependencyInjection\EnvProcessor;
 
+use Mautic\CoreBundle\Helper\Dsn\Dsn;
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
-use Symfony\Component\Mailer\Transport\Dsn;
 
 class MailerDsnEnvVarProcessor implements EnvVarProcessorInterface
 {
@@ -24,7 +24,7 @@ class MailerDsnEnvVarProcessor implements EnvVarProcessorInterface
     public static function getProvidedTypes()
     {
         return [
-            'mailer' => 'string',
+            'mailer'         => 'string',
             'urlencoded-dsn' => 'string',
         ];
     }

--- a/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
+++ b/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
@@ -25,6 +25,7 @@ class MailerDsnEnvVarProcessor implements EnvVarProcessorInterface
     {
         return [
             'mailer' => 'string',
+            'urlencoded-dsn' => 'string',
         ];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -30,7 +30,7 @@ class LeadControllerTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         $this->configParams['mailer_from_email']   = 'admin@mautic-community.test';
-        $this->configParams['messenger_dsn_email'] = 'testEmailSendToContactSync' === $this->getName() ? 'sync://' : 'in-memory://';
+        $this->configParams['messenger_dsn_email'] = 'testEmailSendToContactSync' === $this->getName() ? 'sync://' : 'in-memory://default';
 
         parent::setUp();
     }

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -74,19 +74,19 @@ $container->loadFromExtension('framework', [
     'fragments'            => null,
     'http_method_override' => true,
     'mailer'               => [
-        'dsn' => '%env(mailer:MAUTIC_MAILER_DSN)%',
+        'dsn' => '%env(urlencoded-dsn:MAUTIC_MAILER_DSN)%',
     ],
     'messenger'            => [
         'failure_transport'  => 'failed',
         'transports'         => [
             'email' => [
-                'dsn'            => '%env(MAUTIC_MESSENGER_DSN_EMAIL)%',
+                'dsn'            => '%env(urlencoded-dsn:MAUTIC_MESSENGER_DSN_EMAIL)%',
                 'retry_strategy' => [
                     'service' => \Mautic\MessengerBundle\Retry\RetryStrategy::class,
                 ],
             ],
             'hit' => [
-                'dsn'            => '%env(MAUTIC_MESSENGER_DSN_HIT)%',
+                'dsn'            => '%env(urlencoded-dsn:MAUTIC_MESSENGER_DSN_HIT)%',
                 'retry_strategy' => [
                     'service' => \Mautic\MessengerBundle\Retry\RetryStrategy::class,
                 ],


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13228 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

in https://github.com/mautic/mautic/pull/11598 Symfony Messenger was added, which enables support for various backends to use as queue.

the connection details to that backend are stored in a generic format: Data Source Name (DSN).
As such connection details may contain special characters (e.g. for Amazon SQS) those values need to be urlencoded to ensure they are valid when parsing the DSN. 

THe DSN itself handles the encoding and decoding, see e.g. [here](https://github.com/mautic/mautic/blob/3be38f31b6b5d8d8c7e1feff30dd4d388619ff70/app/bundles/CoreBundle/Helper/Dsn/Dsn.php#L70).

This PR addresses this, by adding using the `MailerDsnEnvVarProcessor` to ensure the double `%%` are replaced.

I also added an extra type (`urlencoded-dsn`), as the current one is not correct IMO, it is not explanatory.
In the same way, I changed the mailer DSN to use the same type.

**other remarks**
This url encoding and double `%` makes it not obvious to manually change the messenger DSN (or any DSN like mailer) in the config file. This should be documented, as you hit issues that are not obvious to troubleshoot, as the value seems correct.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. configure SQS connection details, and ensure there is a special character in any of the properties
3. validate you can queue a message.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
