### PR TITLE
Fix incorrect PSR-4 namespaces in tests

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\CampaignBundle\Tests\Controller\Api;
+namespace Mautic\CampaignBundle\Tests\Command\Api;
 
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\CampaignBundle\Tests\Controller;
+namespace Mautic\CampaignBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\CampaginBundle\Tests\Controller\Api;
+namespace Mautic\CampaignBundle\Tests\Controller\Api;
 
 use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTest;

--- a/app/bundles/ChannelBundle/Tests/Command/SendChannelBroadcastCommandTest.php
+++ b/app/bundles/ChannelBundle/Tests/Command/SendChannelBroadcastCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\ChannelBundle\Tests\Controller\Api;
+namespace Mautic\ChannelBundle\Tests\Command;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTime/DateTokenHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTime/DateTokenHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mautic\CoreBundle\Tests\Helper\DateTime;
+namespace Mautic\CoreBundle\Tests\Unit\Helper\DateTime;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\DateTime\DateTimeLocalization;

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\FormBundle\Tests\Controller;
+namespace Mautic\FormBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -125,7 +125,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($result, $event->getResult());
     }
 
-    public static function valueProvider(): iterable
+    public static function valueProvider(): \Generator
     {
         yield [
             'test & test',

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Integration/ConfigFormNotesTraitTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Integration/ConfigFormNotesTraitTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\IntegrationsBundle\Tests\Integration;
+namespace Mautic\IntegrationsBundle\Tests\Unit\Integration;
 
 use Mautic\IntegrationsBundle\DTO\Note;
 use Mautic\IntegrationsBundle\Integration\ConfigFormNotesTrait;

--- a/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\PluginBundle\Tests\FormType;
+namespace Mautic\PluginBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\StandAloneButtonType;
 use Mautic\PluginBundle\Entity\Integration;

--- a/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\PluginBundle\Tests\FormType;
+namespace Mautic\PluginBundle\Tests\Form\Type;
 
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;

--- a/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\PointBundle\Tests\Functional\EmailTriggerTest;
+namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mautic\PointBundle\Tests\Functional\EmailTriggerTest;
+namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\PointBundle\Tests\Functional\EmailTriggerTest;
+namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\PointBundle\Tests\Functional\EmailTriggerTest;
+namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mautic\PointBundle\Tests\Functional\EmailTriggerTest;
+namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mautic\UserBundle\Tests\Controller\Api;
+namespace Mautic\UserBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;

--- a/plugins/MauticFocusBundle/Tests/Model/FocusModelTest.php
+++ b/plugins/MauticFocusBundle/Tests/Model/FocusModelTest.php
@@ -97,7 +97,7 @@ class FocusModelTest extends TestCase
         $focusModel->getContent($focus);
     }
 
-    public function focusTypeProvider(): iterable
+    public function focusTypeProvider(): \Generator
     {
         yield ['form', self::once()];
         yield ['notice', self::never()];

--- a/plugins/MauticFocusBundle/Tests/Model/FocusModelTest.php
+++ b/plugins/MauticFocusBundle/Tests/Model/FocusModelTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MauticPlugin\MauticFocusBundle\Tests\Helper;
+namespace MauticPlugin\MauticFocusBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Some tests classes have a namespace that's not compatible with PSR-4.
This results in a warning when compiling the autoloader in an optimised way (e.g. via `composer update --lock -o`).

This PR addresses this.

_note_
There is also an external dependency (`twilio/sdk`) with an PSR-4 incompatible namespace.
I'll address this in a separate PR, as this required further investigation as it requires a major bump( from `5` to `6`), which may cause a BC breaking incompatibility.

**before**

```bash
composer update -o --lock
Loading composer repositories with package information
...
Generating optimized autoload files
Class Mautic\ChannelBundle\Tests\Controller\Api\SendChannelBroadcastCommandTest located in ./app/bundles/ChannelBundle/Tests/Command/SendChannelBroadcastCommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\UserBundle\Tests\Controller\Api\UserLogoutFunctionalTest located in ./app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\CoreBundle\Tests\Helper\DateTime\DateTokenHelperTest located in ./app/bundles/CoreBundle/Tests/Unit/Helper/DateTime/DateTokenHelperTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\FormBundle\Tests\Controller\CampaignSubscriberFunctionalTest located in ./app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\IntegrationsBundle\Tests\Integration\ConfigFormNotesTraitTest located in ./app/bundles/IntegrationsBundle/Tests/Unit/Integration/ConfigFormNotesTraitTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\CampaginBundle\Tests\Controller\Api\ContactCampaignApiControllerFunctionalTest located in ./app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\CampaignBundle\Tests\Controller\CampaignApiControllerFunctionalTest located in ./app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\CampaignBundle\Tests\Controller\Api\EventLogApiControllerTest located in ./app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PluginBundle\Tests\FormType\DetailsTypeTest located in ./app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PluginBundle\Tests\FormType\IntegrationsListTypeTest located in ./app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PointBundle\Tests\Functional\EmailTriggerTest\PointTriggerFunctionalTest located in ./app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PointBundle\Tests\Functional\EmailTriggerTest\PointActionFunctionalTest located in ./app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PointBundle\Tests\Functional\EmailTriggerTest\GroupScoreRepositoryFunctionalTest located in ./app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PointBundle\Tests\Functional\EmailTriggerTest\EmailTriggerTest located in ./app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Mautic\PointBundle\Tests\Functional\EmailTriggerTest\SegmentFilterFunctionalTest located in ./app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php does not comply with psr-4 autoloading standard. Skipping.
Class MauticPlugin\MauticFocusBundle\Tests\Helper\FocusModelTest located in ./plugins/MauticFocusBundle/Tests/Model/FocusModelTest.php does not comply with psr-4 autoloading standard. Skipping.
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
...
```

**after**
```
composer update -o --lock
Loading composer repositories with package information
...
Generating optimized autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
...
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Verify the tests run successfully, as there is no real Application impact
3. run `composer update --lock -o` and verify the message displayed above are not visible (you can ignore `twilio/sdk`, see the note above)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
