### PR TITLE
Add standard API endpoints for reports

### DIFF
--- a/app/bundles/ReportBundle/Config/config.php
+++ b/app/bundles/ReportBundle/Config/config.php
@@ -51,13 +51,11 @@ return [
             ],
         ],
         'api' => [
-            'mautic_api_getreports' => [
-                'path'       => '/reports',
-                'controller' => 'Mautic\ReportBundle\Controller\Api\ReportApiController::getEntitiesAction',
-            ],
-            'mautic_api_getreport' => [
-                'path'       => '/reports/{id}',
-                'controller' => 'Mautic\ReportBundle\Controller\Api\ReportApiController::getReportAction',
+            'mautic_api_reportsstandard' => [
+                'standard_entity' => true,
+                'name'            => 'reports',
+                'path'            => '/reports',
+                'controller'      => 'Mautic\ReportBundle\Controller\Api\ReportApiController',
             ],
         ],
     ],

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -74,16 +74,9 @@ class ReportApiController extends CommonApiController
         );
     }
 
-    /**
-     * BC just in case a controller is forwarded but shouldn't be used.
-     *
-     * @param $id
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function getReportAction($id)
+    public function getReportAction(Request $request, int $id): Response
     {
-        return $this->getEntityAction($id);
+        return $this->getEntityAction($request, $id);
     }
 
     /**

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -66,6 +66,9 @@ class ReportApiController extends CommonApiController
             unset($reportData[$key]);
         }
 
+        // Include report metadata
+        $reportData[$this->entityNameOne] = $entity;
+
         return $this->handleView(
             $this->view($reportData, Response::HTTP_OK)
         );

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -72,7 +72,7 @@ class ReportApiController extends CommonApiController
     }
 
     /**
-     * BC just in case a controller is forwarded but shouldn't be used
+     * BC just in case a controller is forwarded but shouldn't be used.
      *
      * @param $id
      *

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -51,7 +51,7 @@ class ReportApiController extends CommonApiController
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function getReportAction(Request $request, $id)
+    public function getEntityAction(Request $request, $id)
     {
         $entity = $this->model->getEntity($id);
 
@@ -69,6 +69,18 @@ class ReportApiController extends CommonApiController
         return $this->handleView(
             $this->view($reportData, Response::HTTP_OK)
         );
+    }
+
+    /**
+     * BC just in case a controller is forwarded but shouldn't be used
+     *
+     * @param $id
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function getReportAction($id)
+    {
+        return $this->getEntityAction($id);
     }
 
     /**

--- a/app/bundles/ReportBundle/Form/Type/ReportType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportType.php
@@ -388,7 +388,8 @@ class ReportType extends AbstractType
                     $data    = $event->getData();
                     $graphs  = $data['graphs'] ?? [];
                     $columns = $data['columns'] ?? [];
-                    $formModifier($event->getForm(), $data['source'], $columns, $graphs, $data);
+                    $source = $data['source'] ?? null;
+                    $formModifier($event->getForm(), $source, $columns, $graphs, $data);
                 }
             );
 

--- a/app/bundles/ReportBundle/Form/Type/ReportType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportType.php
@@ -388,7 +388,7 @@ class ReportType extends AbstractType
                     $data    = $event->getData();
                     $graphs  = $data['graphs'] ?? [];
                     $columns = $data['columns'] ?? [];
-                    $source = $data['source'] ?? null;
+                    $source  = $data['source'] ?? null;
                     $formModifier($event->getForm(), $source, $columns, $graphs, $data);
                 }
             );

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -1,35 +1,25 @@
 <?php
 
-/*
- * @copyright   2019 Mautic Contributors. All rights reserved
- * @author      Mautic, Inc.
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\ReportBundle\Tests\Controller\Api;
 
-use FOS\RestBundle\Util\Codes;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Symfony\Component\HttpFoundation\Response;
 
-class ReportApiControllerTest extends MauticMysqlTestCase
+final class ReportApiControllerTest extends MauticMysqlTestCase
 {
+    protected $useCleanupRollback = false;
+
     /**
      * Testing in a single method to decrease execution time from DB overhead.
      */
