### PR TITLE
Migrate to utf8mb4 for metadata entities

### DIFF
--- a/app/bundles/CoreBundle/Form/DataTransformer/EmojiToHtmlTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/EmojiToHtmlTransformer.php
@@ -5,8 +5,6 @@ namespace Mautic\CoreBundle\Form\DataTransformer;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 use Symfony\Component\Form\DataTransformerInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Mautic 3. Emoji transformation is not necessary anymore due to UTF8MB4 encoding.', EmojiToHtmlTransformer::class), E_USER_DEPRECATED);
-
 /**
  * @deprecated since Mautic 5.0, to be removed in 6.0 with no replacement.
  *

--- a/app/bundles/CoreBundle/Form/DataTransformer/EmojiToHtmlTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/EmojiToHtmlTransformer.php
@@ -5,6 +5,8 @@ namespace Mautic\CoreBundle\Form\DataTransformer;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 use Symfony\Component\Form\DataTransformerInterface;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Mautic 3. Emoji transformation is not necessary anymore due to UTF8MB4 encoding.', EmojiToHtmlTransformer::class), E_USER_DEPRECATED);
+
 /**
  * @deprecated since Mautic 5.0, to be removed in 6.0 with no replacement.
  *

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/EmojiExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/EmojiExtensionTest.php
@@ -12,17 +12,15 @@ final class EmojiExtensionTest extends TestCase
 {
     public function testItContainsAtLeastOneFunction(): void
     {
-        $extension = new EmojiExtension(new EmojiHelper());
-
+        $extension = new EmojiExtension(new EmojiHelper()); /** @phpstan-ignore-line EmojiExtension is deprecated */
         $this->assertGreaterThan(0, $extension->getFunctions());
     }
 
     public function testToHtml(): void
     {
-        $extension = new EmojiExtension(new EmojiHelper());
+        $extension = new EmojiExtension(new EmojiHelper()); /** @phpstan-ignore-line EmojiExtension is deprecated */
+        $text      = 'This is example text';
 
-        $text = 'This is example text';
-
-        $this->assertSame($text, $extension->toHtml($text));
+        $this->assertSame($text, $extension->toHtml($text)); /** @phpstan-ignore-line toHtml() is deprecated */
     }
 }

