### PR TITLE
Remove deprecated mauticfactory dependency from mailhelper.

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -38,7 +38,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
 class MailHelper
@@ -237,7 +237,7 @@ class MailHelper
         private Environment $twig,
         private PathsHelper $pathsHelper,
         private ThemeHelper $themeHelper,
-        private Router $router,
+        private RouterInterface $router,
         private RequestStack $requestStack,
         private EventDispatcherInterface $eventDispatcher,
         private EntityManagerInterface $entityManager,

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2213,6 +2213,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
             $this->getStatRepository()->saveEntities($saveEntities);
         }
 
+        // save some memory
+        $this->mailHelper->reset();
+
         return $errors;
     }
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -273,7 +273,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
      */
     public function testVariantEmailWeightsAreAppropriateForMultipleContacts(): void
     {
-        $this->mailHelper->method('getMailer')->will($this->returnValue($this->mailHelper));
         $this->mailHelper->method('flushQueue')->will($this->returnValue(true));
         $this->mailHelper->method('addTo')->will($this->returnValue(true));
         $this->mailHelper->method('queue')->will($this->returnValue([true, []]));
@@ -418,7 +417,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
      */
     public function testVariantEmailWeightsAreAppropriateForMultipleContactsSentOneAtATime(): void
     {
-        $this->mailHelper->method('getMailer')->will($this->returnValue($this->mailHelper));
         $this->mailHelper->method('flushQueue')->will($this->returnValue(true));
         $this->mailHelper->method('addTo')->will($this->returnValue(true));
         $this->mailHelper->method('queue')->will($this->returnValue([true, []]));

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -2,10 +2,12 @@
 
 namespace Mautic\EmailBundle\Tests\Model;
 
-use Doctrine\ORM\EntityManager;
-use Mautic\CoreBundle\Factory\MauticFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Translation\Translator;
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\CoreBundle\Twig\Helper\SlotsHelper;
 use Mautic\EmailBundle\Entity\CopyRepository;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
@@ -23,13 +25,16 @@ use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\EmailBundle\Tests\Helper\Transport\BatchTransport;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact;
+use Mautic\PageBundle\Model\RedirectModel;
+use Mautic\PageBundle\Model\TrackableModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Routing\Router;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 
 class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 {
@@ -65,30 +70,100 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
     ];
 
     /** @var MockObject&FromEmailHelper */
-    private $fromEmaiHelper;
+    private $fromEmailHelperMock;
 
     /** @var MockObject&CoreParametersHelper */
-    private $coreParametersHelper;
+    private $coreParametersHelperMock;
 
     /** @var MockObject&Mailbox */
-    private $mailbox;
+    private $mailboxMock;
 
     /** @var MockObject&LoggerInterface */
     private MockObject $loggerMock;
 
     private MailHashHelper $mailHashHelper;
 
+    /** @var MockObject&AssetModel */
+    private MockObject $assetModelMock;
+
+    /** @var MockObject&EmailModel */
+    private MockObject $emailModelMock;
+
+    /** @var MockObject&TrackableModel */
+    private MockObject $trackableModelMock;
+
+    /** @var MockObject&RedirectModel */
+    private MockObject $redirectModelMock;
+
+    /** @var MockObject&Environment */
+    private MockObject $twigMock;
+
+    /** @var MockObject&PathsHelper */
+    private MockObject $pathsHelperMock;
+
+    /** @var MockObject&ThemeHelper */
+    private MockObject $themeHelperMock;
+
+    /** @var MockObject&Router */
+    private MockObject $routerMock;
+
+    /** @var MockObject&RequestStack */
+    private MockObject $requestStackMock;
+
+    /** @var MockObject&EventDispatcherInterface */
+    private MockObject $eventDispatcherMock;
+
+    /** @var MockObject&EntityManagerInterface */
+    private MockObject $entityManagerMock;
+
+    private SlotsHelper $slotsHelper;
+
     /** @var MockObject&TranslatorInterface */
-    private MockObject $translator;
+    private MockObject $translatorMock;
+
+    /** @var MockObject&MailHelper */
+    private MockObject $mailHelperMock;
+
+    /** @var MockObject&StatRepository */
+    private MockObject $statRepositoryMock;
+
+    /** @var MockObject&DoNotContact */
+    private MockObject $dncModelMock;
+
+    /** @var MockObject&Email */
+    private MockObject $emailMock;
+
+    private StatHelper $statHelper;
+
+    /** @var MockObject&CopyRepository */
+    private MockObject $copyRepositoryMock;
 
     protected function setUp(): void
     {
-        $this->fromEmaiHelper       = $this->createMock(FromEmailHelper::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->mailbox              = $this->createMock(Mailbox::class);
-        $this->loggerMock           = $this->createMock(LoggerInterface::class);
-        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
-        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $this->fromEmailHelperMock      = $this->createMock(FromEmailHelper::class);
+        $this->coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
+        $this->mailboxMock              = $this->createMock(Mailbox::class);
+        $this->loggerMock               = $this->createMock(LoggerInterface::class);
+        $this->mailHashHelper           = new MailHashHelper($this->coreParametersHelperMock);
+        $this->translatorMock           = $this->createMock(TranslatorInterface::class);
+        $this->assetModelMock           = $this->createMock(AssetModel::class);
+        $this->emailModelMock           = $this->createMock(EmailModel::class);
+        $this->trackableModelMock       = $this->createMock(TrackableModel::class);
+        $this->redirectModelMock        = $this->createMock(RedirectModel::class);
+        $this->twigMock                 = $this->createMock(Environment::class);
+        $this->pathsHelperMock          = $this->createMock(PathsHelper::class);
+        $this->themeHelperMock          = $this->createMock(ThemeHelper::class);
+        $this->routerMock               = $this->createMock(Router::class);
+        $this->requestStackMock         = $this->createMock(RequestStack::class);
+        $this->eventDispatcherMock      = $this->createMock(EventDispatcherInterface::class);
+        $this->entityManagerMock        = $this->createMock(EntityManagerInterface::class);
+        $this->slotsHelper              = new SlotsHelper();
+        $this->mailHelperMock           = $this->createMock(MailHelper::class);
+        $this->statRepositoryMock       = $this->createMock(StatRepository::class);
+        $this->dncModelMock             = $this->createMock(DoNotContact::class);
+        $this->emailMock                = $this->createMock(Email::class);
+        $this->statHelper               = new StatHelper($this->statRepositoryMock);
+        $this->copyRepositoryMock       = $this->createMock(CopyRepository::class);
     }
 
     /**
@@ -103,21 +178,16 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testContactsAreFailedIfSettingEmailEntityFails(): void
     {
-        $mailHelper = $this->createMock(MailHelper::class);
-        $mailHelper->method('setEmail')
+        $this->mailHelperMock->method('setEmail')
             ->willReturn(false);
 
-        $statRepository = $this->createMock(StatRepository::class);
-
-        $dncModel = $this->createMock(DoNotContact::class);
-
         // This should not be called because contact emails are just fine; the problem is with the email entity
-        $dncModel->expects($this->never())
+        $this->dncModelMock->expects($this->never())
             ->method('addDncForContact');
 
-        $statHelper = new StatHelper($statRepository);
+        $statHelper = new StatHelper($this->statRepositoryMock);
 
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $this->translator);
+        $model = new SendEmailToContact($this->mailHelperMock, $statHelper, $this->dncModelMock, $this->translatorMock);
 
         $email = new Email();
         $model->setEmail($email);
@@ -148,45 +218,35 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testExceptionIsThrownIfEmailIsSentToBadContact(): void
     {
-        $emailMock = $this->getMockBuilder(Email::class)
-            ->getMock();
-        $emailMock
+        $this->emailMock
             ->expects($this->any())
             ->method('getId')
             ->will($this->returnValue(1));
 
-        $mailHelper = $this->createMock(MailHelper::class);
-        $mailHelper->method('setEmail')
+        $this->mailHelperMock->method('setEmail')
             ->willReturn(true);
-        $mailHelper->method('addTo')
+        $this->mailHelperMock->method('addTo')
             ->willReturnCallback(
                 fn ($email) => '@bad.com' !== $email
             );
-        $mailHelper->method('queue')
+        $this->mailHelperMock->method('queue')
             ->willReturn([true, []]);
 
         $stat = new Stat();
-        $stat->setEmail($emailMock);
-        $mailHelper->method('createEmailStat')
+        $stat->setEmail($this->emailMock);
+        $this->mailHelperMock->method('createEmailStat')
             ->willReturn($stat);
 
-        $statRepository = $this->createMock(StatRepository::class);
-
-        $dncModel = $this->createMock(DoNotContact::class);
-
-        $dncModel->expects($this->once())
+        $this->dncModelMock->expects($this->once())
             ->method('addDncForContact');
 
-        $statHelper = new StatHelper($statRepository);
+        $model = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $model->setEmail($this->emailMock);
 
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $this->translator);
-        $model->setEmail($emailMock);
-
-        $contacts             = $this->contacts;
-        $contacts[0]['email'] = '@bad.com';
+        $this->contacts[0]['email'] = '@bad.com';
 
         $exceptionThrown = false;
-        foreach ($contacts as $contact) {
+        foreach ($this->contacts as $contact) {
             try {
                 $model->setContact($contact)
                     ->send();
@@ -216,92 +276,72 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testBadEmailDoesNotCauseBatchQueueMaxExceptionOnSubsequentContacts(): void
     {
-        $emailMock = $this->createMock(Email::class);
-        $emailMock->method('getId')->will($this->returnValue(1));
-        $emailMock->method('getFromAddress')->willReturn('test@mautic.com');
-        $emailMock->method('getSubject')->willReturn('Subject');
-        $emailMock->method('getCustomHtml')->willReturn('content');
+        $this->emailMock->method('getId')->will($this->returnValue(1));
+        $this->emailMock->method('getFromAddress')->willReturn('test@mautic.com');
+        $this->emailMock->method('getSubject')->willReturn('Subject');
+        $this->emailMock->method('getCustomHtml')->willReturn('content');
 
         // Use our test token transport limiting to 1 recipient per queue
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getParameter')
-            ->willReturnCallback(
-                fn ($param) => match ($param) {
-                    default => '',
-                }
-            );
-        $factoryMock->method('getLogger')
-            ->willReturn(
-                new NullLogger()
-            );
-        $factoryMock->method('getDispatcher')
-            ->willReturn(
-                new EventDispatcher()
-            );
-        $routerMock = $this->createMock(Router::class);
-        $factoryMock->method('getRouter')
-            ->willReturn($routerMock);
-
-        $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
+        $this->fromEmailHelperMock->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
-        $this->coreParametersHelper->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
+        $this->coreParametersHelperMock->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
 
-        $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper])
+        $this->mailHelperMock = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([
+                $mailer,
+                $this->fromEmailHelperMock,
+                $this->coreParametersHelperMock,
+                $this->mailboxMock,
+                $this->loggerMock,
+                $this->mailHashHelper,
+                $this->assetModelMock,
+                $this->emailModelMock,
+                $this->trackableModelMock,
+                $this->redirectModelMock,
+                $this->twigMock,
+                $this->pathsHelperMock,
+                $this->themeHelperMock,
+                $this->routerMock,
+                $this->requestStackMock,
+                $this->eventDispatcherMock,
+                $this->entityManagerMock,
+                $this->slotsHelper,
+            ])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
-        $mailHelper->method('createEmailStat')
-            ->willReturnCallback(
-                function () use ($emailMock) {
+        $this->mailHelperMock->method('createEmailStat')
+            ->will($this->returnCallback(
+                function () {
                     $stat = new Stat();
-                    $stat->setEmail($emailMock);
-
+                    $stat->setEmail($this->emailMock);
                     $leadMock = $this->getMockBuilder(Lead::class)
-                        ->getMock();
+                       ->getMock();
                     $leadMock->method('getId')
-                        ->willReturn(1);
+                       ->willReturn(1);
 
                     $stat->setLead($leadMock);
 
                     return $stat;
                 }
-            );
+            ));
 
         // Enable queueing
-        $mailHelper->enableQueue();
+        $this->mailHelperMock->enableQueue();
 
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel->expects($this->exactly(1))
+        $this->dncModelMock->expects($this->exactly(1))
             ->method('addDncForContact');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $model = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $model->setEmail($this->emailMock);
 
-        $statHelper = new StatHelper($statRepository);
+        $this->contacts[0]['email'] = '@bad.com';
 
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
-        $model->setEmail($emailMock);
-
-        $contacts             = $this->contacts;
-        $contacts[0]['email'] = '@bad.com';
-
-        foreach ($contacts as $contact) {
+        foreach ($this->contacts as $contact) {
             try {
                 $model->setContact($contact)
                     ->send();
@@ -332,42 +372,18 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testBatchQueueContactsHaveTokensHydrated(): void
     {
-        $this->coreParametersHelper->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
+        $this->coreParametersHelperMock->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
 
-        $emailMock = $this->createMock(Email::class);
-        $emailMock->method('getId')->will($this->returnValue(1));
-        $emailMock->method('getFromAddress')->willReturn('test@mautic.com');
-        $emailMock->method('getSubject')->willReturn('Subject');
-        $emailMock->method('getCustomHtml')->willReturn('Hi {contactfield=firstname}');
+        $this->emailMock->method('getId')->will($this->returnValue(1));
+        $this->emailMock->method('getFromAddress')->willReturn('test@mautic.com');
+        $this->emailMock->method('getSubject')->willReturn('Subject');
+        $this->emailMock->method('getCustomHtml')->willReturn('Hi {contactfield=firstname}');
 
         // Use our test token transport limiting to 1 recipient per queue
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getParameter')
-            ->willReturnCallback(
-                fn ($param) => match ($param) {
-                    default => '',
-                }
-            );
-        $factoryMock->method('getLogger')
-            ->willReturn(
-                new NullLogger()
-            );
-
-        $mockEm = $this->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getEntityManager')
-            ->willReturn($mockEm);
-
-        $mockDispatcher = $this->getMockBuilder(EventDispatcher::class)
-            ->getMock();
-        $mockDispatcher->method('dispatch')
+        $this->eventDispatcherMock->method('dispatch')
             ->willReturnCallback(
                 function (EmailSendEvent $event, $eventName) {
                     $lead = $event->getLead();
@@ -383,41 +399,41 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                     return $event;
                 }
             );
-        $factoryMock->method('getDispatcher')
-            ->willReturn($mockDispatcher);
-        $routerMock = $this->getMockBuilder(Router::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getRouter')
-            ->willReturn($routerMock);
 
-        $copyRepoMock = $this->getMockBuilder(CopyRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $emailModelMock = $this->getMockBuilder(EmailModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $emailModelMock->method('getCopyRepository')
-            ->willReturn($copyRepoMock);
+        $this->emailModelMock->method('getCopyRepository')
+            ->willReturn($this->copyRepositoryMock);
 
-        $factoryMock->method('getModel')
-            ->willReturn($emailModelMock);
-
-        $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
+        $this->fromEmailHelperMock->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
-        $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper])
-            ->onlyMethods([])
-            ->getMock();
+        $this->mailHelperMock = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([
+                $mailer,
+                $this->fromEmailHelperMock,
+                $this->coreParametersHelperMock,
+                $this->mailboxMock,
+                $this->loggerMock,
+                $this->mailHashHelper,
+                $this->assetModelMock,
+                $this->emailModelMock,
+                $this->trackableModelMock,
+                $this->redirectModelMock,
+                $this->twigMock,
+                $this->pathsHelperMock,
+                $this->themeHelperMock,
+                $this->routerMock,
+                $this->requestStackMock,
+                $this->eventDispatcherMock,
+                $this->entityManagerMock,
+                $this->slotsHelper,
+           ])
+           ->onlyMethods([])
+           ->getMock();
 
         // Enable queueing
-        $mailHelper->enableQueue();
+        $this->mailHelperMock->enableQueue();
 
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepository->method('saveEntity')
+        $this->statRepositoryMock->method('saveEntity')
             ->willReturnCallback(
                 function (Stat $stat): void {
                     $tokens = $stat->getTokens();
@@ -426,18 +442,8 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
-        $model->setEmail($emailMock);
+        $model = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $model->setEmail($this->emailMock);
 
         foreach ($this->contacts as $contact) {
             try {
@@ -464,93 +470,72 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testThatStatEntriesAreCreatedAndPersistedEveryBatch(): void
     {
-        $this->coreParametersHelper->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
+        $this->coreParametersHelperMock->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
 
-        $emailMock = $this->createMock(Email::class);
-        $emailMock->method('getId')->willReturn(1);
-        $emailMock->method('getFromAddress')->willReturn('test@mautic.com');
-        $emailMock->method('getSubject')->willReturn('Subject');
-        $emailMock->method('getCustomHtml')->willReturn('content');
+        $this->emailMock->method('getId')->willReturn(1);
+        $this->emailMock->method('getFromAddress')->willReturn('test@mautic.com');
+        $this->emailMock->method('getSubject')->willReturn('Subject');
+        $this->emailMock->method('getCustomHtml')->willReturn('content');
 
         // Use our test token transport limiting to 1 recipient per queue
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getParameter')
-            ->willReturnCallback(
-                fn ($param) => match ($param) {
-                    default => '',
-                }
-            );
-        $factoryMock->method('getLogger')
-            ->willReturn(
-                new NullLogger()
-            );
-        $factoryMock->method('getDispatcher')
-            ->willReturn(
-                new EventDispatcher()
-            );
-        $routerMock = $this->getMockBuilder(Router::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $factoryMock->method('getRouter')
-            ->willReturn($routerMock);
-
-        $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
+        $this->fromEmailHelperMock->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
-        $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper])
+        $this->mailHelperMock = $this->getMockBuilder(MailHelper::class)
+          ->setConstructorArgs([
+            $mailer,
+            $this->fromEmailHelperMock,
+            $this->coreParametersHelperMock,
+            $this->mailboxMock,
+            $this->loggerMock,
+            $this->mailHashHelper,
+            $this->assetModelMock,
+            $this->emailModelMock,
+            $this->trackableModelMock,
+            $this->redirectModelMock,
+            $this->twigMock,
+            $this->pathsHelperMock,
+            $this->themeHelperMock,
+            $this->routerMock,
+            $this->requestStackMock,
+            $this->eventDispatcherMock,
+            $this->entityManagerMock,
+            $this->slotsHelper,
+          ])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
-        $mailHelper->expects($this->exactly(21))
-            ->method('createEmailStat')
-            ->willReturnCallback(
-                function () use ($emailMock) {
+        $this->mailHelperMock->method('createEmailStat')
+            ->will($this->returnCallback(
+                function () {
                     $stat = new Stat();
-                    $stat->setEmail($emailMock);
-
+                    $stat->setEmail($this->emailMock);
                     $leadMock = $this->getMockBuilder(Lead::class)
-                        ->getMock();
+                          ->getMock();
                     $leadMock->method('getId')
-                        ->willReturn(1);
+                      ->willReturn(1);
 
                     $stat->setLead($leadMock);
 
                     return $stat;
                 }
-            );
+            ));
 
         // Enable queueing
-        $mailHelper->enableQueue();
+        $this->mailHelperMock->enableQueue();
 
         // Here's the test; this should be called after 20 contacts are processed
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepository->expects($this->exactly(21))
+        $this->statRepositoryMock->expects($this->exactly(21))
             ->method('saveEntity');
 
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel->expects($this->never())
+        $this->dncModelMock->expects($this->never())
             ->method('addDncForContact');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
-        $model->setEmail($emailMock);
+        $model = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $model->setEmail($this->emailMock);
 
         // Let's generate 20 bogus contacts
         $contacts = [];
@@ -595,67 +580,66 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     public function testThatAFailureFromTransportIsHandled(): void
     {
-        $this->coreParametersHelper->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
+        $this->coreParametersHelperMock->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
 
-        $emailMock = $this->createMock(Email::class);
-        $emailMock->method('getId')->willReturn(1);
-        $emailMock->method('getFromAddress')->willReturn('test@mautic.com');
-        $emailMock->method('getSubject')->willReturn(''); // The subject must be empty for the email to fail.
-        $emailMock->method('getCustomHtml')->willReturn('content');
+        $this->emailMock->method('getId')->willReturn(1);
+        $this->emailMock->method('getFromAddress')->willReturn('test@mautic.com');
+        $this->emailMock->method('getSubject')->willReturn(''); // The subject must be empty for the email to fail.
+        $this->emailMock->method('getCustomHtml')->willReturn('content');
 
         // Use our test token transport limiting to 1 recipient per queue
         $transport = new BatchTransport(true, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->createMock(MauticFactory::class);
-        $factoryMock->method('getParameter')
-            ->willReturnCallback(
-                fn ($param) => match ($param) {
-                    default => '',
-                }
-            );
+        $this->fromEmailHelperMock->method('getFromAddressConsideringOwner')->willReturn(new AddressDTO('someone@somewhere.com'));
 
-        $this->fromEmaiHelper->method('getFromAddressConsideringOwner')->willReturn(new AddressDTO('someone@somewhere.com'));
-        $factoryMock->method('getLogger')->willReturn(new NullLogger());
-        $factoryMock->method('getDispatcher')->willReturn(new EventDispatcher());
-        $routerMock = $this->createMock(Router::class);
-        $factoryMock->method('getRouter')->willReturn($routerMock);
-
-        /** @var MockObject&MailHelper $mailHelper */
-        $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper])
+        $this->mailHelperMock = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([
+                  $mailer,
+                  $this->fromEmailHelperMock,
+                  $this->coreParametersHelperMock,
+                  $this->mailboxMock,
+                  $this->loggerMock,
+                  $this->mailHashHelper,
+                  $this->assetModelMock,
+                  $this->emailModelMock,
+                  $this->trackableModelMock,
+                  $this->redirectModelMock,
+                  $this->twigMock,
+                  $this->pathsHelperMock,
+                  $this->themeHelperMock,
+                  $this->routerMock,
+                  $this->requestStackMock,
+                  $this->eventDispatcherMock,
+                  $this->entityManagerMock,
+                  $this->slotsHelper,
+            ])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
-        $mailHelper->method('createEmailStat')
-            ->willReturnCallback(
-                function () use ($emailMock) {
+        $this->mailHelperMock->method('createEmailStat')
+            ->will($this->returnCallback(
+                function () {
                     $stat = new Stat();
-                    $stat->setEmail($emailMock);
-
-                    $leadMock = $this->createMock(Lead::class);
-                    $leadMock->method('getId')->willReturn(1);
+                    $stat->setEmail($this->emailMock);
+                    $leadMock = $this->getMockBuilder(Lead::class)
+                        ->getMock();
+                    $leadMock->method('getId')
+                        ->willReturn(1);
 
                     $stat->setLead($leadMock);
 
                     return $stat;
                 }
-            );
+            ));
 
         // Enable queueing
-        $mailHelper->enableQueue();
+        $this->mailHelperMock->enableQueue();
 
-        $statRepository = $this->createMock(StatRepository::class);
-        $dncModel       = $this->createMock(DoNotContact::class);
-        $translator     = $this->createMock(Translator::class);
+        $this->dncModelMock->expects($this->never())->method('addDncForContact');
 
-        $dncModel->expects($this->never())->method('addDncForContact');
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
-        $model->setEmail($emailMock);
+        $model = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $model->setEmail($this->emailMock);
 
         foreach ($this->contacts as $contact) {
             try {
@@ -692,31 +676,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
     {
         defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
 
-        /** @var MockObject&MauticFactory $mockFactory */
-        $mockFactory = $this->createMock(MauticFactory::class);
-        $mockFactory->method('getParameter')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['mailer_return_path', false, null],
-                    ]
-                )
-            );
-        $mockFactory->method('getLogger')->willReturn(new NullLogger());
-
-        /** @var MockObject&FromEmailHelper $fromEmailHelper */
-        $fromEmailHelper = $this->createMock(FromEmailHelper::class);
-
-        /** @var MockObject&CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-
-        /** @var MockObject&Mailbox $mailbox */
-        $mailbox = $this->createMock(Mailbox::class);
-
-        /** @var MockObject&LoggerInterface $logger */
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $coreParametersHelper->method('get')
+        $this->coreParametersHelperMock->method('get')
             ->willReturnMap(
                 [
                     ['mailer_from_email', null, 'nobody@nowhere.com'],
@@ -725,27 +685,46 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             );
 
         $mailer         = new Mailer(new BatchTransport());
-        $mailHelper     = new MailHelper($mockFactory, $mailer, $fromEmailHelper, $coreParametersHelper, $mailbox, $logger, $this->mailHashHelper);
-        $statRepository = $this->createMock(StatRepository::class);
-        $dncModel       = $this->createMock(DoNotContact::class);
-        $translator     = $this->createMock(Translator::class);
-        $statHelper     = new StatHelper($statRepository);
-        $model          = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
-        $emailMock      = $this->createMock(Email::class);
-        $emailMock->method('getId')->willReturn(1);
-        $emailMock->method('getSubject')->willReturn('subject');
-        $emailMock->method('getCustomHtml')->willReturn('content');
+
+        $this->mailHelperMock = $this->getMockBuilder(MailHelper::class)
+            ->setConstructorArgs([
+                $mailer,
+                $this->fromEmailHelperMock,
+                $this->coreParametersHelperMock,
+                $this->mailboxMock,
+                $this->loggerMock,
+                $this->mailHashHelper,
+                $this->assetModelMock,
+                $this->emailModelMock,
+                $this->trackableModelMock,
+                $this->redirectModelMock,
+                $this->twigMock,
+                $this->pathsHelperMock,
+                $this->themeHelperMock,
+                $this->routerMock,
+                $this->requestStackMock,
+                $this->eventDispatcherMock,
+                $this->entityManagerMock,
+                $this->slotsHelper,
+            ])
+        ->onlyMethods([])
+        ->getMock();
+
+        $model          = new SendEmailToContact($this->mailHelperMock, $this->statHelper, $this->dncModelMock, $this->translatorMock);
+        $this->emailMock->method('getId')->willReturn(1);
+        $this->emailMock->method('getSubject')->willReturn('subject');
+        $this->emailMock->method('getCustomHtml')->willReturn('content');
 
         // Set invalid BCC (should use comma as separator)
-        $emailMock
+        $this->emailMock
             ->expects($this->any())
             ->method('getBccAddress')
             ->willReturn('test@mautic.com; test@mautic.com');
 
-        $model->setEmail($emailMock);
+        $model->setEmail($this->emailMock);
 
         $stat = new Stat();
-        $stat->setEmail($emailMock);
+        $stat->setEmail($this->emailMock);
 
         $this->expectException(FailedToSendToContactException::class);
         $this->expectExceptionMessage('Email "test@mautic.com; test@mautic.com" does not comply with addr-spec of RFC 2822.');

--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -22,16 +22,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormSubscriber implements EventSubscriberInterface
 {
-    private MailHelper $mailer;
-
     public function __construct(
         private IpLookupHelper $ipLookupHelper,
         private AuditLogModel $auditLogModel,
-        MailHelper $mailer,
+        private MailHelper $mailer,
         private TranslatorInterface $translator,
         private RouterInterface $router
     ) {
-        $this->mailer = $mailer->getMailer();
+        $this->mailer->reset();
     }
 
     public static function getSubscribedEvents(): array

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -38,10 +38,6 @@ class FormSubscriberTest extends TestCase
         $translator           = $this->createMock(TranslatorInterface::class);
         $router               = $this->createMock(RouterInterface::class);
 
-        $this->mailer->expects($this->once())
-            ->method('getMailer')
-            ->willReturnSelf();
-
         $this->subscriber = new FormSubscriber(
             $ipLookupHelper,
             $auditLogModel,

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1402,38 +1402,38 @@ class LeadController extends FormController
 
                     $bodyCheck = trim(strip_tags($email['body']));
                     if (!empty($bodyCheck)) {
-                        $mailer = $mailHelper->getMailer();
+                        $mailHelper->reset();
 
                         // To lead
-                        $mailer->addTo($leadEmail, $leadName);
+                        $mailHelper->addTo($leadEmail, $leadName);
 
                         if (!empty($email[EmailType::REPLY_TO_ADDRESS])) {
                             // The reply to address must be set into an email entity in order to take an effect. Otherwise it's overridden.
                             $emailEntity = new Email();
                             $emailEntity->setSubject($email['subject']);
                             $emailEntity->setReplyToAddress($email[EmailType::REPLY_TO_ADDRESS]);
-                            $mailer->setEmail($emailEntity);
+                            $mailHelper->setEmail($emailEntity);
                         }
 
-                        $mailer->setFrom(
+                        $mailHelper->setFrom(
                             $email['from'],
                             empty($email['fromname']) ? null : $email['fromname']
                         );
 
                         // Set Content
-                        $mailer->setBody($email['body']);
-                        $mailer->parsePlainText($email['body']);
+                        $mailHelper->setBody($email['body']);
+                        $mailHelper->parsePlainText($email['body']);
 
                         // Set lead
-                        $mailer->setLead($leadFields);
-                        $mailer->setIdHash();
+                        $mailHelper->setLead($leadFields);
+                        $mailHelper->setIdHash();
 
-                        $mailer->setSubject($email['subject']);
+                        $mailHelper->setSubject($email['subject']);
 
                         // Ensure safe emoji for notification
                         $subject = EmojiHelper::toHtml($email['subject']);
-                        if ($mailer->send(true, false)) {
-                            $mailer->createEmailStat();
+                        if ($mailHelper->send(true, false)) {
+                            $mailHelper->createEmailStat();
                             $this->addFlashMessage(
                                 'mautic.lead.email.notice.sent',
                                 [
@@ -1442,7 +1442,7 @@ class LeadController extends FormController
                                 ]
                             );
                         } else {
-                            $errors = $mailer->getErrors();
+                            $errors = $mailHelper->getErrors();
 
                             // Unset the array of failed email addresses
                             if (isset($errors['failures'])) {

--- a/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
+++ b/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
@@ -9,19 +9,17 @@ use Mautic\ReportBundle\Exception\FileTooBigException;
 
 class SendSchedule
 {
-    private \Mautic\EmailBundle\Helper\MailHelper $mailer;
-
     public function __construct(
-        MailHelper $mailer,
+        private MailHelper $mailer,
         private MessageSchedule $messageSchedule,
         private FileHandler $fileHandler
     ) {
-        $this->mailer          = $mailer->getMailer();
+        $this->mailer->reset();
     }
 
     public function send(Scheduler $scheduler, $csvFilePath): void
     {
-        $this->mailer->reset(true);
+        $this->mailer->reset();
 
         $transformer = new ArrayStringTransformer();
         $report      = $scheduler->getReport();

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
@@ -44,10 +44,6 @@ class SendScheduleTest extends \PHPUnit\Framework\TestCase
         $this->messageSchedule = $this->createMock(MessageSchedule::class);
         $this->fileHandler     = $this->createMock(FileHandler::class);
 
-        $this->mailHelperMock->expects($this->once())
-            ->method('getMailer')
-            ->willReturnSelf();
-
         $this->sendSchedule = new SendSchedule(
             $this->mailHelperMock,
             $this->messageSchedule,

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -261,7 +261,7 @@ class UserModel extends FormModel
      */
     public function sendResetEmail(User $user): void
     {
-        $mailer = $this->mailHelper->getMailer();
+        $this->mailHelper->reset();
 
         $resetToken = $this->getResetToken($user);
         $this->em->persist($resetToken);
@@ -273,8 +273,8 @@ class UserModel extends FormModel
         }
         $resetLink  = $this->router->generate('mautic_user_passwordresetconfirm', ['token' => $resetToken->getSecret()], UrlGeneratorInterface::ABSOLUTE_URL);
 
-        $mailer->setTo([$user->getEmail() => $user->getName()]);
-        $mailer->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
+        $this->mailHelper->setTo([$user->getEmail() => $user->getName()]);
+        $this->mailHelper->setSubject($this->translator->trans('mautic.user.user.passwordreset.subject'));
         $text = $this->translator->trans(
             'mautic.user.user.passwordreset.email.body',
             ['%name%' => $user->getFirstName(), '%resetlink%' => '<a href="'.$resetLink.'">'.$resetLink.'</a>']
@@ -308,14 +308,14 @@ class UserModel extends FormModel
 
     private function prepareEMail(string $subject, string $content): MailHelper
     {
-        $mailer  = $this->mailHelper->getMailer();
+        $this->mailHelper->reset();
         $content = str_replace('\\n', "\n", $content);
         $html    = nl2br($content);
-        $mailer->setSubject($subject);
-        $mailer->setBody($html);
-        $mailer->setPlainText(strip_tags($content));
+        $this->mailHelper->setSubject($subject);
+        $this->mailHelper->setBody($html);
+        $this->mailHelper->setPlainText(strip_tags($content));
 
-        return $mailer;
+        return $this->mailHelper;
     }
 
     /**

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -95,10 +95,6 @@ class UserModelTest extends TestCase
             ->method('generateSecret')
             ->willReturn($this->userToken);
 
-        $this->mailHelper
-            ->method('getMailer')
-            ->willReturn($this->mailHelper);
-
         $this->mailHelper->expects($this->once())
             ->method('send');
 
@@ -152,10 +148,6 @@ class UserModelTest extends TestCase
             ->willReturn($name);
 
         $this->mailHelper->expects($this->once())
-            ->method('getMailer')
-            ->willReturn($this->mailHelper);
-
-        $this->mailHelper->expects($this->once())
             ->method('setTo')
             ->with($toMail)
             ->willReturn(true);
@@ -172,10 +164,6 @@ class UserModelTest extends TestCase
         $toMails = ['a@test.com', 'b@test.com'];
         $subject = 'subject';
         $content = 'content';
-
-        $this->mailHelper->expects($this->once())
-            ->method('getMailer')
-            ->willReturn($this->mailHelper);
 
         $this->mailHelper->expects($this->once())
             ->method('setTo')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X ]
| Deprecations?                          | [ getMailer and getSampleMailer from Mailhelper, to be replaced with default mailHelper reset function.]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

MauticFactory is deprecated from M2 and scheduled for removal in M3. That did not happen, but let's hope we can remove it in M6. To do this, all internal usage of it must be gone by the time we get to M6. But removal of internal usage can happen in M5. So let's do it. 
This removes the usage from the MailHelper class, which was a big user. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test all functionality MailHelper touches, or trust on testing and phpstan. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
