### PR TITLE
Update phpstan baseline.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,14 +2,6 @@ parameters:
 	ignoreErrors:
 		-
 			message: """
-				#^Call to deprecated function Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ref\\(\\)\\:
-				since Symfony 5\\.1, use service\\(\\) instead\\.$#
-			"""
-			count: 4
-			path: app/bundles/ApiBundle/Config/services.php
-
-		-
-			message: """
 				#^Call to method __construct\\(\\) of deprecated class Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:
 				2\\.3 \\- to be removed in 3\\.0; use AbstractFormController instead$#
 			"""
@@ -176,14 +168,6 @@ parameters:
 			path: app/bundles/ApiBundle/Controller/CommonApiController.php
 
 		-
-			message: """
-				#^Call to deprecated method getParameter\\(\\) of class Mautic\\\\CoreBundle\\\\Helper\\\\CoreParametersHelper\\:
-				3\\.0\\.0 to be removed in 4\\.0; use get\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/ApiBundle/Controller/FetchCommonApiController.php
-
-		-
 			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\<string\\>\\:\\:get\\(\\) expects string\\|null, int given\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -311,14 +295,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method FOS\\\\OAuthServerBundle\\\\Model\\\\ClientInterface\\:\\:isAuthorizedClient\\(\\)\\.$#"
-			count: 1
-			path: app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
 			count: 1
 			path: app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
 
@@ -463,11 +439,6 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
 
 		-
-			message: "#^Method Mautic\\\\ApiBundle\\\\Serializer\\\\Driver\\\\ApiMetadataDriver\\:\\:addGroup\\(\\) has parameter \\$property with no type specified\\.$#"
-			count: 1
-			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
-
-		-
 			message: "#^Method Mautic\\\\ApiBundle\\\\Serializer\\\\Driver\\\\ApiMetadataDriver\\:\\:addListProperties\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
@@ -573,11 +544,6 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
 
 		-
-			message: "#^Property Mautic\\\\ApiBundle\\\\Serializer\\\\Driver\\\\ApiMetadataDriver\\:\\:\\$metadata \\(JMS\\\\Serializer\\\\Metadata\\\\ClassMetadata\\) does not accept null\\.$#"
-			count: 1
-			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
@@ -594,11 +560,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ApiBundle\\\\Serializer\\\\Exclusion\\\\FieldInclusionStrategy\\:\\:__construct\\(\\) has parameter \\$path with no type specified\\.$#"
-			count: 1
-			path: app/bundles/ApiBundle/Serializer/Exclusion/FieldInclusionStrategy.php
-
-		-
-			message: "#^Property Mautic\\\\ApiBundle\\\\Serializer\\\\Exclusion\\\\FieldInclusionStrategy\\:\\:\\$path has no type specified\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Serializer/Exclusion/FieldInclusionStrategy.php
 
@@ -624,14 +585,6 @@ parameters:
 			message: "#^Method Mautic\\\\ApiBundle\\\\Tests\\\\Controller\\\\CommonApiControllerTest\\:\\:getResultFromProtectedMethod\\(\\) has parameter \\$method with no type specified\\.$#"
 			count: 1
 			path: app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
 
 		-
 			message: "#^Property Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:\\$headers \\(Symfony\\\\Component\\\\HttpFoundation\\\\HeaderBag\\) does not accept Symfony\\\\Component\\\\HttpFoundation\\\\ParameterBag\\.$#"
@@ -849,11 +802,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\AssetRepository\\:\\:getAssetSize\\(\\) has parameter \\$assets with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/AssetBundle/Entity/AssetRepository.php
-
-		-
-			message: "#^Method Mautic\\\\AssetBundle\\\\Entity\\\\AssetRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/AssetBundle/Entity/AssetRepository.php
 
@@ -1397,11 +1345,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/AjaxController.php
 
 		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Controller\\\\AjaxController\\:\\:updateScheduledCampaignEventAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/AjaxController.php
-
-		-
 			message: """
 				#^Parameter \\$factory of method Mautic\\\\CampaignBundle\\\\Controller\\\\AjaxController\\:\\:__construct\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
@@ -1485,11 +1428,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -1553,11 +1491,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/Api/EventApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/Api/EventApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Controller/Api/EventApiController.php
@@ -1573,11 +1506,6 @@ parameters:
 		-
 			message: "#^Call to method getRepository\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
-			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
-
-		-
-			message: "#^Cannot use array destructuring on Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLog\\.$#"
-			count: 2
 			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
 
 		-
@@ -1642,11 +1570,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Controller\\\\Api\\\\EventLogApiController\\:\\:getContactEventsAction\\(\\) has parameter \\$contactId with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
 
@@ -2072,11 +1995,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/EventController.php
 
 		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Controller\\\\EventController\\:\\:\\$supportedEventTypes has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/EventController.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Controller/EventController.php
@@ -2096,11 +2014,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Controller\\\\SourceController\\:\\:editAction\\(\\) has parameter \\$objectId with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/SourceController.php
-
-		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Controller\\\\SourceController\\:\\:\\$supportedSourceTypes has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Controller/SourceController.php
 
@@ -2290,17 +2203,7 @@ parameters:
 			path: app/bundles/CampaignBundle/Entity/CampaignRepository.php
 
 		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\CampaignRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/CampaignRepository.php
-
-		-
 			message: "#^Parameter \\#1 \\$maxResults of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:setMaxResults\\(\\) expects int\\|null, true given\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/CampaignRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\CampaignBundle\\\\Entity\\\\CampaignRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/CampaignRepository.php
 
@@ -2515,11 +2418,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Entity/EventRepository.php
 
 		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\EventRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/EventRepository.php
-
-		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\EventRepository\\:\\:nullEventParents\\(\\) has parameter \\$campaignId with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -2631,11 +2529,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
 
 		-
-			message: "#^Return type of method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
-
-		-
 			message: "#^Call to an undefined method Mautic\\\\CampaignBundle\\\\Entity\\\\Lead\\:\\:getId\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -2687,11 +2580,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadRepository\\:\\:getInactiveContactCount\\(\\) has parameter \\$decisionIds with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Entity/LeadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Entity\\\\LeadRepository\\:\\:getInactiveContacts\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Entity/LeadRepository.php
 
@@ -3351,11 +3239,6 @@ parameters:
 			path: app/bundles/CampaignBundle/EventCollector/Builder/EventBuilder.php
 
 		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\EventCollector\\\\EventCollector\\:\\:\\$events \\(Mautic\\\\CampaignBundle\\\\EventCollector\\\\Accessor\\\\EventAccessor\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/EventCollector/EventCollector.php
-
-		-
 			message: "#^Property Mautic\\\\CampaignBundle\\\\EventCollector\\\\EventCollector\\:\\:\\$eventsArray type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/EventCollector/EventCollector.php
@@ -3400,16 +3283,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\ContactFinder\\\\InactiveContactFinder\\:\\:getContactCount\\(\\) has parameter \\$decisionEvents with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/ContactFinder/InactiveContactFinder.php
-
-		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Executioner\\\\ContactFinder\\\\InactiveContactFinder\\:\\:\\$campaignMemberDatesAdded \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\) does not accept array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/ContactFinder/InactiveContactFinder.php
-
-		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Executioner\\\\ContactFinder\\\\InactiveContactFinder\\:\\:\\$campaignMemberDatesAdded \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/ContactFinder/InactiveContactFinder.php
 
@@ -3530,11 +3403,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
-
-		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\EventExecutioner\\:\\:recordLogsAsFailedForEvent\\(\\) has parameter \\$reason with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -3560,24 +3428,9 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
 
 		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:getLastActiveDates\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Helper\\\\InactiveHelper\\:\\:getLastActiveDates\\(\\) return type has no value type specified in iterable type array\\|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
 			message: "#^Variable \\$decision in PHPDoc tag @var does not exist\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 2
-			path: app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -3588,11 +3441,6 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/InactiveExecutioner.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"
@@ -3640,11 +3488,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Executioner/Result/Responses.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
-
-		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\ScheduledExecutioner\\:\\:executeByIds\\(\\) has parameter \\$logIds with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -3663,11 +3506,6 @@ parameters:
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Scheduler\\\\EventScheduler\\:\\:getSortedExecutionDates\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Scheduler/EventScheduler.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Executioner\\\\Scheduler\\\\Mode\\\\Interval\\:\\:getExecutionDateTimeBetweenHours\\(\\) has parameter \\$eventId with no type specified\\.$#"
@@ -3697,21 +3535,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$minute of method DateTime\\:\\:setTime\\(\\) expects int, string given\\.$#"
 			count: 5
-			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
-
-		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Executioner\\\\Scheduler\\\\Mode\\\\Interval\\:\\:\\$coreParametersHelper is never read, only written\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
-
-		-
-			message: "#^Property Mautic\\\\CampaignBundle\\\\Executioner\\\\Scheduler\\\\Mode\\\\Interval\\:\\:\\$defaultTimezone is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
 			path: app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
 
 		-
@@ -3775,11 +3598,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$contacts$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
-
-		-
 			message: "#^Property Mautic\\\\CampaignBundle\\\\Helper\\\\RemovedContactTracker\\:\\:\\$removedContacts type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
@@ -3816,7 +3634,7 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 2
+			count: 1
 			path: app/bundles/CampaignBundle/Membership/MembershipManager.php
 
 		-
@@ -4015,11 +3833,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Model/EventLogModel.php
 
 		-
-			message: "#^Method Mautic\\\\CampaignBundle\\\\Model\\\\EventLogModel\\:\\:updateContactEvent\\(\\) should return Mautic\\\\CampaignBundle\\\\Entity\\\\LeadEventLog\\|string but returns array\\<int, mixed\\>\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Model/EventLogModel.php
-
-		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Model\\\\EventModel\\:\\:deleteEvents\\(\\) has parameter \\$currentEvents with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Model/EventModel.php
@@ -4172,30 +3985,9 @@ parameters:
 			path: app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
 
 		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/CampaignBundle/Tests/Controller/AjaxControllerFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
-
-		-
 			message: "#^Property Mautic\\\\CampaignBundle\\\\Tests\\\\Controller\\\\CampaignControllerFunctionalTest\\:\\:\\$campaignModel \\(Mautic\\\\CampaignBundle\\\\Model\\\\CampaignModel\\) does not accept Mautic\\\\CoreBundle\\\\Model\\\\AbstractCommonModel\\<object\\>\\.$#"
 			count: 1
 			path: app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
-
-		-
-			message: "#^Trying to mock an undefined method getQuery\\(\\) on class Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\.$#"
-			count: 1
-			path: app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
 
 		-
 			message: "#^Method Mautic\\\\CampaignBundle\\\\Tests\\\\Event\\\\CampaignBuilderEventTest\\:\\:initEvent\\(\\) has no return type specified\\.$#"
@@ -4444,11 +4236,6 @@ parameters:
 			path: app/bundles/CategoryBundle/Entity/CategoryRepository.php
 
 		-
-			message: "#^Method Mautic\\\\CategoryBundle\\\\Entity\\\\CategoryRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CategoryBundle/Entity/CategoryRepository.php
-
-		-
 			message: "#^Call to function is_int\\(\\) with string will always evaluate to false\\.$#"
 			count: 1
 			path: app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
@@ -4549,36 +4336,6 @@ parameters:
 			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$batch of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setBatch\\(\\) expects int, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$limit of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setLimit\\(\\) expects int, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$maxContactIdFilter of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setMaxContactIdFilter\\(\\) expects int, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$maxThreads of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setMaxThreads\\(\\) expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$minContactIdFilter of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setMinContactIdFilter\\(\\) expects int, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$threadId of method Mautic\\\\ChannelBundle\\\\Event\\\\ChannelBroadcastEvent\\:\\:setThreadId\\(\\) expects int\\|null, string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