-    public function testPostGetPatchPutDeleteEndPoints()
+    public function testPostGetPatchPutDeleteEndPoints(): void
     {
-        // disabled
-        return;
-
         // Create a new report
         $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
         $this->client->request('POST', '/api/reports/new', $data);
         $response     = $this->client->getResponse();
         $responseData = json_decode($response->getContent(), true);
-        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertTrue(isset($responseData['report']));
         $this->assertEquals($data['name'], $responseData['report']['name']);
         $id     = $responseData['report']['id'];
@@ -39,7 +29,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $this->client->restart();
         $this->client->request('GET', sprintf('/api/reports/%s', $id));
         $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $responseData = json_decode($response->getContent(), true);
         $this->assertTrue(isset($responseData['data']));
         $this->assertTrue(isset($responseData['dataColumns']));
@@ -50,7 +40,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
         $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
         $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $responseData = json_decode($response->getContent(), true);
         $this->assertTrue(isset($responseData['report']));
         $this->assertEquals($source, $responseData['report']['source']);
@@ -59,10 +49,10 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
 
         // PUT a report
-        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
+        $data = json_decode(file_get_contents(__DIR__.'/data/put.json'), true);
         $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
         $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $responseData = json_decode($response->getContent(), true);
         $this->assertTrue(isset($responseData['report']));
         $this->assertEquals($data['name'], $responseData['report']['name']);
@@ -75,11 +65,11 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         // DELETE a report
         $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
         $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
         $this->assertTrue(isset($responseData['report']));
         $this->assertEquals($data['name'], $responseData['report']['name']);
         $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
         $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 }

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+
+namespace Mautic\ReportBundle\Tests\Controller\Api;
+
+
+use FOS\RestBundle\Util\Codes;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class ReportApiControllerTest extends MauticMysqlTestCase
+{
+    /**
+     * Testing in a single method to decrease execution time from DB overhead
+     */
+    public function testPostGetPatchPutDeleteEndPoints()
+    {
+        // Create a new report
+        $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
+        $this->client->request('POST', '/api/reports/new', $data);
+        $response     = $this->client->getResponse();
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $id     = $responseData['report']['id'];
+        $source = $data['source'];
+
+        // Get the new report
+        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['data']));
+        $this->assertTrue(isset($responseData['dataColumns']));
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+
+        // Patch a report
+        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
+        $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($source, $responseData['report']['source']);
+        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+
+        // PUT a report
+        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
+        $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $this->assertEquals($data['source'], $responseData['report']['source']);
+        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+        $this->assertEmpty($responseData['report']['filters']);
+
+        // DELETE a report
+        $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+}

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -22,25 +22,25 @@ class ReportApiControllerTest extends MauticMysqlTestCase
     public function testPostGetPatchPutDeleteEndPoints()
     {
         // Create a new report
-        $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
-        $this->client->request('POST', '/api/reports/new', $data);
-        $response     = $this->client->getResponse();
-        $responseData = json_decode($response->getContent(), true);
-        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
-        $this->assertTrue(isset($responseData['report']));
-        $this->assertEquals($data['name'], $responseData['report']['name']);
+//        $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
+//        $this->client->request('POST', '/api/reports/new', $data);
+//        $response     = $this->client->getResponse();
+//        $responseData = json_decode($response->getContent(), true);
+//        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+//        $this->assertTrue(isset($responseData['report']));
+//        $this->assertEquals($data['name'], $responseData['report']['name']);
 //        $id     = $responseData['report']['id'];
 //        $source = $data['source'];
 
-//        // Get the new report
-//        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
-//        $response = $this->client->getResponse();
-//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-//        $responseData = json_decode($response->getContent(), true);
-//        $this->assertTrue(isset($responseData['data']));
-//        $this->assertTrue(isset($responseData['dataColumns']));
-//        $this->assertTrue(isset($responseData['report']));
-//        $this->assertEquals($data['name'], $responseData['report']['name']);
+        // Get the new report
+        $this->client->request('GET', sprintf('/api/reports/%s', 5));
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['data']));
+        $this->assertTrue(isset($responseData['dataColumns']));
+        $this->assertTrue(isset($responseData['report']));
+        //$this->assertEquals($data['name'], $responseData['report']['name']);
 //
 //        // Patch a report
 //        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -29,8 +29,8 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
         $this->assertTrue(isset($responseData['report']));
         $this->assertEquals($data['name'], $responseData['report']['name']);
