### PR TITLE
Fix segment filteration issue on custom object

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -505,6 +505,7 @@ return [
                     'mautic.lead.model.lead_segment_schema_cache',
                     '@service_container',
                     'mautic.lead.model.lead_segment_decorator_factory',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.tracker.contact' => [

--- a/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Mautic\LeadBundle\Event;
+
+use Mautic\CoreBundle\Event\CommonEvent;
+
+class LeadListMergeFiltersEvent extends CommonEvent
+{
+    /**
+     * @var mixed[]
+     */
+    private array $filters;
+
+    /**
+     * @param mixed[] $filters
+     */
+    public function __construct(array $filters)
+    {
+        $this->filters = $filters;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+
+    /**
+     * @param mixed[] $filters
+     */
+    public function setFilters(array $filters): void
+    {
+        $this->filters = $filters;
+    }
+}

--- a/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
@@ -7,16 +7,10 @@ use Mautic\CoreBundle\Event\CommonEvent;
 class LeadListMergeFiltersEvent extends CommonEvent
 {
     /**
-     * @var mixed[]
-     */
-    private array $filters;
-
-    /**
      * @param mixed[] $filters
      */
-    public function __construct(array $filters)
+    public function __construct(private array $filters)
     {
-        $this->filters = $filters;
     }
 
     /**

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -685,6 +685,16 @@ final class LeadEvents
     public const LIST_FILTERS_ON_FILTERING = 'mautic.list_filters_on_filtering';
 
     /**
+     * The mautic.list_filters_merge event is dispatched when the lists rebuilding.
+     *
+     * The event listener receives a
+     * Mautic\LeadBundle\Event\LeadListMergeFiltersEvent instance.
+     *
+     * @var string
+     */
+    public const LIST_FILTERS_MERGE = 'mautic.list_filters_merge';
+
+    /**
      * The mautic.list_filters_querybuilder_generated event is dispatched when the queryBuilder for segment was generated.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -44,16 +44,22 @@ class ContactSegmentFilterCrate
 
     private $nullValue;
 
+    /**
+     * @var array|mixed[]
+     */
+    private array $mergedProperty;
+
     public function __construct(array $filter)
     {
-        $bcFilter          = $filter['filter'] ?? null;
-        $this->glue        = $filter['glue'] ?? null;
-        $this->field       = $filter['field'] ?? null;
-        $this->object      = $filter['object'] ?? self::CONTACT_OBJECT;
-        $this->type        = $filter['type'] ?? null;
-        $this->filter      = $filter['properties']['filter'] ?? $bcFilter;
-        $this->nullValue   = $filter['null_value'] ?? null;
-        $this->sourceArray = $filter;
+        $bcFilter               = $filter['filter'] ?? null;
+        $this->glue             = $filter['glue'] ?? null;
+        $this->field            = $filter['field'] ?? null;
+        $this->object           = $filter['object'] ?? self::CONTACT_OBJECT;
+        $this->type             = $filter['type'] ?? null;
+        $this->filter           = $filter['properties']['filter'] ?? $bcFilter;
+        $this->nullValue        = $filter['null_value'] ?? null;
+        $this->mergedProperty   = $filter['merged_property'] ?? [];
+        $this->sourceArray      = $filter;
 
         $this->setOperator($filter);
     }
@@ -185,5 +191,21 @@ class ContactSegmentFilterCrate
     public function getObject(): ?string
     {
         return $this->object;
+    }
+
+    /**
+     * @return array|mixed[]
+     */
+    public function getMergedProperty(): array
+    {
+        return $this->mergedProperty;
+    }
+
+    /**
+     * @param array|mixed[] $mergedProperty
+     */
+    public function setMergedProperty(array $mergedProperty): void
+    {
+        $this->mergedProperty = $mergedProperty;
     }
 }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -44,7 +44,6 @@ class ContactSegmentFilterFactory
         $event = new LeadListMergeFiltersEvent($filters);
         $this->eventDispatcher->dispatch(LeadEvents::LIST_FILTERS_MERGE, $event);
         $filters = $event->getFilters();
-
         foreach ($filters as $filter) {
             if (self::CUSTOM_OPERATOR === $filter['operator']) {
                 $mergedProperty      = $filter['merged_property'];
@@ -55,6 +54,7 @@ class ContactSegmentFilterFactory
                     }
                     $factorSegmentFilter                    = $this->factorSegmentFilter($nestedFilter, $batchLimiters);
                     $mergedProperty[$index]['filter_value'] = $factorSegmentFilter->getParameterValue();
+                    $mergedProperty[$index]['operator']     = $factorSegmentFilter->getOperator();
                 }
                 if ($factorSegmentFilter) {
                     $factorSegmentFilter->contactSegmentFilterCrate->setMergedProperty($mergedProperty);

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -58,9 +58,6 @@ class ContactSegmentFilterFactory
                     $contactSegmentFilters->addContactSegmentFilter($factorSegmentFilter);
                 }
             } else {
-                if (!in_array($filter['operator'], $this->operatorsWithEmptyValuesAllowed) && empty($filter['filter']) && !is_numeric($filter['filter'])) {
-                    continue; // If no value set for the filter, don't consider it
-                }
                 $contactSegmentFilters->addContactSegmentFilter($this->factorSegmentFilter($filter, $batchLimiters));
             }
         }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterFactory
 {
-    public const CUSTOM_OPERATOR = 'custom_operator';
+    public const CUSTOM_OPERATOR             = 'custom_operator';
     private $operatorsWithEmptyValuesAllowed = ['empty', '!empty', self::CUSTOM_OPERATOR];
 
     public function __construct(
@@ -22,9 +22,6 @@ class ContactSegmentFilterFactory
         private DecoratorFactory $decoratorFactory,
         private EventDispatcherInterface $eventDispatcher
     ) {
-        $this->schemaCache      = $schemaCache;
-        $this->container        = $container;
-        $this->decoratorFactory = $decoratorFactory;
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -3,18 +3,28 @@
 namespace Mautic\LeadBundle\Segment;
 
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Event\LeadListMergeFiltersEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterFactory
 {
+    public const CUSTOM_OPERATOR = 'custom_operator';
+    private $operatorsWithEmptyValuesAllowed = ['empty', '!empty', self::CUSTOM_OPERATOR];
+
     public function __construct(
         private TableSchemaColumnsCache $schemaCache,
         private Container $container,
-        private DecoratorFactory $decoratorFactory
+        private DecoratorFactory $decoratorFactory,
+        private EventDispatcherInterface $eventDispatcher
     ) {
+        $this->schemaCache      = $schemaCache;
+        $this->container        = $container;
+        $this->decoratorFactory = $decoratorFactory;
     }
 
     /**
@@ -27,8 +37,35 @@ class ContactSegmentFilterFactory
         $contactSegmentFilters = new ContactSegmentFilters();
 
         $filters = $leadList->getFilters();
+
+        // Merge multiple filters of same field with OR
+        $filters = $this->mergeFilters($filters);
+
+        $event = new LeadListMergeFiltersEvent($filters);
+        $this->eventDispatcher->dispatch(LeadEvents::LIST_FILTERS_MERGE, $event);
+        $filters = $event->getFilters();
+
         foreach ($filters as $filter) {
-            $contactSegmentFilters->addContactSegmentFilter($this->factorSegmentFilter($filter, $batchLimiters));
+            if (self::CUSTOM_OPERATOR === $filter['operator']) {
+                $mergedProperty      = $filter['merged_property'];
+                $factorSegmentFilter = null;
+                foreach ($filter['properties'] as $index => $nestedFilter) {
+                    if (!in_array($nestedFilter['operator'], $this->operatorsWithEmptyValuesAllowed) && empty($nestedFilter['filter']) && !is_numeric($nestedFilter['filter'])) {
+                        continue; // If no value set for the filter, don't consider it
+                    }
+                    $factorSegmentFilter                    = $this->factorSegmentFilter($nestedFilter, $batchLimiters);
+                    $mergedProperty[$index]['filter_value'] = $factorSegmentFilter->getParameterValue();
+                }
+                if ($factorSegmentFilter) {
+                    $factorSegmentFilter->contactSegmentFilterCrate->setMergedProperty($mergedProperty);
+                    $contactSegmentFilters->addContactSegmentFilter($factorSegmentFilter);
+                }
+            } else {
+                if (!in_array($filter['operator'], $this->operatorsWithEmptyValuesAllowed) && empty($filter['filter']) && !is_numeric($filter['filter'])) {
+                    continue; // If no value set for the filter, don't consider it
+                }
+                $contactSegmentFilters->addContactSegmentFilter($this->factorSegmentFilter($filter, $batchLimiters));
+            }
         }
 
         return $contactSegmentFilters;

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -14,7 +14,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class ContactSegmentFilterFactory
 {
     public const CUSTOM_OPERATOR             = 'custom_operator';
-    private $operatorsWithEmptyValuesAllowed = ['empty', '!empty', self::CUSTOM_OPERATOR];
+
+    /**
+     * @var array|string[]
+     */
+    private array $operatorsWithEmptyValuesAllowed = ['empty', '!empty', self::CUSTOM_OPERATOR];
 
     public function __construct(
         private TableSchemaColumnsCache $schemaCache,
@@ -34,12 +38,8 @@ class ContactSegmentFilterFactory
         $contactSegmentFilters = new ContactSegmentFilters();
 
         $filters = $leadList->getFilters();
-
-        // Merge multiple filters of same field with OR
-        $filters = $this->mergeFilters($filters);
-
-        $event = new LeadListMergeFiltersEvent($filters);
-        $this->eventDispatcher->dispatch(LeadEvents::LIST_FILTERS_MERGE, $event);
+        $event   = new LeadListMergeFiltersEvent($filters);
+        $this->eventDispatcher->dispatch($event, LeadEvents::LIST_FILTERS_MERGE);
         $filters = $event->getFilters();
         foreach ($filters as $filter) {
             if (self::CUSTOM_OPERATOR === $filter['operator']) {

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
@@ -24,16 +24,16 @@ class ContactSegmentFilterFactoryTest extends \PHPUnit\Framework\TestCase
         $decoratorFactory        = $this->createMock(DecoratorFactory::class);
 
         $filterDecorator = $this->createMock(FilterDecoratorInterface::class);
-        $decoratorFactory->expects($this->exactly(3))
+        $decoratorFactory->expects($this->exactly(4))
             ->method('getDecoratorForFilter')
             ->willReturn($filterDecorator);
 
-        $filterDecorator->expects($this->exactly(3))
+        $filterDecorator->expects($this->exactly(4))
             ->method('getQueryType')
             ->willReturn('MyQueryTypeId');
 
         $filterQueryBuilder = $this->createMock(FilterQueryBuilderInterface::class);
-        $container->expects($this->exactly(3))
+        $container->expects($this->exactly(4))
             ->method('get')
             ->with('MyQueryTypeId')
             ->willReturn($filterQueryBuilder);
@@ -67,11 +67,24 @@ class ContactSegmentFilterFactoryTest extends \PHPUnit\Framework\TestCase
                 'filter'   => 'QLD',
                 'display'  => '',
             ],
+            [
+                'glue'         => 'or',
+                'type'         => 'lookup',
+                'field'        => 'state',
+                'operator'     => ContactSegmentFilterFactory::CUSTOM_OPERATOR,
+                'properties'   => [
+                    [
+                    'operator' => '=',
+                    'filter'   => 'QLD',
+                    ],
+                ],
+                'merged_property' => [],
+            ],
         ]);
 
         $contactSegmentFilters = $contactSegmentFilterFactory->getSegmentFilters($leadList);
 
         $this->assertInstanceOf(ContactSegmentFilters::class, $contactSegmentFilters);
-        $this->assertCount(3, $contactSegmentFilters);
+        $this->assertCount(4, $contactSegmentFilters);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
 use Mautic\LeadBundle\Segment\TableSchemaColumnsCache;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterFactoryTest extends \PHPUnit\Framework\TestCase
 {
@@ -37,7 +38,7 @@ class ContactSegmentFilterFactoryTest extends \PHPUnit\Framework\TestCase
             ->with('MyQueryTypeId')
             ->willReturn($filterQueryBuilder);
 
-        $contactSegmentFilterFactory = new ContactSegmentFilterFactory($tableSchemaColumnsCache, $container, $decoratorFactory);
+        $contactSegmentFilterFactory = new ContactSegmentFilterFactory($tableSchemaColumnsCache, $container, $decoratorFactory, $this->createMock(EventDispatcherInterface::class));
 
         $leadList = new LeadList();
         $leadList->setFilters([


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
There was an error if using custom object filter in segment.
`Fatal error: Uncaught Error: Undefined constant Mautic\LeadBundle\LeadEvents::LIST_FILTERS_MERGE in /var/www/html/docroot/plugins/CustomObjectsBundle/EventListener/SegmentFiltersMergeSubscriber.php:27`

it is fixed now

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Create a segment
2. Add multiple filter on same type of custom object filed 
3. Wait for segment rebuild
4. Segment should be rebuild correctly.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