-
-		-
 			message: """
 				#^Parameter \\$factory of method Mautic\\\\ChannelBundle\\\\Controller\\\\Api\\\\MessageApiController\\:\\:__construct\\(\\) has typehint with deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
@@ -4606,11 +4363,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:contactsAction\\(\\) has invalid return type Mautic\\\\ChannelBundle\\\\Controller\\\\JsonResponse\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/MessageController.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:contactsAction\\(\\) has invalid return type Mautic\\\\ChannelBundle\\\\Controller\\\\Response\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Controller/MessageController.php
 
@@ -4676,26 +4428,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:getViewArguments\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/MessageController.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:indexAction\\(\\) has invalid return type Mautic\\\\CoreBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/MessageController.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:indexAction\\(\\) should return Mautic\\\\CoreBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse\\|Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/MessageController.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:newAction\\(\\) has invalid return type Mautic\\\\CoreBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Controller/MessageController.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Controller\\\\MessageController\\:\\:newAction\\(\\) should return Mautic\\\\CoreBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse but returns array\\|Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Controller/MessageController.php
 
@@ -5136,11 +4868,6 @@ parameters:
 			path: app/bundles/ChannelBundle/Model/MessageQueueModel.php
 
 		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Model\\\\MessageQueueModel\\:\\:getQueuedChannelCount\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Model/MessageQueueModel.php
-
-		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Model\\\\MessageQueueModel\\:\\:getQueuedChannelCount\\(\\) has parameter \\$channel with no type specified\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -5313,11 +5040,6 @@ parameters:
 			message: "#^Property Mautic\\\\ChannelBundle\\\\Tests\\\\EventListener\\\\CampaignSubscriberTest\\:\\:\\$legacyDispatcher \\(Mautic\\\\CampaignBundle\\\\Executioner\\\\Dispatcher\\\\LegacyEventDispatcher&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept Mautic\\\\CampaignBundle\\\\Executioner\\\\Dispatcher\\\\LegacyEventDispatcher\\.$#"
 			count: 1
 			path: app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\ChannelBundle\\\\Model\\\\ChannelActionModel\\:\\:update\\(\\) invoked with 4 parameters, 2 required\\.$#"
-			count: 1
-			path: app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
 
 		-
 			message: "#^Method Mautic\\\\ChannelBundle\\\\Tests\\\\Model\\\\MessageQueueModelTest\\:\\:prepareRescheduleMessageIntervalTest\\(\\) has no return type specified\\.$#"
@@ -5597,11 +5319,6 @@ parameters:
 			path: app/bundles/ConfigBundle/Model/SysinfoModel.php
 
 		-
-			message: "#^Method Mautic\\\\ConfigBundle\\\\Model\\\\SysinfoModel\\:\\:getLogTail\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: app/bundles/ConfigBundle/Model/SysinfoModel.php
-
-		-
 			message: "#^Method Mautic\\\\ConfigBundle\\\\Model\\\\SysinfoModel\\:\\:tail\\(\\) has parameter \\$filename with no type specified\\.$#"
 			count: 1
 			path: app/bundles/ConfigBundle/Model/SysinfoModel.php
@@ -5745,11 +5462,6 @@ parameters:
 			path: app/bundles/CoreBundle/Command/ModeratedCommand.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Command/ModeratedCommand.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Command\\\\ModeratedCommand\\:\\:checkRunStatus\\(\\) has parameter \\$moderationKey with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -5761,11 +5473,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Command\\\\ModeratedCommand\\:\\:\\$checkFile has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Command/ModeratedCommand.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Command\\\\ModeratedCommand\\:\\:\\$lock \\(Symfony\\\\Component\\\\Lock\\\\Lock\\) does not accept Symfony\\\\Component\\\\Lock\\\\LockInterface\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Command/ModeratedCommand.php
 
@@ -5929,17 +5636,7 @@ parameters:
 			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$data$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\AbstractFormController\\:\\:\\$permissionBase has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
 
@@ -6259,41 +5956,6 @@ parameters:
 			path: app/bundles/CoreBundle/Controller/FormController.php
 
 		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedMauticContent has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedModelName has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedPermissionBase has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedRouteBase has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedSessionBase has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedTemplateBase has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:\\:\\$deprecatedTranslationBase has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FormController.php
-
-		-
 			message: """
 				#^Class Mautic\\\\CoreBundle\\\\Controller\\\\ThemeController extends deprecated class Mautic\\\\CoreBundle\\\\Controller\\\\FormController\\:
 				2\\.3 \\- to be removed in 3\\.0; use AbstractFormController instead$#
@@ -6497,22 +6159,6 @@ parameters:
 			path: app/bundles/CoreBundle/DependencyInjection/Compiler/UpdateStepPass.php
 
 		-
-			message: """
-				#^Call to deprecated method getName\\(\\) of class Doctrine\\\\DBAL\\\\Platforms\\\\AbstractPlatform\\:
-				Identify platforms by their class\\.$#
-			"""
-			count: 2
-			path: app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Doctrine\\\\AbstractMauticMigration\\:\\:findPropertyName\\(\\) has parameter \\$suffix with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -6613,30 +6259,6 @@ parameters:
 			path: app/bundles/CoreBundle/Doctrine/GeneratedColumn/GeneratedColumns.php
 
 		-
-			message: """
-				#^Call to deprecated method diffTable\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\Comparator\\:
-				Use \\{@see compareTables\\(\\)\\} and, optionally, \\{@see TableDiff\\:\\:isEmpty\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method listTableDetails\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@see introspectTable\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Doctrine\\\\Helper\\\\ColumnSchemaHelper\\:\\:addColumn\\(\\) has parameter \\$column with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
@@ -6670,30 +6292,6 @@ parameters:
 			message: "#^Property Mautic\\\\CoreBundle\\\\Doctrine\\\\Helper\\\\ColumnSchemaHelper\\:\\:\\$columns has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getDatabasePlatform\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link Connection\\:\\:getDatabasePlatform\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method listTableDetails\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@see introspectTable\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Doctrine\\\\Helper\\\\IndexSchemaHelper\\:\\:addIndex\\(\\) has parameter \\$columns with no type specified\\.$#"
@@ -6754,14 +6352,6 @@ parameters:
 			message: "#^Property Mautic\\\\CoreBundle\\\\Doctrine\\\\Helper\\\\IndexSchemaHelper\\:\\:\\$dropIndexes type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
 
 		-
 			message: "#^If condition is always true\\.$#"
@@ -6829,19 +6419,6 @@ parameters:
 			path: app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$name$#"
-			count: 1
-			path: app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
-
-		-
-			message: """
-				#^Call to deprecated method getName\\(\\) of class Doctrine\\\\DBAL\\\\Platforms\\\\AbstractPlatform\\:
-				Identify platforms by their class\\.$#
-			"""
-			count: 2
-			path: app/bundles/CoreBundle/Doctrine/QueryFormatter/AbstractFormatter.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Doctrine\\\\QueryFormatter\\\\AbstractFormatter\\:\\:toDate\\(\\) has parameter \\$field with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/QueryFormatter/AbstractFormatter.php
@@ -6901,11 +6478,6 @@ parameters:
 			message: "#^Method Mautic\\\\CoreBundle\\\\Doctrine\\\\Type\\\\ArrayType\\:\\:convertToPHPValue\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
-			path: app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between null and DateTime will always evaluate to false\\.$#"
@@ -7085,22 +6657,6 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
 			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonRepository.php
 
@@ -7405,22 +6961,7 @@ parameters:
 			path: app/bundles/CoreBundle/Entity/CommonRepository.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:getSimpleList\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:getSimpleList\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:getStandardSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonRepository.php
 
@@ -7486,11 +7027,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:\\$advancedFilterCommands type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Entity/CommonRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\CoreBundle\\\\Entity\\\\CommonRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Entity/CommonRepository.php
 
@@ -8508,14 +8044,6 @@ parameters:
 			path: app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
 
 		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Exception\\\\BadConfigurationException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Exception/BadConfigurationException.php
@@ -8586,22 +8114,7 @@ parameters:
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:get\\(\\) should return bool but returns object\\|null\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:getBundleConfig\\(\\) has parameter \\$bundleName with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:getDispatcher\\(\\) has invalid return type Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:getDispatcher\\(\\) should return Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher but returns Symfony\\\\Component\\\\HttpKernel\\\\Debug\\\\TraceableEventDispatcher\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
 
@@ -8612,11 +8125,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:getInstalledThemes\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Factory/MauticFactory.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:\\:getLocalConfigFile\\(\\) should return bool but returns string\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Factory/MauticFactory.php
 
@@ -8741,16 +8249,6 @@ parameters:
 			path: app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\ArrayLinebreakTransformer\\:\\:reverseTransform\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/ArrayLinebreakTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\ArrayStringTransformer\\:\\:reverseTransform\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/ArrayStringTransformer.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\DatetimeToStringTransformer\\:\\:reverseTransform\\(\\) should return string but returns null\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/DataTransformer/DatetimeToStringTransformer.php
@@ -8806,16 +8304,6 @@ parameters:
 			path: app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
 
 		-
-			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\)$#"
-			count: 2
-			path: app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/NullToEmptyTransformer.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SecondsConversionTransformer\\:\\:__construct\\(\\) has parameter \\$viewFormat with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/DataTransformer/SecondsConversionTransformer.php
@@ -8831,47 +8319,7 @@ parameters:
 			path: app/bundles/CoreBundle/Form/DataTransformer/SecondsConversionTransformer.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:formatList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:formatList\\(\\) has parameter \\$array with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:reverseTransform\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:reverseTransformKeyValuePair\\(\\) has parameter \\$array with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:reverseTransformKeyValuePair\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:transform\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:transformKeyValuePair\\(\\) has parameter \\$array with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Form\\\\DataTransformer\\\\SortableListTransformer\\:\\:transformKeyValuePair\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$atRootLevel$#"
 			count: 1
 			path: app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
 
@@ -9101,21 +8549,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/ArrayHelper.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ArrayHelper\\:\\:sum\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ArrayHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ArrayHelper\\:\\:sum\\(\\) has parameter \\$a1 with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ArrayHelper.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ArrayHelper\\:\\:sum\\(\\) has parameter \\$b2 with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ArrayHelper.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ArrayHelper\\:\\:sumOrSub\\(\\) has parameter \\$a1 with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/ArrayHelper.php
@@ -9187,11 +8620,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\BuilderTokenHelper\\:\\:\\$bundleName has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\BuilderTokenHelper\\:\\:\\$isConfigured has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
 
@@ -9337,7 +8765,7 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 3
+			count: 2
 			path: app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
 
 		-
@@ -9516,11 +8944,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/ClickthroughHelper.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ColorHelper\\:\\:__construct\\(\\) has parameter \\$hex with no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ColorHelper.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ColorHelper\\:\\:getColorArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/ColorHelper.php
@@ -9537,11 +8960,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @param has invalid value \\(float \\(0 \\- 1\\)\\)\\: Unexpected token \"\\(\", expected variable at offset 95$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ColorHelper.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(string in format \\#xxxxxx or \\#xxx\\)\\: Unexpected token \"in\", expected variable at offset 53$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/ColorHelper.php
 
@@ -9831,11 +9249,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/InputHelper.php
 
 		-
-			message: "#^Static property Mautic\\\\CoreBundle\\\\Helper\\\\InputHelper\\:\\:\\$htmlFilter \\(Joomla\\\\Filter\\\\InputFilter\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/InputHelper.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\IpLookupHelper\\:\\:getClientIpFromProxyList\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -9874,16 +9287,6 @@ parameters:
 			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\IpLookupHelper\\:\\:\\$trackPrivateIPRanges type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/IpLookupHelper.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\Language\\\\Installer\\:\\:\\$installDirectory \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/Language/Installer.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\Language\\\\Installer\\:\\:\\$sourceDirectory \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/Language/Installer.php
 
 		-
 			message: "#^Access to an undefined property Psr\\\\Http\\\\Message\\\\ResponseInterface\\:\\:\\$code\\.$#"
@@ -10142,11 +9545,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\ThemeHelper\\:\\:\\$steps type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Helper/ThemeHelper.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Helper\\\\ThemeHelper\\:\\:\\$themesInfo type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Helper/ThemeHelper.php
 
@@ -10477,11 +9875,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\IpLookup\\\\DoNotSellList\\\\MaxMindDoNotSellList\\:\\:\\$listPath has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/IpLookup/DoNotSellList/MaxMindDoNotSellList.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\IpLookup\\\\DoNotSellList\\\\MaxMindDoNotSellList\\:\\:\\$position has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/IpLookup/DoNotSellList/MaxMindDoNotSellList.php
 
@@ -11325,14 +10718,6 @@ parameters:
 			path: app/bundles/CoreBundle/Test/Listeners/SeparateProcessListener.php
 
 		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 4
-			path: app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
-
-		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Test\\\\MauticMysqlTestCase\\:\\:applySqlFromFile\\(\\) has parameter \\$file with no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -11415,14 +10800,6 @@ parameters:
 			message: "#^Property Mautic\\\\CoreBundle\\\\Tests\\\\Unit\\\\DependencyInjection\\\\Builder\\\\BundleMetadataBuilderTest\\:\\:\\$paths type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/BundleMetadataBuilderTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/ConfigMetadataTest.php
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Tests\\\\Unit\\\\Entity\\\\CommonRepositoryTest\\:\\:callBuildWhereClauseFromArray\\(\\) has no return type specified\\.$#"
@@ -11534,19 +10911,9 @@ parameters:
 			path: app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
 
 		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\Chart\\\\ChartQuery\\:\\:completeTimeData\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
-
-		-
 			message: "#^Property Mautic\\\\CoreBundle\\\\Tests\\\\Unit\\\\Helper\\\\Chart\\\\DateRangeUnitTraitTest\\:\\:\\$trait has invalid type Mautic\\\\CoreBundle\\\\Helper\\\\Chart\\\\DateRangeUnitTrait\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Tests/Unit/Helper/Chart/DateRangeUnitTraitTest.php
-
-		-
-			message: "#^Method Mautic\\\\CoreBundle\\\\Helper\\\\ColorHelper\\:\\:toRgba\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Tests/Unit/Helper/ColorHelperTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with array\\<int, array\\<int, array\\<int, string\\>\\|string\\>\\> and array\\<string\\> will always evaluate to false\\.$#"
@@ -11745,16 +11112,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\CoreBundle\\\\Update\\\\StepProvider\\:\\:orderSteps\\(\\) has parameter \\$steps with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Update/StepProvider.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Update\\\\StepProvider\\:\\:\\$finalSteps has no type specified\\.$#"
-			count: 1
-			path: app/bundles/CoreBundle/Update/StepProvider.php
-
-		-
-			message: "#^Property Mautic\\\\CoreBundle\\\\Update\\\\StepProvider\\:\\:\\$initialSteps has no type specified\\.$#"
 			count: 1
 			path: app/bundles/CoreBundle/Update/StepProvider.php
 
@@ -11989,11 +11346,6 @@ parameters:
 			path: app/bundles/DashboardBundle/Event/WidgetFormEvent.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$form$#"
-			count: 1
-			path: app/bundles/DashboardBundle/Event/WidgetFormEvent.php
-
-		-
 			message: "#^Property Mautic\\\\DashboardBundle\\\\Event\\\\WidgetFormEvent\\:\\:\\$form has no type specified\\.$#"
 			count: 1
 			path: app/bundles/DashboardBundle/Event/WidgetFormEvent.php
@@ -12044,21 +11396,6 @@ parameters:
 			path: app/bundles/DashboardBundle/EventListener/DashboardSubscriber.php
 
 		-
-			message: "#^Call to method dispatch\\(\\) on an unknown class Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\.$#"
-			count: 2
-			path: app/bundles/DashboardBundle/Form/Type/WidgetType.php
-
-		-
-			message: "#^Property Mautic\\\\DashboardBundle\\\\Form\\\\Type\\\\WidgetType\\:\\:\\$dispatcher \\(Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\) does not accept Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface\\.$#"
-			count: 1
-			path: app/bundles/DashboardBundle/Form/Type/WidgetType.php
-
-		-
-			message: "#^Property Mautic\\\\DashboardBundle\\\\Form\\\\Type\\\\WidgetType\\:\\:\\$dispatcher has unknown class Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher as its type\\.$#"
-			count: 1
-			path: app/bundles/DashboardBundle/Form/Type/WidgetType.php
-
-		-
 			message: """
 				#^Fetching class constant ADAPTOR_FILESYSTEM of deprecated class Mautic\\\\CoreBundle\\\\Helper\\\\CacheStorageHelper\\:
 				This helper is deprecated in favor of CacheBundle$#