-        $id     = $responseData['report']['id'];
-        $source = $data['source'];
+//        $id     = $responseData['report']['id'];
+//        $source = $data['source'];
 
 //        // Get the new report
 //        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -21,62 +21,65 @@ class ReportApiControllerTest extends MauticMysqlTestCase
      */
     public function testPostGetPatchPutDeleteEndPoints()
     {
+        // disabled
+        return;
+
         // Create a new report
-//        $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
-//        $this->client->request('POST', '/api/reports/new', $data);
-//        $response     = $this->client->getResponse();
-//        $responseData = json_decode($response->getContent(), true);
-//        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
-//        $this->assertTrue(isset($responseData['report']));
-//        $this->assertEquals($data['name'], $responseData['report']['name']);
-//        $id     = $responseData['report']['id'];
-//        $source = $data['source'];
+        $data = json_decode(file_get_contents(__DIR__.'/data/post.json'), true);
+        $this->client->request('POST', '/api/reports/new', $data);
+        $response     = $this->client->getResponse();
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertSame(Codes::HTTP_CREATED, $response->getStatusCode());
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $id     = $responseData['report']['id'];
+        $source = $data['source'];
 
         // Get the new report
         $this->client->restart();
-        $this->client->request('GET', sprintf('/api/reports/%s', 5));
+        $this->client->request('GET', sprintf('/api/reports/%s', $id));
         $response = $this->client->getResponse();
         $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
         $responseData = json_decode($response->getContent(), true);
         $this->assertTrue(isset($responseData['data']));
         $this->assertTrue(isset($responseData['dataColumns']));
         $this->assertTrue(isset($responseData['report']));
-        //$this->assertEquals($data['name'], $responseData['report']['name']);
-//
-//        // Patch a report
-//        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
-//        $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
-//        $response = $this->client->getResponse();
-//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-//        $responseData = json_decode($response->getContent(), true);
-//        $this->assertTrue(isset($responseData['report']));
-//        $this->assertEquals($source, $responseData['report']['source']);
-//        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
-//        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
-//        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
-//
-//        // PUT a report
-//        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
-//        $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
-//        $response = $this->client->getResponse();
-//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-//        $responseData = json_decode($response->getContent(), true);
-//        $this->assertTrue(isset($responseData['report']));
-//        $this->assertEquals($data['name'], $responseData['report']['name']);
-//        $this->assertEquals($data['source'], $responseData['report']['source']);
-//        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
-//        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
-//        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
-//        $this->assertEmpty($responseData['report']['filters']);
-//
-//        // DELETE a report
-//        $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
-//        $response = $this->client->getResponse();
-//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-//        $this->assertTrue(isset($responseData['report']));
-//        $this->assertEquals($data['name'], $responseData['report']['name']);
-//        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
-//        $response = $this->client->getResponse();
-//        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+
+        // Patch a report
+        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
+        $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($source, $responseData['report']['source']);
+        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+
+        // PUT a report
+        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
+        $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $responseData = json_decode($response->getContent(), true);
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $this->assertEquals($data['source'], $responseData['report']['source']);
+        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+        $this->assertEmpty($responseData['report']['filters']);
+
+        // DELETE a report
+        $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+        $this->assertTrue(isset($responseData['report']));
+        $this->assertEquals($data['name'], $responseData['report']['name']);
+        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
+        $response = $this->client->getResponse();
+        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 }

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -9,9 +9,7 @@
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-
 namespace Mautic\ReportBundle\Tests\Controller\Api;
-
 
 use FOS\RestBundle\Util\Codes;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
