### PR TITLE
Ajax call on keyup instead of enter key integration

### DIFF
--- a/app/bundles/IntegrationsBundle/Assets/js/integrations.js
+++ b/app/bundles/IntegrationsBundle/Assets/js/integrations.js
@@ -1,19 +1,17 @@
 Mautic.integrationsConfigOnLoad = function () {
     mQuery('.integration-keyword-filter').each(function() {
-        mQuery(this).off("keydown.integration-filter").on("keydown.integration-filter", function (event) {
-            if (event.which == 13) {
-                var integration = mQuery(this).attr('data-integration');
-                var object = mQuery(this).attr('data-object');
-                Mautic.getPaginatedIntegrationFields(
-                    {
-                        'integration': integration,
-                        'object': object,
-                        'keyword': mQuery(this).val()
-                    },
-                    1,
-                    this
-                );
-            }
+        mQuery(this).off("keyup.integration-filter").on("keyup.integration-filter", function (event) {
+            var integration = mQuery(this).attr('data-integration');
+            var object = mQuery(this).attr('data-object');
+            Mautic.getPaginatedIntegrationFields(
+                {
+                    'integration': integration,
+                    'object': object,
+                    'keyword': mQuery(this).val()
+                },
+                1,
+                this
+            );
         });
     });
 

--- a/app/bundles/IntegrationsBundle/Helper/FieldFilterHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/FieldFilterHelper.php
@@ -77,7 +77,7 @@ class FieldFilterHelper
         $found = [];
 
         foreach ($fields as $name => $field) {
-            if (!stristr($field->getName(), $keyword)) {
+            if (!stristr($field->getLabel(), $keyword)) {
                 continue;
             }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
@@ -65,19 +65,19 @@ class FieldFilterHelperTest extends TestCase
     private function getIntegrationObject()
     {
         $field1 = $this->createMock(MappedFieldInfoInterface::class);
-        $field1->method('getName')
+        $field1->method('getLabel')
             ->willReturn('field one');
         $field2 = $this->createMock(MappedFieldInfoInterface::class);
-        $field2->method('getName')
+        $field2->method('getLabel')
             ->willReturn('field two');
         $field3 = $this->createMock(MappedFieldInfoInterface::class);
-        $field3->method('getName')
+        $field3->method('getLabel')
             ->willReturn('field three');
         $field4 = $this->createMock(MappedFieldInfoInterface::class);
-        $field4->method('getName')
+        $field4->method('getLabel')
             ->willReturn('field four');
         $field5 = $this->createMock(MappedFieldInfoInterface::class);
-        $field5->method('getName')
+        $field5->method('getLabel')
             ->willReturn('field five');
 
         $integrationObject = $this->createMock(ConfigFormSyncInterface::class);


### PR DESCRIPTION
[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Yes
| New feature? | No
| Automated tests included? | No
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Change search request on key up instead of enter key.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Go To - Plugins -> Salesforce -> Lead Field Mapping (Configure salesforce if not exists )
use  for configure salesforce.
2. In Filter user need to press "Enter" to filter field.
3. Switch to "Lead Field Mapping" tab
4. Start typing in "Filter Integration fields"
5. Type word with space Ex. "Last Name" or "Clean S".
6. The fields are available but would not display fields.


#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Go To - Plugins -> Salesforce -> Lead Field Mapping 
3. Field should be filter on type keyword only.
4. Switch to "Lead Field Mapping" tab
5. Start typing in "Filter Integration fields"
6. Type word with space Ex. "Last Name" or "Clean S".
7. If fields are available then should be display.

#### Other areas of Mautic that may be affected by the change:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
