### PR TITLE
Fixing asset edit page permissions

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -417,7 +417,7 @@ class AssetController extends FormController
         $model  = $this->getModel('asset');
         $entity = $model->getEntity($objectId);
 
-        if (!$this->get('mautic.security')->hasEntityAccess('asset:assets:viewown', 'asset:assets:viewother', $entity->getCreatedBy())) {
+        if (!$this->get('mautic.security')->hasEntityAccess('asset:assets:editown', 'asset:assets:editother', $entity->getCreatedBy())) {
             return $this->accessDenied();
         }
 

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\FileHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Oneup\UploaderBundle\Templating\Helper\UploaderHelper;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,11 +19,8 @@ class AssetController extends FormController
     /**
      * @return JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function indexAction(Request $request, CoreParametersHelper $parametersHelper, int $page = 1)
+    public function indexAction(Request $request, CoreParametersHelper $parametersHelper, AssetModel $assetModel, int $page = 1)
     {
-        $assetModel = $this->getModel('asset');
-        \assert($assetModel instanceof AssetModel);
-
         // set some permissions
         $permissions = $this->security->isGranted([
             'asset:assets:viewown',
@@ -129,10 +127,8 @@ class AssetController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, AssetModel $model, $objectId)
     {
-        $model       = $this->getModel('asset');
-        \assert($model instanceof AssetModel);
         $activeAsset = $model->getEntity($objectId);
 
         // set the asset we came from
@@ -219,12 +215,12 @@ class AssetController extends FormController
     /**
      * Show a preview of the file.
      *
+     * @param int $objectId
+     *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function previewAction(Request $request, $objectId)
+    public function previewAction(Request $request, AssetModel $model, $objectId)
     {
-        /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model       = $this->getModel('asset');
         $activeAsset = $model->getEntity($objectId);
 
         if (null === $activeAsset || !$this->security->hasEntityAccess('asset:assets:viewown', 'asset:assets:viewother', $activeAsset->getCreatedBy())) {
@@ -273,12 +269,8 @@ class AssetController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function newAction(Request $request, CoreParametersHelper $parametersHelper, UploaderHelper $uploaderHelper, $entity = null)
+    public function newAction(Request $request, CoreParametersHelper $parametersHelper, UploaderHelper $uploaderHelper, AssetModel $model, $entity = null)
     {
-        /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model = $this->getModel('asset');
-
-        /** @var \Mautic\AssetBundle\Entity\Asset $entity */
         if (null == $entity) {
             $entity = $model->getEntity();
         }
@@ -344,7 +336,7 @@ class AssetController extends FormController
 
                     if (!$this->getFormButton($form, ['buttons', 'save'])->isClicked()) {
                         // return edit view so that all the session stuff is loaded
-                        return $this->editAction($request, $uploaderHelper, $entity->getId(), true);
+                        return $this->editAction($request, $uploaderHelper, $model, $entity->getId(), true);
                     }
 
                     $viewParameters = [
@@ -411,13 +403,11 @@ class AssetController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request, UploaderHelper $uploaderHelper, $objectId, $ignorePost = false)
+    public function editAction(Request $request, UploaderHelper $uploaderHelper, AssetModel $model, $objectId, $ignorePost = false)
     {
-        /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model  = $this->getModel('asset');
         $entity = $model->getEntity($objectId);
 
-        if (!$this->get('mautic.security')->hasEntityAccess('asset:assets:editown', 'asset:assets:editother', $entity->getCreatedBy())) {
+        if (!$this->security->hasEntityAccess('asset:assets:editown', 'asset:assets:editother', $entity->getCreatedBy())) {
             return $this->accessDenied();
         }
 
@@ -579,10 +569,8 @@ class AssetController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function cloneAction(Request $request, CoreParametersHelper $parametersHelper, UploaderHelper $uploaderHelper, $objectId)
+    public function cloneAction(Request $request, CoreParametersHelper $parametersHelper, UploaderHelper $uploaderHelper, AssetModel $model, $objectId)
     {
-        /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-        $model  = $this->getModel('asset');
         $entity = $model->getEntity($objectId);
         $clone  = null;
 
@@ -602,7 +590,7 @@ class AssetController extends FormController
             $clone->setIsPublished(false);
         }
 
-        return $this->newAction($request, $parametersHelper, $uploaderHelper, $clone);
+        return $this->newAction($request, $parametersHelper, $uploaderHelper, $model, $clone);
     }
 
     /**
@@ -612,7 +600,7 @@ class AssetController extends FormController
      *
      * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, AssetModel $model, $objectId)
     {
         $page      = $request->getSession()->get('mautic.asset.page', 1);
         $returnUrl = $this->generateUrl('mautic_asset_index', ['page' => $page]);
@@ -629,8 +617,6 @@ class AssetController extends FormController
         ];
 
         if ('POST' === $request->getMethod()) {
-            /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-            $model  = $this->getModel('asset');
             $entity = $model->getEntity($objectId);
 
             if (null === $entity) {
@@ -675,7 +661,7 @@ class AssetController extends FormController
      *
      * @return Response
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request, AssetModel $model)
     {
         $page      = $request->getSession()->get('mautic.asset.page', 1);
         $returnUrl = $this->generateUrl('mautic_asset_index', ['page' => $page]);
@@ -692,8 +678,6 @@ class AssetController extends FormController
         ];
 
         if ('POST' === $request->getMethod()) {
-            /** @var \Mautic\AssetBundle\Model\AssetModel $model */
-            $model     = $this->getModel('asset');
             $ids       = json_decode($request->query->get('ids', '{}'));
             $deleteIds = [];
 
@@ -745,12 +729,9 @@ class AssetController extends FormController
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function remoteAction(Request $request): Response
+    public function remoteAction(Request $request, IntegrationHelper $integrationHelper): Response
     {
         // Check for integrations to cloud providers
-        /** @var \Mautic\PluginBundle\Helper\IntegrationHelper $integrationHelper */
-        $integrationHelper = $this->factory->getHelper('integration');
-
         $integrations = $integrationHelper->getIntegrationObjects(null, ['cloud_storage']);
 
         $tmpl = $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index';

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -417,6 +417,10 @@ class AssetController extends FormController
         $model  = $this->getModel('asset');
         $entity = $model->getEntity($objectId);
 
+        if (!$this->get('mautic.security')->hasEntityAccess('asset:assets:viewown', 'asset:assets:viewother', $entity->getCreatedBy())) {
+            return $this->accessDenied();
+        }
+
         $entity->setMaxSize(FileHelper::convertMegabytesToBytes($this->coreParametersHelper->get('max_size')));
 
         $session    = $request->getSession();

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -1,16 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\AssetBundle\Tests\Asset\AbstractAssetTest;
 use Mautic\CoreBundle\Tests\Traits\ControllerTrait;
 use Mautic\PageBundle\Tests\Controller\PageControllerTest;
+use Mautic\UserBundle\Entity\Permission;
+use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AssetControllerFunctionalTest extends AbstractAssetTest
 {
     use ControllerTrait;
+
+    private const USER_EDITOR_USERNAME  = 'sales';
+    private const USER_CREATOR_USERNAME = 'admin';
 
     /**
      * Index action should return status code 200.
@@ -94,5 +103,116 @@ class AssetControllerFunctionalTest extends AbstractAssetTest
             $content,
             'The return must contain the assert slug'
         );
+    }
+
+    /**
+     * @param array<string, string[]> $permission
+     *
+     * @dataProvider getValuesProvider
+     */
+    public function testEditWithPermissions(array $permission, int $expectedStatusCode, string $userCreatorUN): void
+    {
+        $userCreator = $this->getUser($userCreatorUN);
+        $userEditor  = $this->getUser(self::USER_EDITOR_USERNAME);
+        $this->setPermission($userEditor, $permission);
+
+        $asset = new Asset();
+        $asset->setTitle('Asset A');
+        $asset->setAlias('asset-a');
+        $asset->setStorageLocation('local');
+        $asset->setPath('broken-image.jpg');
+        $asset->setExtension('jpg');
+        $asset->setCreatedByUser($userCreator->getUsername());
+        $asset->setCreatedBy($userCreator->getId());
+        $this->em->persist($asset);
+        $this->em->flush();
+        $this->em->clear();
+
+        // Logout admin.
+        $this->client->request(Request::METHOD_GET, '/s/logout');
+
+        $this->loginUser(self::USER_EDITOR_USERNAME);
+
+        $this->client->setServerParameter('PHP_AUTH_USER', self::USER_EDITOR_USERNAME);
+        $this->client->request(Request::METHOD_GET, sprintf('/s/assets/edit/%d', $asset->getId()));
+
+        Assert::assertSame($expectedStatusCode, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @return \Generator<string, mixed[]>
+     */
+    public function getValuesProvider(): \Generator
+    {
+        yield 'The sales user edits its own asset' => [
+            'permission' => [
+                'asset:assets' => ['editown', 'editother'],
+            ],
+            'expectedStatusCode' => Response::HTTP_OK,
+            'userCreatorUN'      => self::USER_EDITOR_USERNAME,
+        ];
+
+        yield 'The sales user cannot edit asset created by admin' => [
+            'permission' => [
+                'asset:assets' => ['editown'],
+            ],
+            'expectedStatusCode' => Response::HTTP_FORBIDDEN,
+            'userCreatorUN'      => self::USER_CREATOR_USERNAME,
+        ];
+
+        yield 'The sales user can edit asset created by admin' => [
+            'permission' => [
+                'asset:assets' => ['editown', 'editother'],
+            ],
+            'expectedStatusCode' => Response::HTTP_OK,
+            'userCreatorUN'      => self::USER_CREATOR_USERNAME,
+        ];
+
+        yield 'The sales user cannot edit or view asset created by admin' => [
+            'permission' => [
+                'asset:assets' => ['viewown'],
+            ],
+            'expectedStatusCode' => Response::HTTP_FORBIDDEN,
+            'userCreatorUN'      => self::USER_CREATOR_USERNAME,
+        ];
+
+        yield 'The sales user can edit or view asset created by admin' => [
+            'permission' => [
+                'asset:assets' => ['viewown', 'viewother'],
+            ],
+            'expectedStatusCode' => Response::HTTP_OK,
+            'userCreatorUN'      => self::USER_CREATOR_USERNAME,
+        ];
+    }
+
+    private function getUser(string $username): User
+    {
+        $repository = $this->em->getRepository(User::class);
+
+        return $repository->findOneBy(['username' => $username]);
+    }
+
+    /**
+     * @param array<string, string[]> $permissions
+     */
+    private function setPermission(User $user, array $permissions): void
+    {
+        $role = $user->getRole();
+
+        // Delete previous permissions
+        $this->em->createQueryBuilder()
+            ->delete(Permission::class, 'p')
+            ->where('p.bundle = :bundle')
+            ->andWhere('p.role = :role_id')
+            ->setParameters(['bundle' => 'asset', 'role_id' => $role->getId()])
+            ->getQuery()
+            ->execute();
+
+        // Set new permissions
+        $role->setIsAdmin(false);
+        $roleModel = self::$container->get('mautic.user.model.role');
+        $roleModel->setRolePermissions($role, $permissions);
+        $this->em->persist($role);
+        $this->em->flush();
     }
 }

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Tests\Traits\ControllerTrait;
 use Mautic\PageBundle\Tests\Controller\PageControllerTest;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -122,7 +123,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTest
         $asset->setStorageLocation('local');
         $asset->setPath('broken-image.jpg');
         $asset->setExtension('jpg');
-        $asset->setCreatedByUser($userCreator->getUsername());
+        $asset->setCreatedByUser($userCreator->getUserIdentifier());
         $asset->setCreatedBy($userCreator->getId());
         $this->em->persist($asset);
         $this->em->flush();
@@ -209,7 +210,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTest
     }
 
     /**
-     * @param array<string, string[]> $permissions
+     * @param array<string, array<string, array<string>>> $permissions
      */
     private function setPermission(User $user, array $permissions): void
     {
@@ -226,7 +227,8 @@ class AssetControllerFunctionalTest extends AbstractAssetTest
 
         // Set new permissions
         $role->setIsAdmin(false);
-        $roleModel = self::$container->get('mautic.user.model.role');
+        $roleModel = static::getContainer()->get('mautic.user.model.role');
+        \assert($roleModel instanceof RoleModel);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);
         $this->em->flush();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Users with "View Others" permission on assets can edit and save any asset

While such user is not shown the edit button, they can navigate to the edit url like https://[your-mautic]/s/assets/edit/1 and can edit the asset.

This PR prevents accessing the edit page for unautorized users and instead returns the 403 page (Forbidden).

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an "Asset A"
3. Create new user with permission of asset:viewown
4. Login to Mautic with this new user
5. Try to access the edit page of the asset created in step 2.

Before this change the edit page is accessible and you can edit the asset of another user.

After this change the edit page is not accessible for the second user.

Test also other permissions. Like editother, viewother, editown.

#### Other areas of Mautic that may be affected by the change:
1. Just the asset edit page

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The asset edit page is covered by functional tests and testing users with various permissions.
