### PR TITLE
Enable an integration to set a default expiration for access tokens

### DIFF
--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationToken.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationToken.php
@@ -52,6 +52,12 @@ class IntegrationToken implements TokenInterface
 
     public function isExpired(): bool
     {
+        // Consider expired if there is not an access token
+        if (!$this->getAccessToken()) {
+            return true;
+        }
+
+        // Otherwise, consider expired if the expiration time has passed
         return $this->expiresAt && $this->expiresAt < time();
     }
 

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
@@ -9,7 +9,7 @@ use kamermans\OAuth2\Token\TokenInterface;
 class IntegrationTokenFactory implements TokenFactoryInterface
 {
     /**
-     * @param mixed[] $extraKeysToStore Extra keys returned by the service during the token process that needs to be captured
+     * @param mixed[]  $extraKeysToStore Extra keys returned by the service during the token process that needs to be captured
      * @param int|null $defaultExpiresIn Default time in seconds that tokens are good for if not given in the response
      */
     public function __construct(
@@ -55,6 +55,9 @@ class IntegrationTokenFactory implements TokenFactoryInterface
         return $extraData;
     }
 
+    /**
+     * @param mixed[] $data
+     */
     private function getExpiration(array $data): ?int
     {
         // Read the "expires_at" attribute

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
@@ -9,10 +9,12 @@ use kamermans\OAuth2\Token\TokenInterface;
 class IntegrationTokenFactory implements TokenFactoryInterface
 {
     /**
-     * @param mixed[] $extraKeysToStore
+     * @param mixed[] $extraKeysToStore Extra keys returned by the service during the token process that needs to be captured
+     * @param int|null $defaultExpiresIn Default time in seconds that tokens are good for if not given in the response
      */
     public function __construct(
-        private array $extraKeysToStore = []
+        private array $extraKeysToStore = [],
+        private ?int $defaultExpiresIn = null
     ) {
     }
 
@@ -20,7 +22,6 @@ class IntegrationTokenFactory implements TokenFactoryInterface
     {
         $accessToken  = null;
         $refreshToken = null;
-        $expiresAt    = null;
 
         // Read "access_token" attribute
         if (isset($data['access_token'])) {
@@ -39,18 +40,7 @@ class IntegrationTokenFactory implements TokenFactoryInterface
             $refreshToken = $previousToken->getRefreshToken();
         }
 
-        // Read the "expires_in" attribute
-        $expiresIn = isset($data['expires_in']) ? (int) $data['expires_in'] : null;
-
-        // Facebook unfortunately breaks the spec by using 'expires' instead of 'expires_in'
-        if (!$expiresIn && isset($data['expires'])) {
-            $expiresIn = (int) $data['expires'];
-        }
-
-        // Set the absolute expiration if a relative expiration was provided
-        if ($expiresIn) {
-            $expiresAt = time() + $expiresIn;
-        }
+        $expiresAt = $this->getExpiration($data);
 
         return new IntegrationToken($accessToken, $refreshToken, $expiresAt, $this->getExtraData($data));
     }
@@ -63,5 +53,30 @@ class IntegrationTokenFactory implements TokenFactoryInterface
         }
 
         return $extraData;
+    }
+
+    private function getExpiration(array $data): ?int
+    {
+        // Read the "expires_at" attribute
+        if (isset($data['expires_at'])) {
+            return (int) $data['expires_at'];
+        }
+
+        // Read the "expires_in" attribute
+        if (isset($data['expires_in'])) {
+            return time() + (int) $data['expires_in'];
+        }
+
+        // Facebook unfortunately breaks the spec by using 'expires' instead of 'expires_in'
+        if (isset($data['expires'])) {
+            return time() + (int) $data['expires'];
+        }
+
+        // Fallback to the default if set
+        if ($this->defaultExpiresIn) {
+            return time() + $this->defaultExpiresIn;
+        }
+
+        return null;
     }
 }

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -74,7 +74,8 @@ class TokenPersistence implements TokenPersistenceInterface
 
         $apiKeys = $integration->getApiKeys();
 
