### PR TITLE
Since v0.11.0 the Typeahead must have a `wildcard` options defined.

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -1622,7 +1622,8 @@ Mautic.activateTypeahead = function (el, options) {
         if (options.remote) {
             sourceOptions.remote = {
                 url: mauticAjaxUrl + "?action=" + options.action + "&filter=%QUERY",
-                filter: filterClosure
+                filter: filterClosure,
+                wildcard: '%QUERY',
             };
         }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ x ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
While developing the PR #13131 found that the Typeahead changed it's behavior (https://github.com/twitter/typeahead.js/commit/c28acb6f733930e45b972176ed8bffcb0fc4fe8c#diff-83111179e8f92277f41cb62cf67bce4c1f167f93d805895dc227cee605adacceR83), and now we need to pass a `wildcard` parameter.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test any affected Typeahead (non-standard HTML, but js dropdown). Ones can be found on the contact create page: "title", segment list: "filter", etc.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
