### PR TITLE
Translate option label

### DIFF
--- a/app/bundles/PluginBundle/Resources/views/FormTheme/Integration/layout.html.twig
+++ b/app/bundles/PluginBundle/Resources/views/FormTheme/Integration/layout.html.twig
@@ -182,9 +182,9 @@
                 {% for keyLabel, options in mauticChoices %}
                   {% if options is iterable %}
                     <optgroup label="{{ keyLabel }}">
-                        {% for o, keyValue in options %}
+                        {% for optionLabel, keyValue in options %}
                           <option value="{{ keyValue|e }}" {% if keyValue == child.vars.data %}selected{% set selected = true %}{% elseif selected is defined and selected is empty and '-1' == keyValue %}selected{% endif %}>
-                              {{- o -}}
+                              {{- optionLabel|trans -}}
                           </option>
                         {% endfor %}
                     </optgroup>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The special fields weren't translated. 

Before: 
<img width="659" alt="Screen Shot 2020-07-01 at 12 13 42" src="https://user-images.githubusercontent.com/63312/86272948-09f82500-bb95-11ea-937f-a2c7fbe79dbc.png">

With this PR it looks like this:
<img width="602" alt="Screen Shot 2020-07-01 at 12 13 26" src="https://user-images.githubusercontent.com/63312/86273027-2ac07a80-bb95-11ea-8653-9350e557ef1d.png">

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure SF v1
3. Go to the Contact Mapping tab and click the dropdown of Mautic fields. Scroll to the bottom and note it'll match the first screenshot above. Inspecting the select box will confirm the labels and values are flipped.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
