### PR TITLE
Attribute changes made by the integration to the integration in the audit log

### DIFF
--- a/app/bundles/IntegrationsBundle/Command/SyncCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/SyncCommand.php
@@ -106,7 +106,7 @@ class SyncCommand extends Command
             defined('MAUTIC_INTEGRATION_SYNC_IN_PROGRESS') or define('MAUTIC_INTEGRATION_SYNC_IN_PROGRESS', $inputOptions->getIntegration());
 
             // Tell audit log to use integration name rather than "System"
-            define('MAUTIC_AUDITLOG_USER', $inputOptions->getIntegration());
+            defined('MAUTIC_AUDITLOG_USER') or define('MAUTIC_AUDITLOG_USER', $inputOptions->getIntegration());
 
             $this->syncService->processIntegrationSync($inputOptions);
         } catch (\Throwable $e) {

--- a/app/bundles/IntegrationsBundle/Command/SyncCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/SyncCommand.php
@@ -105,6 +105,9 @@ class SyncCommand extends Command
         try {
             defined('MAUTIC_INTEGRATION_SYNC_IN_PROGRESS') or define('MAUTIC_INTEGRATION_SYNC_IN_PROGRESS', $inputOptions->getIntegration());
 
+            // Tell audit log to use integration name rather than "System"
+            define('MAUTIC_AUDITLOG_USER', $inputOptions->getIntegration());
+
             $this->syncService->processIntegrationSync($inputOptions);
         } catch (\Throwable $e) {
             if ('dev' === $input->getOption('env') || (defined('MAUTIC_ENV') && MAUTIC_ENV === 'dev')) {


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | No namely due to issues with setting a constant in tests
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Changes made to contacts by integrations built on the IntegrationBundle framework are attributed to System in the audit log rather than the integration itself. This makes it tricky to know what exactly is making changes.

The legacy sync command set the constant that defines that but the new sync command does not.

https://github.com/mautic/mautic/blob/3.x/app/bundles/PluginBundle/Command/FetchLeadsCommand.php#L132

[//]: # ( As applicable: )
#### Steps to reproduce the bug:

This cannot be tested without a plugin based on the IntegrationsBundle. Let's just review it an merge unless someone has such plugin available for testing.

Original steps:

1. Setup Salesforce v2 and update a contact in SF and let it sync back to Mautic
2. Look at the audit log history for that contact and note that the update is attributed to "System"

#### Steps to test this PR:
1. Load up [this PR](https://mautibox.com)
2. Repeat and this time the update should be attributed to Salesforce2

#### Other areas of Mautic that may be affected by the change:
1. There shouldn't be any