@@ -12076,11 +11413,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\DashboardBundle\\\\Model\\\\DashboardModel\\:\\:createForm\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DashboardBundle/Model/DashboardModel.php
-
-		-
-			message: "#^Method Mautic\\\\DashboardBundle\\\\Model\\\\DashboardModel\\:\\:createForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\<mixed\\>\\.$#"
 			count: 1
 			path: app/bundles/DashboardBundle/Model/DashboardModel.php
 
@@ -12477,11 +11809,6 @@ parameters:
 			path: app/bundles/DynamicContentBundle/Entity/DynamicContentRepository.php
 
 		-
-			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\DynamicContentRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Entity/DynamicContentRepository.php
-
-		-
 			message: "#^Method Mautic\\\\DynamicContentBundle\\\\Entity\\\\DynamicContentRepository\\:\\:upSentCount\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Entity/DynamicContentRepository.php
@@ -12655,11 +11982,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\DynamicContentBundle\\\\Form\\\\Type\\\\DynamicContentType\\:\\:\\$fieldChoices has no type specified\\.$#"
-			count: 1
-			path: app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
-
-		-
-			message: "#^Property Mautic\\\\DynamicContentBundle\\\\Form\\\\Type\\\\DynamicContentType\\:\\:\\$tagChoices has no type specified\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
 
@@ -12859,14 +12181,6 @@ parameters:
 			path: app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
 
 		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
-
-		-
 			message: "#^Property Mautic\\\\DynamicContentBundle\\\\Tests\\\\EventListener\\\\DynamicContentSubscriberTest\\:\\:\\$leadModel is never read, only written\\.$#"
 			count: 1
 			path: app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -12903,11 +12217,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\AjaxController\\:\\:getBuilderTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Controller/AjaxController.php
-
-		-
-			message: "#^Parameter \\#1 \\$form of method Mautic\\\\CoreBundle\\\\Controller\\\\CommonController\\:\\:setFormTheme\\(\\) expects Symfony\\\\Component\\\\Form\\\\FormInterface\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>, Symfony\\\\Component\\\\Form\\\\FormInterface\\<array\\{\\}\\> given\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/AjaxController.php
 
@@ -12958,11 +12267,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Controller\\\\Api\\\\EmailApiController\\:\\:checkLeadAccess\\(\\) has parameter \\$leadId with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Controller/Api/EmailApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
 			count: 1
 			path: app/bundles/EmailBundle/Controller/Api/EmailApiController.php
 
@@ -13745,11 +13049,6 @@ parameters:
 			path: app/bundles/EmailBundle/Entity/EmailRepository.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Entity/EmailRepository.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Entity\\\\EmailRepository\\:\\:getSentReadCount\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -13855,14 +13154,6 @@ parameters:
 		-
 			message: "#^Call to method setMaxResults\\(\\) on an unknown class Mautic\\\\EmailBundle\\\\Entity\\\\QueryBuilder\\.$#"
 			count: 1
-			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 4
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
 
 		-
@@ -14034,11 +13325,6 @@ parameters:
 			message: "#^Parameter \\$query of method Mautic\\\\EmailBundle\\\\Entity\\\\StatRepository\\:\\:getMostEmails\\(\\) has invalid type Mautic\\\\EmailBundle\\\\Entity\\\\QueryBuilder\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Entity/StatRepository.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$email$#"
-			count: 1
-			path: app/bundles/EmailBundle/Event/EmailOpenEvent.php
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Event\\\\EmailSendEvent\\:\\:__construct\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
@@ -14353,14 +13639,6 @@ parameters:
 			path: app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/ReportSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\EventListener\\\\ReportSubscriber\\:\\:isJoined\\(\\) has parameter \\$alias with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -14456,32 +13734,12 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/EmailValidator.php
 
 		-
-			message: "#^Call to method dispatch\\(\\) on an unknown class Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 2
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:__construct\\(\\) has parameter \\$from with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:addBcc\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:addCc\\(\\) has parameter \\$name with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
@@ -14591,11 +13849,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:getSystemHeaders\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:getTrackableLink\\(\\) has parameter \\$url with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
@@ -14686,16 +13939,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:setDefaultFrom\\(\\) has parameter \\$systemFrom with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:setDefaultReplyTo\\(\\) has parameter \\$systemFromEmail with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:setDefaultReplyTo\\(\\) has parameter \\$systemReplyToEmail with no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
@@ -14776,11 +14019,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: "#^Offset 'owner_id' on array in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: "#^Parameter \\#3 \\$code of method Mautic\\\\AssetBundle\\\\Model\\\\AssetModel\\:\\:trackDownload\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
@@ -14814,17 +14052,7 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$contentHash \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$copies type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$dispatcher \\(null\\) does not accept Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
@@ -14885,16 +14113,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$source type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$systemFrom has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Helper\\\\MailHelper\\:\\:\\$transport has no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
@@ -15032,14 +14250,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/PointEventHelper.php
 
 		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/EmailBundle/Helper/StatsCollectionHelper.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Helper\\\\StatsCollectionHelper\\:\\:addCampaignFilter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Helper/StatsCollectionHelper.php
@@ -15092,14 +14302,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Mautic\\\\CoreBundle\\\\Entity\\\\VariantEntityInterface\\:\\:isPublished\\(\\)\\.$#"
 			count: 1
-			path: app/bundles/EmailBundle/Model/EmailModel.php
-
-		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
-			count: 2
 			path: app/bundles/EmailBundle/Model/EmailModel.php
 
 		-
@@ -16036,11 +15238,6 @@ parameters:
 			path: app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
 
 		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\MonitoredEmail\\\\Mailbox\\:\\:\\$folders has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
-
-		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\MonitoredEmail\\\\Mailbox\\:\\:\\$imapFolder has no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -16261,11 +15458,6 @@ parameters:
 			path: app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BouncedEmail.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$originalTo$#"
-			count: 1
-			path: app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BouncedEmail.php
-
-		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\MonitoredEmail\\\\Processor\\\\Bounce\\\\BouncedEmail\\:\\:\\$final \\(int\\) does not accept bool\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BouncedEmail.php
@@ -16436,22 +15628,6 @@ parameters:
 			path: app/bundles/EmailBundle/Stats/FetchOptions/EmailStatOptions.php
 
 		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Stats\\\\Helper\\\\AbstractHelper\\:\\:addCampaignFilter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
@@ -16508,11 +15684,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Stats\\\\StatHelperContainer\\:\\:getHelper\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Stats/StatHelperContainer.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Stats\\\\StatHelperContainer\\:\\:\\$helpers has no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Stats/StatHelperContainer.php
 
@@ -16635,11 +15806,6 @@ parameters:
 				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
 			"""
-			count: 2
-			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\MailHelperTest\\:\\:\\$contacts type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
 
@@ -16667,32 +15833,7 @@ parameters:
 			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
 
 		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:getFromAddresses\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
 			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:getMetadata\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:getMetadatas\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:\\$fromAddresses has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:\\$message has no type specified\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:\\$metadatas has no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
 
@@ -16703,11 +15844,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:\\$numberToFail is never read, only written\\.$#"
-			count: 1
-			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
-
-		-
-			message: "#^Property Mautic\\\\EmailBundle\\\\Tests\\\\Helper\\\\Transport\\\\BcInterfaceTokenTransport\\:\\:\\$validate has no type specified\\.$#"
 			count: 1
 			path: app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
 
@@ -16781,11 +15917,6 @@ parameters:
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\) with int will always evaluate to false\\.$#"
 			count: 2
 			path: app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
-
-		-
-			message: "#^Method Mautic\\\\EmailBundle\\\\MonitoredEmail\\\\Processor\\\\Bounce\\\\Parser\\:\\:parse\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 2
-			path: app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/ParserTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$emailsInString of method Mautic\\\\EmailBundle\\\\Validator\\\\MultipleEmailsValidValidator\\:\\:validate\\(\\) expects string, null given\\.$#"
@@ -16878,11 +16009,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Controller\\\\Api\\\\SubmissionApiController\\:\\:getEntityAction\\(\\) has parameter \\$submissionId with no type specified\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$id$#"
 			count: 1
 			path: app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
 
@@ -17294,16 +16420,6 @@ parameters:
 			path: app/bundles/FormBundle/Entity/FormRepository.php
 
 		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\FormRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/FormRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\FormBundle\\\\Entity\\\\FormRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/FormRepository.php
-
-		-
 			message: """
 				#^Call to deprecated method addLead\\(\\) of class Mautic\\\\CoreBundle\\\\Doctrine\\\\Mapping\\\\ClassMetadataBuilder\\:
 				Use addContact instead; existing implementations will need a migration to rename lead_id to contact_id$#
@@ -17367,11 +16483,6 @@ parameters:
 			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
 
 		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getSubmissionCountsByPage\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getSubmissionCountsByPage\\(\\) has parameter \\$pageId with no type specified\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -17418,11 +16529,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$value of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:set\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\FormBundle\\\\Entity\\\\SubmissionRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Entity/SubmissionRepository.php
 
@@ -17617,16 +16723,6 @@ parameters:
 			path: app/bundles/FormBundle/Event/SubmissionEvent.php
 
 		-
-			message: "#^Property Mautic\\\\FormBundle\\\\Event\\\\SubmissionEvent\\:\\:\\$contactFieldMatches type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Event/SubmissionEvent.php
-
-		-
-			message: "#^Property Mautic\\\\FormBundle\\\\Event\\\\SubmissionEvent\\:\\:\\$feedback type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Event/SubmissionEvent.php
-
-		-
 			message: "#^Property Mautic\\\\FormBundle\\\\Event\\\\SubmissionEvent\\:\\:\\$fields type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Event/SubmissionEvent.php
@@ -17647,22 +16743,7 @@ parameters:
 			path: app/bundles/FormBundle/Event/SubmissionEvent.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Event/SubmissionEvent.php
-
-		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Event\\\\ValidationEvent\\:\\:failedValidation\\(\\) has parameter \\$reason with no type specified\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Event/ValidationEvent.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$form$#"
-			count: 1
-			path: app/bundles/FormBundle/Event/ValidationEvent.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$isNew$#"
 			count: 1
 			path: app/bundles/FormBundle/Event/ValidationEvent.php
 
@@ -17773,32 +16854,12 @@ parameters:
 			path: app/bundles/FormBundle/EventListener/FormSubscriber.php
 
 		-
-			message: "#^Property Mautic\\\\FormBundle\\\\EventListener\\\\PageSubscriber\\:\\:\\$formRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/EventListener/PageSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Exception\\\\ValidationException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Exception/ValidationException.php
 
 		-
 			message: "#^Method Mautic\\\\FormBundle\\\\Exception\\\\ValidationException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Exception/ValidationException.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Exception\\\\ValidationException\\:\\:getViolations\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Exception/ValidationException.php
-
-		-
-			message: "#^Method Mautic\\\\FormBundle\\\\Exception\\\\ValidationException\\:\\:setViolations\\(\\) has parameter \\$violations with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Exception/ValidationException.php
-
-		-
-			message: "#^Property Mautic\\\\FormBundle\\\\Exception\\\\ValidationException\\:\\:\\$violations has no type specified\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Exception/ValidationException.php
 
@@ -18347,22 +17408,6 @@ parameters:
 			path: app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
 
 		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
-
-		-
 			message: "#^You should use assertCount\\(\\$expectedCount, \\$variable\\) instead of assertSame\\(\\$expectedCount, \\$variable\\-\\>count\\(\\)\\)\\.$#"
 			count: 8
 			path: app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -18394,14 +17439,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
-
-		-
-			message: """
 				#^Instantiation of deprecated class Mautic\\\\CampaignBundle\\\\Event\\\\CampaignExecutionEvent\\:
 				2\\.13\\.0; to be removed in 3\\.0$#
 			"""
@@ -18412,11 +17449,6 @@ parameters:
 			message: "#^Method Mautic\\\\FormBundle\\\\Tests\\\\Controller\\\\CampaignSubscriberFunctionalTest\\:\\:valueProvider\\(\\) return type has no value type specified in iterable type iterable\\.$#"
 			count: 1
 			path: app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
-
-		-
-			message: "#^Offset 'data' on array\\{\\} in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: app/bundles/FormBundle/Tests/Form/Type/FormFieldConditionTypeTest.php
 
 		-
 			message: "#^Property Mautic\\\\FormBundle\\\\Tests\\\\FormTestAbstract\\:\\:\\$formRepository has no type specified\\.$#"
@@ -18705,38 +17737,6 @@ parameters:
 			path: app/bundles/InstallBundle/Exception/AlreadyInstalledException.php
 
 		-
-			message: """
-				#^Access to deprecated property \\$newName of class Doctrine\\\\DBAL\\\\Schema\\\\TableDiff\\:
-				Rename tables via \\{@link AbstractSchemaManager\\:\\:renameTable\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getDatabasePlatform\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link Connection\\:\\:getDatabasePlatform\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getName\\(\\) of class Doctrine\\\\DBAL\\\\Platforms\\\\AbstractPlatform\\:
-				Identify platforms by their class\\.$#
-			"""
-			count: 1
-			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 3
-			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
-
-		-
 			message: "#^Method Mautic\\\\InstallBundle\\\\Helper\\\\SchemaHelper\\:\\:__construct\\(\\) has parameter \\$dbParams with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -18905,33 +17905,7 @@ parameters:
 			path: app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
 
 		-
