### PR TITLE
optimize query

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1773,4 +1773,17 @@ class CommonRepository extends ServiceEntityRepository
             $f[$key] = (!empty($alias)) ? $alias.'.'.$col : $col;
         }
     }
+
+    /**
+     * Checks if table contains any rows.
+     */
+    protected function tableHasRows(string $table): bool
+    {
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $query->select('null')
+            ->from($table)
+            ->setMaxResults(1);
+
+        return (bool) count($query->executeQuery()->fetchAllAssociative());
+    }
 }

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -31,23 +31,22 @@ class FrequencyRuleRepository extends CommonRepository
             return [];
         }
 
-        $violations = $this->getCustomFrequencyRuleViolations($channel, $leadIds, $statTable, $statContactColumn, $statSentColumn);
+        $frequencyRuleViolations = $this->getCustomFrequencyRuleViolations($channel, $leadIds, $statTable, $statContactColumn, $statSentColumn);
 
-        if ($defaultFrequencyNumber && $defaultFrequencyTime) {
-            $violations = array_merge(
-                $violations,
-                $this->getDefaultFrequencyRuleViolations(
-                    $leadIds,
-                    $defaultFrequencyNumber,
-                    $defaultFrequencyTime,
-                    $statTable,
-                    $statContactColumn,
-                    $statSentColumn
-                )
-            );
+        if (!$this->validateDefaultParameters($defaultFrequencyNumber, $defaultFrequencyTime)) {
+            // It makes no sense to calculate default rule violations
+            // if default parameters are not valid
+            return $frequencyRuleViolations;
         }
 
-        return $violations;
+        $defaultRuleViolations = $this->getDefaultFrequencyRuleViolations($leadIds, $defaultFrequencyNumber, $defaultFrequencyTime, $statTable, $statContactColumn, $statSentColumn);
+
+        return array_merge($frequencyRuleViolations, $defaultRuleViolations);
+    }
+
+    private function validateDefaultParameters(mixed $number, mixed $time): bool
+    {
+        return $number && $time;
     }
 
     public function getFrequencyRules($channel = null, $leadIds = null): array
@@ -170,9 +169,9 @@ class FrequencyRuleRepository extends CommonRepository
         $statContactColumn,
         $statSentColumn
     ) {
-        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
-        $q->select("ch.$statContactColumn")
+        $query->select("ch.$statContactColumn")
             ->from(MAUTIC_TABLE_PREFIX.$statTable, 'ch');
 
         switch ($defaultFrequencyTime) {
@@ -189,29 +188,33 @@ class FrequencyRuleRepository extends CommonRepository
                 return [];
         }
 
-        $q->andWhere('ch.'.$statSentColumn.' >= :frequencyTime')
+        $query->andWhere('ch.'.$statSentColumn.' >= :frequencyTime')
             ->setParameter('frequencyTime', $since->format('Y-m-d H:i:s'));
 
-        $q->andWhere(
-            $q->expr()->in("ch.$statContactColumn", $leadIds)
+        $query->andWhere(
+            $query->expr()->in("ch.$statContactColumn", $leadIds)
         );
 
-        // Exclude contacts with custom rules defined
-        $subQuery = $this->getEntityManager()->getConnection()->createQueryBuilder();
-        $subQuery->select('null')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr')
-            ->where("fr.lead_id = ch.{$statContactColumn}")
-            ->andWhere('fr.frequency_time IS NOT NULL AND fr.frequency_number IS NOT NULL');
-        $q->andWhere(
-            sprintf('NOT EXISTS (%s)', $subQuery->getSQL())
-        );
+        $hasCustomRules = $this->tableHasRows(MAUTIC_TABLE_PREFIX.'lead_frequencyrules');
+        // We don't need to check if users have custom rules if there are no records inside that table
+        if ($hasCustomRules) {
+            // Exclude contacts with custom rules defined
+            $subQuery = $this->getEntityManager()->getConnection()->createQueryBuilder();
+            $subQuery->select('null')
+                ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr')
+                ->where("fr.lead_id = ch.{$statContactColumn}")
+                ->andWhere('fr.frequency_time IS NOT NULL AND fr.frequency_number IS NOT NULL');
+            $query->andWhere(
+                sprintf('NOT EXISTS (%s)', $subQuery->getSQL())
+            );
+        }
 
-        $q->groupBy("ch.$statContactColumn");
+        $query->groupBy("ch.$statContactColumn");
 
-        $q->having("count(ch.$statContactColumn) >= :defaultNumber")
+        $query->having("count(ch.$statContactColumn) >= :defaultNumber")
             ->setParameter('defaultNumber', $defaultFrequencyNumber);
 
-        $results = $q->executeQuery()->fetchAllAssociative();
+        $results = $query->executeQuery()->fetchAllAssociative();
 
         foreach ($results as $key => $result) {
             $results[$key]['frequency_number'] = $defaultFrequencyNumber;

--- a/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
@@ -79,4 +79,15 @@ class FrequencyRuleRepositoryTest extends MauticMysqlTestCase
         ];
         Assert::assertSame($expectedViolations, $violations);
     }
+
+    public function testValidateDefaultParameters(): void
+    {
+        $method = new \ReflectionMethod(FrequencyRuleRepository::class, 'validateDefaultParameters');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($this->frequencyRuleRepository, false, false));
+        $this->assertFalse($method->invoke($this->frequencyRuleRepository, false, true));
+        $this->assertFalse($method->invoke($this->frequencyRuleRepository, true, false));
+        $this->assertTrue($method->invoke($this->frequencyRuleRepository, true, true));
+    }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Y
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | Y <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR fixes a bug inside the `FrequencyRuleRepository::getAppliedFrequencyRules`.
We don't have to call `FrequencyRuleRepository::getDefaultFrequencyRuleViolations` if any of the default frequency parameters is empty.
E.g. we had queries like that:
```sql
SELECT 
    ch.lead_id
FROM
    mautic_email_stats ch
WHERE
    (ch.date_sent >= '2019-07-30 14:22:46')
        AND (ch.lead_id IN (        
        10520292,
        10520296,
        10520300))
        AND (NOT EXISTS( SELECT 
            NULL
        FROM
            mautic_lead_frequencyrules fr
        WHERE
            (fr.lead_id = ch.lead_id)
                AND (fr.frequency_time IS NOT NULL
                AND fr.frequency_number IS NOT NULL)))
GROUP BY ch.lead_id
HAVING COUNT(ch.lead_id) >= NULL
```
At the very bottom of it we are filtering by
```sql
HAVING COUNT(ch.lead_id) >= NULL
```
Therefore this query makes no sense. NULL can't be used for comparisons and it will always return false.
Also, this PR contains an optimization for `FrequencyRuleRepository::getDefaultFrequencyRuleViolations` method.
Instead of using a subquery to filter out leads that have some custom frequency rules defined we can remove that subquery altogether if `lead_frequencyrules` table has no records.
On average, 75% of our customers don't have any custom frequency rules defined, so I suppose this optimisation makes sense.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Enable logging for MySQL queries.
3. Go to email settings (Settings -> Emails). "Don't update more than ..." should be set to empty, and make sure that "each" setting below it has some value (it doesn't matter if you use day or week or month). Save settings.
4. Create a campaign that sends marketing emails (it's important to send marketing, and not transactional emails) to one or more leads (contacts).
5. Let the campaign run.
6. There must be no queries like the query above in the description.  



<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
