### PR TITLE
DPMMA-2566 Support old contactId type in point groups migration

### DIFF
--- a/app/migrations/Version20230621074925.php
+++ b/app/migrations/Version20230621074925.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\BigIntType;
 use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupContactScore;
@@ -94,7 +95,7 @@ final class Version20230621074925 extends PreUpAssertionMigration
 
         $this->addSql("CREATE TABLE `{$this->contactScoreTableName}`
 (
-    `contact_id`          BIGINT UNSIGNED NOT NULL,
+    `contact_id`          {$this->getContactIdColumnType($schema)} NOT NULL,
     `group_id`           INT UNSIGNED    NOT NULL,
     `score`               INT             NOT NULL,
     PRIMARY KEY (`contact_id`, `group_id`)
@@ -188,5 +189,13 @@ final class Version20230621074925 extends PreUpAssertionMigration
             fn (Schema $schema) => $schema->getTable("{$tableName}")->hasForeignKey($fkName),
             "Foreign key {$fkName} already exists in {$tableName} table"
         );
+    }
+
+    private function getContactIdColumnType(Schema $schema): string
+    {
+        $contactTable    = $schema->getTable($this->contactTableName);
+        $contactIdColumn = $contactTable->getColumn('id');
+
+        return $contactIdColumn->getType() instanceof BigIntType ? 'BIGINT UNSIGNED' : 'INT';
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ N ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13282 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR fixes an issue with migrating point groups on databases with `leads.id` type INT.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `ddev exec php bin/console doctrine:migrations:migrate`

If you have already executed this migration before the fix, you will need to run the `--down` procedure first: 
`ddev exec php bin/console doctrine:migration:execute 'Mautic\Migrations\Version20230621074925' --down`