-			message: """
-				#^Call to deprecated method getDatabasePlatform\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link Connection\\:\\:getDatabasePlatform\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 6
-			path: app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
-
-		-
 			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getApiKey\\(\\)\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getKeyName\\(\\)\\.$#"
-			count: 4
-			path: app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\ApiKey\\\\HttpFactory\\:\\:\\$credentials \\(Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\ApiKey\\\\Credentials\\\\HeaderCredentialsInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\ApiKey\\\\Credentials\\\\ParameterCredentialsInterface\\) does not accept Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
 
@@ -18981,47 +17955,12 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/AbstractClientFactory.php
 
 		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getClientId\\(\\)\\.$#"
-			count: 5
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\HttpFactory\\:\\:getReAuthConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
 			message: "#^Parameter \\#1 \\$credentials of method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\HttpFactory\\:\\:credentialsAreConfigured\\(\\) expects Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\Credentials\\\\CredentialsInterface, Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface given\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\HttpFactory\\:\\:\\$config \\(Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigCredentialsSignerInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigTokenFactoryInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigTokenPersistenceInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigTokenSignerInterface\\) does not accept Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthConfigInterface\\|null\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\HttpFactory\\:\\:\\$credentials \\(Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\Credentials\\\\CredentialsInterface\\) does not accept Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2ThreeLegged\\\\HttpFactory\\:\\:\\$reAuthClient is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2ThreeLegged/HttpFactory.php
 
@@ -19032,16 +17971,11 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getClientId\\(\\)\\.$#"
-			count: 5
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getClientSecret\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: "#^Call to an undefined method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\:\\:getClientSecret\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
 
@@ -19052,31 +17986,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\HttpFactory\\:\\:getReAuthConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\HttpFactory\\:\\:\\$config \\(Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigCredentialsSignerInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigTokenPersistenceInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Support\\\\Oauth2\\\\ConfigAccess\\\\ConfigTokenSignerInterface\\) does not accept Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthConfigInterface\\|null\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\HttpFactory\\:\\:\\$credentials \\(Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\Credentials\\\\ClientCredentialsGrantInterface\\|Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\Credentials\\\\PasswordCredentialsGrantInterface\\) does not accept Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\AuthCredentialsInterface\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Auth\\\\Provider\\\\Oauth2TwoLegged\\\\HttpFactory\\:\\:\\$reAuthClient is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
 
@@ -19131,11 +18040,6 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Controller/ConfigController.php
 
 		-
-			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Controller\\\\ConfigController\\:\\:getForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\FormInterface\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\> but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\<Mautic\\\\PluginBundle\\\\Entity\\\\Integration\\>\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Controller/ConfigController.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Controller\\\\FieldPaginationController\\:\\:getFields\\(\\) has parameter \\$featureSettings with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
@@ -19144,14 +18048,6 @@ parameters:
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Controller\\\\FieldPaginationController\\:\\:getFields\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
 
 		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Entity\\\\FieldChangeRepository\\:\\:deleteEntitiesForObjectByColumnName\\(\\) has parameter \\$columnNames with no value type specified in iterable type array\\.$#"
@@ -19197,14 +18093,6 @@ parameters:
 			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Entity\\\\ObjectMapping\\:\\:\\$internalStorage type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
 
 		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Entity\\\\ObjectMappingRepository\\:\\:getIntegrationObject\\(\\) has parameter \\$integration with no type specified\\.$#"
@@ -19592,22 +18480,6 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Integration/Interfaces/ConfigFormSyncInterface.php
 
 		-
-			message: """
-				#^Call to deprecated method createSchema\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link introspectSchema\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Migration/AbstractMigration.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Migration/AbstractMigration.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Sync\\\\DAO\\\\DateRange\\:\\:getFromDate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Sync/DAO/DateRange.php
@@ -19779,11 +18651,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Sync\\\\DAO\\\\Sync\\\\Order\\\\OrderDAO\\:\\:getSyncDateTime\\(\\) should return DateTime but returns DateTimeInterface\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
-
-		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Sync\\\\DAO\\\\Sync\\\\Order\\\\OrderDAO\\:\\:\\$objectMappings type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
 
@@ -20017,14 +18884,6 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ObjectHelper\\\\CompanyObjectHelper\\:\\:findObjectsBetweenDates\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -20068,14 +18927,6 @@ parameters:
 			message: """
 				#^Call to deprecated method getFieldList\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
 				Use FieldList\\:\\:getFieldList method instead$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
 			"""
 			count: 1
 			path: app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -20256,11 +19107,6 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Sync/VariableExpresser/VariableExpresserHelper.php
 
 		-
