### PR TITLE
[UX] Create a subtitle below signature field (Account page) to remember variables the user can use

### DIFF
--- a/app/bundles/UserBundle/Form/Type/UserType.php
+++ b/app/bundles/UserBundle/Form/Type/UserType.php
@@ -193,6 +193,7 @@ class UserType extends AbstractType
                     'class' => 'form-control',
                 ],
                 'data' => $defaultSignature,
+                'help' => 'mautic.user.config.signature.helper',
             ]
         );
 

--- a/app/bundles/UserBundle/Translations/en_US/messages.ini
+++ b/app/bundles/UserBundle/Translations/en_US/messages.ini
@@ -89,3 +89,4 @@ mautic.user.config.form.saml.idp.own_private_key.tooltip="Upload the private key
 mautic.user.config.form.saml.idp.own_password="Private key encryption password"
 mautic.user.config.form.saml.idp.own_password.tooltip="If the private key is encrypted with a password, enter it here."
 mautic.user.config.header.saml="SAML SSO Settings"
+mautic.user.config.signature.helper="You can use the |FROM_NAME| variable in your signature to automatically insert the sender's name."


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13323  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Users are currently facing difficulty in understanding what variables they can use after changing their signatures. This issue can be resolved by providing a clear and comprehensive list of usable variables, along with their descriptions, immediately after a user changes their signature.

Impact: Addressing this issue would significantly enhance the user experience, as it would provide users with immediate clarity and guidance, reducing confusion and potential errors. This improvement would be particularly beneficial for new users or those less familiar with the system, making the platform more accessible and user-friendly.

![image](https://github.com/mautic/mautic/assets/116097999/78e919d8-6240-4881-aa60-cf499339ae82)


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open user account page
3. Look at the signature field

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
