### PR TITLE
DPMMA-2588 Change List-Unsubscribe order to favour one-click unsubscribe

### DIFF
--- a/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
@@ -61,7 +61,7 @@ class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
             $unsubscribeEmail = "<mailto:$unsubscribeEmail>";
             if ($existing) {
                 if (!str_contains($existing, $unsubscribeEmail)) {
-                    $updatedHeader = $unsubscribeEmail.', '.$existing;
+                    $updatedHeader = $existing.', '.$unsubscribeEmail;
                 } else {
                     $updatedHeader = $existing;
                 }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1322,7 +1322,7 @@ class MailHelper
             if (!empty($headers['List-Unsubscribe'])) {
                 if (!str_contains($headers['List-Unsubscribe'], $listUnsubscribeHeader)) {
                     // Ensure Mautic's is always part of this header
-                    $headers['List-Unsubscribe'] .= ','.$listUnsubscribeHeader;
+                    $headers['List-Unsubscribe'] = $listUnsubscribeHeader.','.$headers['List-Unsubscribe'];
                 }
             } else {
                 $headers['List-Unsubscribe'] = $listUnsubscribeHeader;

--- a/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Mautic\EmailBundle\EventListener\ProcessUnsubscribeSubscriber;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\MonitoredEmail\Processor\FeedbackLoop;
+use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class ProcessUnsubscribeSubscriberTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var MockObject|Unsubscribe
+     */
+    private MockObject $unsubscribe;
+
+    /**
+     * @var MockObject|FeedbackLoop
+     */
+    private MockObject $feedbackLoop;
+
+    protected function setup(): void
+    {
+        parent::setUp();
+
+        $this->unsubscribe      = $this->createMock(Unsubscribe::class);
+        $this->feedbackLoop     = $this->createMock(FeedbackLoop::class);
+        $this->subscriber       = new ProcessUnsubscribeSubscriber($this->unsubscribe, $this->feedbackLoop);
+    }
+
+    public function testOnEmailSend()
+    {
+        $helper = $this->createMock(MailHelper::class);
+        $helper->method('generateUnsubscribeEmail')->willReturn('unsubscribe@example.com');
+        $helper->method('getCustomHeaders')->willReturn([
+            'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
+            'List-Unsubscribe'      => '<https://example.com/email/unsubscribe/65cf64d8cb367903848157>',
+        ]);
+
+        $helper->expects($this->once())
+            ->method('addCustomHeader')
+            ->with('List-Unsubscribe', '<https://example.com/email/unsubscribe/65cf64d8cb367903848157>, <mailto:unsubscribe@example.com>');
+
+        $event = new EmailSendEvent($helper);
+        $this->subscriber->onEmailSend($event);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
@@ -23,6 +23,8 @@ final class ProcessUnsubscribeSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $feedbackLoop;
 
+    private ProcessUnsubscribeSubscriber $subscriber;
+
     protected function setup(): void
     {
         parent::setUp();
@@ -32,7 +34,7 @@ final class ProcessUnsubscribeSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->subscriber       = new ProcessUnsubscribeSubscriber($this->unsubscribe, $this->feedbackLoop);
     }
 
-    public function testOnEmailSend()
+    public function testOnEmailSend(): void
     {
         $helper = $this->createMock(MailHelper::class);
         $helper->method('generateUnsubscribeEmail')->willReturn('unsubscribe@example.com');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ N ]
| New feature/enhancement? (use the a.x branch)      | [ Y ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
When you use monitored mailbox for unsubscribe as an additional option it's added as the first value of `List-Unsubscribe` email header. Google's Gmail prioritizes the first option from the header, resulting in the unsubscribe action being performed via email rather than the preferred one-click method.
![image](https://github.com/mautic/mautic/assets/8580942/4d0da987-7065-4677-8a1d-4ff69427835a)

This PR adjusts the parameter's order to prioritize the one-click unsubscribe option.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure the Monitored mailbox for unsubscribe in Mautic Email Settings
3. Send email to segment. You can include a Gmail address
4. Check the `List-Unsubscribe` values order. For example:
```
List-Unsubscribe: <https://example.com/email/unsubscribe/65cf8765897fd946309834>,
 <mailto:do-no-reply+unsubscribe_65cf8765897fd946309834@example.com>
```
5. If you sent the email to gmail address check the warning message after clicking the Unsubscribe button
![image](https://github.com/mautic/mautic/assets/8580942/61127894-0b73-46c7-b7cb-aeb831f3594f)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
