### PR TITLE
Pass mauticTemplateVars to twig templates

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -173,6 +173,8 @@ class CommonController extends AbstractController implements MauticController
             $parameters = $event->getVars();
         }
 
+        $parameters['mauticTemplateVars'] = $parameters;
+
         return $this->render($template, $parameters, $response);
     }
 

--- a/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
@@ -26,11 +26,7 @@ final class ContentHelper
     public function getCustomContent($context = null, array $vars = [], $viewName = null): string
     {
         if (null === $viewName) {
-            if (empty($vars['mauticTemplate'])) {
-                return '';
-            }
-
-            $viewName = $vars['mauticTemplate'];
+            $viewName = $vars['mauticTemplate'] ?? null;
         }
 
         /** @var CustomContentEvent $event */

--- a/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
@@ -25,8 +25,8 @@ final class ContentHelper
      */
     public function getCustomContent($context = null, array $vars = [], $viewName = null): string
     {
-        if (null === $viewName) {
-            $viewName = $vars['mauticTemplate'] ?? null;
+        if (null === $viewName && isset($vars['mauticTemplate'])) {
+            $viewName = $vars['mauticTemplate'];
         }
 
         /** @var CustomContentEvent $event */

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -248,7 +248,7 @@
                   </div>
               </div>
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars is defined ?: []) }}
+              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
 
               <!-- tabs controls -->
               <ul class="nav nav-tabs pr-md pl-md">


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Follow up of https://github.com/mautic/mautic/pull/12924

Seems like customContent twig function does not work because pass not existed mauticTemplateVars. 

           ` {{ customContent('tabs.content', mauticTemplateVars|default([])) }}`

This PR inject mauticTemplateVars to twig templates, similar like we did in M4
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  Just test your own subscriber to contact detail page tab content. After PR should work properly

```php
  public static function getSubscribedEvents()
    {
        return [
            CoreEvents::VIEW_INJECT_CUSTOM_CONTENT => ['injectViewCustomContent', 0],
        ];
    }

    public function injectViewCustomContent(CustomContentEvent $customContentEvent): void
    {
        if ('tabs.content' == $customContentEvent->getContext()) {
            
        }
    }

```
<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
