### PR TITLE
[UX] Change marketplace Composer message to be marketer-friendly

### DIFF
--- a/app/bundles/MarketplaceBundle/Translations/en_US/messages.ini
+++ b/app/bundles/MarketplaceBundle/Translations/en_US/messages.ini
@@ -1,6 +1,6 @@
 marketplace.title="Marketplace <sup>BETA</sup>"
 marketplace.beta.warning="<strong>Heads up!</strong> This is a preview of the Mautic Marketplace. Some things might not work as expected yet. <a target='_blank' href='https://docs.mautic.org/en/marketplace'>[Read more]</a>"
-marketplace.composer.required="<strong>Heads up!</strong> Composer is required for installing and updating plugins in the Marketplace. It looks like you're not using Composer yet, so you'll only be able to browse the Marketplace. Want to switch to Composer today? <a target='_blank' href='https://mau.tc/switch-to-composer'>Read more in the Mautic documentation</a>"
+marketplace.composer.required="<strong>Heads up!</strong> Technical setup required to install or update plugins. <a target='_blank' href='https://mau.tc/switch-to-composer'>Send these instructions to a developer.</a>"
 mautic.marketplace.permissions.header="Marketplace Permissions"
 mautic.marketplace.permissions.packages="Packages - User has access to"
 marketplace.vendor="Vendor"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13325  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
The current message displayed in the Marketplace Composer is not marketer-friendly, meaning it may not effectively communicate the value proposition or appeal to potential customers. This issue can be resolved by revising the message to direct the user to send instructions for a developer.

#### Impact
Addressing this issue would be beneficial for marketers and businesses using the platform, as it would enhance the understanding of the messages. A more marketer-friendly message could potentially improve the overall user experience for those browsing the marketplace.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open marketplace
3. Look at the message

![image](https://github.com/mautic/mautic/assets/116097999/d1295d11-c4e7-4d5f-bec6-b9505e3939e9)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
