### PR TITLE
Change phpstan cache location.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       if: ${{matrix.commands == 'PHPSTAN'}}
       uses: actions/cache@v4
       with:
-        path: ./var/cache/phpstan
+        path: ./var/phpstan-cache
         key: ${{ runner.os }}-phpstan-${{ hashFiles('**/composer.lock') }}-${{ github.run_id }}
         restore-keys: |
           ${{ runner.os }}-phpstan-${{ hashFiles('**/composer.lock') }}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 
 parameters:
-	tmpDir: ./var/cache/phpstan
+	tmpDir: ./var/phpstan-cache
 	level: 6
 	reportUnmatchedIgnoredErrors: false
 	checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Phpstan uses a cache dir to (very much) speed up subsequent phpstan runs. (Going from minutes to seconds). When developing locally you tend to swithc branches quite a lot. 
Mautic has a git hook on post-checkout which clears the cache when you change branches. https://github.com/mautic/mautic/blob/5.x/build/hooks/post-checkout

Currently this also clears the phpcache, causing that phpstan runs locally are (almost) always uncached and take a lot of time. Therefore i suggest to move the phpstan-cache out of var/cache, but into a seperate directory. 

For users this has no impact, since phpstan can only run in test (with debug) mode, and the var folder is needed to be writable anyhow. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