--- a/app/bundles/CoreBundle/Twig/Extension/EmojiExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/EmojiExtension.php
@@ -8,6 +8,9 @@ use Mautic\CoreBundle\Helper\EmojiHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @deprecated since Mautic 5.0, to be removed in 6.0 with no replacement.
+ */
 class EmojiExtension extends AbstractExtension
 {
     public function __construct(
@@ -24,6 +27,8 @@ class EmojiExtension extends AbstractExtension
 
     /**
      * Convert to html.
+     *
+     * @deprecated since Mautic 5.0, to be removed in 6.0 with no replacement.
      */
     public function toHtml(string $text, string $from = 'emoji'): string
     {

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -133,16 +133,14 @@ class DynamicContentType extends AbstractType
         );
 
         $builder->add(
-            $builder->create(
-                'description',
-                TextareaType::class,
-                [
-                    'label'      => 'mautic.dynamicContent.description',
-                    'label_attr' => ['class' => 'control-label'],
-                    'attr'       => ['class' => 'form-control'],
-                    'required'   => false,
-                ]
-            )
+            'description',
+            TextareaType::class,
+            [
+                'label'      => 'mautic.dynamicContent.description',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => ['class' => 'form-control'],
+                'required'   => false,
+            ]
         );
 
         $builder->add('isPublished', YesNoButtonGroupType::class);

--- a/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentTypeTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentTypeTest.php
@@ -16,7 +16,6 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -65,19 +64,9 @@ class DynamicContentTypeTest extends TestCase
             $tagChoices[$tag['value']] = $tag['label'];
         }
 
-        $formBuilderInterfaceMock->expects($this->exactly(3))
+        $formBuilderInterfaceMock->expects($this->exactly(2))
             ->method('create')
             ->withConsecutive(
-                [
-                    'description',
-                    TextareaType::class,
-                    [
-                        'label'      => 'mautic.dynamicContent.description',
-                        'label_attr' => ['class' => 'control-label'],
-                        'attr'       => ['class' => 'form-control'],
-                        'required'   => false,
-                    ],
-                ],
                 [
                     'translationParent',
                     DynamicContentListType::class,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\CoreBundle\Form\Type\BuilderSectionType;
 use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Translation\Translator;
@@ -1106,9 +1105,6 @@ class EmailController extends FormController
             // Update the content for processSlots
             $entity->setContent($content);
         }
-
-        // Replace short codes to emoji
-        $content = array_map(fn ($text) => EmojiHelper::toEmoji($text, 'short'), $content);
 
         $this->processSlots($slotsHelper, $slots, $entity);
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -3,7 +3,6 @@
 namespace Mautic\EmailBundle\Controller;
 
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\TrackingPixelHelper;
 use Mautic\CoreBundle\Twig\Helper\AnalyticsHelper;
 use Mautic\EmailBundle\EmailEvents;
@@ -60,10 +59,6 @@ class PublicController extends CommonFormController
             if ($copy = $stat->getStoredCopy()) {
                 $subject = $copy->getSubject();
                 $content = $copy->getBody();
-
-                // Convert emoji
-                $content = EmojiHelper::toEmoji($content, 'short');
-                $subject = EmojiHelper::toEmoji($subject, 'short');
 
                 // Replace tokens
                 $content = str_ireplace(array_keys($tokens), $tokens, $content);
@@ -498,9 +493,6 @@ class PublicController extends CommonFormController
             // replace tokens
             $content = $response->getContent();
         }
-
-        // Convert emojis
-        $content = EmojiHelper::toEmoji($content, 'short');
 
         // Override tracking_pixel
         $tokens = ['{tracking_pixel}' => ''];

--- a/app/bundles/EmailBundle/Entity/Copy.php
+++ b/app/bundles/EmailBundle/Entity/Copy.php
@@ -4,7 +4,6 @@ namespace Mautic\EmailBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 
 class Copy
 {
@@ -107,9 +106,6 @@ class Copy
      */
     public function setBody($body)
     {
-        // Ensure it's clean of emoji
-        $body = EmojiHelper::toShort($body);
-
         $this->body = $body;
 
         return $this;
@@ -130,9 +126,6 @@ class Copy
      */
     public function setSubject($subject)
     {
-        // Ensure it's clean of emoji
-        $subject = EmojiHelper::toShort($subject);
-
         $this->subject = $subject;
 
         return $this;
@@ -145,7 +138,6 @@ class Copy
 
     public function setBodyText(?string $bodyText): self
     {
-        $bodyText       = EmojiHelper::toShort($bodyText);
         $this->bodyText = $bodyText;
 
         return $this;

--- a/app/bundles/EmailBundle/Entity/CopyRepository.php
+++ b/app/bundles/EmailBundle/Entity/CopyRepository.php
@@ -4,7 +4,6 @@ namespace Mautic\EmailBundle\Entity;
 
 use Doctrine\ORM\NoResultException;
 use Mautic\CoreBundle\Entity\CommonRepository;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 
 /**
  * @extends CommonRepository<Copy>
@@ -22,9 +21,6 @@ class CopyRepository extends CommonRepository
         $db = $this->getEntityManager()->getConnection();
 
         try {
-            $body     = EmojiHelper::toShort($body);
-            $subject  = EmojiHelper::toShort($subject);
-            $bodyText = EmojiHelper::toShort($bodyText);
             $db->insert(
                 MAUTIC_TABLE_PREFIX.'email_copies',
                 [

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -241,9 +241,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         $this->setDateModified(new \DateTime());
     }
 
-    /**
-     * Clear stats.
-     */
     public function clearStats(): void
     {
         $this->stats = new ArrayCollection();
@@ -557,9 +554,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      */
     public function setContent($content)
     {
-        // Ensure safe emoji
-        $content = array_map(fn ($text) => EmojiHelper::toShort($text), $content);
-
         $this->isChanged('content', $content);
         $this->content = $content;
 

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -15,7 +15,6 @@ use Mautic\CoreBundle\Entity\TranslationEntityInterface;
 use Mautic\CoreBundle\Entity\TranslationEntityTrait;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Entity\VariantEntityTrait;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\EmailBundle\Validator\EmailOrEmailTokenList;
 use Mautic\FormBundle\Entity\Form;

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -68,18 +68,16 @@ class EmailType extends AbstractType
         );
 
         $builder->add(
-            $builder->create(
-                'subject',
-                TextType::class,
-                [
-                    'label'      => 'mautic.email.subject',
-                    'label_attr' => ['class' => 'control-label'],
-                    'attr'       => [
-                        'class'   => 'form-control',
-                        'onBlur'  => 'Mautic.copySubjectToName(mQuery(this))',
-                    ],
-                ]
-            )
+            'subject',
+            TextType::class,
+            [
+                'label'      => 'mautic.email.subject',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class'   => 'form-control',
+                    'onBlur'  => 'Mautic.copySubjectToName(mQuery(this))',
+                ],
+            ]
         );
 
         $builder->add(
@@ -226,22 +224,20 @@ class EmailType extends AbstractType
         );
 
         $builder->add(
-            $builder->create(
-                'customHtml',
-                TextareaType::class,
-                [
-                    'label'      => 'mautic.email.form.body',
-                    'label_attr' => ['class' => 'control-label'],
-                    'required'   => false,
-                    'attr'       => [
-                        'tooltip'              => 'mautic.email.form.body.help',
-                        'class'                => 'form-control editor-builder-tokens builder-html editor-email',
-                        'data-token-callback'  => 'email:getBuilderTokens',
-                        'data-token-activator' => '{',
-                        'rows'                 => '15',
-                    ],
-                ]
-            )
+            'customHtml',
+            TextareaType::class,
+            [
+                'label'      => 'mautic.email.form.body',
+                'label_attr' => ['class' => 'control-label'],
+                'required'   => false,
+                'attr'       => [
+                    'tooltip'              => 'mautic.email.form.body.help',
+                    'class'                => 'form-control editor-builder-tokens builder-html editor-email',
+                    'data-token-callback'  => 'email:getBuilderTokens',
+                    'data-token-activator' => '{',
+                    'rows'                 => '15',
+                ],
+            ]
         );
 
         $transformer = new IdToEntityModelTransformer($this->em, \Mautic\FormBundle\Entity\Form::class, 'id');

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\ORMException;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
@@ -611,7 +610,7 @@ class MailHelper
     {
         // Body
         $body         = $message->getHtmlBody();
-        $bodyReplaced = str_ireplace($search, $replace, $body, $updated);
+        $bodyReplaced = str_ireplace($search, $replace, (string) $body, $updated);
         if ($updated) {
             $message->html($bodyReplaced);
         }
@@ -773,7 +772,7 @@ class MailHelper
         if (!$ignoreTrackingPixel && $this->factory->getParameter('mailer_append_tracking_pixel')) {
             // Append tracking pixel
             $trackingImg = '<img height="1" width="1" src="{tracking_pixel}" alt="" />';
-            if (str_contains($content, '</body>')) {
+            if (str_contains((string) $content, '</body>')) {
                 $content = str_replace('</body>', $trackingImg.'</body>', $content);
             } else {
                 $content .= $trackingImg;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1215,9 +1215,6 @@ class MailHelper
 
         $subject = $email->getSubject();
 
-        // Convert short codes to emoji
-        $subject = EmojiHelper::toEmoji($subject ?? '', 'short');
-
         // Set message settings from the email
         $this->setSubject($subject);
 
@@ -1258,9 +1255,6 @@ class MailHelper
                 'template' => $template,
             ], true);
         }
-
-        // Convert short codes to emoji
-        $customHtml = EmojiHelper::toEmoji($customHtml ?? '', 'short');
 
         $this->setBody($customHtml, 'text/html', null, $ignoreTrackingPixel);
 

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -127,7 +127,7 @@
               <div class="pr-md pl-md pt-lg pb-lg">
                   <div class="box-layout">
                       <div class="col-xs-10">
-                          <div>{{ emoji_to_html(email.subject, 'short') }}</div>
+                          <div>{{ email.subject }}</div>
                           {% if email.isVariant(true) %}
                             <div class="small">
                               <a href="{{ path('mautic_email_action', {'objectAction' : 'view', 'objectId' : variants.parent.id}) }}" data-toggle="ajax">

--- a/app/bundles/EmailBundle/Resources/views/Send/progress.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Send/progress.html.twig
@@ -13,7 +13,7 @@
             <div class="panel panel-{{ ('inprogress' != status) ? 'success' : 'danger' }}">
                 <div class="panel-heading">
                     <h4 class="panel-title">
-                        {{ ('mautic.email.send.' ~ status)|trans({'%subject%' : emoji_to_html(email.getSubject(), 'short')})|purify }}
+                        {{ ('mautic.email.send.' ~ status)|trans({ '%subject%' : email.getSubject() })|purify }}
                     </h4>
                 </div>
                 <div class="panel-body">

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -181,6 +181,7 @@ class MailHelperTest extends TestCase
         $email = new Email();
         $email->setFromAddress('override@nowhere.com');
         $email->setFromName('Test');
+        $email->setSubject('Test');
 
         $singleMailHelper->setEmail($email);
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1431,7 +1431,7 @@ class LeadController extends FormController
                         $mailer->setSubject($email['subject']);
 
                         // Ensure safe emoji for notification
-                        $subject = EmojiHelper::toHtml($email['subject']);
+                        $subject = $email['subject'];
                         if ($mailer->send(true, false)) {
                             $mailer->createEmailStat();
                             $this->addFlashMessage(

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -6,7 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Membership\MembershipManager;
 use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\CoreBundle\Controller\FormController;
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\ExportHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UserHelper;

--- a/app/migrations/Version20201026101117.php
+++ b/app/migrations/Version20201026101117.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use Mautic\CoreBundle\Helper\EmojiHelper;
+use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\EmailBundle\Entity\Copy;
+use Mautic\EmailBundle\Entity\Email;
+
+final class Version20201026101117 extends AbstractMauticMigration
+{
+    /**
+     * @throws SkipMigrationException
+     */
+    public function preUp(Schema $schema): void
+    {
+        $table = $schema->getTable($this->prefix.'emails');
+
+        if ('utf8mb4' === $table->getColumn('subject')->getPlatformOption('charset')) {
+            throw new SkipMigration('Schema includes this migration');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Note: all these columns are type of LONGTEXT.
+        $tables = [
+            'emails'       => ['subject', 'custom_html', 'plain_text', 'name'],
+            'email_copies' => ['subject', 'body', 'body_text'],
+        ];
+
+        foreach ($tables as $table => $columns) {
+            foreach ($columns as $column) {
+                $this->addSql("ALTER TABLE {$this->prefix}{$table} CHANGE {$column} {$column} LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+            }
+        }
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        $this->convertEmailsEmojies();
+        $this->convertEmailCopiesEmojies();
+        $this->convertDynamicContentEmojies();
+    }
+
+    private function convertEmailsEmojies(): void
+    {
+        $this->iterateOverAllEntities(
+            Email::class,
+            function (Email $email) {
+                $email->setName(EmojiHelper::toEmoji($email->getName(), 'short'));
+                $email->setSubject(EmojiHelper::toEmoji($email->getSubject(), 'short'));
+                $email->setCustomHtml(EmojiHelper::toEmoji($email->getCustomHtml(), 'short'));
+                $email->setPlainText(EmojiHelper::toEmoji($email->getPlainText(), 'short'));
+            }
+        );
+    }
+
+    private function convertEmailCopiesEmojies(): void
+    {
+        $this->iterateOverAllEntities(
+            Copy::class,
+            function (Copy $emailCopy) {
+                $emailCopy->setSubject(EmojiHelper::toEmoji($emailCopy->getSubject(), 'short'));
+                $emailCopy->setBody(EmojiHelper::toEmoji($emailCopy->getBody(), 'short'));
+                $emailCopy->setBodyText(EmojiHelper::toEmoji($emailCopy->getBodyText(), 'short'));
+            }
+        );
+    }
+
+    private function convertDynamicContentEmojies(): void
+    {
+        $this->iterateOverAllEntities(
+            DynamicContent::class,
+            function (DynamicContent $dynamicContent) {
+                $dynamicContent->setDescription(EmojiHelper::toEmoji($dynamicContent->getDescription(), 'short'));
+            }
+        );
+    }
+
+    private function iterateOverAllEntities(string $entityClass, callable $entityModifier): void
+    {
+        $batchSize      = 50;
+        $i              = 1;
+        $q              = $this->entityManager->createQuery("SELECT t from {$entityClass} t");
+        $iterableResult = $q->iterate();
+        foreach ($iterableResult as $row) {
+            $entityModifier($row[0]);
+            $this->entityManager->persist($row[0]);
+
+            if (0 === ($i % $batchSize)) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+            }
+            ++$i;
+        }
+        $this->entityManager->flush();
+    }
+}

--- a/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -2,7 +2,6 @@
 
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
-use Mautic\CoreBundle\Helper\EmojiHelper;
 use MauticPlugin\MauticSocialBundle\Form\Type\TwitterType;
 
 class TwitterIntegration extends SocialIntegration
@@ -171,7 +170,7 @@ class TwitterIntegration extends SocialIntegration
                 }
 
                 $tweet = [
-                    'tweet'       => EmojiHelper::toHtml($d['text']),
+                    'tweet'       => $d['text'],
                     'url'         => "https://twitter.com/{$id}/status/{$d['id']}",
                     'coordinates' => $d['coordinates'],
                     'published'   => $d['created_at'],


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | /
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | Y

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

UTF8 encoding does not contain all emojis. Mautic 2 used this encoding and so there was EmojiHelper that was replacing emojis to short codes on database save and then replacing them back to emojis on view. However if the email has HTML like this:

```html
<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
```

Then it's becoming tricky. It contains `:office:` which is a short code for an emoji. So when the email is displayed/sent then the HTML attribute is corrupted with an emoji:

```html
<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com🏢 office"><head>
```

So this PR contains a migration that will convert some metadata table columns from UTF8 to UTFMB4. We cannot do it on stat tables as such conversion would take forever and could hit some time limits and leave the database in an inconsistent state.

After the encoding is updated, then the migration will translate all short codes back to the original emojis.

And if some entities does not use entity short codes at all then we can remove the EmojiHelper conversion from several places.

_Note about the tests: As the code that was removed is all over the place and it's mostly tested already and the decreased coverage is in the EmojiHelper and Emoji transformers which are deprecated so I didn't want to cover deprecated code with tests. I decided to increase the coverage by functional test for email unsubscription instead._

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Save an email with this text in subject and body: `🏢 City Building :office:`
2. Notice that in the database it's saved as `:office: City Building :office:`
3. When you view the email in the UI then the text looks like this: `🏢 City Building 🏢 ` but it should be `🏢 City Building :office:`

#### Steps to test this PR:
1. Downgrade your encoding on some columns to Mautic 2 encoding to test the migration fully:
```sql
ALTER TABLE emails CHANGE subject subject LONGTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
ALTER TABLE emails CHANGE custom_html custom_html LONGTEXT CHARACTER SET utf8 COLLATE utf8_unicode_ci;
```
2. Run the migration
3. Check the database that the email you've created above has the emojis in the database. Not `:office:` short codes.
4. Check the encoding for email.subject, email.custom_html have UTF8MB4 encoding.
5. If you repeat the steps to reproduce then the short code `:office:` will stay.
6. Test email sends, web view previews with some emojies.

#### Other areas of Mautic that may be affected by the change:
1. Emails
2. Tweets

#### List deprecations along with the new alternative:
1. `EmojiToHtmlTransformer`
2. `EmojiToShortTransformer`

Those transformers are not used anywhere anymore and will not be needed going forward due to having database with UTF8MB4 encoding.

