### PR TITLE
DPMMA-2401 Use object's timezone when comparing with 'now' in DateTimeHelper

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -195,15 +195,15 @@ class DateTimeHelper
     /**
      * Gets a difference.
      *
-     * @param string     $compare
-     * @param bool|false $resetTime
+     * @param string|\DateTime $compare
+     * @param bool|false       $resetTime
      *
      * @return bool|\DateInterval|string
      */
     public function getDiff($compare = 'now', $format = null, $resetTime = false)
     {
         if ('now' == $compare) {
-            $compare = new \DateTime();
+            $compare = new \DateTime('now', $this->datetime->getTimezone());
         }
 
         $with = clone $this->datetime;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
@@ -126,4 +126,121 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         // Assert that the interval has the correct timezone
         $this->assertEquals($nonDefaultTimezone->getName(), $dateTimeHelper->getDateTime()->getTimezone()->getName());
     }
+
+    public function testAddMethodModifiesOriginalDateTime()
+    {
+        $originalDate   = '2023-01-01 12:00:00';
+        $intervalString = 'P1D'; // Interval of 1 day
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Add interval to the original DateTime object
+        $dateTimeHelper->add($intervalString);
+
+        // Get the modified DateTime object
+        $modifiedDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the date has been modified correctly
+        $this->assertEquals('2023-01-02 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
+
+    public function testAddMethodReturnsClonedDateTime()
+    {
+        $originalDate   = '2023-01-01 12:00:00';
+        $intervalString = 'P1D'; // Interval of 1 day
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Add interval to a clone of the original DateTime object
+        $clonedDateTime = $dateTimeHelper->add($intervalString, true);
+
+        // Get the original DateTime object
+        $originalDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the clone has been modified correctly
+        $this->assertEquals('2023-01-02 12:00:00', $clonedDateTime->format(DateTimeHelper::FORMAT_DB));
+
+        // Assert that the original DateTime object remains unchanged
+        $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
+
+    public function testSubMethodModifiesOriginalDateTime()
+    {
+        $originalDate   = '2023-01-02 12:00:00';
+        $intervalString = 'P1D'; // Interval of 1 day
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Subtract interval from the original DateTime object
+        $dateTimeHelper->sub($intervalString);
+
+        // Get the modified DateTime object
+        $modifiedDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the date has been modified correctly
+        $this->assertEquals('2023-01-01 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
+
+    public function testSubMethodReturnsClonedDateTime()
+    {
+        $originalDate   = '2023-01-02 12:00:00';
+        $intervalString = 'P1D'; // Interval of 1 day
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Subtract interval from a clone of the original DateTime object
+        $clonedDateTime = $dateTimeHelper->sub($intervalString, true);
+
+        // Get the original DateTime object
+        $originalDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the clone has been modified correctly
+        $this->assertEquals('2023-01-01 12:00:00', $clonedDateTime->format(DateTimeHelper::FORMAT_DB));
+
+        // Assert that the original DateTime object remains unchanged
+        $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
+
+    public function testModifyMethodModifiesOriginalDateTime()
+    {
+        $originalDate       = '2023-01-02 12:00:00';
+        $modificationString = '+1 day';
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Modify the original DateTime object
+        $dateTimeHelper->modify($modificationString);
+
+        // Get the modified DateTime object
+        $modifiedDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the date has been modified correctly
+        $this->assertEquals('2023-01-03 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
+
+    public function testModifyMethodReturnsClonedDateTime()
+    {
+        $originalDate       = '2023-01-02 12:00:00';
+        $modificationString = '+1 day';
+
+        // Initialize DateTimeHelper with a specific date
+        $dateTimeHelper = new DateTimeHelper($originalDate, DateTimeHelper::FORMAT_DB, 'UTC');
+
+        // Modify a clone of the original DateTime object
+        $clonedDateTime = $dateTimeHelper->modify($modificationString, true);
+
+        // Get the original DateTime object
+        $originalDateTime = $dateTimeHelper->getDateTime();
+
+        // Assert that the clone has been modified correctly
+        $this->assertEquals('2023-01-03 12:00:00', $clonedDateTime->format(DateTimeHelper::FORMAT_DB));
+
+        // Assert that the original DateTime object remains unchanged
+        $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
+    }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
@@ -127,7 +127,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($nonDefaultTimezone->getName(), $dateTimeHelper->getDateTime()->getTimezone()->getName());
     }
 
-    public function testAddMethodModifiesOriginalDateTime()
+    public function testAddMethodModifiesOriginalDateTime(): void
     {
         $originalDate   = '2023-01-01 12:00:00';
         $intervalString = 'P1D'; // Interval of 1 day
@@ -145,7 +145,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2023-01-02 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    public function testAddMethodReturnsClonedDateTime()
+    public function testAddMethodReturnsClonedDateTime(): void
     {
         $originalDate   = '2023-01-01 12:00:00';
         $intervalString = 'P1D'; // Interval of 1 day
@@ -166,7 +166,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    public function testSubMethodModifiesOriginalDateTime()
+    public function testSubMethodModifiesOriginalDateTime(): void
     {
         $originalDate   = '2023-01-02 12:00:00';
         $intervalString = 'P1D'; // Interval of 1 day
@@ -184,7 +184,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2023-01-01 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    public function testSubMethodReturnsClonedDateTime()
+    public function testSubMethodReturnsClonedDateTime(): void
     {
         $originalDate   = '2023-01-02 12:00:00';
         $intervalString = 'P1D'; // Interval of 1 day
@@ -205,7 +205,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    public function testModifyMethodModifiesOriginalDateTime()
+    public function testModifyMethodModifiesOriginalDateTime(): void
     {
         $originalDate       = '2023-01-02 12:00:00';
         $modificationString = '+1 day';
@@ -223,7 +223,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2023-01-03 12:00:00', $modifiedDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    public function testModifyMethodReturnsClonedDateTime()
+    public function testModifyMethodReturnsClonedDateTime(): void
     {
         $originalDate       = '2023-01-02 12:00:00';
         $modificationString = '+1 day';


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13331 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This pull request addresses an issue in the DateTimeHelper class where comparing a date with the current time ('now') did not take into account the timezone of the DateTimeHelper object's internal DateTime.

Comparing the `DateTime` objects with different timezones and using the `$resetTime` option may cause problems when displaying the date in today/yesterday format, like the one described in #13331.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Follow the steps to reproduce the issue: #13331.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
