### PR TITLE
Making sure that not all DNC records are loaded when searching for a contact that do not exist

### DIFF
--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -137,10 +137,18 @@ class DoNotContactRepository extends CommonRepository
     }
 
     /**
-     * @param array $contacts Array of contacts to filter by
+     * @param string|null    $channel
+     * @param string[]|int[] $contacts Array of contact IDs to filter by
+     *
+     * @return mixed[]
      */
     public function getChannelList($channel, array $contacts = null): array
     {
+        // If no contacts are sent then stop querying for all of the DNC records as it leads to the out of memory error.
+        if (is_array($contacts) && empty($contacts)) {
+            return [];
+        }
+
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'lead_donotcontact', 'dnc')
             ->leftJoin('dnc', MAUTIC_TABLE_PREFIX.'leads', 'l', 'l.id = dnc.lead_id');
@@ -149,8 +157,8 @@ class DoNotContactRepository extends CommonRepository
             $q->select('dnc.channel, dnc.reason, l.id as lead_id');
         } else {
             $q->select('l.id, dnc.reason')
-              ->where('dnc.channel = :channel')
-              ->setParameter('channel', $channel);
+                ->where('dnc.channel = :channel')
+                ->setParameter('channel', $channel);
         }
 
         if ($contacts) {

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -145,7 +145,7 @@ class DoNotContactRepository extends CommonRepository
     public function getChannelList($channel, array $contacts = null): array
     {
         // If no contacts are sent then stop querying for all of the DNC records as it leads to the out of memory error.
-        if (empty($contacts)) {
+        if (is_array($contacts) && empty($contacts)) {
             return [];
         }
 

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -145,7 +145,7 @@ class DoNotContactRepository extends CommonRepository
     public function getChannelList($channel, array $contacts = null): array
     {
         // If no contacts are sent then stop querying for all of the DNC records as it leads to the out of memory error.
-        if (is_array($contacts) && empty($contacts)) {
+        if (empty($contacts)) {
             return [];
         }
 

--- a/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Entity;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+final class DoNotContactRepositoryFunctionalTest extends MauticMysqlTestCase
+{
+    public function testGetChannelList(): void
+    {
+        $john = $this->createContact('Company A');
+        $jane = $this->createContact('Company B');
+        $josh = $this->createContact('Company B');
+
+        $this->createDnc('email', $josh, DoNotContact::IS_CONTACTABLE);
+        $this->createDnc('email', $john, DoNotContact::UNSUBSCRIBED);
+        $this->createDnc('sms', $john, DoNotContact::BOUNCED);
+        $this->createDnc('sms', $jane, DoNotContact::MANUAL);
+
+        $this->em->flush();
+
+        $repository = $this->em->getRepository(DoNotContact::class);
+        \assert($repository instanceof DoNotContactRepository);
+
+        $allDncRecords = $repository->getChannelList(null);
+        $allSmsRecords = $repository->getChannelList('sms');
+
+        Assert::assertCount(3, $allDncRecords, 'Get all records for all channels (dangerous, do not use, there is no limit. One would expect this to return all 4 records, but they are grouped by contact ID.');
+        Assert::assertCount(2, $allSmsRecords, 'Get all records for sms channel (dangerous, do not use, there is no limit.');
+        Assert::assertCount(0, $repository->getChannelList('sms', []), 'Get all records for sms channel where the user filtered for a contact that do not exist. It must return an empty array. Not all DNC records.');
+        Assert::assertCount(1, $repository->getChannelList('sms', [$john->getId()]));
+        Assert::assertCount(2, $repository->getChannelList('sms', [$john->getId(), $jane->getId(), $josh->getId()]));
+        Assert::assertSame(['email' => (string) DoNotContact::IS_CONTACTABLE], $allDncRecords[$josh->getId()]);
+        Assert::assertSame(['email' => (string) DoNotContact::UNSUBSCRIBED, 'sms' => (string) DoNotContact::BOUNCED], $allDncRecords[$john->getId()]);
+        Assert::assertSame(['sms' => (string) DoNotContact::MANUAL], $allDncRecords[$jane->getId()]);
+        Assert::assertSame((string) DoNotContact::BOUNCED, $allSmsRecords[$john->getId()]);
+        Assert::assertSame((string) DoNotContact::MANUAL, $allSmsRecords[$jane->getId()]);
+    }
+
+    public function createDnc(string $channel, Lead $contact, int $reason): DoNotContact
+    {
+        $dnc = new DoNotContact();
+        $dnc->setChannel($channel);
+        $dnc->setLead($contact);
+        $dnc->setReason($reason);
+        $dnc->setDateAdded(new \DateTime());
+        $this->em->persist($dnc);
+
+        return $dnc;
+    }
+
+    private function createContact(string $firstName): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname($firstName);
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+}


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

If a user searches for a contact that do not exist then the method loading DNC records will get an empty array and loads all of the DNC records for all the contacts instead of none. This leads to hitting the memory limit and the user has to log out of Mautic and log back in to be able to see the list of contacts again. The same method is used from multiple places and I can see that none expects to get all the DNC records. 

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. We are able to see the problem when the memory limit is set to 512MB and there is more than 1.7M DNC records. No one will probably test this with as many data so let's just make sure it works as expected. The new functional tests ensure that the correct DNC records are loaded.
3. Create a contact.
4. Set it as unsubscribed from any channel.
5. Ensure that the DNC label is visible in the list of contacts as well as in the contact detail page.

#### Other areas of Mautic that may be affected by the change:
1. Same method is used when sending SMS. If a contact has a DNC record then the contact will not be scheduled to send the SMS.

#### List deprecations along with the new alternative:
1. 
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The method making the problematic SQL query is covered by functional tests for all possible types of input values.