-			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Tests\\\\Functional\\\\Entity\\\\ObjectMappingRepositoryTest\\:\\:\\$repository \\(Mautic\\\\IntegrationsBundle\\\\Entity\\\\ObjectMappingRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\.$#"
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
-
-		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/SyncServiceTest.php
@@ -20304,14 +19150,6 @@ parameters:
 			message: "#^Property Mautic\\\\IntegrationsBundle\\\\Tests\\\\Functional\\\\Services\\\\SyncService\\\\TestExamples\\\\Sync\\\\SyncDataExchange\\\\ExampleSyncDataExchange\\:\\:\\$payload type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/TestExamples/Sync/SyncDataExchange/ExampleSyncDataExchange.php
-
-		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/NotifierTest.php
 
 		-
 			message: """
@@ -20510,35 +19348,14 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
-
-		-
 			message: "#^Method Mautic\\\\IntegrationsBundle\\\\Tests\\\\Unit\\\\Sync\\\\SyncDataExchange\\\\Internal\\\\ReportBuilder\\\\FieldBuilderTest\\:\\:getFieldBuilder\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Command\\\\ImportCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Command/ImportCommand.php
-
-		-
-			message: "#^Cannot call method next\\(\\) on array\\|Doctrine\\\\ORM\\\\Tools\\\\Pagination\\\\Paginator\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Command\\\\UpdateLeadListsCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
@@ -20651,11 +19468,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -20715,11 +19527,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\Api\\\\DeviceApiController\\:\\:preSaveEntity\\(\\) has parameter \\$parameters with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/Api/DeviceApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/Api/DeviceApiController.php
 
@@ -20836,11 +19643,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\Api\\\\LeadApiController\\:\\:getAuditlogs\\(\\) has parameter \\$orderBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\Api\\\\LeadApiController\\:\\:getAuditlogs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
 
@@ -21093,11 +19895,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/Api/ListApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/Api/ListApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -21162,11 +19959,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\Api\\\\NoteApiController\\:\\:preSaveEntity\\(\\) has parameter \\$parameters with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/Api/NoteApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/Api/NoteApiController.php
 
@@ -21287,11 +20079,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/AuditlogController.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\AuditlogController\\:\\:getAuditlogs\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/AuditlogController.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\AuditlogController\\:\\:getCompanyEngagementData\\(\\) has parameter \\$contacts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/AuditlogController.php
@@ -21353,11 +20140,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\AuditlogController\\:\\:sanitizeEventFilter\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/AuditlogController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/AuditlogController.php
 
@@ -21459,11 +20241,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\CompanyController\\:\\:getAuditlogs\\(\\) has parameter \\$orderBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/CompanyController.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\CompanyController\\:\\:getAuditlogs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/CompanyController.php
 
@@ -21615,11 +20392,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/ImportController.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\ImportController\\:\\:cancelAction\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/ImportController.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\ImportController\\:\\:generateUrl\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/ImportController.php
@@ -21651,11 +20423,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\ImportController\\:\\:indexAction\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse\\|Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/ImportController.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\ImportController\\:\\:queueAction\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/ImportController.php
 
@@ -21800,11 +20567,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\LeadController\\:\\:getAuditlogs\\(\\) has parameter \\$orderBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/LeadController.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\LeadController\\:\\:getAuditlogs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/LeadController.php
 
@@ -22198,11 +20960,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/NoteController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/NoteController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/NoteController.php
@@ -22299,11 +21056,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\TimelineController\\:\\:getAuditlogs\\(\\) has parameter \\$orderBy with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/TimelineController.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Controller\\\\TimelineController\\:\\:getAuditlogs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/TimelineController.php
 
@@ -22408,11 +21160,6 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/TimelineController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/LeadBundle/Controller/TimelineController.php
-
-		-
 			message: "#^PHPDoc tag @throws with type Mautic\\\\LeadBundle\\\\Controller\\\\InvalidArgumentException is not subtype of Throwable$#"
 			count: 1
 			path: app/bundles/LeadBundle/Controller/TimelineController.php
@@ -22435,11 +21182,6 @@ parameters:
 				#^Call to deprecated method getUniqueIdentifierFields\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
 				Use FieldsWithUniqueIdentifier\\:\\:getFieldsWithUniqueIdentifier method instead$#
 			"""
-			count: 1
-			path: app/bundles/LeadBundle/Deduplicate/CompanyDeduper.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Deduplicate\\\\CompanyDeduper\\:\\:checkForDuplicateCompanies\\(\\) has invalid return type Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Deduplicate/CompanyDeduper.php
 
@@ -22523,14 +21265,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Deduplicate\\\\Helper\\\\MergeValueHelper\\:\\:isNotEmpty\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaDefinition\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
-				Use SchemaDefinition\\:\\:getSchemaDefinition method instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Company.php
 
 		-
 			message: "#^Cannot cast Mautic\\\\UserBundle\\\\Entity\\\\User to int\\.$#"
@@ -22749,11 +21483,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyLeadRepository\\:\\:getCompanyLeadEntity\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyLeadRepository\\:\\:getCompanyLeadEntity\\(\\) has parameter \\$companyId with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -22795,14 +21524,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:execute\\(\\)\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
-
-		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
 			count: 1
 			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
 
@@ -22887,11 +21608,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyRepository\\:\\:getCompaniesByUniqueFields\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyRepository\\:\\:getCompaniesByUniqueFields\\(\\) has parameter \\$uniqueFieldsWithData with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -22963,11 +21679,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyRepository\\:\\:getMostCompanies\\(\\) has parameter \\$query with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\CompanyRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/CompanyRepository.php
 
@@ -23146,14 +21857,6 @@ parameters:
 			message: "#^Property Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContact\\:\\:\\$channelId has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/DoNotContact.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Entity/DoNotContactRepository.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\DoNotContactRepository\\:\\:getChannelList\\(\\) has parameter \\$channel with no type specified\\.$#"
@@ -23377,14 +22080,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\ImportRepository\\:\\:getQueryForStatuses\\(\\) has parameter \\$statuses with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/ImportRepository.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaDefinition\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
-				Use SchemaDefinition\\:\\:getSchemaDefinition method instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/Lead.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:__call\\(\\) has parameter \\$arguments with no type specified\\.$#"
@@ -23823,14 +22518,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadEventLog.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadEventLogRepository\\:\\:getEvents\\(\\) has parameter \\$actions with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -23894,14 +22581,6 @@ parameters:
 			message: "#^Property Mautic\\\\LeadBundle\\\\Entity\\\\LeadField\\:\\:\\$properties type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadField.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadFieldRepository.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadFieldRepository\\:\\:addCatchAllWhereClause\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -23979,35 +22658,6 @@ parameters:
 				#^Call to deprecated method normalizeType\\(\\) of class Mautic\\\\LeadBundle\\\\Entity\\\\LeadListRepository\\:
 				These aliases are subscribed in the TypeOperatorSubscriber now so this is not necessary\\. To be removed in next Mautic version\\.$#
 			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
-
-		-
-			message: """
-				#^Call to deprecated method orX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `or\\(\\)` instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
-
-		-
-			message: "#^Method Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
 
@@ -24137,11 +22787,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadListRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadListRepository\\:\\:prepareRegex\\(\\) has parameter \\$regex with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -24205,11 +22850,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadNoteRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadNoteRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadNoteRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadNoteRepository\\:\\:updateLead\\(\\) has parameter \\$fromLeadId with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadNoteRepository.php
@@ -24223,14 +22863,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$value of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:set\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadNoteRepository.php
-
-		-
-			message: """
-				#^Call to deprecated method andX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `and\\(\\)` instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
 
 		-
 			message: """
@@ -24249,14 +22881,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadRepository.php
 
 		-
-			message: """
-				#^Call to deprecated method orX\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:
-				Use `or\\(\\)` instead\\.$#
-			"""
-			count: 4
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
 			message: "#^Call to function is_array\\(\\) with Mautic\\\\LeadBundle\\\\Entity\\\\Lead will always evaluate to false\\.$#"
 			count: 2
 			path: app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -24267,39 +22891,8 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/LeadRepository.php
 
 		-
-			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_INT_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:INTEGER\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
-			message: "#^Method Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:andX\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
-			message: "#^Method Doctrine\\\\DBAL\\\\Query\\\\Expression\\\\ExpressionBuilder\\:\\:orX\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
-			count: 4
 			path: app/bundles/LeadBundle/Entity/LeadRepository.php
 
 		-
@@ -24524,11 +23117,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadRepository\\:\\:getNextIdentifiedContact\\(\\) has parameter \\$lastId with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Entity/LeadRepository.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\LeadRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/LeadRepository.php
 
@@ -24762,14 +23350,6 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Entity/TagRepository.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Entity\\\\TagRepository\\:\\:checkLeadByTags\\(\\) has parameter \\$tags with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Entity/TagRepository.php
@@ -24846,22 +23426,7 @@ parameters:
 			path: app/bundles/LeadBundle/Entity/UtmTagRepository.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\CategoryChangeEvent\\:\\:__construct\\(\\) has parameter \\$leads with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/CategoryChangeEvent.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\CategoryChangeEvent\\:\\:getLeads\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/CategoryChangeEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\CategoryChangeEvent\\:\\:\\$lead has no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/CategoryChangeEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\CategoryChangeEvent\\:\\:\\$leads has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Event/CategoryChangeEvent.php
 
@@ -24936,27 +23501,7 @@ parameters:
 			path: app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\LeadChangeCompanyEvent\\:\\:__construct\\(\\) has parameter \\$added with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\LeadChangeCompanyEvent\\:\\:__construct\\(\\) has parameter \\$leads with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\LeadChangeCompanyEvent\\:\\:getLeads\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\LeadChangeCompanyEvent\\:\\:\\$lead has no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\LeadChangeCompanyEvent\\:\\:\\$leads has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
 
@@ -25141,22 +23686,7 @@ parameters:
 			path: app/bundles/LeadBundle/Event/LeadTimelineEvent.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\ListChangeEvent\\:\\:__construct\\(\\) has parameter \\$leads with no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/ListChangeEvent.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Event\\\\ListChangeEvent\\:\\:getLeads\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/ListChangeEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\ListChangeEvent\\:\\:\\$lead has no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Event/ListChangeEvent.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Event\\\\ListChangeEvent\\:\\:\\$leads has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Event/ListChangeEvent.php
 
@@ -25387,14 +23917,6 @@ parameters:
 			path: app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
 
 		-
-			message: """
-				#^Call to deprecated method getSchemaDefinition\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
-				Use SchemaDefinition\\:\\:getSchemaDefinition method instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
-
-		-
 			message: "#^Parameter \\#4 \\$skipIfExists of method Mautic\\\\LeadBundle\\\\Model\\\\CompanyModel\\:\\:import\\(\\) expects bool, string\\|null given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
@@ -25594,16 +24116,6 @@ parameters:
 
 		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\EventListener\\\\ReportSubscriber\\:\\:\\$channels type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/ReportSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\EventListener\\\\ReportSubscriber\\:\\:\\$companyContexts has no type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/ReportSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\EventListener\\\\ReportSubscriber\\:\\:\\$leadContexts has no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/EventListener/ReportSubscriber.php
 
@@ -25924,26 +24436,6 @@ parameters:
 			path: app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
 
 		-
-			message: "#^Cannot call method getOrder\\(\\) on int\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\DataTransformer\\\\FieldToOrderTransformer\\:\\:reverseTransform\\(\\) should return Mautic\\\\LeadBundle\\\\Entity\\\\LeadField\\|null but returns int\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Form\\\\DataTransformer\\\\FieldToOrderTransformer\\:\\:transform\\(\\) should return string but returns null\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and int will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<object\\>\\:\\:getEntities\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
@@ -26000,11 +24492,6 @@ parameters:
 
 		-
 			message: "#^Offset 'properties' on array on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/FilterType.php
-
-		-
-			message: "#^Parameter \\#1 \\$modelData of method Symfony\\\\Component\\\\Form\\\\FormInterface\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>\\:\\:setData\\(\\) expects Symfony\\\\Component\\\\Form\\\\FormInterface, array\\<string, mixed\\> given\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Form/Type/FilterType.php
 
@@ -26423,57 +24910,12 @@ parameters:
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
 
 		-
-			message: "#^Call to method addUpdatedField\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method getProfileFields\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method isNew\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method setCreatedBy\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method setDateAdded\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method setDateModified\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method setModifiedBy\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Call to method setOwner\\(\\) on an unknown class Mautic\\\\LeadBundle\\\\Deduplicate\\\\Company\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\CompanyModel\\:\\:addLeadToCompany\\(\\) has parameter \\$companies with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\CompanyModel\\:\\:addLeadToCompany\\(\\) has parameter \\$lead with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/CompanyModel.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\CompanyModel\\:\\:checkForDuplicateCompanies\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/CompanyModel.php
 
@@ -26723,11 +25165,6 @@ parameters:
 			path: app/bundles/LeadBundle/Model/FieldModel.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:\\:getFieldList\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/FieldModel.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:\\:getFieldListWithProperties\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/FieldModel.php
@@ -26930,14 +25367,6 @@ parameters:
 				2\\.12\\.0 to be removed in 3\\.0; use Mautic\\\\LeadBundle\\\\Model\\\\DoNotContact instead$#
 			"""
 			count: 2
-			path: app/bundles/LeadBundle/Model/LeadModel.php
-
-		-
-			message: """
-				#^Call to deprecated method loadUserByUsername\\(\\) of class Mautic\\\\UserBundle\\\\Security\\\\Provider\\\\UserProvider\\:
-				since Symfony 5\\.3, use loadUserByIdentifier\\(\\) instead$#
-			"""
-			count: 1
 			path: app/bundles/LeadBundle/Model/LeadModel.php
 
 		-
@@ -27180,11 +25609,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\LeadModel\\:\\:getPreferredChannel\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Model/LeadModel.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Model\\\\LeadModel\\:\\:getTagList\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Model/LeadModel.php
 
@@ -28105,19 +26529,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/Filter/SegmentReferenceFilterQueryBuilder.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\Expression\\\\ExpressionBuilder will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:addJoinCondition\\(\\) has parameter \\$alias with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -28198,17 +26609,7 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
 		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$_expr is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Segment\\\\Query\\\\QueryBuilder\\:\\:\\$logicStack type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
 
@@ -28336,14 +26737,6 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Stat/SegmentDependencies.php
 
 		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Segment\\\\TableSchemaColumnsCache\\:\\:getColumns\\(\\) has parameter \\$tableName with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
@@ -28375,30 +26768,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Services\\\\ContactColumnsDictionary\\:\\:getFields\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Services/ContactColumnsDictionary.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 3
-			path: app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Command/DeduplicateIdsCommandFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with '1' and array\\|int will always evaluate to false\\.$#"
@@ -28492,22 +26861,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\Controller\\\\ListControllerFunctionalTest\\:\\:saveSegment\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -28531,14 +26884,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\DataFixtures\\\\ORM\\\\LoadSegmentsData\\:\\:createSegment\\(\\) has parameter \\$listConfig with no type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
 
 		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Tests\\\\Deduplicate\\\\ContactMergerTest\\:\\:\\$leadRepo \\(Mautic\\\\LeadBundle\\\\Entity\\\\MergeRecordRepository&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept Mautic\\\\LeadBundle\\\\Entity\\\\LeadRepository&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
@@ -28581,18 +26926,13 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
 
 		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Tests\\\\Entity\\\\FrequencyRuleRepositoryTest\\:\\:\\$frequencyRuleRepository \\(Mautic\\\\LeadBundle\\\\Entity\\\\FrequencyRuleRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with DateTimeInterface will always evaluate to false\\.$#"
 			count: 2
 			path: app/bundles/LeadBundle/Tests/Entity/ImportTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\) with 0 and float will always evaluate to false\\.$#"
-			count: 3
+			count: 2
 			path: app/bundles/LeadBundle/Tests/Entity/ImportTest.php
 
 		-
@@ -28614,14 +26954,6 @@ parameters:
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\Entity\\\\ImportTest\\:\\:fakeImportStartDate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Entity/ImportTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$field of method Mautic\\\\LeadBundle\\\\Entity\\\\LeadFieldRepository\\:\\:compareDateValue\\(\\) expects int, string given\\.$#"
@@ -28679,19 +27011,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/Entity/LeadListTest.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Mautic\\\\LeadBundle\\\\Entity\\\\LeadRepository\\:\\:getLeadsByFieldValue\\(\\) expects string, array\\<int, string\\> given\\.$#"
-			count: 2
-			path: app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
-
-		-
 			message: "#^Call to an undefined method Mautic\\\\LeadBundle\\\\Entity\\\\Lead\\:\\:getTest\\(\\)\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -28735,14 +27054,6 @@ parameters:
 			message: "#^Parameter \\#4 \\$operator of method Mautic\\\\LeadBundle\\\\Tests\\\\Entity\\\\LeadTest\\:\\:adjustPointsTest\\(\\) expects bool, string given\\.$#"
 			count: 6
 			path: app/bundles/LeadBundle/Tests/Entity/LeadTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Entity/TagRepositoryTest.php
 
 		-
 			message: """
@@ -28801,21 +27112,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
 
 		-
-			message: "#^Call to method expects\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^Call to method getModel\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 7
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^Call to method method\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 4
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
 			message: """
 				#^Fetching class constant class of deprecated class Mautic\\\\CoreBundle\\\\Factory\\\\MauticFactory\\:
 				2\\.0 to be removed in 3\\.0$#
@@ -28824,37 +27120,7 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
 
 		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\OwnerSubscriberTest\\:\\:getMockFactory\\(\\) has invalid return type PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\OwnerSubscriberTest\\:\\:getMockFactory\\(\\) has parameter \\$parameterMap with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\OwnerSubscriberTest\\:\\:getMockMailer\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\OwnerSubscriberTest\\:\\:getMockMailer\\(\\) has parameter \\$lead with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\OwnerSubscriberTest\\:\\:getMockTranslator\\(\\) has invalid return type PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$mockFactory contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$translator contains unknown class PHPUnit_Framework_MockObject_MockObject\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
 
@@ -28935,29 +27201,6 @@ parameters:
 			message: "#^Trying to mock an undefined method getData\\(\\) on class Mautic\\\\LeadBundle\\\\Tests\\\\EventListener\\\\ReportDataEventMock\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
-
-		-
-			message: "#^Trying to mock an undefined method isNotNull\\(\\) on class Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
-
-		-
-			message: "#^Trying to mock an undefined method or\\(\\) on class Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Tests\\\\Field\\\\BackgroundServiceTest\\:\\:\\$backgroundService \\(Mautic\\\\LeadBundle\\\\Field\\\\BackgroundService&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept Mautic\\\\LeadBundle\\\\Field\\\\BackgroundService\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
 
 		-
 			message: "#^You should use assertCount\\(\\$expectedCount, \\$variable\\) instead of assertSame\\(\\$expectedCount, \\$variable\\-\\>count\\(\\)\\)\\.$#"
@@ -29074,19 +27317,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
-
-		-
-			message: "#^Property Mautic\\\\LeadBundle\\\\Tests\\\\Model\\\\LeadModelTest\\:\\:\\$channelListHelperMock \\(Mautic\\\\ChannelBundle\\\\Helper\\\\ChannelListHelper&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept Mautic\\\\ChannelBundle\\\\Helper\\\\ChannelListHelper\\.$#"
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
-
-		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\Model\\\\ListModelTest\\:\\:prepareMockForTestGetSourcesLists\\(\\) has parameter \\$getLookupResultsReturn with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -29127,14 +27357,6 @@ parameters:
 			path: app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
-
-		-
 			message: "#^Property Mautic\\\\LeadBundle\\\\Tests\\\\Segment\\\\ContactSegmentFilterTest\\:\\:\\$filterDecorator \\(Mautic\\\\LeadBundle\\\\Segment\\\\Decorator\\\\BaseDecorator&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept Mautic\\\\LeadBundle\\\\Segment\\\\Decorator\\\\FilterDecoratorInterface&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 2
 			path: app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
@@ -29148,14 +27370,6 @@ parameters:
 			message: "#^Trying to mock an undefined method getRelationJoinTableField\\(\\) on class Mautic\\\\LeadBundle\\\\Segment\\\\Decorator\\\\FilterDecoratorInterface\\.$#"
 			count: 1
 			path: app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 5
-			path: app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$filterName of method Mautic\\\\LeadBundle\\\\Tests\\\\Segment\\\\Decorator\\\\Date\\\\DateOptionFactoryTest\\:\\:getFilterDecorator\\(\\) expects string, null given\\.$#"
@@ -29231,22 +27445,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$fromFormat of class Mautic\\\\CoreBundle\\\\Helper\\\\DateTimeHelper constructor expects string, null given\\.$#"
 			count: 2
 			path: app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearThisTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
 
 		-
 			message: "#^Method Mautic\\\\LeadBundle\\\\Tests\\\\StandardImportTestHelper\\:\\:initImportEntity\\(\\) has parameter \\$methods with no value type specified in iterable type array\\.$#"
@@ -29801,11 +27999,6 @@ parameters:
 			path: app/bundles/NotificationBundle/Entity/NotificationRepository.php
 
 		-
-			message: "#^Method Mautic\\\\NotificationBundle\\\\Entity\\\\NotificationRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/NotificationBundle/Entity/NotificationRepository.php
-
-		-
 			message: "#^Method Mautic\\\\NotificationBundle\\\\Entity\\\\NotificationRepository\\:\\:getSentReadCount\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/NotificationBundle/Entity/NotificationRepository.php
@@ -30171,11 +28364,6 @@ parameters:
 			path: app/bundles/PageBundle/Controller/AjaxController.php
 
 		-
-			message: "#^Parameter \\#1 \\$form of method Mautic\\\\CoreBundle\\\\Controller\\\\CommonController\\:\\:setFormTheme\\(\\) expects Symfony\\\\Component\\\\Form\\\\FormInterface\\<Symfony\\\\Component\\\\Form\\\\FormInterface\\>, Symfony\\\\Component\\\\Form\\\\FormInterface\\<array\\{\\}\\> given\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Controller/AjaxController.php
-
-		-
 			message: "#^Parameter \\#2 \\$template of method Mautic\\\\CoreBundle\\\\Controller\\\\CommonController\\:\\:setFormTheme\\(\\) expects string, array given\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Controller/AjaxController.php
@@ -30350,11 +28538,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getBounces\\(\\) has parameter \\$pageIds with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/HitRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\HitRepository\\:\\:getBounces\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/HitRepository.php
 
@@ -30644,11 +28827,6 @@ parameters:
 			path: app/bundles/PageBundle/Entity/Page.php
 
 		-
-			message: "#^Elseif condition is always false\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/PageRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\PageRepository\\:\\:addCatchAllWhereClause\\(\\) has parameter \\$filter with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/PageRepository.php
@@ -30694,11 +28872,6 @@ parameters:
 			path: app/bundles/PageBundle/Entity/PageRepository.php
 
 		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\PageRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/PageRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Entity\\\\PageRepository\\:\\:resetVariants\\(\\) has parameter \\$date with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/PageRepository.php
@@ -30714,17 +28887,7 @@ parameters:
 			path: app/bundles/PageBundle/Entity/PageRepository.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$entity$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/PageRepository.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of method Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:\\:set\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Entity/PageRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\PageBundle\\\\Entity\\\\PageRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Entity/PageRepository.php
 
@@ -31022,14 +29185,6 @@ parameters:
 			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
 
 		-
-			message: """
-				#^Call to deprecated method getExpressionBuilder\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createExpressionBuilder\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:renderCategoryList\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -31066,36 +29221,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:renderSuccessMessage\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$descriptionRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$dwcTokenRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$langBarRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$pageTokenRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$shareButtonsRegex has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\PageBundle\\\\EventListener\\\\BuilderSubscriber\\:\\:\\$titleRegex has no type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/EventListener/BuilderSubscriber.php
 
@@ -31227,11 +29352,6 @@ parameters:
 			message: "#^Offset 'formTypeOptions' on array\\{label\\: false\\} in isset\\(\\) does not exist\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Form/Type/AbTestPropertiesType.php
-
-		-
-			message: "#^Parameter \\#5 \\$topLevel of method Mautic\\\\PageBundle\\\\Entity\\\\PageRepository\\:\\:getPageList\\(\\) expects bool, string given\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Form/Type/PageType.php
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Helper\\\\PointActionHelper\\:\\:validatePageHit\\(\\) has parameter \\$action with no type specified\\.$#"
@@ -31366,11 +29486,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:generateUrl\\(\\) has parameter \\$clickthrough with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PageBundle/Model/PageModel.php
-
-		-
-			message: "#^Method Mautic\\\\PageBundle\\\\Model\\\\PageModel\\:\\:getBounces\\(\\) should return int but returns array\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Model/PageModel.php
 
@@ -31983,14 +30098,6 @@ parameters:
 			path: app/bundles/PageBundle/Tests/Model/Tracking404ModelTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethods\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: app/bundles/PageBundle/Tests/PageTestAbstract.php
-
-		-
 			message: "#^Method Mautic\\\\PageBundle\\\\Tests\\\\PageTestAbstract\\:\\:getPageModel\\(\\) has parameter \\$transliterationEnabled with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -32009,11 +30116,6 @@ parameters:
 			message: "#^Property Mautic\\\\PageBundle\\\\Tests\\\\PageTestAbstract\\:\\:\\$mockName has no type specified\\.$#"
 			count: 1
 			path: app/bundles/PageBundle/Tests/PageTestAbstract.php
-
-		-
-			message: "#^Call to deprecated method getMigrateToSql\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\Schema\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Bundle/PluginBundleBase.php
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Bundle\\\\PluginBundleBase\\:\\:dropPluginSchema\\(\\) has parameter \\$metadata with no value type specified in iterable type array\\.$#"
@@ -32113,11 +30215,6 @@ parameters:
 			path: app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
-			count: 2
-			path: app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Command\\\\ReloadCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Command/ReloadCommand.php
@@ -32130,16 +30227,6 @@ parameters:
 		-
 			message: "#^If condition is always true\\.$#"
 			count: 4
-			path: app/bundles/PluginBundle/Controller/AjaxController.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Controller\\\\AjaxController\\:\\:getIntegrationCampaignStatusAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Controller/AjaxController.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Controller\\\\AjaxController\\:\\:matchFieldsAction\\(\\) has no return type specified\\.$#"
-			count: 1
 			path: app/bundles/PluginBundle/Controller/AjaxController.php
 
 		-
@@ -32255,14 +30342,6 @@ parameters:
 			message: "#^Property Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntity\\:\\:\\$internal type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Entity/IntegrationEntity.php
-
-		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 2
-			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
 
 		-
 			message: "#^If condition is always false\\.$#"
@@ -32440,11 +30519,6 @@ parameters:
 			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
 
 		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) has parameter \\$endDate with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) has parameter \\$integration with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -32455,17 +30529,7 @@ parameters:
 			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
 
 		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) has parameter \\$integrationEntityIds with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) has parameter \\$internalEntity with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:getIntegrationsEntityId\\(\\) has parameter \\$startDate with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
 