@@ -19,7 +17,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 class ReportApiControllerTest extends MauticMysqlTestCase
 {
     /**
-     * Testing in a single method to decrease execution time from DB overhead
+     * Testing in a single method to decrease execution time from DB overhead.
      */
     public function testPostGetPatchPutDeleteEndPoints()
     {
@@ -34,50 +32,50 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $id     = $responseData['report']['id'];
         $source = $data['source'];
 
-        // Get the new report
-        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
-        $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-        $responseData = json_decode($response->getContent(), true);
-        $this->assertTrue(isset($responseData['data']));
-        $this->assertTrue(isset($responseData['dataColumns']));
-        $this->assertTrue(isset($responseData['report']));
-        $this->assertEquals($data['name'], $responseData['report']['name']);
-
-        // Patch a report
-        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
-        $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
-        $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-        $responseData = json_decode($response->getContent(), true);
-        $this->assertTrue(isset($responseData['report']));
-        $this->assertEquals($source, $responseData['report']['source']);
-        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
-        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
-        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
-
-        // PUT a report
-        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
-        $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
-        $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-        $responseData = json_decode($response->getContent(), true);
-        $this->assertTrue(isset($responseData['report']));
-        $this->assertEquals($data['name'], $responseData['report']['name']);
-        $this->assertEquals($data['source'], $responseData['report']['source']);
-        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
-        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
-        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
-        $this->assertEmpty($responseData['report']['filters']);
-
-        // DELETE a report
-        $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
-        $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
-        $this->assertTrue(isset($responseData['report']));
-        $this->assertEquals($data['name'], $responseData['report']['name']);
-        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
-        $response = $this->client->getResponse();
-        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
+//        // Get the new report
+//        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
+//        $response = $this->client->getResponse();
+//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+//        $responseData = json_decode($response->getContent(), true);
+//        $this->assertTrue(isset($responseData['data']));
+//        $this->assertTrue(isset($responseData['dataColumns']));
+//        $this->assertTrue(isset($responseData['report']));
+//        $this->assertEquals($data['name'], $responseData['report']['name']);
+//
+//        // Patch a report
+//        $data = json_decode(file_get_contents(__DIR__.'/data/patch.json'), true);
+//        $this->client->request('PATCH', sprintf('/api/reports/%s/edit', $id), $data);
+//        $response = $this->client->getResponse();
+//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+//        $responseData = json_decode($response->getContent(), true);
+//        $this->assertTrue(isset($responseData['report']));
+//        $this->assertEquals($source, $responseData['report']['source']);
+//        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+//        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+//        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+//
+//        // PUT a report
+//        $data = json_decode(file_get_contents(__DIR__.'/data/PUT.json'), true);
+//        $this->client->request('PUT', sprintf('/api/reports/%s/edit', $id), $data);
+//        $response = $this->client->getResponse();
+//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+//        $responseData = json_decode($response->getContent(), true);
+//        $this->assertTrue(isset($responseData['report']));
+//        $this->assertEquals($data['name'], $responseData['report']['name']);
+//        $this->assertEquals($data['source'], $responseData['report']['source']);
+//        $this->assertEquals($data['scheduleUnit'], $responseData['report']['scheduleUnit']);
+//        $this->assertEquals($data['toAddress'], $responseData['report']['toAddress']);
+//        $this->assertEquals($data['scheduleDay'], $responseData['report']['scheduleDay']);
+//        $this->assertEmpty($responseData['report']['filters']);
+//
+//        // DELETE a report
+//        $this->client->request('DELETE', sprintf('/api/reports/%s/delete', $id), $data);
+//        $response = $this->client->getResponse();
+//        $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());
+//        $this->assertTrue(isset($responseData['report']));
+//        $this->assertEquals($data['name'], $responseData['report']['name']);
+//        $this->client->request('GET', sprintf('/api/reports/%s', $id), $data);
+//        $response = $this->client->getResponse();
+//        $this->assertSame(Codes::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 }

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -33,6 +33,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
 //        $source = $data['source'];
 
         // Get the new report
+        $this->client->restart();
         $this->client->request('GET', sprintf('/api/reports/%s', 5));
         $response = $this->client->getResponse();
         $this->assertSame(Codes::HTTP_OK, $response->getStatusCode());

--- a/app/bundles/ReportBundle/Tests/Controller/Api/data/patch.json
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/data/patch.json
@@ -1,0 +1,6 @@
+{
+  "isScheduled": true,
+  "scheduleUnit": "WEEKLY",
+  "toAddress": "test@mailinator.com",
+  "scheduleDay": "TU"
+}

--- a/app/bundles/ReportBundle/Tests/Controller/Api/data/post.json
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/data/post.json
@@ -1,0 +1,42 @@
+{
+  "name": "New Report",
+  "description": "A new report",
+  "system": true,
+  "isScheduled": false,
+  "source": "email.stats",
+  "columns": [
+    "es.date_sent",
+    "es.date_read",
+    "e.subject",
+    "es.email_address",
+    "e.id"
+  ],
+  "filters": [
+    {
+      "column": "e.is_published",
+      "condition": "eq",
+      "value": "1"
+    }
+  ],
+  "tableOrder": [
+    {
+      "column": "es.date_sent",
+      "direction": "ASC"
+    }
+  ],
+  "graphs": [
+    "mautic.email.graph.line.stats",
+    "mautic.email.graph.pie.ignored.read.failed",
+    "mautic.email.table.most.emails.read",
+    "mautic.email.table.most.emails.sent",
+    "mautic.email.table.most.emails.read.percent",
+    "mautic.email.table.most.emails.failed"
+  ],
+  "groupBy": null,
+  "settings": [],
+  "aggregators": null,
+  "scheduleUnit": null,
+  "toAddress": null,
+  "scheduleDay": null,
+  "scheduleMonthFrequency": null
+}

--- a/app/bundles/ReportBundle/Tests/Controller/Api/data/post.json
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/data/post.json
@@ -34,7 +34,6 @@
   ],
   "groupBy": null,
   "settings": [],
-  "aggregators": null,
   "scheduleUnit": null,
   "toAddress": null,
   "scheduleDay": null,

--- a/app/bundles/ReportBundle/Tests/Controller/Api/data/put.json
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/data/put.json
@@ -27,7 +27,6 @@
   ],
   "groupBy": null,
   "settings": [],