-        unset($apiKeys['access_token']);
+        // Must delete both the access token and the expiration in order for the middleware to refresh
+        unset($apiKeys['access_token'], $apiKeys['expires_at']);
 
         $integration->setApiKeys($apiKeys);
 

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -34,7 +34,7 @@ class TokenPersistence implements TokenPersistenceInterface
         return new IntegrationToken(
             empty($apiKeys['access_token']) ? null : $apiKeys['access_token'],
             empty($apiKeys['refresh_token']) ? null : $apiKeys['refresh_token'],
-            $apiKeys['expires_at'] ? $apiKeys['expires_at'] - time() : -1
+            $apiKeys['expires_at'] ?? null
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/IntegrationTokenFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/IntegrationTokenFactoryTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class IntegrationTokenFactoryTest extends TestCase
 {
-    public function testTokenGeneratedWithExpires(): void
+    public function testTokenGeneratedWithExpiresIn(): void
     {
         $factory = new IntegrationTokenFactory();
         $data    = [
@@ -24,6 +24,7 @@ class IntegrationTokenFactoryTest extends TestCase
         $this->assertEquals($data['access_token'], $token->getAccessToken());
         $this->assertEquals($data['refresh_token'], $token->getRefreshToken());
         $this->assertFalse($token->isExpired());
+        $this->assertEquals(time() + 10, $token->getExpiresAt());
     }
 
     public function testTokenGeneratedWithExpiresAt(): void
@@ -32,7 +33,7 @@ class IntegrationTokenFactoryTest extends TestCase
         $data    = [
             'access_token'  => '123',
             'refresh_token' => '456',
-            'expires_at'    => 10,
+            'expires_at'    => time() + 10,
         ];
 
         $token = $factory($data);
@@ -40,6 +41,56 @@ class IntegrationTokenFactoryTest extends TestCase
         $this->assertEquals($data['access_token'], $token->getAccessToken());
         $this->assertEquals($data['refresh_token'], $token->getRefreshToken());
         $this->assertFalse($token->isExpired());
+        $this->assertEquals($data['expires_at'], $token->getExpiresAt());
+    }
+
+    public function testTokenGeneratedWithExpires(): void
+    {
+        $factory = new IntegrationTokenFactory();
+        $data    = [
+            'access_token'  => '123',
+            'refresh_token' => '456',
+            'expires'       => 10,
+        ];
+
+        $token = $factory($data);
+
+        $this->assertEquals($data['access_token'], $token->getAccessToken());
+        $this->assertEquals($data['refresh_token'], $token->getRefreshToken());
+        $this->assertFalse($token->isExpired());
+        $this->assertEquals(time() + 10, $token->getExpiresAt());
+    }
+
+    public function testTokenGeneratedWithDefaultExpires(): void
+    {
+        $factory = new IntegrationTokenFactory([], 100);
+        $data    = [
+            'access_token'  => '123',
+            'refresh_token' => '456',
+        ];
+
+        $token = $factory($data);
+
+        $this->assertEquals($data['access_token'], $token->getAccessToken());
+        $this->assertEquals($data['refresh_token'], $token->getRefreshToken());
+        $this->assertFalse($token->isExpired());
+        $this->assertEquals(time() + 100, $token->getExpiresAt());
+    }
+
+    public function testTokenGeneratedWithUnexpiredTokenByDefault(): void
+    {
+        $factory = new IntegrationTokenFactory();
+        $data    = [
+            'access_token'  => '123',
+            'refresh_token' => '456',
+        ];
+
+        $token = $factory($data);
+
+        $this->assertEquals($data['access_token'], $token->getAccessToken());
+        $this->assertEquals($data['refresh_token'], $token->getRefreshToken());
+        $this->assertFalse($token->isExpired());
+        $this->assertEquals(0, $token->getExpiresAt());
     }
 
     public function testTokenGeneratedWithPreviousRefreshToken(): void
@@ -47,7 +98,6 @@ class IntegrationTokenFactoryTest extends TestCase
         $factory = new IntegrationTokenFactory();
         $data    = [
             'access_token' => '123',
-            'expires_at'   => 10,
         ];
 
         $previousToken = new IntegrationToken('789', '456');
@@ -64,7 +114,6 @@ class IntegrationTokenFactoryTest extends TestCase
         $data    = [
             'access_token'  => '123',
             'refresh_token' => '456',
-            'expires_at'    => 10,
             'foo'           => 'bar',
             'bar'           => 'foo',
         ];

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/IntegrationTokenTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/IntegrationTokenTest.php
@@ -28,6 +28,13 @@ class IntegrationTokenTest extends TestCase
         $this->assertTrue($token->isExpired());
     }
 
+    public function testIsExpiredIfAccessTokenIsMissing(): void
+    {
+        $token = new IntegrationToken('', 'refreshToken');
+
+        $this->assertTrue($token->isExpired());
+    }
+
     public function testIsNotExpired(): void
     {
         $token = new IntegrationToken('accessToken', 'refreshToken', time() + 100);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
@@ -143,9 +143,8 @@ class TokenPersistenceTest extends TestCase
             $expected
         );
 
-        $integration = $this->createMock(Integration::class);
-        $integration->method('getApiKeys')
-            ->willReturn($apiKeys, $apiKeys);
+        $integration = new Integration();
+        $integration->setApiKeys($apiKeys);
 
         $this->tokenPersistence->setIntegration($integration);
 
@@ -156,8 +155,15 @@ class TokenPersistenceTest extends TestCase
         $this->assertTrue($this->tokenPersistence->hasToken());
 
         $this->tokenPersistence->deleteToken();
-
         $this->assertFalse($this->tokenPersistence->hasToken());
+
+        $apiKeys = $integration->getApiKeys();
+        $this->assertFalse(isset($apiKeys['access_token']));
+        $this->assertFalse(isset($apiKeys['expires_in']));
+
+        $newToken = $this->tokenPersistence->restoreToken($token);
+        $this->assertTrue($newToken->isExpired());
+        $this->assertEmpty($newToken->getAccessToken());
     }
 
     public function testHasToken(): void


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

Some services such as SF does not return expirations in the response when fetching access tokens. This means that every process results in a login or a refresh of the token. SF has a login limit that once exceeded, API calls will fail till the start of the new hour. Therefore, such integrations should be able to set a default expiration so that the access token is only refreshed by the oauth2 middleware if the service returns a 401. This PR enables that. 

In the process, a bug was also found that restoring expirations was incorrect as the context given is expires in when the context needed is expires at so this PR fixes that as well. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Requires an integration built on the Integration framework

#### Steps to test this PR:

1. Load up [this PR](https://mautibox.com)
2. Requires an integration built on the Integration framework - possibly not testable for most
3. Review the included automated tests

#### Other areas of Mautic that may be affected by the change:
1. This should not impact other areas of Mautic