@@ -32516,11 +30580,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Entity\\\\PluginRepository\\:\\:getDefaultOrder\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Entity/PluginRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\PluginBundle\\\\Entity\\\\PluginRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Entity/PluginRepository.php
 
@@ -32633,11 +30692,6 @@ parameters:
 			path: app/bundles/PluginBundle/Event/PluginIntegrationRequestEvent.php
 
 		-
-			message: "#^Property Mautic\\\\PluginBundle\\\\Event\\\\PluginIntegrationRequestEvent\\:\\:\\$response has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Event/PluginIntegrationRequestEvent.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\EventListener\\\\CampaignSubscriber\\:\\:pushIt\\(\\) has parameter \\$config with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -32649,11 +30703,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\EventListener\\\\CampaignSubscriber\\:\\:pushIt\\(\\) has parameter \\$lead with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\EventListener\\\\CampaignSubscriber\\:\\:pushToIntegration\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
 
@@ -32687,11 +30736,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\EventListener\\\\FormSubscriber\\:\\:pushIt\\(\\) has parameter \\$lead with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\EventListener\\\\FormSubscriber\\:\\:pushToIntegration\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/EventListener/FormSubscriber.php
 
@@ -32834,11 +30878,6 @@ parameters:
 			path: app/bundles/PluginBundle/Form/Type/FieldsType.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Form/Type/KeysType.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Helper\\\\Cleaner\\:\\:clean\\(\\) has parameter \\$fieldType with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/Cleaner.php
@@ -32870,11 +30909,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Helper\\\\EventHelper\\:\\:pushLead\\(\\) has parameter \\$lead with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/EventHelper.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Helper\\\\EventHelper\\:\\:pushToIntegration\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/EventHelper.php
 
@@ -32968,26 +31002,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:getUserProfiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: "#^Property Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:\\$available has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: "#^Property Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:\\$byFeatureList has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: "#^Property Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:\\$byPlugin has no type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: "#^Property Mautic\\\\PluginBundle\\\\Helper\\\\IntegrationHelper\\:\\:\\$integrations has no type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
 
@@ -33879,30 +31893,6 @@ parameters:
 			path: app/bundles/PluginBundle/Model/IntegrationEntityModel.php
 
 		-
-			message: """
-				#^Call to deprecated method createSchema\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link introspectSchema\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/PluginBundle/Model/PluginModel.php
-
-		-
-			message: """
-				#^Call to deprecated method getFieldList\\(\\) of class Mautic\\\\LeadBundle\\\\Model\\\\FieldModel\\:
-				Use FieldList\\:\\:getFieldList method instead$#
-			"""
-			count: 2
-			path: app/bundles/PluginBundle/Model/PluginModel.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/PluginBundle/Model/PluginModel.php
-
-		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Model\\\\PluginModel\\:\\:createPluginSchemas\\(\\) has parameter \\$installedPluginsTables with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Model/PluginModel.php
@@ -33914,11 +31904,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Model\\\\PluginModel\\:\\:getAllPluginsConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Model/PluginModel.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Model\\\\PluginModel\\:\\:getCompanyFields\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Model/PluginModel.php
 
@@ -33939,11 +31924,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PluginBundle\\\\Model\\\\PluginModel\\:\\:getIntegrationEntityRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/PluginBundle/Model/PluginModel.php
-
-		-
-			message: "#^Method Mautic\\\\PluginBundle\\\\Model\\\\PluginModel\\:\\:getLeadFields\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/PluginBundle/Model/PluginModel.php
 
@@ -34150,16 +32130,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\PointBundle\\\\Controller\\\\Api\\\\PointApiController\\:\\:logApiPointChange\\(\\) has parameter \\$operator with no type specified\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$leadId$#"
 			count: 1
 			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
 
@@ -34392,16 +32362,6 @@ parameters:
 			path: app/bundles/PointBundle/Entity/PointRepository.php
 
 		-
-			message: "#^Method Mautic\\\\PointBundle\\\\Entity\\\\PointRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Entity/PointRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\PointBundle\\\\Entity\\\\PointRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Entity/PointRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PointBundle\\\\Entity\\\\Trigger\\:\\:addTriggerEvent\\(\\) has parameter \\$key with no type specified\\.$#"
 			count: 1
 			path: app/bundles/PointBundle/Entity/Trigger.php
@@ -34512,17 +32472,7 @@ parameters:
 			path: app/bundles/PointBundle/Entity/TriggerRepository.php
 
 		-
-			message: "#^Method Mautic\\\\PointBundle\\\\Entity\\\\TriggerRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Entity/TriggerRepository.php
-
-		-
 			message: "#^Method Mautic\\\\PointBundle\\\\Entity\\\\TriggerRepository\\:\\:getTriggerColors\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/PointBundle/Entity/TriggerRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\PointBundle\\\\Entity\\\\TriggerRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/PointBundle/Entity/TriggerRepository.php
 
@@ -34757,20 +32707,7 @@ parameters:
 			path: app/bundles/PointBundle/Tests/Unit/Model/TriggerModelTest.php
 
 		-
-			message: """
-				#^Call to deprecated method getType\\(\\) of class Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\:
-				If necessary, track the type of the query being built outside of the builder\\.$#
-			"""
-			count: 1
-			path: app/bundles/ReportBundle/Builder/MauticReportBuilder.php
-
-		-
 			message: "#^Constant Mautic\\\\ReportBundle\\\\Builder\\\\MauticReportBuilder\\:\\:OPERATORS type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ReportBundle/Builder/MauticReportBuilder.php
-
-		-
-			message: "#^Fetching deprecated class constant SELECT of class Doctrine\\\\DBAL\\\\Query\\\\QueryBuilder\\.$#"
 			count: 1
 			path: app/bundles/ReportBundle/Builder/MauticReportBuilder.php
 
@@ -34857,11 +32794,6 @@ parameters:
 			message: "#^Variable \\$report in empty\\(\\) always exists and is not falsy\\.$#"
 			count: 1
 			path: app/bundles/ReportBundle/Controller/ReportController.php
-
-		-
-			message: "#^Method Mautic\\\\ReportBundle\\\\Controller\\\\ScheduleController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/ReportBundle/Controller/ScheduleController.php
 
 		-
 			message: "#^Method Mautic\\\\ReportBundle\\\\Controller\\\\ScheduleController\\:\\:indexAction\\(\\) has parameter \\$isScheduled with no type specified\\.$#"
@@ -35072,22 +33004,12 @@ parameters:
 			path: app/bundles/ReportBundle/Entity/ReportRepository.php
 
 		-
-			message: "#^Method Mautic\\\\ReportBundle\\\\Entity\\\\ReportRepository\\:\\:findReportsWithGraphs\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/ReportBundle/Entity/ReportRepository.php
-
-		-
 			message: "#^Method Mautic\\\\ReportBundle\\\\Entity\\\\ReportRepository\\:\\:findReportsWithGraphs\\(\\) has parameter \\$ownedBy with no type specified\\.$#"
 			count: 1
 			path: app/bundles/ReportBundle/Entity/ReportRepository.php
 
 		-
 			message: "#^Method Mautic\\\\ReportBundle\\\\Entity\\\\ReportRepository\\:\\:getDefaultOrder\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/ReportBundle/Entity/ReportRepository.php
-
-		-
-			message: "#^Method Mautic\\\\ReportBundle\\\\Entity\\\\ReportRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/ReportBundle/Entity/ReportRepository.php
 
@@ -35567,11 +33489,6 @@ parameters:
 			path: app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$filePath$#"
-			count: 1
-			path: app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: app/bundles/ReportBundle/Scheduler/Option/ExportOption.php
@@ -35764,11 +33681,6 @@ parameters:
 			path: app/bundles/SmsBundle/Controller/Api/SmsApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/SmsBundle/Controller/Api/SmsApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -35916,16 +33828,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\SmsRepository\\:\\:addSearchCommandWhereClause\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/SmsRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\SmsRepository\\:\\:getPublishedBroadcasts\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Entity/SmsRepository.php
-
-		-
-			message: "#^Method Mautic\\\\SmsBundle\\\\Entity\\\\SmsRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Entity/SmsRepository.php
 
@@ -36156,14 +34058,6 @@ parameters:
 			path: app/bundles/SmsBundle/Helper/ContactHelper.php
 
 		-
-			message: """
-				#^Fetching deprecated class constant PARAM_STR_ARRAY of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see ArrayParameterType\\:\\:STRING\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/SmsBundle/Helper/ContactHelper.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$contacts contains unknown class Mautic\\\\SmsBundle\\\\Helper\\\\Lead\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Helper/ContactHelper.php
@@ -36177,21 +34071,6 @@ parameters:
 			message: "#^Method Mautic\\\\SmsBundle\\\\Helper\\\\SmsHelper\\:\\:unsubscribe\\(\\) has parameter \\$number with no type specified\\.$#"
 			count: 1
 			path: app/bundles/SmsBundle/Helper/SmsHelper.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
-			message: "#^Property Mautic\\\\SmsBundle\\\\Integration\\\\Twilio\\\\TwilioTransport\\:\\:\\$client is never written, only read\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
 
 		-
 			message: "#^Call to method add\\(\\) on an unknown class Mautic\\\\PluginBundle\\\\Integration\\\\Form\\.$#"