-  "aggregators": null,
   "isScheduled": true,
   "scheduleUnit": "DAILY",
   "toAddress": "test2@mailinator.com",

--- a/app/bundles/ReportBundle/Tests/Controller/Api/data/put.json
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/data/put.json
@@ -1,0 +1,36 @@
+{
+  "name": "Brand New Report",
+  "description": "A new report",
+  "system": true,
+  "source": "email.stats",
+  "columns": [
+    "es.date_sent",
+    "es.date_read",
+    "e.subject",
+    "es.email_address",
+    "e.id"
+  ],
+  "filters": [],
+  "tableOrder": [
+    {
+      "column": "es.date_sent",
+      "direction": "ASC"
+    }
+  ],
+  "graphs": [
+    "mautic.email.graph.line.stats",
+    "mautic.email.graph.pie.ignored.read.failed",
+    "mautic.email.table.most.emails.read",
+    "mautic.email.table.most.emails.sent",
+    "mautic.email.table.most.emails.read.percent",
+    "mautic.email.table.most.emails.failed"
+  ],
+  "groupBy": null,
+  "settings": [],
+  "aggregators": null,
+  "isScheduled": true,
+  "scheduleUnit": "DAILY",
+  "toAddress": "test2@mailinator.com",
+  "scheduleDay": null,
+  "scheduleMonthFrequency": null
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | No
| New feature/enhancement? (use the a.x branch)      | Yes
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Yes <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | https://github.com/mautic/developer-documentation-new/pull/180
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Exposure to API endpoints for reports which allows create, update and delete. We currently do not have an endpoint to get descriptions for the reports (sources available, columns available to the source, etc) so likely requires building in the UI then fetching the data to know what to use to create future reports.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Try to create a new report
```
curl -X POST \
  https://your-mautic-url.com/api/reports/new \
  -H 'content: application/json' \
  -d '{
    "name": "New Report",
    "description": "A new report",
    "system": true,
    "isScheduled": false,
    "source": "email.stats",
    "columns": [
        "es.date_sent",
        "es.date_read",
        "e.subject",
        "es.email_address",
        "e.id"
    ],
    "filters": [
        {
            "column": "e.is_published",
            "condition": "eq",
            "value": "1"
        }
    ],
    "tableOrder": [
        {
            "column": "es.date_sent",
            "direction": "ASC"
        }
    ],
    "graphs": [
        "mautic.email.graph.line.stats",
        "mautic.email.graph.pie.ignored.read.failed",
        "mautic.email.table.most.emails.read",
        "mautic.email.table.most.emails.sent",
        "mautic.email.table.most.emails.read.percent",
        "mautic.email.table.most.emails.failed"
    ],
    "groupBy": null,
    "settings": [],
    "scheduleUnit": null,
    "toAddress": null,
    "scheduleDay": null,
    "scheduleMonthFrequency": null
}
```
3. Update a report
```
curl -X PATCH \
   https://your-mautic-url.com/api/reports/7/edit \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d name=Updated%20Report

```

4. Delete a report
```
curl -X DELETE \
  https://your-mautic-url.com/api/reports/7/delete 

```
5. Ensure that /reports and /report/ID still work as expected.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
