### PR TITLE
Fixing segment filters that have NULL value in properties.filter

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -388,9 +388,18 @@ class LeadList extends FormEntity
     private function addLegacyParams(array $filters): array
     {
         return array_map(
-            function (array $filter): array {
-                $filter['filter']  = $filter['properties']['filter'] ?? $filter['filter'] ?? null;
-                $filter['display'] = $filter['properties']['display'] ?? $filter['display'] ?? null;
+            function (array $filter) {
+                if (isset($filter['properties']) && $filter['properties'] && array_key_exists('filter', $filter['properties'])) {
+                    $filter['filter'] = $filter['properties']['filter'];
+                } else {
+                    $filter['filter'] = $filter['filter'] ?? null;
+                }
+
+                if (isset($filter['properties']) && $filter['properties'] && array_key_exists('display', $filter['properties'])) {
+                    $filter['display'] = $filter['properties']['display'];
+                } else {
+                    $filter['display'] = $filter['display'] ?? null;
+                }
 
                 return $filter;
             },

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -388,7 +388,7 @@ class LeadList extends FormEntity
     private function addLegacyParams(array $filters): array
     {
         return array_map(
-            function (array $filter) {
+            function (array $filter): array {
                 if (isset($filter['properties']) && $filter['properties'] && array_key_exists('filter', $filter['properties'])) {
                     $filter['filter'] = $filter['properties']['filter'];
                 } else {

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -66,6 +66,26 @@ final class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCa
             [
                 'object'     => 'lead',
                 'glue'       => 'and',
+                'field'      => 'address1',
+                'type'       => 'text',
+                'operator'   => '!empty',
+                'properties' => ['filter' => null],
+                // The filter key is deprecated but sometimes it contains rubbish values including a string.
+                'filter'     => 'somestring',
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'address1',
+                'type'       => 'text',
+                'operator'   => '!=',
+                'properties' => ['filter' => null],
+                // The filter key is deprecated but sometimes it contains rubbish values including an array.
+                'filter'     => ['option A', 'option B'],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
                 'field'      => 'firstname',
                 'type'       => 'text',
                 'operator'   => '=',


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We found an error in our logs:
```
Next Doctrine\DBAL\Exception\InvalidFieldNameException: An exception occurred while executing 'SELECT l.id FROM mautic_leads l WHERE (l.eab_contact_type = ?) AND (l.funnel_stage_calc IN (?)) AND (l.stu_hs_grade_level_calc = ?) AND ((l.do_not_direct_mail_calc IS NULL) OR (l.do_not_direct_mail_calc <> ?)) AND ((l.address1 IS NOT NULL) AND (l.address1 <> '')) AND ((l.city IS NOT NULL) AND (l.city <> '')) AND ((l.state IS NOT NULL) AND (l.state <> '')) AND ((l.zipcode IS NOT NULL) AND (l.zipcode <> '')) AND (l.all_sources_blnd REGEXP ?) AND ((l.address1 IS NULL) OR (l.address1 <> Array)) AND (NOT l.email REGEXP ?) AND ((l.is_deleted IS NULL) OR (l.is_deleted <> ?)) AND (l.id NOT IN (SELECT par1c.lead_id FROM mautic_lead_lists_leads par1c WHERE (par1c.leadlist_id = ?) AND (par1c.lead_id IN (17664, 51115)) AND (l.date_identified IS NOT NULL) LIMIT 2000' with params ["test", "test", 12, 1, "(([|]|^)test([|]|$))", "\\test.com\\b", 1, 121]:SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Array' in 'where clause' in vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:79
Stack trace:
#0 vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(182): Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception oc...', Object(Doctrine\DBAL\Driver\PDO\Exception))
#1 vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(159): Doctrine\DBAL\DBALException::wrapException(Object(Doctrine\DBAL\Driver\PDO\MySQL\Driver), Object(Doctrine\DBAL\Driver\PDO\Exception), 'An exception oc...')
#2 vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(2225): Doctrine\DBAL\DBALException::driverExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDO\MySQL\Driver), Object(Doctrine\DBAL\Driver\PDO\Exception), 'SELECT l.id FRO...', Array)
#3 vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1312): Doctrine\DBAL\Connection->handleExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDO\Exception), 'SELECT l.id FRO...', Array, Array)
#4 vendor/doctrine/dbal/lib/Doctrine/DBAL/Query/QueryBuilder.php(212): Doctrine\DBAL\Connection->executeQuery('SELECT l.id FRO...', Array, Array)
#5 app/bundles/LeadBundle/Segment/ContactSegmentService.php(349): Doctrine\DBAL\Query\QueryBuilder->execute()
#6 app/bundles/LeadBundle/Segment/ContactSegmentService.php(171): Mautic\LeadBundle\Segment\ContactSegmentService->timedFetchAll(Object(Mautic\LeadBundle\Segment\Query\QueryBuilder), 121
```
on segment rebuild with this problematic filter in that segment:
```
[9] => Array
        (
            [object] => lead
            [glue] => and
            [field] => address1
            [type] => text
            [operator] => !=
            [properties] => Array
                (
                    [filter] => 
                )

            [filter] => Array
                (
                    [0] => option 1
                )

            [display] => 
        ) 
```
I noticed that one of the filters have some rubbish value in the "filter" property which is deprecated and the "properties.filter" property should be used instead. We have code to ensure the right filter is used in the code but it does not count with "params.filter" value being NULL. In that case this value is skipped and the deprecated "filter" value is used instead. Since it has rubbish in it it will fail the SQL query resulting in the error I found or it will use the rubbish value and the segment will result in rubbish segment members.

#### Steps to test this PR:

I tried to find out how the rubbish values get to the "filter" param but there are no records in the audit_log table for this segment so there are no data to inspect. So I cannot provide any steps to reproduce. Just the fix and automated functional test with it.
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Ensure segments are building like before.

#### Other areas of Mautic that may be affected by the change:
1. Just segment build

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The buggy data in the segments are covered with the test