@@ -36484,11 +34363,6 @@ parameters:
 			path: app/bundles/StageBundle/Controller/Api/StageApiController.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$intgegration$#"
-			count: 1
-			path: app/bundles/StageBundle/Controller/Api/StageApiController.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$model contains unknown class Mautic\\\\LeadBundle\\\\Controller\\\\LeadModel\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Controller/Api/StageApiController.php
@@ -36530,27 +34404,12 @@ parameters:
 			path: app/bundles/StageBundle/Entity/LeadStageLogRepository.php
 
 		-
-			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\Stage\\:\\:addLog\\(\\) has invalid return type Mautic\\\\StageBundle\\\\Entity\\\\Log\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/Stage.php
-
-		-
-			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\Stage\\:\\:addLog\\(\\) should return Mautic\\\\StageBundle\\\\Entity\\\\Log but returns \\$this\\(Mautic\\\\StageBundle\\\\Entity\\\\Stage\\)\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/Stage.php
-
-		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\Stage\\:\\:convertToArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Entity/Stage.php
 
 		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\Stage\\:\\:setWeight\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/Stage.php
-
-		-
-			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\Stage\\:\\:setWeight\\(\\) should return int but returns \\$this\\(Mautic\\\\StageBundle\\\\Entity\\\\Stage\\)\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Entity/Stage.php
 
@@ -36600,11 +34459,6 @@ parameters:
 			path: app/bundles/StageBundle/Entity/StageRepository.php
 
 		-
-			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\StageRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/StageRepository.php
-
-		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\StageRepository\\:\\:getStageByName\\(\\) has parameter \\$stageName with no type specified\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Entity/StageRepository.php
@@ -36626,21 +34480,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Entity\\\\StageRepository\\:\\:getStages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/StageRepository.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$alias$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/StageRepository.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$name$#"
-			count: 1
-			path: app/bundles/StageBundle/Entity/StageRepository.php
-
-		-
-			message: "#^Return type of method Mautic\\\\StageBundle\\\\Entity\\\\StageRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/Entity/StageRepository.php
 
@@ -36693,11 +34532,6 @@ parameters:
 			message: "#^Property Mautic\\\\StageBundle\\\\EventListener\\\\DashboardSubscriber\\:\\:\\$types \\(string\\) does not accept default value of type array\\<string, array\\>\\.$#"
 			count: 1
 			path: app/bundles/StageBundle/EventListener/DashboardSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\StageBundle\\\\Form\\\\Type\\\\StageListType\\:\\:\\$choices has no type specified\\.$#"
-			count: 1
-			path: app/bundles/StageBundle/Form/Type/StageListType.php
 
 		-
 			message: "#^Method Mautic\\\\StageBundle\\\\Helper\\\\EventHelper\\:\\:engageStageAction\\(\\) has parameter \\$action with no value type specified in iterable type array\\.$#"
@@ -36825,11 +34659,6 @@ parameters:
 			path: app/bundles/StatsBundle/Aggregate/Collection/DAO/StatsDAO.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Mautic\\\\StatsBundle\\\\Aggregate\\\\Calculator will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
-
-		-
 			message: "#^Method Mautic\\\\StatsBundle\\\\Aggregate\\\\Collection\\\\StatCollection\\:\\:addStatByDateTimeStringInUTC\\(\\) has parameter \\$count with no type specified\\.$#"
 			count: 1
 			path: app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
@@ -36926,11 +34755,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\StatsBundle\\\\Aggregate\\\\Helper\\\\CalculatorHelper\\:\\:getYearLabel\\(\\) has parameter \\$year with no type specified\\.$#"
-			count: 1
-			path: app/bundles/StatsBundle/Aggregate/Helper/CalculatorHelper.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$day$#"
 			count: 1
 			path: app/bundles/StatsBundle/Aggregate/Helper/CalculatorHelper.php
 
@@ -37136,11 +34960,6 @@ parameters:
 			path: app/bundles/UserBundle/Controller/PublicController.php
 
 		-
-			message: "#^Method Mautic\\\\UserBundle\\\\Controller\\\\PublicController\\:\\:passwordResetAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Controller/PublicController.php
-
-		-
 			message: """
 				#^Call to deprecated method get\\(\\) of class Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:
 				since Symfony 5\\.4, use method or constructor injection in your controller instead$#
@@ -37216,14 +35035,6 @@ parameters:
 			path: app/bundles/UserBundle/DependencyInjection/Firewall/Factory/PluginFactory.php
 
 		-
-			message: """
-				#^Call to deprecated method useResultCache\\(\\) of class Doctrine\\\\ORM\\\\AbstractQuery\\:
-				2\\.7 Use \\{@see enableResultCache\\} and \\{@see disableResultCache\\} instead\\.$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Entity/PermissionRepository.php
-
-		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Entity\\\\PermissionRepository\\:\\:getPermissionsByRole\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Entity/PermissionRepository.php
@@ -37274,11 +35085,6 @@ parameters:
 			path: app/bundles/UserBundle/Entity/RoleRepository.php
 
 		-
-			message: "#^Method Mautic\\\\UserBundle\\\\Entity\\\\RoleRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Entity/RoleRepository.php
-
-		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Entity\\\\RoleRepository\\:\\:getUserCount\\(\\) has parameter \\$roleIds with no type specified\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Entity/RoleRepository.php
@@ -37290,22 +35096,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Entity/User.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Entity/User.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
 			count: 1
 			path: app/bundles/UserBundle/Entity/User.php
 
@@ -37420,11 +35210,6 @@ parameters:
 			path: app/bundles/UserBundle/Entity/UserRepository.php
 
 		-
-			message: "#^Method Mautic\\\\UserBundle\\\\Entity\\\\UserRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Entity/UserRepository.php
-
-		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Entity\\\\UserRepository\\:\\:getUserList\\(\\) has parameter \\$permissionLimiter with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Entity/UserRepository.php
@@ -37458,14 +35243,6 @@ parameters:
 			message: "#^Property Mautic\\\\UserBundle\\\\Event\\\\AuthenticationContentEvent\\:\\:\\$content type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Event/AuthenticationContentEvent.php
-
-		-
-			message: """
-				#^Call to deprecated method isAuthenticated\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\:
-				since Symfony 5\\.4, return null from "getUser\\(\\)" instead when a token is not authenticated$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Event/AuthenticationEvent.php
 
 		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Event\\\\AuthenticationEvent\\:\\:getIntegration\\(\\) has parameter \\$integrationName with no type specified\\.$#"
@@ -37530,11 +35307,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\UserBundle\\\\EventListener\\\\ConfigSubscriber\\:\\:validateXml\\(\\) has parameter \\$content with no type specified\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/EventListener/ConfigSubscriber.php
-
-		-
-			message: "#^Property Mautic\\\\UserBundle\\\\EventListener\\\\ConfigSubscriber\\:\\:\\$fileFields has no type specified\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/EventListener/ConfigSubscriber.php
 
@@ -37656,22 +35428,6 @@ parameters:
 
 		-
 			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/Authenticator/FormAuthenticator.php
-
-		-
-			message: """
-				#^Call to deprecated method loadUserByUsername\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserProviderInterface\\:
-				since Symfony 5\\.3, use loadUserByIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/Authenticator/FormAuthenticator.php
-
-		-
-			message: """
 				#^Class Mautic\\\\UserBundle\\\\Security\\\\Authenticator\\\\FormAuthenticator extends deprecated class Symfony\\\\Component\\\\Security\\\\Guard\\\\Authenticator\\\\AbstractFormLoginAuthenticator\\:
 				since Symfony 5\\.3, use the new authenticator system instead$#
 			"""
@@ -37715,14 +35471,6 @@ parameters:
 			path: app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
 
 		-
-			message: """
-				#^Call to deprecated method isAuthenticated\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\AbstractToken\\:
-				since Symfony 5\\.4$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php
-
-		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Security\\\\Permissions\\\\UserPermissions\\:\\:__construct\\(\\) has parameter \\$params with no type specified\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -37743,30 +35491,6 @@ parameters:
 			path: app/bundles/UserBundle/Security/Permissions/UserPermissions.php
 
 		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/UserBundle/Security/Provider/UserProvider.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/Provider/UserProvider.php
-
-		-
-			message: """
-				#^Call to deprecated method loadUserByUsername\\(\\) of class Mautic\\\\UserBundle\\\\Security\\\\Provider\\\\UserProvider\\:
-				since Symfony 5\\.3, use loadUserByIdentifier\\(\\) instead$#
-			"""
-			count: 3
-			path: app/bundles/UserBundle/Security/Provider/UserProvider.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Security/Provider/UserProvider.php
@@ -37785,21 +35509,6 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Security/SAML/Store/EntityDescriptorStore.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
-
-		-
-			message: "#^Method Mautic\\\\UserBundle\\\\Security\\\\SAML\\\\Store\\\\TrustOptionsStore\\:\\:createTrustOptions\\(\\) is unused\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
 
 		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Security\\\\SAML\\\\User\\\\UserCreator\\:\\:__construct\\(\\) has parameter \\$defaultRole with no type specified\\.$#"
@@ -37817,49 +35526,9 @@ parameters:
 			path: app/bundles/UserBundle/Security/SAML/User/UserCreator.php
 
 		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Security/SAML/User/UserMapper.php
-
-		-
 			message: "#^Method Mautic\\\\UserBundle\\\\Security\\\\SAML\\\\User\\\\UserMapper\\:\\:extractAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/UserBundle/Security/SAML/User/UserMapper.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 8
-			path: app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Tests/Security/Firewall/AuthenticationListenerTest.php
-
-		-
-			message: """
-				#^Call to deprecated method getUsername\\(\\) of class Mautic\\\\UserBundle\\\\Entity\\\\User\\:
-				since Symfony 5\\.3, use getUserIdentifier\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/UserBundle/Tests/Security/SAML/User/UserMapperTest.php
 
 		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Command\\\\ProcessWebhookQueuesCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
@@ -37878,11 +35547,6 @@ parameters:
 
 		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Controller\\\\AjaxController\\:\\:loadPayloads\\(\\) has parameter \\$paths with no type specified\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Controller/AjaxController.php
-
-		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Controller\\\\AjaxController\\:\\:sendHookTestAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: app/bundles/WebhookBundle/Controller/AjaxController.php
 
@@ -38145,11 +35809,6 @@ parameters:
 			path: app/bundles/WebhookBundle/Entity/WebhookRepository.php
 
 		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Entity\\\\WebhookRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Entity/WebhookRepository.php
-
-		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Event\\\\WebhookBuilderEvent\\:\\:addEvent\\(\\) has parameter \\$event with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/WebhookBundle/Event/WebhookBuilderEvent.php
@@ -38206,16 +35865,6 @@ parameters:
 			"""
 			count: 1
 			path: app/bundles/WebhookBundle/EventListener/CampaignSubscriber.php
-
-		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Form\\\\DataTransformer\\\\EventsToArrayTransformer\\:\\:transform\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
-
-		-
-			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Form/Type/WebhookType.php
 
 		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Helper\\\\CampaignHelper\\:\\:fireWebhook\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
@@ -38378,11 +36027,6 @@ parameters:
 			path: app/bundles/WebhookBundle/Model/WebhookModel.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between null and string will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Model/WebhookModel.php
-
-		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Security\\\\Permissions\\\\WebhookPermissions\\:\\:__construct\\(\\) has parameter \\$params with no type specified\\.$#"
 			count: 1
 			path: app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -38408,50 +36052,9 @@ parameters:
 			path: app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
 
 		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 2
-			path: app/bundles/WebhookBundle/Tests/Functional/RemoveOldLogTest.php
-
-		-
-			message: """
-				#^Call to deprecated method runCommand\\(\\) of class Mautic\\\\CoreBundle\\\\Test\\\\AbstractMauticTestCase\\:
-				use testSymfonyCommand\\(\\) instead$#
-			"""
-			count: 1
-			path: app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
-
-		-
 			message: "#^Method Mautic\\\\WebhookBundle\\\\Tests\\\\Functional\\\\WebhookFunctionalTest\\:\\:createContacts\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
-
-		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Tests\\\\Helper\\\\CampaignHelperTest\\:\\:provideSampleConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Tests\\\\Helper\\\\CampaignHelperTest\\:\\:provideSampleConfig\\(\\) has parameter \\$method with no type specified\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
-
-		-
-			message: "#^Method Mautic\\\\WebhookBundle\\\\Tests\\\\Helper\\\\CampaignHelperTest\\:\\:provideSampleConfig\\(\\) has parameter \\$type with no type specified\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Tests/Helper/CampaignHelperTest.php
-
-		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: app/bundles/WebhookBundle/Tests/Model/WebhookModelTest.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$fileName$#"
-			count: 1
-			path: plugins/GrapesJsBuilderBundle/Controller/FileManagerController.php
 
 		-
 			message: """
@@ -38518,11 +36121,6 @@ parameters:
 			message: "#^Property MauticPlugin\\\\GrapesJsBuilderBundle\\\\Integration\\\\GrapesJsBuilderIntegration\\:\\:\\$integration \\(Mautic\\\\PluginBundle\\\\Entity\\\\Integration\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: plugins/GrapesJsBuilderBundle/Integration/GrapesJsBuilderIntegration.php
-
-		-
-			message: "#^Property MauticPlugin\\\\GrapesJsBuilderBundle\\\\Integration\\\\Support\\\\BuilderSupport\\:\\:\\$featuresSupported has no type specified\\.$#"
-			count: 1
-			path: plugins/GrapesJsBuilderBundle/Integration/Support/BuilderSupport.php
 
 		-
 			message: "#^Method MauticPlugin\\\\GrapesJsBuilderBundle\\\\Model\\\\GrapesJsBuilderModel\\:\\:getGrapesJsFromEmailId\\(\\) has no return type specified\\.$#"
