### PR TITLE
Display the message even if there is an error for debugging reasons

### DIFF
--- a/app/bundles/SmsBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
@@ -44,6 +44,9 @@
     <dt>{{ 'mautic.sms.timeline.type'|trans }}</dt>
     <dd>{{ item.type|trans }}</dd>
 </dl>
+{% endif %}
+
+{% if item.message is defined and item.message is not empty %}
 <div class="small">
     <hr />
     <strong>{{ 'mautic.sms.timeline.content.heading'|trans }}</strong>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This simply displays the message content in a failed SMS send timeline event from a campaign so that we can see exactly what message was rejected due to possibly token replacement that could cause the message to be more than 160 characters. 

Companion PR to https://github.com/mautic-inc/plugin-slooce/pull/5. Use testing instructions there and you should see the content of the original message in addition to the last execution error message. 

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. A code review is good enough I think as it's very small and straight forward change.
3. However if you want to reproduce, you can send an SMS that will fail for whatever reason and then you'll be able to see the SMS message in the contact timeline. Before there was just the error message.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
