### PR TITLE
Create temp directories if they don't exist

### DIFF
--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -147,7 +147,7 @@ class PathsHelper
                 return $this->kernelLogsDir;
             case 'temporary':
             case 'tmp':
-                if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir) && is_writable($this->temporaryDir)) {
+                if (!file_exists($this->temporaryDir)) {
                     mkdir($this->temporaryDir, 0777, true);
                 }
 
@@ -171,8 +171,8 @@ class PathsHelper
 
                 $userPath .= '/'.$this->user->getId();
 
-                if (!is_dir($userPath) && !file_exists($userPath) && is_writable($userPath)) {
-                    mkdir($userPath);
+                if (!file_exists($userPath)) {
+                    mkdir($userPath, 0777, true);
                 }
 
                 return $userPath;

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -147,7 +147,7 @@ class PathsHelper
                 return $this->kernelLogsDir;
             case 'temporary':
             case 'tmp':
-                if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir) && is_writable($this->temporaryDir)) {
+                if (!file_exists($this->temporaryDir)) {
                     mkdir($this->temporaryDir, 0777, true);
                 }
 
@@ -171,7 +171,7 @@ class PathsHelper
 
                 $userPath .= '/'.$this->user->getId();
 
-                if (!is_dir($userPath) && !file_exists($userPath) && is_writable($userPath)) {
+                if (!file_exists($userPath)) {
                     mkdir($userPath, 0777, true);
                 }
 

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -147,7 +147,7 @@ class PathsHelper
                 return $this->kernelLogsDir;
             case 'temporary':
             case 'tmp':
-                if (!file_exists($this->temporaryDir)) {
+                if (!is_dir($this->temporaryDir) && !file_exists($this->temporaryDir) && is_writable($this->temporaryDir)) {
                     mkdir($this->temporaryDir, 0777, true);
                 }
 
@@ -171,7 +171,7 @@ class PathsHelper
 
                 $userPath .= '/'.$this->user->getId();
 
-                if (!file_exists($userPath)) {
+                if (!is_dir($userPath) && !file_exists($userPath) && is_writable($userPath)) {
                     mkdir($userPath, 0777, true);
                 }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -102,14 +102,14 @@ class PathsHelperTest extends TestCase
         $this->assertEquals(__DIR__.'/resource/paths/plugins', $this->helper->getPluginsPath());
     }
 
-    public function testTempDirectoryIsCreatedIfItDoesNotExist()
+    public function testTempDirectoryIsCreatedIfItDoesNotExist(): void
     {
         $tempPath = __DIR__.'/resource/paths/no_exist/tmp';
 
-        /** @var UserHelper|MockObject $userHelper */
-        $userHelper           = $this->createMock(UserHelper::class);
+        /** @var UserHelper&MockObject $userHelper */
+        $userHelper = $this->createMock(UserHelper::class);
 
-        /** @var CoreParametersHelper|MockObject $coreParametersHelper */
+        /** @var CoreParametersHelper&MockObject $coreParametersHelper */
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelper->method('get')
             ->willReturnCallback(
@@ -123,7 +123,7 @@ class PathsHelperTest extends TestCase
                 }
             );
 
-        $this->assertFileNotExists($tempPath);
+        $this->assertFileDoesNotExist($tempPath);
 
         $helper = new PathsHelper($userHelper, $coreParametersHelper, $this->cacheDir, $this->logsDir, $this->rootDir);
 
@@ -136,11 +136,11 @@ class PathsHelperTest extends TestCase
         $fs->remove(__DIR__.'/resource/paths/no_exist');
     }
 
-    public function testUserDashboardDirectoryIsCreatedIfItDoesNotExist()
+    public function testUserDashboardDirectoryIsCreatedIfItDoesNotExist(): void
     {
         $dashboardDir = __DIR__.'/resource/paths/no_exist/dashboard';
 
-        /** @var UserHelper|MockObject $userHelper */
+        /** @var UserHelper&MockObject $userHelper */
         $userHelper           = $this->createMock(UserHelper::class);
         $user                 = $this->createMock(User::class);
         $user->method('getId')
@@ -148,7 +148,7 @@ class PathsHelperTest extends TestCase
         $userHelper->method('getUser')
             ->willReturn($user);
 
-        /** @var CoreParametersHelper|MockObject $coreParametersHelper */
+        /** @var CoreParametersHelper&MockObject $coreParametersHelper */
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelper->method('get')
             ->willReturnCallback(
@@ -162,7 +162,7 @@ class PathsHelperTest extends TestCase
                 }
             );
 
-        $this->assertFileNotExists($dashboardDir);
+        $this->assertFileDoesNotExist($dashboardDir);
 
         $helper = new PathsHelper($userHelper, $coreParametersHelper, $this->cacheDir, $this->logsDir, $this->rootDir);
         $helper->getSystemPath('dashboard.user');

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -5,8 +5,10 @@ namespace Mautic\CoreBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class PathsHelperTest extends TestCase
 {
@@ -98,5 +100,76 @@ class PathsHelperTest extends TestCase
     public function testGetPluginsPath(): void
     {
         $this->assertEquals(__DIR__.'/resource/paths/plugins', $this->helper->getPluginsPath());
+    }
+
+    public function testTempDirectoryIsCreatedIfItDoesNotExist()
+    {
+        $tempPath = __DIR__.'/resource/paths/no_exist/tmp';
+
+        /** @var UserHelper|MockObject $userHelper */
+        $userHelper           = $this->createMock(UserHelper::class);
+
+        /** @var CoreParametersHelper|MockObject $coreParametersHelper */
+        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $coreParametersHelper->method('get')
+            ->willReturnCallback(
+                function (string $key) use ($tempPath) {
+                    switch ($key) {
+                        case 'tmp_path':
+                            return $tempPath;
+                        default:
+                            return '';
+                    }
+                }
+            );
+
+        $this->assertFileNotExists($tempPath);
+
+        $helper = new PathsHelper($userHelper, $coreParametersHelper, $this->cacheDir, $this->logsDir, $this->rootDir);
+
+        $helper->getSystemPath('tmp');
+
+        $this->assertFileExists($tempPath);
+
+        // Cleanup
+        $fs = new Filesystem();
+        $fs->remove(__DIR__.'/resource/paths/no_exist');
+    }
+
+    public function testUserDashboardDirectoryIsCreatedIfItDoesNotExist()
+    {
+        $dashboardDir = __DIR__.'/resource/paths/no_exist/dashboard';
+
+        /** @var UserHelper|MockObject $userHelper */
+        $userHelper           = $this->createMock(UserHelper::class);
+        $user                 = $this->createMock(User::class);
+        $user->method('getId')
+            ->willReturn(1);
+        $userHelper->method('getUser')
+            ->willReturn($user);
+
+        /** @var CoreParametersHelper|MockObject $coreParametersHelper */
+        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $coreParametersHelper->method('get')
+            ->willReturnCallback(
+                function (string $key) use ($dashboardDir) {
+                    switch ($key) {
+                        case 'dashboard_import_dir':
+                            return $dashboardDir;
+                        default:
+                            return '';
+                    }
+                }
+            );
+
+        $this->assertFileNotExists($dashboardDir);
+
+        $helper = new PathsHelper($userHelper, $coreParametersHelper, $this->cacheDir, $this->logsDir, $this->rootDir);
+        $helper->getSystemPath('dashboard.user');
+        $this->assertFileExists($dashboardDir.'/1');
+
+        // Cleanup
+        $fs = new Filesystem();
+        $fs->remove(__DIR__.'/resource/paths/no_exist');
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/resource/paths/app/config/local.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/resource/paths/app/config/local.php
@@ -1,0 +1,3 @@
+<?php
+
+$parameters = [];


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
For whatever reason, the checks to see if the temp and dashboard user directories exist used is_writable which only returns true if the file exists to start with. This fixes that by removing that check. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Ensure that the tmp directory does not exist (config's `temp_path`)
2. Go to the cog wheel in Mautic's UI then Themes
3. Download a theme
4. It will fail because the system's tmp directory doesn't exist
5. The same thing is with the `dashboard.user` path. 
6. Ensure that the dashboard directory does not exist (config's `dashboard_import_user_dir`  with a fallback to `dashboard_import_dir`)
7. Go to Mautic's dashboard and try to Save a new dashboard layout
8. The directory will not get created automatically

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and this time the directories will be created as expected and the theme and dashboard downloaded

#### Other areas of Mautic that may be affected by the change:
1. The PathsHelper was updated from community but just included more convenient helper methods. They aren't currently used except in the latest M3 community code. 

