### PR TITLE
fix incorrect migration from old mail config to mailer_dsn config

### DIFF
--- a/app/migrations/Version20230615101328.php
+++ b/app/migrations/Version20230615101328.php
@@ -38,7 +38,7 @@ final class Version20230615101328 extends PreUpAssertionMigration
             (int) ($parameters['mailer_port'] ?? 25),
         );
 
-        $parameters['mailer_dsn'] = (string) $dsn;
+        $parameters['mailer_dsn'] = str_replace('%', '%%', (string) $dsn);
 
         $configurator->mergeParameters($parameters);
         $configurator->write();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13236 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The switch to Symfony mailer is handled by a migration, where the connection details are stored in a DSN format.
This different parts of the DSN need to be urlencoded, to ensure that e.g. a `/` or a `:` in a password is not parsed as separator.

urlenencoding uses `%` as character, which is also used as character to determine var names in Symfony. This leads to the problem described in the linked issue.

This PR addresses this by ensuring the `%` character in the sting version of the DSN is doubled, so it can be used in the config file.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
