### PR TITLE
Filtering out sensitive information from SQL error message

### DIFF
--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -903,7 +903,7 @@ class Import extends FormEntity
     /**
      * Get pie graph data for row status counts.
      *
-     * @return array
+     * @return array{labels: mixed[], datasets: mixed[]}
      */
     public function getRowStatusesPieChart(Translator $translator)
     {

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -905,7 +905,7 @@ class Import extends FormEntity
      *
      * @return array{labels: mixed[], datasets: mixed[]}
      */
-    public function getRowStatusesPieChart(Translator $translator)
+    public function getRowStatusesPieChart(Translator $translator): array
     {
         $chart = new PieChart();
         $chart->setDataset($translator->trans('mautic.lead.import.inserted.count'), $this->getInsertedCount());

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
+use Mautic\CoreBundle\Helper\Chart\PieChart;
+use Mautic\CoreBundle\Translation\Translator;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -896,5 +898,20 @@ class Import extends FormEntity
         }
 
         return parent::setIsPublished($isPublished);
+    }
+
+    /**
+     * Get pie graph data for row status counts.
+     *
+     * @return array
+     */
+    public function getRowStatusesPieChart(Translator $translator)
+    {
+        $chart = new PieChart();
+        $chart->setDataset($translator->trans('mautic.lead.import.inserted.count'), $this->getInsertedCount());
+        $chart->setDataset($translator->trans('mautic.lead.import.updated.count'), $this->getUpdatedCount());
+        $chart->setDataset($translator->trans('mautic.lead.import.ignored.count'), $this->getIgnoredCount());
+
+        return $chart->render();
     }
 }

--- a/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadEventLogRepository.php
@@ -26,6 +26,23 @@ class LeadEventLogRepository extends CommonRepository
         return $this->getSpecificRows($importId, 'failed', $args, $bundle, $object);
     }
 
+    public function getEntities(array $args = [])
+    {
+        $entities = parent::getEntities($args);
+        $entities = iterator_to_array($entities);
+
+        foreach ($entities as $key => $row) {
+            if (
+                isset($row['properties']['error'])
+                && preg_match('/SQLSTATE\[\w+\]: (.*)/', $row['properties']['error'], $matches)
+            ) {
+                $entities[$key]['properties']['error'] = $matches[1];
+            }
+        }
+
+        return $entities;
+    }
+
     /**
      * Returns paginator with specific type of rows.
      *

--- a/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
@@ -146,7 +146,7 @@
                             </div>
                             <div class="pt-0 pl-15 pb-10 pr-15">
                                 {{ include('@MauticCore/Helper/chart.html.twig', {
-                                      'chartData': item.rowStatusesPieChart(translatorGetHelper()),
+                                      'chartData': item.getRowStatusesPieChart(translatorGetHelper()),
                                       'chartType': 'pie',
                                       'chartHeight': 210,
                                 }) }}

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -102,6 +102,9 @@ final class ImportControllerTest extends MauticMysqlTestCase
         $contacts = $leadRepository->findBy(['email' => ['john@doe.email', 'ferda@mravenec.email']], ['email' => 'desc']);
         Assert::assertSame($expectedName, $contacts[0]->getFirstname());
         Assert::assertCount(2, $contacts);
+
+        $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/import/view/'.$importEntity->getId());
+        Assert::assertStringContainsString('No failed rows found', $crawler->html(), 'No failed rows exist.');
     }
 
     private function setPhoneFieldIsRequired(bool $required): void

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -107,6 +107,48 @@ final class ImportControllerTest extends MauticMysqlTestCase
         Assert::assertStringContainsString('No failed rows found', $crawler->html(), 'No failed rows exist.');
     }
 
+    public function testImportFailedWithReason(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $form = $crawler->selectButton('Save')->form();
+        $form['leadfield[label]']->setValue('Duedate');
+        $form['leadfield[type]']->setValue('date');
+        $this->client->submit($form);
+        $text = strip_tags($this->client->getResponse()->getContent());
+        Assert::assertTrue($this->client->getResponse()->isOk(), $text);
+
+        $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/import/new');
+        $uploadForm = $crawler->selectButton('Upload')->form();
+        $file       = new UploadedFile(__DIR__.'/../Fixtures/contacts_invalid_date.csv', 'contacts_invalid_date.csv', 'itext/csv');
+
+        $uploadForm['lead_import[file]']->setValue((string) $file);
+        $crawler     = $this->client->submit($uploadForm);
+        $mappingForm = $crawler->selectButton('Import')->form();
+        $crawler     = $this->client->submit($mappingForm);
+
+        Assert::assertStringContainsString('Import process was successfully created. You will be notified when finished.', $crawler->html());
+
+        /** @var ImportRepository $importRepository */
+        $importRepository = $this->em->getRepository(Import::class);
+
+        $this->testSymfonyCommand(ImportCommand::COMMAND_NAME);
+
+        $this->em->clear();
+
+        /** @var Import $importEntity */
+        $importEntity = $importRepository->findOneBy(['originalFile' => 'contacts_invalid_date.csv']);
+
+        Assert::assertNotNull($importEntity);
+        Assert::assertSame(1, $importEntity->getLineCount());
+        Assert::assertSame(0, $importEntity->getInsertedCount());
+        Assert::assertSame(0, $importEntity->getUpdatedCount());
+        Assert::assertSame(Import::IMPORTED, $importEntity->getStatus());
+
+        $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/import/view/'.$importEntity->getId());
+        Assert::assertStringContainsString("Invalid datetime format: 1292 Incorrect date value: '123456'", $crawler->html());
+    }
+
     private function setPhoneFieldIsRequired(bool $required): void
     {
         /** @var LeadFieldRepository $fieldRepository */

--- a/app/bundles/LeadBundle/Tests/Fixtures/contacts_invalid_date.csv
+++ b/app/bundles/LeadBundle/Tests/Fixtures/contacts_invalid_date.csv
@@ -1,2 +1,0 @@
-email,firstname,lastname,duedate
-test@doe.email,John,doe,123456

--- a/app/bundles/LeadBundle/Tests/Fixtures/contacts_invalid_date.csv
+++ b/app/bundles/LeadBundle/Tests/Fixtures/contacts_invalid_date.csv
@@ -1,0 +1,2 @@
+email,firstname,lastname,duedate
+test@doe.email,John,doe,123456


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N/A]
| BC breaks? (use the c.x branch)        | [N/A]
| Automated tests included?              | [Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

SQL errors are recorded in import details page which looks terrible and reveals table structure.

For example, SQL error that describes incorrect date looks like this, 

`An exception occurred while executing 'UPDATE mautic_leads SET birthday = ?, cooking = ?, credit_score = ?, date_added1 = ?, debt_amount = ?, diabetes_test_freq = ?, has_car = ?, health_insurance = ?, home_improvement = ?, homeowner = ?, income = ?, interest_education = ?, kids_age = ?, online_shopping = ?, prescription_count = ?, solar = ?, surveys = ?, sweepstakes = ?, travel_deals = ?, zid = ? WHERE id = ?' with params ["1\/1\/70", "yes", "660", "2017-01-28", "0", "2", "1", "work", "home_window", "owned", "0", "0", "6-11", "1", "6", "1", "1", "0", "1", "5599c733cd7d102f1903d391", 74845]: SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect date value: '1/1/70' for column 'birthday' at row 1`

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a date field.
3. Create a CSV with a bad date column
4. Import
5.It will display the message without the table structure information. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
