### PR TITLE
Corrected the query building when fetching contacts by multiple email addresses.

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -91,10 +91,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     /**
      * Get a list of leads based on field value.
      *
-     * @param string $field
-     * @param string $value
-     * @param ?int   $ignoreId
-     * @param bool   $indexByColumn
+     * @param string          $field
+     * @param string[]|string $value
+     * @param ?int            $ignoreId
+     * @param bool            $indexByColumn
      *
      * @return array
      */
@@ -117,9 +117,9 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      *
      * @internal
      *
-     * @param string $field
-     * @param string $value
-     * @param ?int   $ignoreId
+     * @param string          $field
+     * @param string[]|string $value
+     * @param ?int            $ignoreId
      *
      * @return QueryBuilder
      */
@@ -144,7 +144,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
              */
             $valueParams = [];
             for ($i = 0; $i < count($value); ++$i) {
-                $valueParams[$this->generateRandomParameterName()] = $value[$i];
+                $valueParams[':'.$this->generateRandomParameterName()] = $value[$i];
             }
 
             $q->andWhere(

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -4,6 +4,8 @@ namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 {
@@ -107,10 +109,84 @@ class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(220, $this->lead->getPoints());
     }
 
-    private function createLead(): Lead
+    /**
+     * @param string[]|string $emails
+     *
+     * @dataProvider dataForTestAjaxGetLeadsByFieldValue
+     */
+    public function testAjaxGetLeadsByFieldValue($emails, bool $createFlag, int $expectedCount): void
+    {
+        $this->createLeads($emails, $createFlag);
+
+        $payload = [
+            'action' => 'lead:getLeadIdsByFieldValue',
+            'field'  => 'email',
+            'value'  => $emails,
+        ];
+
+        $this->client->request(Request::METHOD_GET, '/s/ajax', $payload, [], $this->createAjaxHeaders());
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $contentArray = json_decode($this->client->getResponse()->getContent(), true);
+
+        $this->assertCount($expectedCount, $contentArray['items']);
+    }
+
+    /**
+     * @return array<string, array<int, int|string|bool|string[]>>
+     */
+    public function dataForTestAjaxGetLeadsByFieldValue(): iterable
+    {
+        yield 'Email passed as string with associated contact' => [
+            'john@doe.com', // Email
+            true,
+            1, // Count
+        ];
+
+        yield 'Email passed as string without associated contact' => [
+            'john@doe.com', // Email
+            false,
+            0, // Count
+        ];
+
+        yield 'Email passed as array with associated contacts' => [
+            ['john@doe.com', 'doe@doe.com'], // Email
+            true,
+            2, // Count
+        ];
+
+        yield 'Email passed as array without associated contacts' => [
+            ['john@doe.com', 'doe@doe.com'], // Email
+            false,
+            0, // Count
+        ];
+    }
+
+    /**
+     * @param string[]|string $emails
+     */
+    private function createLeads($emails, bool $flag): void
+    {
+        if (!$flag) {
+            return;
+        }
+
+        if (!is_array($emails)) {
+            $emails = [$emails];
+        }
+
+        foreach ($emails as $email) {
+            $this->createLead($email);
+        }
+    }
+
+    private function createLead(string $email = ''): Lead
     {
         $lead = new Lead();
         $lead->setPoints(100);
+
+        if ($email) {
+            $lead->setEmail($email);
+        }
 
         $this->em->persist($lead);
         $this->em->flush();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ✅ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ❌ ]
| BC breaks? (use the c.x branch)        | [ ❌ ]
| Automated tests included?              | [ ✅ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

In a custom logic, I was fetching the contacts based on emails. It was not working and throwing an exception  like, 
``` 
An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'par0' in 'where clause'
```
These changes will correct the query construction and yield the results.


#### Steps to test this PR:

This is technical PR. 