### PR TITLE
New EmailStatModel that will dispatch events on email Stat pre and post save

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -107,18 +107,6 @@ return [
                     'monolog.logger.mautic',
                 ],
             ],
-            'mautic.message.processor.bounce' => [
-                'class'     => \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::class,
-                'arguments' => [
-                    'mailer.default_transport',
-                    'mautic.message.search.contact',
-                    'mautic.email.model.email_stat',
-                    'mautic.lead.model.lead',
-                    'translator',
-                    'monolog.logger.mautic',
-                    'mautic.lead.model.dnc',
-                ],
-            ],
             'mautic.message.processor.unsubscribe' => [
                 'class'     => \Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe::class,
                 'arguments' => [
@@ -138,18 +126,6 @@ return [
                     'mautic.lead.model.dnc',
                 ],
             ],
-            'mautic.message.processor.replier' => [
-                'class'     => \Mautic\EmailBundle\MonitoredEmail\Processor\Reply::class,
-                'arguments' => [
-                    'mautic.email.model.email_stat',
-                    'mautic.message.search.contact',
-                    'mautic.lead.model.lead',
-                    'event_dispatcher',
-                    'monolog.logger.mautic',
-                    'mautic.tracker.contact',
-                    'mautic.helper.email.address',
-                ],
-            ],
             'mautic.validator.email' => [
                 'class'     => \Mautic\EmailBundle\Helper\EmailValidator::class,
                 'arguments' => [
@@ -163,12 +139,6 @@ return [
                     'mautic.helper.mailbox',
                     'event_dispatcher',
                     'translator',
-                ],
-            ],
-            'mautic.email.helper.stat' => [
-                'class'     => \Mautic\EmailBundle\Stat\StatHelper::class,
-                'arguments' => [
-                    'mautic.email.model.email_stat',
                 ],
             ],
             'mautic.email.helper.stats_collection' => [

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -112,7 +112,7 @@ return [
                 'arguments' => [
                     'mailer.default_transport',
                     'mautic.message.search.contact',
-                    'mautic.email.repository.stat',
+                    'mautic.email.model.email_stat',
                     'mautic.lead.model.lead',
                     'translator',
                     'monolog.logger.mautic',
@@ -141,7 +141,7 @@ return [
             'mautic.message.processor.replier' => [
                 'class'     => \Mautic\EmailBundle\MonitoredEmail\Processor\Reply::class,
                 'arguments' => [
-                    'mautic.email.repository.stat',
+                    'mautic.email.model.email_stat',
                     'mautic.message.search.contact',
                     'mautic.lead.model.lead',
                     'event_dispatcher',
@@ -168,7 +168,7 @@ return [
             'mautic.email.helper.stat' => [
                 'class'     => \Mautic\EmailBundle\Stat\StatHelper::class,
                 'arguments' => [
-                    'mautic.email.repository.stat',
+                    'mautic.email.model.email_stat',
                 ],
             ],
             'mautic.email.helper.stats_collection' => [

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -31,6 +31,9 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(\Mautic\EmailBundle\Mailer\Transport\TransportFactory::class)
         ->decorate('mailer.transport_factory');
 
+    $services->set(\Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::class);
+    $services->set(\Mautic\EmailBundle\MonitoredEmail\Processor\Reply::class);
+    
     $services->alias('mautic.email.model.email', \Mautic\EmailBundle\Model\EmailModel::class);
     $services->alias('mautic.email.model.send_email_to_user', \Mautic\EmailBundle\Model\SendEmailToUser::class);
     $services->alias('mautic.email.model.send_email_to_contacts', \Mautic\EmailBundle\Model\SendEmailToContact::class);
@@ -41,4 +44,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.email.repository.stat', \Mautic\EmailBundle\Entity\StatRepository::class);
     $services->alias('mautic.helper.mailbox', \Mautic\EmailBundle\MonitoredEmail\Mailbox::class);
     $services->alias('mautic.helper.mailer', \Mautic\EmailBundle\Helper\MailHelper::class);
+    $services->alias('mautic.message.processor.bounce', \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::class);
+    $services->alias('mautic.message.processor.replier', \Mautic\EmailBundle\MonitoredEmail\Processor\Reply::class);
+    $services->alias('mautic.email.helper.stat', \Mautic\EmailBundle\Stat\StatHelper::class);
 };

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -33,7 +33,7 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(\Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::class);
     $services->set(\Mautic\EmailBundle\MonitoredEmail\Processor\Reply::class);
-    
+
     $services->alias('mautic.email.model.email', \Mautic\EmailBundle\Model\EmailModel::class);
     $services->alias('mautic.email.model.send_email_to_user', \Mautic\EmailBundle\Model\SendEmailToUser::class);
     $services->alias('mautic.email.model.send_email_to_contacts', \Mautic\EmailBundle\Model\SendEmailToContact::class);

--- a/app/bundles/EmailBundle/EmailEvents.php
+++ b/app/bundles/EmailBundle/EmailEvents.php
@@ -254,4 +254,20 @@ final class EmailEvents
      * @var string
      */
     public const ON_DETERMINE_CLICKTHROUGH_RATE_WINNER = 'mautic.email.on_clickthrough_rate_winner';
+
+    /**
+     * The mautic.email.on_email_stat_pre_save event is fired before an email stat batch is saved.
+     *
+     * The event listener receives a
+     * Mautic\EmailBundle\Event\EmailStatEvent
+     */
+    public const ON_EMAIL_STAT_PRE_SAVE = 'mautic.email.on_email_stat_pre_save';
+
+    /**
+     * The mautic.email.on_email_stat_post_save event is fired after an email stat batch is saved.
+     *
+     * The event listener receives a
+     * Mautic\EmailBundle\Event\EmailStatEvent
+     */
+    public const ON_EMAIL_STAT_POST_SAVE = 'mautic.email.on_email_stat_post_save';
 }

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -122,6 +122,9 @@ class Stat
      */
     private $replies;
 
+    /**
+     * @var array<string,mixed[]>
+     */
     private $changes = [];
 
     public function __construct()
@@ -643,11 +646,18 @@ class Stat
         $this->replies[] = $reply;
     }
 
+    /**
+     * @return array<string,mixed[]>
+     */
     public function getChanges(): array
     {
         return $this->changes;
     }
 
+    /**
+     * @param mixed $currentValue
+     * @param mixed $newValue
+     */
     private function addChange(string $property, $currentValue, $newValue): void
     {
         if ($currentValue === $newValue) {

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -122,6 +122,8 @@ class Stat
      */
     private $replies;
 
+    private $changes = [];
+
     public function __construct()
     {
         $this->replies = new ArrayCollection();
@@ -266,6 +268,7 @@ class Stat
      */
     public function setDateRead($dateRead): void
     {
+        $this->addChange('dateRead', $this->dateRead, $dateRead);
         $this->dateRead = $dateRead;
     }
 
@@ -282,6 +285,7 @@ class Stat
      */
     public function setDateSent($dateSent): void
     {
+        $this->addChange('dateSent', $this->dateSent, $dateSent);
         $this->dateSent = $dateSent;
     }
 
@@ -340,6 +344,7 @@ class Stat
      */
     public function setIsRead($isRead): void
     {
+        $this->addChange('isRead', $this->isRead, $isRead);
         $this->isRead = $isRead;
     }
 
@@ -401,6 +406,7 @@ class Stat
      */
     public function setRetryCount($retryCount): void
     {
+        $this->addChange('retryCount', $this->retryCount, $retryCount);
         $this->retryCount = $retryCount;
     }
 
@@ -409,6 +415,7 @@ class Stat
      */
     public function upRetryCount(): void
     {
+        $this->addChange('retryCount', $this->retryCount, $this->retryCount + 1);
         ++$this->retryCount;
     }
 
@@ -425,6 +432,7 @@ class Stat
      */
     public function setIsFailed($isFailed): void
     {
+        $this->addChange('isFailed', $this->isFailed, $isFailed);
         $this->isFailed = $isFailed;
     }
 
@@ -449,6 +457,7 @@ class Stat
      */
     public function setEmailAddress($emailAddress): void
     {
+        $this->addChange('emailAddress', $this->emailAddress, $emailAddress);
         $this->emailAddress = $emailAddress;
     }
 
@@ -465,6 +474,7 @@ class Stat
      */
     public function setViewedInBrowser($viewedInBrowser): void
     {
+        $this->addChange('viewedInBrowser', $this->viewedInBrowser, $viewedInBrowser);
         $this->viewedInBrowser = $viewedInBrowser;
     }
 
@@ -481,6 +491,7 @@ class Stat
      */
     public function setSource($source): void
     {
+        $this->addChange('source', $this->source, $source);
         $this->source = $source;
     }
 
@@ -497,6 +508,7 @@ class Stat
      */
     public function setSourceId($sourceId): void
     {
+        $this->addChange('sourceId', $this->sourceId, (int) $sourceId);
         $this->sourceId = (int) $sourceId;
     }
 
@@ -528,6 +540,7 @@ class Stat
      */
     public function setOpenCount($openCount)
     {
+        $this->addChange('openCount', $this->openCount, $openCount);
         $this->openCount = $openCount;
 
         return $this;
@@ -552,7 +565,8 @@ class Stat
      */
     public function upOpenCount()
     {
-        $count           = (int) $this->openCount + 1;
+        $count = (int) $this->openCount + 1;
+        $this->addChange('openCount', $this->openCount, $count);
         $this->openCount = $count;
 
         return $this;
@@ -573,6 +587,7 @@ class Stat
      */
     public function setLastOpened($lastOpened)
     {
+        $this->addChange('lastOpened', $this->lastOpened, $lastOpened);
         $this->lastOpened = $lastOpened;
 
         return $this;
@@ -624,6 +639,21 @@ class Stat
 
     public function addReply(EmailReply $reply): void
     {
+        $this->addChange('replyAdded', false, true);
         $this->replies[] = $reply;
+    }
+
+    public function getChanges(): array
+    {
+        return $this->changes;
+    }
+
+    private function addChange(string $property, $currentValue, $newValue): void
+    {
+        if ($currentValue === $newValue) {
+            return;
+        }
+
+        $this->changes[$property] = [$currentValue, $newValue];
     }
 }

--- a/app/bundles/EmailBundle/Event/EmailStatEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailStatEvent.php
@@ -2,33 +2,19 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\EmailBundle\Event;
 
 use Mautic\EmailBundle\Entity\Stat;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class EmailStatEvent extends Event
 {
     /**
-     * @var Stat[]
+     * @param Stat[] $stats
      */
-    private $stats;
-
-    /**
-     * @var Stat[]
-     */
-    public function __construct(array $stats)
-    {
-        $this->stats = $stats;
+    public function __construct(
+        private array $stats
+    ) {
     }
 
     /**

--- a/app/bundles/EmailBundle/Event/EmailStatEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailStatEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Event;
+
+use Mautic\EmailBundle\Entity\Stat;
+use Symfony\Component\EventDispatcher\Event;
+
+final class EmailStatEvent extends Event
+{
+    /**
+     * @var Stat[]
+     */
+    private $stats;
+
+    /**
+     * @var Stat[]
+     */
+    public function __construct(array $stats)
+    {
+        $this->stats = $stats;
+    }
+
+    /**
+     * @return Stat[]
+     */
+    public function getStats(): array
+    {
+        return $this->stats;
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
@@ -14,12 +13,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EmailSubscriber implements EventSubscriberInterface
 {
+    private const RETRY_COUNT = 3;
+
     public function __construct(
         private IpLookupHelper $ipLookupHelper,
         private AuditLogModel $auditLogModel,
         private EmailModel $emailModel,
-        private TranslatorInterface $translator,
-        private EntityManager $entityManager
+        private TranslatorInterface $translator
     ) {
     }
 
@@ -94,14 +94,13 @@ class EmailSubscriber implements EventSubscriberInterface
      */
     public function onEmailResend(Events\QueueEmailEvent $event): void
     {
-        $message    = $event->getMessage();
-        $leadIdHash = $message->getLeadIdHash();
+        $message = $event->getMessage();
 
-        if (!isset($message->leadIdHash)) {
+        if (empty($message->getLeadIdHash())) {
             return;
         }
 
-        $stat = $this->emailModel->getEmailStatus($message->leadIdHash);
+        $stat = $this->emailModel->getEmailStatus($message->getLeadIdHash());
 
         if (!$stat) {
             return;
@@ -110,13 +109,13 @@ class EmailSubscriber implements EventSubscriberInterface
         $stat->upRetryCount();
 
         if ($stat->getRetryCount() > self::RETRY_COUNT) {
-            //tried too many times so just fail
+            // tried too many times so just fail
             $reason = $this->translator->trans('mautic.email.dnc.retries', [
                 '%subject%' => EmojiHelper::toShort($message->getSubject()),
             ]);
             $this->emailModel->setDoNotContact($stat, $reason);
         } else {
-            //set it to try again
+            // set it to try again
             $event->tryAgain();
         }
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Entity\Copy;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\EmailSendEvent;
@@ -1729,14 +1730,14 @@ class MailHelper
 
         if (isset($this->copies[$id])) {
             try {
-                $stat->setStoredCopy($this->factory->getEntityManager()->getReference(\Mautic\EmailBundle\Entity\Copy::class, $this->copies[$id]));
+                $stat->setStoredCopy($this->factory->getEntityManager()->getReference(Copy::class, $this->copies[$id]));
             } catch (ORMException) {
                 // keep IDE happy
             }
         }
 
         if ($persist) {
-            $emailModel->getStatRepository()->saveEntity($stat);
+            $emailModel->saveEmailStat($stat);
         }
 
         return $stat;

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -31,6 +31,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatDevice;
+use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Mautic\EmailBundle\Event\EmailEvent;
 use Mautic\EmailBundle\Event\EmailOpenEvent;
@@ -113,7 +114,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         UserHelper $userHelper,
         LoggerInterface $mauticLogger,
         CoreParametersHelper $coreParametersHelper,
-        EmailStatModel $emailStatModel
+        private EmailStatModel $emailStatModel
     ) {
         $this->connection = $connection;
 
@@ -128,10 +129,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         return $this->em->getRepository(\Mautic\EmailBundle\Entity\Email::class);
     }
 
-    /**
-     * @return \Mautic\EmailBundle\Entity\StatRepository
-     */
-    public function getStatRepository()
+    public function getStatRepository(): StatRepository
     {
         return $this->emailStatModel->getRepository();
     }

--- a/app/bundles/EmailBundle/Model/EmailStatModel.php
+++ b/app/bundles/EmailBundle/Model/EmailStatModel.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Model;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Event\EmailStatEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EmailStatModel
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    public function __construct(EntityManagerInterface $entityManager, EventDispatcherInterface $dispatcher)
+    {
+        $this->entityManager = $entityManager;
+        $this->dispatcher    = $dispatcher;
+    }
+
+    public function saveEntity(Stat $stat): void
+    {
+        $this->saveEntities([$stat]);
+    }
+
+    /**
+     * @var Stat[]
+     */
+    public function saveEntities(array $stats): void
+    {
+        $event = new EmailStatEvent($stats);
+
+        $this->dispatcher->dispatch(EmailEvents::ON_EMAIL_STAT_PRE_SAVE, $event);
+
+        $this->getRepository()->saveEntities($stats);
+
+        $this->dispatcher->dispatch(EmailEvents::ON_EMAIL_STAT_POST_SAVE, $event);
+    }
+
+    public function getRepository(): StatRepository
+    {
+        return $this->entityManager->getRepository(Stat::class);
+    }
+}

--- a/app/bundles/EmailBundle/Model/EmailStatModel.php
+++ b/app/bundles/EmailBundle/Model/EmailStatModel.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\EmailBundle\Model;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -22,20 +13,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class EmailStatModel
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-
-    public function __construct(EntityManagerInterface $entityManager, EventDispatcherInterface $dispatcher)
+    public function __construct(private EntityManagerInterface $entityManager, private EventDispatcherInterface $dispatcher)
     {
-        $this->entityManager = $entityManager;
-        $this->dispatcher    = $dispatcher;
     }
 
     public function saveEntity(Stat $stat): void
@@ -44,17 +23,17 @@ class EmailStatModel
     }
 
     /**
-     * @var Stat[]
+     * @param Stat[] $stats
      */
     public function saveEntities(array $stats): void
     {
         $event = new EmailStatEvent($stats);
 
-        $this->dispatcher->dispatch(EmailEvents::ON_EMAIL_STAT_PRE_SAVE, $event);
+        $this->dispatcher->dispatch($event, EmailEvents::ON_EMAIL_STAT_PRE_SAVE);
 
         $this->getRepository()->saveEntities($stats);
 
-        $this->dispatcher->dispatch(EmailEvents::ON_EMAIL_STAT_POST_SAVE, $event);
+        $this->dispatcher->dispatch($event, EmailEvents::ON_EMAIL_STAT_POST_SAVE);
     }
 
     public function getRepository(): StatRepository

--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -4,7 +4,6 @@ namespace Mautic\EmailBundle\Model;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
 use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Model\DoNotContact;
@@ -14,7 +13,7 @@ class TransportCallback
     public function __construct(
         private DoNotContact $dncModel,
         private ContactFinder $finder,
-        private StatRepository $statRepository
+        private EmailStatModel $emailStatModel
     ) {
     }
 
@@ -83,6 +82,6 @@ class TransportCallback
             'reason'   => $comments,
         ];
         $stat->setOpenDetails($openDetails);
-        $this->statRepository->saveEntity($stat);
+        $this->emailStatModel->saveEntity($stat);
     }
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Search/ContactFinder.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Search/ContactFinder.php
@@ -38,6 +38,9 @@ class ContactFinder
         return $this->findByAddress($contactEmail);
     }
 
+    /**
+     * @param string $hash
+     */
     public function findByHash($hash): Result
     {
         $result = new Result();

--- a/app/bundles/EmailBundle/Stat/StatHelper.php
+++ b/app/bundles/EmailBundle/Stat/StatHelper.php
@@ -3,7 +3,7 @@
 namespace Mautic\EmailBundle\Stat;
 
 use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\Stat\Exception\StatNotFoundException;
 
 class StatHelper
@@ -21,25 +21,25 @@ class StatHelper
     private $deleteUs = [];
 
     public function __construct(
-        private StatRepository $repo
+        private EmailStatModel $emailStatModel
     ) {
     }
 
     public function storeStat(Stat $stat, $emailAddress): void
     {
-        $this->repo->saveEntity($stat);
+        $this->emailStatModel->saveEntity($stat);
 
         // to avoid Doctrine RAM issues, we're just going to hold onto ID references
         $this->stats[$emailAddress] = new Reference($stat);
 
         // clear stat from doctrine memory
-        $this->repo->detachEntity($stat);
+        $this->emailStatModel->getRepository()->detachEntity($stat);
     }
 
     public function deletePending(): void
     {
         if (count($this->deleteUs)) {
-            $this->repo->deleteStats($this->deleteUs);
+            $this->emailStatModel->getRepository()->deleteStats($this->deleteUs);
         }
     }
 

--- a/app/bundles/EmailBundle/Tests/Entity/StatTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatTest.php
@@ -67,7 +67,7 @@ class StatTest extends TestCase
         $stat->setRetryCount(3);
         $stat->setSource('campaign');
         $stat->setSourceId(123);
-        $stat->addReply(new EmailReply($stat, 456));
+        $stat->addReply(new EmailReply($stat, '456'));
 
         Assert::assertSame([null, 'john@doe.email'], $stat->getChanges()['emailAddress']);
         Assert::assertSame([false, true], $stat->getChanges()['isFailed']);
@@ -91,7 +91,7 @@ class StatTest extends TestCase
         $stat->setIsRead(true);
         $stat->setSource('campaign');
         $stat->setSourceId(321);
-        $stat->addReply(new EmailReply($stat, 456));
+        $stat->addReply(new EmailReply($stat, '456'));
 
         Assert::assertSame([null, 'john@doe.email'], $stat->getChanges()['emailAddress']);
         Assert::assertSame([false, true], $stat->getChanges()['isFailed']);

--- a/app/bundles/EmailBundle/Tests/Entity/StatTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Entity;
 
+use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\Stat;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class StatTest extends TestCase
@@ -50,5 +52,58 @@ class StatTest extends TestCase
             'slightly above threshold'  => [Stat::MAX_OPEN_DETAILS + 10],
             'well beyond threshold'     => [Stat::MAX_OPEN_DETAILS * 10],
         ];
+    }
+
+    public function testChanges(): void
+    {
+        $stat = new Stat();
+        $stat->setEmailAddress('john@doe.email');
+        $stat->setIsFailed(true);
+        $stat->setDateRead(new \DateTime());
+        $stat->setDateSent(new \DateTime());
+        $stat->setLastOpened(new \DateTime());
+        $stat->setIsRead(false);
+        $stat->setOpenCount(2);
+        $stat->setRetryCount(3);
+        $stat->setSource('campaign');
+        $stat->setSourceId(123);
+        $stat->addReply(new EmailReply($stat, 456));
+
+        Assert::assertSame([null, 'john@doe.email'], $stat->getChanges()['emailAddress']);
+        Assert::assertSame([false, true], $stat->getChanges()['isFailed']);
+        Assert::assertSame([0, 2], $stat->getChanges()['openCount']);
+        Assert::assertSame([0, 3], $stat->getChanges()['retryCount']);
+        Assert::assertSame([null, 'campaign'], $stat->getChanges()['source']);
+        Assert::assertSame([null, 123], $stat->getChanges()['sourceId']);
+        Assert::assertSame([false, true], $stat->getChanges()['replyAdded']);
+        Assert::assertArrayNotHasKey('isRead', $stat->getChanges()); // Don't want to record changes from false to false.
+        Assert::assertNull($stat->getChanges()['dateRead'][0]);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['dateRead'][1]);
+        Assert::assertNull($stat->getChanges()['dateSent'][0]);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['dateSent'][1]);
+        Assert::assertNull($stat->getChanges()['lastOpened'][0]);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['lastOpened'][1]);
+
+        $stat->upOpenCount();
+        $stat->upRetryCount();
+        $stat->setEmailAddress('john@doe.email');
+        $stat->setDateRead(new \DateTime());
+        $stat->setIsRead(true);
+        $stat->setSource('campaign');
+        $stat->setSourceId(321);
+        $stat->addReply(new EmailReply($stat, 456));
+
+        Assert::assertSame([null, 'john@doe.email'], $stat->getChanges()['emailAddress']);
+        Assert::assertSame([false, true], $stat->getChanges()['isFailed']);
+        Assert::assertSame([2, 3], $stat->getChanges()['openCount']);
+        Assert::assertSame([3, 4], $stat->getChanges()['retryCount']);
+        Assert::assertSame([null, 'campaign'], $stat->getChanges()['source']);
+        Assert::assertSame([123, 321], $stat->getChanges()['sourceId']);
+        Assert::assertSame([false, true], $stat->getChanges()['replyAdded']);
+        Assert::assertSame([false, true], $stat->getChanges()['isRead']);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['dateRead'][0]);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['dateRead'][1]);
+        Assert::assertNull($stat->getChanges()['dateSent'][0]);
+        Assert::assertInstanceOf(\DateTime::class, $stat->getChanges()['dateSent'][1]);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -64,148 +64,148 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
     /**
      * @var Connection|LeadDeviceRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $leadDeviceRepository;
+    private MockObject $leadDeviceRepository;
 
     /**
      * @var Connection|MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $connection;
+    private MockObject $connection;
 
     /**
-     * @var MockObject|IpLookupHelper
+     * @var MockObject&IpLookupHelper
      */
-    private \PHPUnit\Framework\MockObject\MockObject $ipLookupHelper;
+    private MockObject $ipLookupHelper;
 
     /**
-     * @var MockObject|ThemeHelperInterface
+     * @var MockObject&ThemeHelperInterface
      */
-    private \PHPUnit\Framework\MockObject\MockObject $themeHelper;
+    private MockObject $themeHelper;
 
     /**
-     * @var MockObject|Mailbox
+     * @var MockObject&Mailbox
      */
-    private \PHPUnit\Framework\MockObject\MockObject $mailboxHelper;
+    private MockObject $mailboxHelper;
 
     /**
-     * @var MockObject|MailHelper
+     * @var MockObject&MailHelper
      */
-    private \PHPUnit\Framework\MockObject\MockObject $mailHelper;
+    private MockObject $mailHelper;
 
     /**
-     * @var MockObject|LeadModel
+     * @var MockObject&LeadModel
      */
-    private \PHPUnit\Framework\MockObject\MockObject $leadModel;
+    private MockObject $leadModel;
 
     /**
-     * @var MockObject|TrackableModel
+     * @var MockObject&TrackableModel
      */
-    private \PHPUnit\Framework\MockObject\MockObject $trackableModel;
+    private MockObject $trackableModel;
 
     /**
-     * @var MockObject|UserModel
+     * @var MockObject&UserModel
      */
-    private \PHPUnit\Framework\MockObject\MockObject $userModel;
+    private MockObject $userModel;
 
     /**
-     * @var MockObject|UserHelper
+     * @var MockObject&UserHelper
      */
-    private \PHPUnit\Framework\MockObject\MockObject $userHelper;
+    private MockObject $userHelper;
 
     /**
-     * @var MockObject|Translator
+     * @var MockObject&Translator
      */
-    private \PHPUnit\Framework\MockObject\MockObject $translator;
+    private MockObject $translator;
 
     /**
-     * @var MockObject|Email
+     * @var MockObject&Email
      */
-    private \PHPUnit\Framework\MockObject\MockObject $emailEntity;
+    private MockObject $emailEntity;
 
     /**
-     * @var MockObject|EntityManager
+     * @var MockObject&EntityManager
      */
-    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private MockObject $entityManager;
 
     /**
-     * @var MockObject|StatRepository
+     * @var MockObject&StatRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $statRepository;
+    private MockObject $statRepository;
 
     /**
-     * @var MockObject|EmailRepository
+     * @var MockObject&EmailRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $emailRepository;
+    private MockObject $emailRepository;
 
     /**
-     * @var MockObject|EmailStatModel
+     * @var MockObject&EmailStatModel
      */
     private $emailStatModel;
 
     /**
-     * @var MockObject|FrequencyRuleRepository
+     * @var MockObject&FrequencyRuleRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $frequencyRepository;
+    private MockObject $frequencyRepository;
 
     /**
-     * @var MockObject|MessageQueueModel
+     * @var MockObject&MessageQueueModel
      */
-    private \PHPUnit\Framework\MockObject\MockObject $messageModel;
+    private MockObject $messageModel;
 
     /**
-     * @var MockObject|CompanyModel
+     * @var MockObject&CompanyModel
      */
-    private \PHPUnit\Framework\MockObject\MockObject $companyModel;
+    private MockObject $companyModel;
 
     /**
-     * @var MockObject|CompanyRepository
+     * @var MockObject&CompanyRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $companyRepository;
+    private MockObject $companyRepository;
 
     /**
-     * @var MockObject|DoNotContact
+     * @var MockObject&DoNotContact
      */
-    private \PHPUnit\Framework\MockObject\MockObject $dncModel;
+    private MockObject $dncModel;
 
-    private \Mautic\EmailBundle\Stat\StatHelper $statHelper;
+    private StatHelper $statHelper;
 
-    private \Mautic\EmailBundle\Model\SendEmailToContact $sendToContactModel;
+    private SendEmailToContact $sendToContactModel;
 
     /**
-     * @var MockObject|DeviceTracker
+     * @var MockObject&DeviceTracker
      */
-    private \PHPUnit\Framework\MockObject\MockObject $deviceTrackerMock;
+    private MockObject $deviceTrackerMock;
 
     /**
-     * @var MockObject|RedirectRepository
+     * @var MockObject&RedirectRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $redirectRepositoryMock;
+    private MockObject $redirectRepositoryMock;
 
     /**
-     * @var MockObject|CacheStorageHelper
+     * @var MockObject&CacheStorageHelper
      */
-    private \PHPUnit\Framework\MockObject\MockObject $cacheStorageHelperMock;
+    private MockObject $cacheStorageHelperMock;
 
     /**
-     * @var MockObject|ContactTracker
+     * @var MockObject&ContactTracker
      */
-    private \PHPUnit\Framework\MockObject\MockObject $contactTracker;
+    private MockObject $contactTracker;
 
-    private \Mautic\EmailBundle\Model\EmailModel $emailModel;
-
-    /**
-     * @var MockObject|DoNotContact
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $doNotContact;
+    private EmailModel $emailModel;
 
     /**
-     * @var MockObject|CorePermissions
+     * @var MockObject&DoNotContact
      */
-    private \PHPUnit\Framework\MockObject\MockObject $corePermissions;
+    private MockObject $doNotContact;
+
+    /**
+     * @var MockObject&CorePermissions
+     */
+    private MockObject $corePermissions;
 
     /**
      * @var StatsCollectionHelper|MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $statsCollectionHelper;
+    private MockObject $statsCollectionHelper;
 
     /**
      * @var MockObject&EventDispatcherInterface
@@ -266,7 +266,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->doNotContact,
             $this->statsCollectionHelper,
             $this->corePermissions,
-            $this->emailStatModel,
             $this->connection,
             $this->entityManager,
             $this->eventDispatcher,
@@ -274,7 +273,8 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->translator,
             $this->createMock(UserHelper::class),
             $this->createMock(LoggerInterface::class),
-            $this->createMock(CoreParametersHelper::class)
+            $this->createMock(CoreParametersHelper::class),
+            $this->emailStatModel
         );
 
         $this->emailStatModel->method('getRepository')->willReturn($this->statRepository);
@@ -680,7 +680,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->doNotContact,
             $this->statsCollectionHelper,
             $this->corePermissions,
-            $this->emailStatModel,
             $this->connection,
             $this->entityManager,
             $this->eventDispatcher,
@@ -688,7 +687,8 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->translator,
             $this->createMock(UserHelper::class),
             $this->createMock(LoggerInterface::class),
-            $this->createMock(CoreParametersHelper::class)
+            $this->createMock(CoreParametersHelper::class),
+            $this->emailStatModel
         );
 
         $this->emailEntity->method('getId')
@@ -746,7 +746,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->entityManager->expects($this->once())
+        $this->entityManager->expects($this->exactly(2))
             ->method('flush');
 
         $this->entityManager->expects($this->exactly(0))
@@ -787,16 +787,9 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
             ->with($contactDevice->getId())
             ->willReturn($contactDevice);
 
-        $this->entityManager->expects($this->exactly(2))
+        $this->entityManager->expects($this->exactly(1))
             ->method('persist')
             ->withConsecutive(
-                [
-                    $this->callback(function ($statDevice) {
-                        $this->assertInstanceOf(Stat::class, $statDevice);
-
-                        return true;
-                    }),
-                ],
                 [
                     $this->callback(function ($statDevice) use ($stat, $ipAddress) {
                         $this->assertInstanceOf(StatDevice::class, $statDevice);

--- a/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Model;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Model\EmailStatModel;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class EmailStatModelTest extends TestCase
+{
+    public function testSave(): void
+    {
+        $entityManager = new class() extends EntityManager {
+            public function __construct()
+            {
+            }
+
+            public function getRepository($entityName)
+            {
+                Assert::assertSame(Stat::class, $entityName);
+
+                return new class() extends StatRepository {
+                    public function __construct()
+                    {
+                    }
+
+                    public function saveEntities($entities)
+                    {
+                        Assert::assertCount(1, $entities);
+                        Assert::assertInstanceOf(Stat::class, $entities[0]);
+
+                        // Emulate database adding the entity some autoincrement ID.
+                        $entities[0]->id = 123;
+                    }
+                };
+            }
+        };
+
+        $dispatcher                       = new class() extends EventDispatcher {
+            public $dispatchMethodCounter = 0;
+
+            public function __construct()
+            {
+            }
+
+            /**
+             * @var EmailStatEvent
+             */
+            public function dispatch($eventName, ?Event $event = null)
+            {
+                switch ($this->dispatchMethodCounter) {
+                    case 0:
+                        Assert::assertSame(EmailEvents::ON_EMAIL_STAT_PRE_SAVE, $eventName);
+                        Assert::assertCount(1, $event->getStats());
+                        Assert::assertNull($event->getStats()[0]->id);
+                        break;
+
+                    case 1:
+                        Assert::assertSame(EmailEvents::ON_EMAIL_STAT_POST_SAVE, $eventName);
+                        Assert::assertCount(1, $event->getStats());
+                        Assert::assertSame(123, $event->getStats()[0]->id);
+                        break;
+                }
+                ++$this->dispatchMethodCounter;
+            }
+        };
+
+        $emailStatModel = new EmailStatModel($entityManager, $dispatcher);
+
+        $emailStat = new class() extends Stat {
+            // Making the id property public to make it mutable by the repository fake.
+            public $id;
+        };
+
+        $emailStatModel->saveEntity($emailStat);
+
+        Assert::assertSame(2, $dispatcher->dispatchMethodCounter);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
@@ -1,13 +1,6 @@
 <?php
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
+declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Model;
 
@@ -17,78 +10,83 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Model\EmailStatModel;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class EmailStatModelTest extends TestCase
+final class EmailStatModelTest extends TestCase
 {
     public function testSave(): void
     {
-        $entityManager = new class() extends EntityManager {
-            public function __construct()
-            {
-            }
+        /** @var MockObject&EntityManager */
+        $entityManager = $this->createMock(EntityManager::class);
 
-            public function getRepository($entityName)
-            {
-                Assert::assertSame(Stat::class, $entityName);
+        /** @var MockObject&StatRepository */
+        $statRepository = $this->createMock(StatRepository::class);
 
-                return new class() extends StatRepository {
-                    public function __construct()
-                    {
-                    }
+        $entityManager->method('getRepository')->willReturn($statRepository);
 
-                    public function saveEntities($entities)
-                    {
-                        Assert::assertCount(1, $entities);
-                        Assert::assertInstanceOf(Stat::class, $entities[0]);
+        $statRepository->expects($this->once())
+            ->method('saveEntities')
+            ->willReturnCallback(
+                function (array $entities) {
+                    Assert::assertCount(1, $entities);
+                    Assert::assertInstanceOf(StatTest::class, $entities[0]);
 
-                        // Emulate database adding the entity some autoincrement ID.
-                        $entities[0]->id = 123;
-                    }
-                };
-            }
-        };
+                    // Emulate database adding the entity some autoincrement ID.
+                    $entities[0]->setId('123');
+                }
+            );
 
-        $dispatcher                       = new class() extends EventDispatcher {
-            public $dispatchMethodCounter = 0;
+        $dispatcher = new class() extends EventDispatcher {
+            public int $dispatchMethodCounter = 0;
 
             public function __construct()
             {
             }
 
-            /**
-             * @var EmailStatEvent
-             */
-            public function dispatch($eventName, ?Event $event = null)
+            public function dispatch(object $event, string $eventName = null): object
             {
                 switch ($this->dispatchMethodCounter) {
                     case 0:
                         Assert::assertSame(EmailEvents::ON_EMAIL_STAT_PRE_SAVE, $eventName);
                         Assert::assertCount(1, $event->getStats());
-                        Assert::assertNull($event->getStats()[0]->id);
+                        Assert::assertSame(0, $event->getStats()[0]->getId());
                         break;
 
                     case 1:
                         Assert::assertSame(EmailEvents::ON_EMAIL_STAT_POST_SAVE, $eventName);
                         Assert::assertCount(1, $event->getStats());
-                        Assert::assertSame(123, $event->getStats()[0]->id);
+                        Assert::assertSame(123, $event->getStats()[0]->getId());
                         break;
                 }
                 ++$this->dispatchMethodCounter;
+
+                return $event;
             }
         };
 
         $emailStatModel = new EmailStatModel($entityManager, $dispatcher);
 
-        $emailStat = new class() extends Stat {
-            // Making the id property public to make it mutable by the repository fake.
-            public $id;
-        };
+        $emailStat = new StatTest();
 
         $emailStatModel->saveEntity($emailStat);
 
         Assert::assertSame(2, $dispatcher->dispatchMethodCounter);
+    }
+}
+
+class StatTest extends Stat
+{
+    private ?string $id = null;
+
+    public function setId(string $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->id;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -32,7 +32,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 {
-    protected $contacts = [
+    /**
+     * @var array<array<string,int|string>>
+     */
+    private array $contacts = [
         [
             'id'        => 1,
             'email'     => 'contact1@somewhere.com',
@@ -63,32 +66,32 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         ],
     ];
 
-    /** @var MockObject&FromEmailHelper */
+    /**
+     * @var MockObject&FromEmailHelper
+     */
     private $fromEmaiHelper;
 
-    /** @var MockObject&CoreParametersHelper */
+    /**
+     * @var MockObject&CoreParametersHelper
+     */
     private $coreParametersHelper;
 
-    /** @var MockObject&Mailbox */
+    /**
+     * @var MockObject&Mailbox
+     */
     private $mailbox;
 
-    /** @var MockObject&LoggerInterface */
+    /**
+     * @var MockObject&LoggerInterface
+     */
     private MockObject $loggerMock;
 
     private MailHashHelper $mailHashHelper;
 
-    /** @var MockObject&TranslatorInterface */
+    /**
+     * @var MockObject&TranslatorInterface
+     */
     private MockObject $translator;
-
-    protected function setUp(): void
-    {
-        $this->fromEmaiHelper       = $this->createMock(FromEmailHelper::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->mailbox              = $this->createMock(Mailbox::class);
-        $this->loggerMock           = $this->createMock(LoggerInterface::class);
-        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
-        $this->translator           = $this->createMock(TranslatorInterface::class);
-    }
 
     /**
      * @var MockObject|MailHelper
@@ -105,24 +108,21 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
      */
     private $emailStatModel;
 
-    /**
-     * @var MockObject|TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var StatHelper
-     */
-    private $statHelper;
+    private StatHelper $statHelper;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailHelper     = $this->createMock(MailHelper::class);
-        $this->dncModel       = $this->createMock(DoNotContact::class);
-        $this->emailStatModel = $this->createMock(EmailStatModel::class);
-        $this->statHelper     = new StatHelper($this->emailStatModel);
-        $this->translator     = $this->createMock(TranslatorInterface::class);
+        $this->dncModel             = $this->createMock(DoNotContact::class);
+        $this->mailHelper           = $this->createMock(MailHelper::class);
+        $this->emailStatModel       = $this->createMock(EmailStatModel::class);
+        $this->statHelper           = new StatHelper($this->emailStatModel);
+        $this->fromEmaiHelper       = $this->createMock(FromEmailHelper::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->mailbox              = $this->createMock(Mailbox::class);
+        $this->loggerMock           = $this->createMock(LoggerInterface::class);
+        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
+        $this->translator           = $this->createMock(TranslatorInterface::class);
     }
 
     /**
@@ -647,11 +647,9 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
         $mailer         = new Mailer(new BatchTransport());
         $mailHelper     = new MailHelper($mockFactory, $mailer, $fromEmailHelper, $coreParametersHelper, $mailbox, $logger, $this->mailHashHelper);
-        $statRepository = $this->createMock(StatRepository::class);
         $dncModel       = $this->createMock(DoNotContact::class);
-        $translator     = $this->createMock(Translator::class);
-        $statHelper     = new StatHelper($statRepository);
-        $model          = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+        $translator     = $this->createMock(TranslatorInterface::class);
+        $model          = new SendEmailToContact($mailHelper, $this->statHelper, $dncModel, $translator);
         $emailMock      = $this->createMock(Email::class);
         $emailMock->method('getId')->willReturn(1);
         $emailMock->method('getSubject')->willReturn('subject');

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -5,11 +5,9 @@ namespace Mautic\EmailBundle\Tests\Model;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\CopyRepository;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Exception\FailedToSendToContactException;
 use Mautic\EmailBundle\Helper\DTO\AddressDTO;
@@ -17,6 +15,7 @@ use Mautic\EmailBundle\Helper\FromEmailHelper;
 use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\Model\SendEmailToContact;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Stat\StatHelper;
@@ -92,32 +91,53 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @var MockObject|MailHelper
+     */
+    private $mailHelper;
+
+    /**
+     * @var MockObject|DoNotContact
+     */
+    private $dncModel;
+
+    /**
+     * @var MockObject|EmailStatModel
+     */
+    private $emailStatModel;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var StatHelper
+     */
+    private $statHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mailHelper     = $this->createMock(MailHelper::class);
+        $this->dncModel       = $this->createMock(DoNotContact::class);
+        $this->emailStatModel = $this->createMock(EmailStatModel::class);
+        $this->statHelper     = new StatHelper($this->emailStatModel);
+        $this->translator     = $this->createMock(TranslatorInterface::class);
+    }
+
+    /**
      * @testdox Tests that all contacts are temporarily failed if an Email entity happens to be incorrectly configured
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setEmail()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::finalFlush()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
      */
     public function testContactsAreFailedIfSettingEmailEntityFails(): void
     {
-        $mailHelper = $this->createMock(MailHelper::class);
-        $mailHelper->method('setEmail')
+        $this->mailHelper->method('setEmail')
             ->willReturn(false);
 
-        $statRepository = $this->createMock(StatRepository::class);
-
-        $dncModel = $this->createMock(DoNotContact::class);
-
         // This should not be called because contact emails are just fine; the problem is with the email entity
-        $dncModel->expects($this->never())
+        $this->dncModel->expects($this->never())
             ->method('addDncForContact');
 
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $this->translator);
+        $model = new SendEmailToContact($this->mailHelper, $this->statHelper, $this->dncModel, $this->translator);
 
         $email = new Email();
         $model->setEmail($email);
@@ -139,12 +159,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Tests that bad emails are failed
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::finalFlush()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
      */
     public function testExceptionIsThrownIfEmailIsSentToBadContact(): void
     {
@@ -155,31 +169,24 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             ->method('getId')
             ->will($this->returnValue(1));
 
-        $mailHelper = $this->createMock(MailHelper::class);
-        $mailHelper->method('setEmail')
+        $this->mailHelper->method('setEmail')
             ->willReturn(true);
-        $mailHelper->method('addTo')
+        $this->mailHelper->method('addTo')
             ->willReturnCallback(
                 fn ($email) => '@bad.com' !== $email
             );
-        $mailHelper->method('queue')
+        $this->mailHelper->method('queue')
             ->willReturn([true, []]);
 
         $stat = new Stat();
         $stat->setEmail($emailMock);
-        $mailHelper->method('createEmailStat')
+        $this->mailHelper->method('createEmailStat')
             ->willReturn($stat);
 
-        $statRepository = $this->createMock(StatRepository::class);
-
-        $dncModel = $this->createMock(DoNotContact::class);
-
-        $dncModel->expects($this->once())
+        $this->dncModel->expects($this->once())
             ->method('addDncForContact');
 
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $this->translator);
+        $model = new SendEmailToContact($this->mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $model->setEmail($emailMock);
 
         $contacts             = $this->contacts;
@@ -208,11 +215,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test a tokenized transport that limits batches does not throw BatchQueueMaxException on subsequent contacts when one fails
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
      */
     public function testBadEmailDoesNotCauseBatchQueueMaxExceptionOnSubsequentContacts(): void
     {
@@ -227,9 +229,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $mailer    = new Mailer($transport);
 
         // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $factoryMock = $this->createMock(MauticFactory::class);
         $factoryMock->method('getParameter')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
@@ -278,24 +278,10 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         // Enable queueing
         $mailHelper->enableQueue();
 
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel->expects($this->exactly(1))
+        $this->dncModel->expects($this->exactly(1))
             ->method('addDncForContact');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+        $model = new SendEmailToContact($mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $model->setEmail($emailMock);
 
         $contacts             = $this->contacts;
@@ -324,11 +310,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test a tokenized transport that fills tokens correctly
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
      */
     public function testBatchQueueContactsHaveTokensHydrated(): void
     {
@@ -345,9 +326,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $mailer    = new Mailer($transport);
 
         // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $factoryMock = $this->createMock(MauticFactory::class);
         $factoryMock->method('getParameter')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
@@ -359,9 +338,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                 new NullLogger()
             );
 
-        $mockEm = $this->getMockBuilder(EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockEm = $this->createMock(EntityManager::class);
         $factoryMock->method('getEntityManager')
             ->willReturn($mockEm);
 
@@ -385,18 +362,12 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             );
         $factoryMock->method('getDispatcher')
             ->willReturn($mockDispatcher);
-        $routerMock = $this->getMockBuilder(Router::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $routerMock = $this->createMock(Router::class);
         $factoryMock->method('getRouter')
             ->willReturn($routerMock);
 
-        $copyRepoMock = $this->getMockBuilder(CopyRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $emailModelMock = $this->getMockBuilder(EmailModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $copyRepoMock   = $this->createMock(CopyRepository::class);
+        $emailModelMock = $this->createMock(EmailModel::class);
         $emailModelMock->method('getCopyRepository')
             ->willReturn($copyRepoMock);
 
@@ -414,10 +385,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         // Enable queueing
         $mailHelper->enableQueue();
 
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepository->method('saveEntity')
+        $this->emailStatModel->method('saveEntity')
             ->willReturnCallback(
                 function (Stat $stat): void {
                     $tokens = $stat->getTokens();
@@ -426,17 +394,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+        $model = new SendEmailToContact($mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $model->setEmail($emailMock);
 
         foreach ($this->contacts as $contact) {
@@ -455,12 +413,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that stat entries are saved in batches of 20
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::createContactStatEntry()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
      */
     public function testThatStatEntriesAreCreatedAndPersistedEveryBatch(): void
     {
@@ -477,9 +429,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $mailer    = new Mailer($transport);
 
         // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
-        $factoryMock = $this->getMockBuilder(MauticFactory::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $factoryMock = $this->createMock(MauticFactory::class);
         $factoryMock->method('getParameter')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
@@ -494,9 +444,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             ->willReturn(
                 new EventDispatcher()
             );
-        $routerMock = $this->getMockBuilder(Router::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $routerMock = $this->createMock(Router::class);
         $factoryMock->method('getRouter')
             ->willReturn($routerMock);
 
@@ -530,26 +478,13 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $mailHelper->enableQueue();
 
         // Here's the test; this should be called after 20 contacts are processed
-        $statRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepository->expects($this->exactly(21))
+        $this->emailStatModel->expects($this->exactly(21))
             ->method('saveEntity');
 
-        $dncModel = $this->getMockBuilder(DoNotContact::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dncModel->expects($this->never())
+        $this->dncModel->expects($this->never())
             ->method('addDncForContact');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+        $model = new SendEmailToContact($mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $model->setEmail($emailMock);
 
         // Let's generate 20 bogus contacts
@@ -584,14 +519,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that a failed email from the transport is handled
-     *
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::setContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::send()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::failContact()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getFailedContacts()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::upEmailSentCount()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::downEmailSentCount()
-     * @covers \Mautic\EmailBundle\Model\SendEmailToContact::getSentCounts()
      */
     public function testThatAFailureFromTransportIsHandled(): void
     {
@@ -646,15 +573,9 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         // Enable queueing
         $mailHelper->enableQueue();
 
-        $statRepository = $this->createMock(StatRepository::class);
-        $dncModel       = $this->createMock(DoNotContact::class);
-        $translator     = $this->createMock(Translator::class);
+        $this->dncModel->expects($this->never())->method('addDncForContact');
 
-        $dncModel->expects($this->never())->method('addDncForContact');
-
-        $statHelper = new StatHelper($statRepository);
-
-        $model = new SendEmailToContact($mailHelper, $statHelper, $dncModel, $translator);
+        $model = new SendEmailToContact($mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $model->setEmail($emailMock);
 
         foreach ($this->contacts as $contact) {

--- a/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Model;
+
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Model\EmailStatModel;
+use Mautic\EmailBundle\Model\TransportCallback;
+use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
+use Mautic\EmailBundle\MonitoredEmail\Search\Result;
+use Mautic\LeadBundle\Entity\DoNotContact as DNC;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\DoNotContact;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class TransportCallbackTest extends TestCase
+{
+    public function testStatSave(): void
+    {
+        $dncModel = new class() extends DoNotContact {
+            public function __construct()
+            {
+            }
+
+            public function addDncForContact($contactId, $channel, $reason = DNC::BOUNCED, $comments = '', $persist = true, $checkCurrentStatus = true, $allowUnsubscribeOverride = false)
+            {
+                Assert::assertSame('email', $channel);
+                Assert::assertSame(DNC::BOUNCED, $reason);
+            }
+        };
+
+        $contactFinder = new class() extends ContactFinder {
+            public function __construct()
+            {
+            }
+
+            public function findByHash($hash)
+            {
+                Assert::assertSame('some-hash-id', $hash);
+
+                $result  = new Result();
+                $contact = new Lead();
+                $stat    = new Stat();
+                $result->addContact($contact);
+                $result->setStat($stat);
+
+                return $result;
+            }
+        };
+
+        $emailStatModel = new class() extends EmailStatModel {
+            public function __construct()
+            {
+            }
+
+            public function saveEntity(Stat $stat): void
+            {
+                Assert::assertTrue($stat->isFailed());
+                Assert::assertArrayHasKey('bounces', $stat->getOpenDetails());
+                Assert::assertArrayHasKey(0, $stat->getOpenDetails()['bounces']);
+                Assert::assertArrayHasKey('datetime', $stat->getOpenDetails()['bounces'][0]);
+                Assert::assertArrayHasKey('reason', $stat->getOpenDetails()['bounces'][0]);
+                Assert::assertSame('some-comments', $stat->getOpenDetails()['bounces'][0]['reason']);
+            }
+        };
+
+        $transportCallback = new TransportCallback($dncModel, $contactFinder, $emailStatModel);
+
+        $transportCallback->addFailureByHashId('some-hash-id', 'some-comments');
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        http://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\EmailBundle\Tests\Model;
 
 use Mautic\EmailBundle\Entity\Stat;
@@ -37,6 +28,8 @@ class TransportCallbackTest extends TestCase
             {
                 Assert::assertSame('email', $channel);
                 Assert::assertSame(DNC::BOUNCED, $reason);
+
+                return true;
             }
         };
 
@@ -45,7 +38,7 @@ class TransportCallbackTest extends TestCase
             {
             }
 
-            public function findByHash($hash)
+            public function findByHash($hash): Result
             {
                 Assert::assertSame('some-hash-id', $hash);
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
@@ -6,6 +6,7 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
 use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
@@ -21,20 +22,11 @@ class BounceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @testdox Test that the transport interface processes the message appropriately
-     *
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::process()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::updateStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::setStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::setContacts()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getContacts()
      */
     public function testProcessorInterfaceProcessesMessage(): void
     {
         $transport     = new TestTransport();
-        $contactFinder = $this->getMockBuilder(ContactFinder::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contactFinder = $this->createMock(ContactFinder::class);
         $contactFinder->method('find')
             ->willReturnCallback(
                 function ($email, $bounceAddress) {
@@ -59,27 +51,21 @@ class BounceTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $statRepo = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepo->expects($this->once())
+        $emailStatModel = $this->createMock(EmailStatModel::class);
+        $emailStatModel->expects($this->once())
             ->method('saveEntity');
 
-        $leadModel = $this->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $leadModel = $this->createMock(LeadModel::class);
+        $leadModel->expects($this->once())
+            ->method('addDncForLead');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $translator = $this->createMock(Translator::class);
 
-        $logger = $this->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $logger = $this->createMock(Logger::class);
 
         $doNotContact = $this->createMock(DoNotContact::class);
 
-        $bouncer = new Bounce($transport, $contactFinder, $statRepo, $leadModel, $translator, $logger, $doNotContact);
+        $bouncer = new Bounce($transport, $contactFinder, $emailStatModel, $leadModel, $translator, $logger, $doNotContact);
 
         $message = new Message();
         $this->assertTrue($bouncer->process($message));
@@ -87,20 +73,11 @@ class BounceTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @testdox Test that the message is processed appropriately
-     *
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::process()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::updateStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::setStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getStat()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::setContacts()
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getContacts()
      */
     public function testContactIsFoundFromMessageAndDncRecordAdded(): void
     {
         $transport     = new NullTransport();
-        $contactFinder = $this->getMockBuilder(ContactFinder::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contactFinder = $this->createMock(ContactFinder::class);
         $contactFinder->method('find')
             ->willReturnCallback(
                 function ($email, $bounceAddress) {
@@ -125,27 +102,21 @@ class BounceTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $statRepo = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $statRepo->expects($this->once())
+        $emailStatModel = $this->createMock(EmailStatModel::class);
+        $emailStatModel->expects($this->once())
             ->method('saveEntity');
 
-        $leadModel = $this->getMockBuilder(LeadModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $leadModel = $this->createMock(LeadModel::class);
+        $leadModel->expects($this->once())
+            ->method('addDncForLead');
 
-        $translator = $this->getMockBuilder(Translator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $translator = $this->createMock(Translator::class);
 
-        $logger = $this->getMockBuilder(Logger::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $logger = $this->createMock(Logger::class);
 
         $doNotContact = $this->createMock(DoNotContact::class);
 
-        $bouncer = new Bounce($transport, $contactFinder, $statRepo, $leadModel, $translator, $logger, $doNotContact);
+        $bouncer = new Bounce($transport, $contactFinder, $emailStatModel, $leadModel, $translator, $logger, $doNotContact);
 
         $message            = new Message();
         $message->to        = ['contact+bounce_123abc@test.com' => null];

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
@@ -5,7 +5,6 @@ namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
@@ -56,8 +55,6 @@ class BounceTest extends \PHPUnit\Framework\TestCase
             ->method('saveEntity');
 
         $leadModel = $this->createMock(LeadModel::class);
-        $leadModel->expects($this->once())
-            ->method('addDncForLead');
 
         $translator = $this->createMock(Translator::class);
 
@@ -107,8 +104,6 @@ class BounceTest extends \PHPUnit\Framework\TestCase
             ->method('saveEntity');
 
         $leadModel = $this->createMock(LeadModel::class);
-        $leadModel->expects($this->once())
-            ->method('addDncForLead');
 
         $translator = $this->createMock(Translator::class);
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -11,6 +11,7 @@ use Mautic\EmailBundle\Entity\EmailReply;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Event\EmailReplyEvent;
+use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
@@ -27,17 +28,40 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
 {
     private EmailAddressHelper $emailAddressHelper;
 
-    private \PHPUnit\Framework\MockObject\MockObject $statRepo;
+    /**
+     * @var MockObject&StatRepository
+     */
+    private MockObject $statRepo;
 
-    private \PHPUnit\Framework\MockObject\MockObject $contactFinder;
+    /**
+     * @var MockObject&EmailStatModel
+     */
+    private MockObject $emailStatModel;
 
-    private \PHPUnit\Framework\MockObject\MockObject $leadModel;
+    /**
+     * @var MockObject&ContactFinder
+     */
+    private MockObject $contactFinder;
 
-    private \PHPUnit\Framework\MockObject\MockObject $dispatcher;
+    /**
+     * @var MockObject&LeadModel
+     */
+    private MockObject $leadModel;
 
-    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    /**
+     * @var MockObject&EventDispatcherInterface
+     */
+    private MockObject $dispatcher;
 
-    private \PHPUnit\Framework\MockObject\MockObject $contactTracker;
+    /**
+     * @var MockObject&Logger
+     */
+    private MockObject $logger;
+
+    /**
+     * @var MockObject&ContactTracker
+     */
+    private MockObject $contactTracker;
 
     private \Mautic\EmailBundle\MonitoredEmail\Processor\Reply $processor;
 
@@ -51,6 +75,7 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->statRepo           = $this->createMock(StatRepository::class);
+        $this->emailStatModel     = $this->createMock(EmailStatModel::class);
         $this->contactFinder      = $this->createMock(ContactFinder::class);
         $this->leadModel          = $this->createMock(LeadModel::class);
         $this->dispatcher         = $this->createMock(EventDispatcherInterface::class);
@@ -60,7 +85,7 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
         $this->leadRepository     = $this->createMock(LeadRepository::class);
         $this->leadModel->method('getRepository')->willReturn($this->leadRepository);
         $this->processor          = new Reply(
-            $this->statRepo,
+            $this->emailStatModel,
             $this->contactFinder,
             $this->leadModel,
             $this->dispatcher,
@@ -68,19 +93,17 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
             $this->contactTracker,
             $this->emailAddressHelper
         );
+
+        $this->emailStatModel->method('getRepository')->willReturn($this->statRepo);
     }
 
     /**
      * @testdox Test that the message is processed appropriately
-     *
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Processor\Reply::process
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getStat
-     * @covers  \Mautic\EmailBundle\MonitoredEmail\Search\Result::getContacts
      */
     public function testContactIsFoundFromMessageAndDncRecordAdded(): void
     {
         // This tells us that a reply was found and processed
-        $this->statRepo->expects($this->once())
+        $this->emailStatModel->expects($this->once())
             ->method('saveEntity');
 
         $this->leadRepository->expects(self::atLeastOnce())
@@ -170,7 +193,7 @@ BODY;
                 return true;
             }));
 
-        $this->statRepo->expects($this->once())
+        $this->emailStatModel->expects($this->once())
             ->method('saveEntity')
             ->with($this->isInstanceOf(Stat::class));
 

--- a/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
@@ -5,6 +5,7 @@ namespace Mautic\EmailBundle\Tests\Stat;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Model\EmailStatModel;
 use Mautic\EmailBundle\Stat\Exception\StatNotFoundException;
 use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\LeadBundle\Entity\Lead;
@@ -13,15 +14,16 @@ class StatHelperTest extends \PHPUnit\Framework\TestCase
 {
     public function testStatsAreCreatedAndDeleted(): void
     {
-        $mockStatRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $emailStatmodel     = $this->createMock(EmailStatModel::class);
+        $mockStatRepository = $this->createMock(StatRepository::class);
+
+        $emailStatmodel->method('getRepository')->willReturn($mockStatRepository);
 
         $mockStatRepository->expects($this->once())
             ->method('deleteStats')
             ->withConsecutive([[1, 2, 3, 4, 5]]);
 
-        $statHelper = new StatHelper($mockStatRepository);
+        $statHelper = new StatHelper($emailStatmodel);
 
         $mockEmail = $this->getMockBuilder(Email::class)
             ->getMock();
@@ -69,12 +71,9 @@ class StatHelperTest extends \PHPUnit\Framework\TestCase
     public function testExceptionIsThrownIfEmailAddressIsNotFound(): void
     {
         $this->expectException(StatNotFoundException::class);
-        $mockStatRepository = $this->getMockBuilder(StatRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
-        $statHelper = new StatHelper($mockStatRepository);
+        $statHelper = new StatHelper($this->createMock(EmailStatModel::class));
 
-        $reference = $statHelper->getStat('nada@nada.com');
+        $statHelper->getStat('nada@nada.com');
     }
 }

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -54,7 +54,7 @@ class DoNotContact implements MauticModelInterface
      * Create a DNC entry for a lead.
      *
      * @param \Mautic\LeadBundle\Entity\Lead|int|null $contactId
-     * @param string|array                            $channel                  If an array with an ID, use the structure ['email' => 123]
+     * @param string|mixed[]                          $channel                  If an array with an ID, use the structure ['email' => 123]
      * @param string                                  $comments
      * @param int                                     $reason                   Must be a class constant from the DoNotContact class
      * @param bool                                    $persist


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

We have a plugin that needs to make an action on email Stat entity save. The problem was that the Stat entity was saved through many places, sometimes through StatRepository, sometimes through EntityManager directly. 

This PR creates a new EmailStatModel that is dispatching new events on before and after the save and then refactors all the places where I could find was the Stat entity saved and used the new model instead.

This PR does not change any functionality. It should all still work as before.

Although there was 1 bug I discovered when I was covering a method I have changed with a test. The emails were not retried for 3 times before creating a DNC record but on the first retrial. It looks like someone forgot a debug `true` there.

All the changes are covered by unit tests. I cannot tell what different use cases needs to be tested.

#### Steps to test this PR:
1. Make sure you can send an email to a contact (or better multiple) and you can see in the contact detail page if you open the email or click a link.
2. Also test unsubscribtion.
3. And email reply events.

#### Other areas of Mautic that may be affected by the change:
1. All areas concerning sending email and recording changes on email stats like opens and retries.

#### List deprecations along with the new alternative:
1. None

#### List backwards compatibility breaks:
1. None