### PR TITLE
Maut 10853Fixing Array to string conversion

### DIFF
--- a/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\ChannelBundle\Entity;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\LeadBundle\Entity\TimelineTrait;
 
@@ -78,12 +79,9 @@ class MessageQueueRepository extends CommonRepository
         return (int) $q->select('count(*)')
             ->from(MAUTIC_TABLE_PREFIX.'message_queue', $this->getTableAlias())
             ->where($expr)
-            ->setParameters(
-                [
-                    'channel' => $channel,
-                    'status'  => MessageQueue::STATUS_SENT,
-                ]
-            )
+            ->setParameter('channel', $channel)
+            ->setParameter('status', MessageQueue::STATUS_SENT)
+            ->setParameter('ids', $ids, ArrayParameterType::INTEGER)
             ->executeQuery()
             ->fetchOne();
     }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

On local environment when we are developing in the debug mode, the PHP warnings are showed as hard errors. It blocks developers from doing their work.

This warning shows up on the email list view when we are counting how many emails were sent for each email:


```
500 Internal Server Error - An exception occurred while executing 'SELECT count(*) FROM mautic_message_queue e WHERE (e.channel = ?) AND (e.status <> ?) AND (e.channel_id IN (?))' with params ["email", "sent", [2]]: PHP Warning - Array to string conversion
```


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Use the dev environment
3. Visit the email list view
4. Make sure that after the fix you can see the queued counts.

#### Other areas of Mautic that may be affected by the change:
1. None

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. None
