### PR TITLE
Fixed gitpod installation for Mautic 5.x.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,4 +8,4 @@ RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
 # Update package information and install DDEV
-RUN sudo apt update && sudo apt install -y ddev=1.21.6
+RUN sudo apt update && sudo apt install -y ddev=1.21.7

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,4 +8,4 @@ RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor | sudo tee /etc/
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/ddev.gpg] https://pkg.ddev.com/apt/ * *" | sudo tee /etc/apt/sources.list.d/ddev.list >/dev/null
 
 # Update package information and install DDEV
-RUN sudo apt update && sudo apt install -y ddev=1.21.7
+RUN sudo apt update && sudo apt install -y ddev=1.22.7


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ 5.x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

From - https://github.com/ddev/ddev/issues/5795

> TL;DR
> As of 16 Feb 2024 the (upstream) old deb.sury.org key is expiring. This key is used for installing PHP packages in the `ddev-webserver `Docker image. Its expiration may cause failures of `apt update` or `apt install/webimage_extra_packages` (with PHP packages).

> DDEV v1.22.7 doesn't have this problem, so upgrade to solve any problems you have with PHP packages during ddev start
> In DDEV v1.22.6 (if you don't want to upgrade) docker pull ddev/ddev-webserver:v1.22.6 to get an upgraded version with the new package key.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
The gitpod builds for Mautic 5.x versions should build without any errors.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