@@ -38762,11 +36360,6 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
-			path: plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
-
-		-
-			message: "#^Result of \\|\\| is always false\\.$#"
 			count: 1
 			path: plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
 
@@ -39128,11 +36721,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Api\\\\SalesforceApi\\:\\:getCampaignMembers\\(\\) has parameter \\$campaignId with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Api\\\\SalesforceApi\\:\\:getCampaignMembers\\(\\) has parameter \\$modifiedSince with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
 
@@ -39792,11 +37380,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\ConnectwiseIntegration\\:\\:pushLead\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\ConnectwiseIntegration\\:\\:saveCampaignMembers\\(\\) has parameter \\$allCampaignMembers with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -40218,14 +37801,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method MauticPlugin\\\\MauticCrmBundle\\\\Api\\\\CrmApi\\:\\:updateLeads\\(\\)\\.$#"
 			count: 2
-			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
-
-		-
-			message: """
-				#^Call to deprecated method setSQLLogger\\(\\) of class Doctrine\\\\DBAL\\\\Configuration\\:
-				Use \\{@see setMiddlewares\\(\\)\\} and \\{@see \\\\Doctrine\\\\DBAL\\\\Logging\\\\Middleware\\} instead\\.$#
-			"""
-			count: 1
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
 
 		-
@@ -40688,11 +38263,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\Salesforce\\\\Helper\\\\StateValidationHelper\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\Salesforce\\\\Helper\\\\StateValidationHelper\\:\\:\\$supportedCountriesWithStates has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
 
@@ -41597,21 +39167,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:pushLeadToCampaign\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:pushLeadToCampaign\\(\\) should return array but returns bool\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:pushLeadToCampaign\\(\\) should return array but returns false\\.$#"
-			count: 2
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:pushLeads\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -41654,16 +39209,6 @@ parameters:
 		-
 			message: "#^Parameter \\#4 \\$limit of method Mautic\\\\PluginBundle\\\\Entity\\\\IntegrationEntityRepository\\:\\:findLeadsToUpdate\\(\\) expects int, false given\\.$#"
 			count: 2
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:\\$failureFetchingLeads \\(bool\\) does not accept string\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SalesforceIntegration\\:\\:\\$objects has no type specified\\.$#"
-			count: 1
 			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 
 		-
@@ -42145,16 +39690,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
 
 		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SugarcrmIntegration\\:\\:\\$objects has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SugarcrmIntegration\\:\\:\\$sugarDncKeys has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
 			message: "#^Return type \\(array\\) of method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\SugarcrmIntegration\\:\\:authCallback\\(\\) should be compatible with return type \\(bool\\|string\\) of method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:authCallback\\(\\)$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -42200,16 +39735,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:authCallback\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:authCallback\\(\\) should return array but returns false\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:getFormCompanyFields\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -42241,16 +39766,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\$builder of method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:appendToForm\\(\\) has invalid type Mautic\\\\PluginBundle\\\\Integration\\\\Form\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:\\$authorzationError has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
-
-		-
-			message: "#^Return type \\(array\\) of method MauticPlugin\\\\MauticCrmBundle\\\\Integration\\\\VtigerIntegration\\:\\:authCallback\\(\\) should be compatible with return type \\(bool\\|string\\) of method Mautic\\\\PluginBundle\\\\Integration\\\\AbstractIntegration\\:\\:authCallback\\(\\)$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
 
@@ -42470,22 +39985,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
 
 		-
-			message: """
-				#^Call to deprecated method createSchema\\(\\) of class Doctrine\\\\DBAL\\\\Schema\\\\AbstractSchemaManager\\:
-				Use \\{@link introspectSchema\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: plugins/MauticCrmBundle/MauticCrmBundle.php
-
-		-
-			message: """
-				#^Call to deprecated method getSchemaManager\\(\\) of class Doctrine\\\\DBAL\\\\Connection\\:
-				Use \\{@see createSchemaManager\\(\\)\\} instead\\.$#
-			"""
-			count: 1
-			path: plugins/MauticCrmBundle/MauticCrmBundle.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\MauticCrmBundle\\:\\:getMetadata\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/MauticCrmBundle.php
@@ -42501,22 +40000,12 @@ parameters:
 			path: plugins/MauticCrmBundle/MauticCrmBundle.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Services/Transport.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Services/Transport.php
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:delete\\(\\) has parameter \\$uri with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Services/Transport.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:get\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Services/Transport.php
 
@@ -42531,22 +40020,12 @@ parameters:
 			path: plugins/MauticCrmBundle/Services/Transport.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:post\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Services/Transport.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:post\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Services/Transport.php
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:post\\(\\) has parameter \\$uri with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticCrmBundle/Services/Transport.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Services\\\\Transport\\:\\:put\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Services/Transport.php
 
@@ -42621,14 +40100,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Services/TransportInterface.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 1
-			path: plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Tests\\\\Api\\\\ConnectwiseApiTest\\:\\:generateData\\(\\) has parameter \\$maxPages with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
@@ -42649,14 +40120,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
 
 		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 4
-			path: plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
-
-		-
 			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Tests\\\\Api\\\\Zoho\\\\MapperTest\\:\\:\\$availableFields type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
@@ -42670,14 +40133,6 @@ parameters:
 			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Tests\\\\Api\\\\Zoho\\\\MapperTest\\:\\:\\$mappedFields type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 3
-			path: plugins/MauticCrmBundle/Tests/CrmAbstractIntegrationTest.php
 
 		-
 			message: "#^Call to method disableOriginalConstructor\\(\\) on an unknown class PHPUnit_Framework_MockObject_MockBuilder\\.$#"
@@ -42698,14 +40153,6 @@ parameters:
 			message: "#^Property MauticPlugin\\\\MauticCrmBundle\\\\Tests\\\\DynamicsApiTest\\:\\:\\$api is never read, only written\\.$#"
 			count: 1
 			path: plugins/MauticCrmBundle/Tests/DynamicsApiTest.php
-
-		-
-			message: """
-				#^Call to deprecated method setMethodsExcept\\(\\) of class PHPUnit\\\\Framework\\\\MockObject\\\\MockBuilder\\:
-				https\\://github\\.com/sebastianbergmann/phpunit/pull/3687$#
-			"""
-			count: 2
-			path: plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticCrmBundle\\\\Tests\\\\Integration\\\\ConnectwiseIntegrationTest\\:\\:generateData\\(\\) has parameter \\$maxPages with no type specified\\.$#"
@@ -43008,11 +40455,6 @@ parameters:
 			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
 
 		-
-			message: "#^Property MauticPlugin\\\\MauticEmailMarketingBundle\\\\Api\\\\ConstantContactApi\\:\\:\\$version has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
-
-		-
 			message: "#^Property MauticPlugin\\\\MauticEmailMarketingBundle\\\\Api\\\\EmailMarketingApi\\:\\:\\$keys has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticEmailMarketingBundle/Api/EmailMarketingApi.php
@@ -43084,11 +40526,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticEmailMarketingBundle\\\\Api\\\\MailchimpApi\\:\\:subscribeLead\\(\\) has parameter \\$listId with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticEmailMarketingBundle\\\\Api\\\\MailchimpApi\\:\\:\\$version has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
 
@@ -43172,11 +40609,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticEmailMarketingBundle\\\\Integration\\\\IcontactIntegration\\:\\:authCallback\\(\\) should return bool\\|string but return statement is missing\\.$#"
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticEmailMarketingBundle\\\\Integration\\\\IcontactIntegration\\:\\:getApiUrl\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
 
@@ -43404,16 +40836,6 @@ parameters:
 			path: plugins/MauticFocusBundle/Entity/FocusRepository.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\Entity\\\\FocusRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Entity/FocusRepository.php
-
-		-
-			message: "#^Return type of method MauticPlugin\\\\MauticFocusBundle\\\\Entity\\\\FocusRepository\\:\\:getEntities\\(\\) has typehint with deprecated class Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\IterableResult\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Entity/FocusRepository.php
-
-		-
 			message: """
 				#^Call to deprecated method addLead\\(\\) of class Mautic\\\\CoreBundle\\\\Doctrine\\\\Mapping\\\\ClassMetadataBuilder\\:
 				Use addContact instead; existing implementations will need a migration to rename lead_id to contact_id$#
@@ -43450,11 +40872,6 @@ parameters:
 			path: plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
 
 		-
-			message: "#^Property MauticPlugin\\\\MauticFocusBundle\\\\EventListener\\\\PageSubscriber\\:\\:\\$regex has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/EventListener/PageSubscriber.php
-
-		-
 			message: "#^Property MauticPlugin\\\\MauticFocusBundle\\\\Form\\\\Type\\\\FocusListType\\:\\:\\$repo has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Form/Type/FocusListType.php
@@ -43476,11 +40893,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticFocusBundle\\\\Helper\\\\TokenHelper\\:\\:findFocusTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticFocusBundle/Helper/TokenHelper.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticFocusBundle\\\\Helper\\\\TokenHelper\\:\\:\\$regex has no type specified\\.$#"
 			count: 1
 			path: plugins/MauticFocusBundle/Helper/TokenHelper.php
 
@@ -43911,11 +41323,6 @@ parameters:
 			path: plugins/MauticFullContactBundle/Services/FullContact_Location.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$name$#"
-			count: 1
-			path: plugins/MauticFullContactBundle/Services/FullContact_Location.php
-
-		-
 			message: "#^Parameter \\$casing of method MauticPlugin\\\\MauticFullContactBundle\\\\Services\\\\FullContact_Location\\:\\:normalizer\\(\\) has invalid type MauticPlugin\\\\MauticFullContactBundle\\\\Services\\\\type\\.$#"
 			count: 1
 			path: plugins/MauticFullContactBundle/Services/FullContact_Location.php
@@ -44007,11 +41414,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticFullContactBundle\\\\Services\\\\FullContact_Name\\:\\:stats\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticFullContactBundle/Services/FullContact_Name.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$name$#"
 			count: 1
 			path: plugins/MauticFullContactBundle/Services/FullContact_Name.php
 
@@ -44210,11 +41612,6 @@ parameters:
 			path: plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
 
 		-
-			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$mid of method MauticPlugin\\\\MauticSocialBundle\\\\Helper\\\\TwitterCommandHelper\\:\\:getMonitor\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -44377,21 +41774,6 @@ parameters:
 			path: plugins/MauticSocialBundle/Controller/TweetController.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:cloneAction\\(\\) has invalid return type MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:editAction\\(\\) has invalid return type MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:editAction\\(\\) should return MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:getEntityFormOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Controller/TweetController.php
@@ -44407,42 +41789,7 @@ parameters:
 			path: plugins/MauticSocialBundle/Controller/TweetController.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:indexAction\\(\\) has invalid return type MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:indexAction\\(\\) should return MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse\\|Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:newAction\\(\\) has invalid return type MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:newAction\\(\\) should return MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse but returns array\\|Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:viewAction\\(\\) has invalid return type MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:viewAction\\(\\) has parameter \\$objectId with no type specified\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:viewAction\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Controller/TweetController.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\TweetController\\:\\:viewAction\\(\\) should return array\\|MauticPlugin\\\\MauticSocialBundle\\\\Controller\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse\\|Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Controller/TweetController.php
 
@@ -44541,11 +41888,6 @@ parameters:
 
 		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Entity\\\\MonitoringRepository\\:\\:getPublishedEntities\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Entity/MonitoringRepository.php
-
-		-
-			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Entity\\\\MonitoringRepository\\:\\:getSearchCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Entity/MonitoringRepository.php
 
@@ -45020,11 +42362,6 @@ parameters:
 			path: plugins/MauticSocialBundle/Model/MonitoringModel.php
 
 		-
-			message: "#^Property MauticPlugin\\\\MauticSocialBundle\\\\Model\\\\MonitoringModel\\:\\:\\$networkTypes has no type specified\\.$#"
-			count: 1
-			path: plugins/MauticSocialBundle/Model/MonitoringModel.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticSocialBundle\\\\Model\\\\PostCountModel\\:\\:getEntity\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticSocialBundle/Model/PostCountModel.php
@@ -45148,11 +42485,6 @@ parameters:
 			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
 
 		-
-			message: "#^Method MauticPlugin\\\\MauticTagManagerBundle\\\\Entity\\\\TagRepository\\:\\:countOccurrences\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
-
-		-
 			message: "#^Method MauticPlugin\\\\MauticTagManagerBundle\\\\Entity\\\\TagRepository\\:\\:countOccurrences\\(\\) has parameter \\$tag with no type specified\\.$#"
 			count: 1
 			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
@@ -45189,13 +42521,3 @@ parameters:
 			message: "#^Parameter \\#1 \\$permissionNames of method Mautic\\\\CoreBundle\\\\Security\\\\Permissions\\\\AbstractPermissions\\:\\:addStandardPermissions\\(\\) expects array, string given\\.$#"
 			count: 1
 			path: plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\:\\:saveEntity\\(\\)\\.$#"
-			count: 1
-			path: plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
-
-		-
-			message: "#^Property MauticPlugin\\\\MauticTagManagerBundle\\\\Tests\\\\Functional\\\\Entity\\\\TagRepositoryTest\\:\\:\\$tagRepository \\(MauticPlugin\\\\MauticTagManagerBundle\\\\Entity\\\\TagRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\.$#"
-			count: 1
-			path: plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

This regenerates the PHPSTAN baseline to be back up to date. 
Currently it's not automatically up to date because of
`reportUnmatchedIgnoredErrors: false`

Although in general this should be set to true, for now i would wait with that untill we get to a more manageable baseline, since now this would cause the need for developers to regenerate the baseline because almost every file in core is there, so touching something would need the developer to regenerate (which is also a non-cached phpstan run, and quite heavy to run).

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No code is changed, only the phpstan baseline, so no manual user testing needed. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
