### PR TITLE
Fixing audit log for companies

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonEntity.php
+++ b/app/bundles/CoreBundle/Entity/CommonEntity.php
@@ -56,6 +56,8 @@ class CommonEntity implements \Stringable
     /**
      * @param string $prop
      * @param mixed  $val
+     *
+     * @return void
      */
     protected function isChanged($prop, $val)
     {

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -182,7 +182,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     {
         $prefix = 'company';
 
-        if (substr($prop, 0, strlen($prefix)) === $prefix) {
+        if (str_starts_with($prop, $prefix)) {
             $getter  = 'get'.ucfirst(substr($prop, strlen($prefix)));
             $current = $this->$getter();
             if ($current !== $val) {

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -179,6 +179,38 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
+     * @param string $prop
+     * @param mixed  $val
+     */
+    protected function isChanged($prop, $val)
+    {
+        $prefix = 'company';
+
+        if (substr($prop, 0, strlen($prefix)) === $prefix) {
+            $getter  = 'get'.ucfirst(substr($prop, strlen($prefix)));
+            $current = $this->$getter();
+            if ($current !== $val) {
+                $this->addChange($prop, [$current, $val]);
+            }
+        } elseif ('owner' == $prop) {
+            $getter  = 'get'.ucfirst($prop);
+            $current = $this->$getter();
+            if ($current && !$val) {
+                $this->changes['owner'] = [$current->getName().' ('.$current->getId().')', $val];
+            } elseif (!$current && $val) {
+                $this->changes['owner'] = [$current, $val->getName().' ('.$val->getId().')'];
+            } elseif ($current && $val && $current->getId() != $val->getId()) {
+                $this->changes['owner'] = [
+                    $current->getName().'('.$current->getId().')',
+                    $val->getName().'('.$val->getId().')',
+                ];
+            }
+        } else {
+            parent::isChanged($prop, $val);
+        }
+    }
+
+    /**
      * @return int
      */
     public function getId()
@@ -250,7 +282,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getName()
     {
@@ -258,19 +290,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $name
+     * @param string|null $name
      *
      * @return Company
      */
     public function setName($name)
     {
+        $this->isChanged('companyname', $name);
         $this->name = $name;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getEmail()
     {
@@ -278,19 +311,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $email
+     * @param string|null $email
      *
      * @return Company
      */
     public function setEmail($email)
     {
+        $this->isChanged('companyemail', $email);
         $this->email = $email;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getAddress1()
     {
@@ -298,19 +332,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $address1
+     * @param string|null $address1
      *
      * @return Company
      */
     public function setAddress1($address1)
     {
+        $this->isChanged('companyaddress1', $address1);
         $this->address1 = $address1;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getAddress2()
     {
@@ -318,19 +353,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $address2
+     * @param string|null $address2
      *
      * @return Company
      */
     public function setAddress2($address2)
     {
+        $this->isChanged('companyaddress2', $address2);
         $this->address2 = $address2;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getPhone()
     {
@@ -338,19 +374,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $phone
+     * @param string|null $phone
      *
      * @return Company
      */
     public function setPhone($phone)
     {
+        $this->isChanged('companyphone', $phone);
         $this->phone = $phone;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getCity()
     {
@@ -358,19 +395,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $city
+     * @param string|null $city
      *
      * @return Company
      */
     public function setCity($city)
     {
+        $this->isChanged('companycity', $city);
         $this->city = $city;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getState()
     {
@@ -378,19 +416,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $state
+     * @param string|null $state
      *
      * @return Company
      */
     public function setState($state)
     {
+        $this->isChanged('companystate', $state);
         $this->state = $state;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getZipcode()
     {
@@ -398,19 +437,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $zipcode
+     * @param string|null $zipcode
      *
      * @return Company
      */
     public function setZipcode($zipcode)
     {
+        $this->isChanged('companyzipcode', $zipcode);
         $this->zipcode = $zipcode;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getCountry()
     {
@@ -418,19 +458,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $country
+     * @param string|null $country
      *
      * @return Company
      */
     public function setCountry($country)
     {
+        $this->isChanged('companycountry', $country);
         $this->country = $country;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getWebsite()
     {
@@ -438,19 +479,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $website
+     * @param string|null $website
      *
      * @return Company
      */
     public function setWebsite($website)
     {
+        $this->isChanged('companywebsite', $website);
         $this->website = $website;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getIndustry()
     {
@@ -458,19 +500,20 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $industry
+     * @param string|null $industry
      *
      * @return Company
      */
     public function setIndustry($industry)
     {
+        $this->isChanged('companyindustry', $industry);
         $this->industry = $industry;
 
         return $this;
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getDescription()
     {
@@ -478,12 +521,13 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param mixed $description
+     * @param string|null $description
      *
      * @return Company
      */
     public function setDescription($description)
     {
+        $this->isChanged('companydescription', $description);
         $this->description = $description;
 
         return $this;

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -178,10 +178,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
         ];
     }
 
-    /**
-     * @param string $prop
-     * @param mixed  $val
-     */
     protected function isChanged($prop, $val)
     {
         $prefix = 'company';
@@ -192,14 +188,13 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
             if ($current !== $val) {
                 $this->addChange($prop, [$current, $val]);
             }
-        } elseif ('owner' == $prop) {
-            $getter  = 'get'.ucfirst($prop);
-            $current = $this->$getter();
+        } elseif ('owner' === $prop) {
+            $current = $this->getOwner();
             if ($current && !$val) {
                 $this->changes['owner'] = [$current->getName().' ('.$current->getId().')', $val];
             } elseif (!$current && $val) {
                 $this->changes['owner'] = [$current, $val->getName().' ('.$val->getId().')'];
-            } elseif ($current && $val && $current->getId() != $val->getId()) {
+            } elseif ($current && $current->getId() != $val->getId()) {
                 $this->changes['owner'] = [
                     $current->getName().'('.$current->getId().')',
                     $val->getName().'('.$val->getId().')',
@@ -259,7 +254,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     }
 
     /**
-     * @param User $score
+     * @param int $score
      *
      * @return Company
      */

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyUnitTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyUnitTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Mautic\LeadBundle\Entity\Company;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class CompanyUnitTest extends TestCase
+{
+    public function testChanges(): void
+    {
+        $company = new Company();
+
+        Assert::assertSame([], $company->getChanges());
+
+        $company->setEmail('john.doe@email.com');
+        $company->setScore(2);
+        $company->setName('Acquia');
+        $company->setAddress1('Acquia avenue');
+        $company->setAddress2('1234');
+        $company->setPhone('123456789');
+        $company->setCity('Boston');
+        $company->setState('MA');
+        $company->setZipcode('MA1234');
+        $company->setCountry('US');
+        $company->setWebsite('acquia.com');
+        $company->setIndustry('DXP');
+        $company->setDescription('Supports open source');
+
+        Assert::assertSame(
+            [
+                'companyemail'       => [null, 'john.doe@email.com'],
+                'score'              => [0, 2],
+                'companyname'        => [null, 'Acquia'],
+                'companyaddress1'    => [null, 'Acquia avenue'],
+                'companyaddress2'    => [null, '1234'],
+                'companyphone'       => [null, '123456789'],
+                'companycity'        => [null, 'Boston'],
+                'companystate'       => [null, 'MA'],
+                'companyzipcode'     => [null, 'MA1234'],
+                'companycountry'     => [null, 'US'],
+                'companywebsite'     => [null, 'acquia.com'],
+                'companyindustry'    => [null, 'DXP'],
+                'companydescription' => [null, 'Supports open source'],
+            ],
+            $company->getChanges()
+        );
+
+        $company->setEmail('john.doe@email.com - updated');
+        $company->setScore(5);
+        $company->setName('Acquia - updated');
+        $company->setAddress1('Acquia avenue - updated');
+        $company->setAddress2('1234 - updated');
+        $company->setPhone('123456789 - updated');
+        $company->setCity('Boston - updated');
+        $company->setState('MA - updated');
+        $company->setZipcode('MA1234 - updated');
+        $company->setCountry('US - updated');
+        $company->setWebsite('acquia.com - updated');
+        $company->setIndustry('DXP - updated');
+        $company->setDescription('Supports open source - updated');
+
+        Assert::assertSame(
+            [
+                'companyemail'       => ['john.doe@email.com', 'john.doe@email.com - updated'],
+                'score'              => [2, 5],
+                'companyname'        => ['Acquia', 'Acquia - updated'],
+                'companyaddress1'    => ['Acquia avenue', 'Acquia avenue - updated'],
+                'companyaddress2'    => ['1234', '1234 - updated'],
+                'companyphone'       => ['123456789', '123456789 - updated'],
+                'companycity'        => ['Boston', 'Boston - updated'],
+                'companystate'       => ['MA', 'MA - updated'],
+                'companyzipcode'     => ['MA1234', 'MA1234 - updated'],
+                'companycountry'     => ['US', 'US - updated'],
+                'companywebsite'     => ['acquia.com', 'acquia.com - updated'],
+                'companyindustry'    => ['DXP', 'DXP - updated'],
+                'companydescription' => ['Supports open source', 'Supports open source - updated'],
+            ],
+            $company->getChanges()
+        );
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
@@ -37,6 +37,6 @@ class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(AuditLog::class, $auditLogs);
         $auditLogDetail = $auditLogs->getDetails();
         $this->assertArrayHasKey('owner', $auditLogDetail);
-        $this->assertSame([null, $user->getId()], $auditLogDetail['owner']);
+        $this->assertSame([null, "Admin User ({$user->getId()})"], $auditLogDetail['owner']);
     }
 }

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -21,7 +21,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     public const CACHE_NAMESPACE = 'User';
 
     /**
-     * @var int
+     * @var ?int
      */
     protected $id;
 
@@ -412,9 +412,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     }
 
     /**
-     * Get id.
-     *
-     * @return int
+     * @return ?int
      */
     public function getId()
     {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We were missing the owner changes in the company audit log. This PR fixes that.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Change company owner
3. Check the audit_log table that the owner change is present there.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
