### PR TITLE
Replaces the `manipulator` entry in the audit log with something useful

### DIFF
--- a/app/bundles/LeadBundle/DataObject/LeadManipulator.php
+++ b/app/bundles/LeadBundle/DataObject/LeadManipulator.php
@@ -70,4 +70,29 @@ class LeadManipulator
     {
         $this->logged = true;
     }
+
+    public function getManipulatedBy(): string
+    {
+        if ($this->objectDescription) {
+            return (string) $this->objectDescription;
+        }
+
+        return $this->getManipulatorKey();
+    }
+
+    public function getManipulatorKey(): string
+    {
+        $objectParts = [];
+        if ($this->bundleName) {
+            $objectParts[] = $this->bundleName;
+        }
+        if ($this->objectName) {
+            $objectParts[] = $this->objectName;
+        }
+        if ($this->objectId) {
+            $objectParts[] = $this->objectId;
+        }
+
+        return implode(':', $objectParts);
+    }
 }

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -630,7 +630,23 @@ class CampaignSubscriber implements EventSubscriberInterface
 
     public function onCampaignTriggerActionSetManipulator(CampaignExecutionEvent $event): void
     {
-        $event->getLead()->setManipulator(new LeadManipulator('campaign', 'trigger-action'));
+        $lead = $event->getLead();
+
+        if (!$lead instanceof Lead) {
+            return;
+        }
+
+        $campaign      = $event->getLogEntry()->getCampaign();
+        $campaignEvent = $event->getLogEntry()->getEvent();
+
+        $lead->setManipulator(
+            new LeadManipulator(
+                'campaign',
+                'trigger-action',
+                $campaignEvent->getId(),
+                sprintf('%s (%s)', $campaignEvent->getName(), $campaign->getName())
+            )
+        );
     }
 
     /**

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -114,7 +114,7 @@ class LeadSubscriber implements EventSubscriberInterface
             $this->lastContactId = $lead->getId();
         }
 
-        //Because there is an event within an event, there is a risk that something will trigger a loop which needs to be prevented
+        // Because there is an event within an event, there is a risk that something will trigger a loop which needs to be prevented
         $check = base64_encode($lead->getId().md5(json_encode($details)));
         if (in_array($check, $this->preventLoop)) {
             return;
@@ -135,7 +135,7 @@ class LeadSubscriber implements EventSubscriberInterface
 
         // Date identified entry
         if (isset($details['dateIdentified'])) {
-            //log the day lead was identified
+            // log the day lead was identified
             $log = [
                 'bundle'    => 'lead',
                 'object'    => 'lead',

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -39,6 +39,16 @@ class LeadSubscriber implements EventSubscriberInterface
     private $router;
 
     /**
+     * @var string[]
+     */
+    private $preventLoop = [];
+
+    /**
+     * @var int|null
+     */
+    private $lastContactId;
+
+    /**
      * @param ModelFactory<object> $modelFactory
      * @param bool                 $isTest       whether or not we're running in a test environment
      */
@@ -81,64 +91,71 @@ class LeadSubscriber implements EventSubscriberInterface
      */
     public function onLeadPostSave(Events\LeadEvent $event): void
     {
-        // Because there is an event within an event, there is a risk that something will trigger a loop which
-        // needs to be prevented
-        static $preventLoop = [];
-
         $lead = $event->getLead();
 
-        if ($details = $event->getChanges()) {
-            // Unset dateLastActive and dateModified and ipAddress to prevent un-necessary audit log entries
-            unset($details['dateLastActive'], $details['dateModified'], $details['ipAddressList']);
-            if (empty($details)) {
-                return;
-            }
-
-            $check = base64_encode($lead->getId().md5(json_encode($details)));
-            if (!in_array($check, $preventLoop)) {
-                $preventLoop[] = $check;
-
-                // Change entry
-                $log = [
-                    'bundle'    => 'lead',
-                    'object'    => 'lead',
-                    'objectId'  => $lead->getId(),
-                    'action'    => ($event->isNew()) ? 'create' : 'update',
-                    'details'   => $details,
-                    'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
-                ];
-                $this->auditLogModel->writeToLog($log);
-
-                // Date identified entry
-                if (isset($details['dateIdentified'])) {
-                    // log the day lead was identified
-                    $log = [
-                        'bundle'    => 'lead',
-                        'object'    => 'lead',
-                        'objectId'  => $lead->getId(),
-                        'action'    => 'identified',
-                        'details'   => [],
-                        'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
-                    ];
-                    $this->auditLogModel->writeToLog($log);
-                }
-
-                // IP added entry
-                if (isset($details['ipAddresses']) && !empty($details['ipAddresses'][1])) {
-                    $log = [
-                        'bundle'    => 'lead',
-                        'object'    => 'lead',
-                        'objectId'  => $lead->getId(),
-                        'action'    => 'ipadded',
-                        'details'   => $details['ipAddresses'],
-                        'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
-                    ];
-                    $this->auditLogModel->writeToLog($log);
-                }
-
-                $this->leadEventDispatcher->dispatchEvents($event, $details);
-            }
+        if (!$details = $event->getChanges()) {
+            return;
         }
+
+        // Unset dateLastActive and dateModified and ipAddress to prevent un-necessary audit log entries
+        unset($details['dateLastActive'], $details['dateModified'], $details['ipAddressList']);
+        if (empty($details)) {
+            return;
+        }
+
+        // Reset the loop prevention if processing a new contact to prevent a memory leak when manipulating large numbers of contacts
+        if ($lead->getId() !== $this->lastContactId) {
+            $this->preventLoop   = [];
+            $this->lastContactId = $lead->getId();
+        }
+
+        //Because there is an event within an event, there is a risk that something will trigger a loop which needs to be prevented
+        $check = base64_encode($lead->getId().md5(json_encode($details)));
+        if (in_array($check, $this->preventLoop)) {
+            return;
+        }
+
+        $this->preventLoop[] = $check;
+
+        // Change entry
+        $log = [
+            'bundle'    => 'lead',
+            'object'    => 'lead',
+            'objectId'  => $lead->getId(),
+            'action'    => ($event->isNew()) ? 'create' : 'update',
+            'details'   => $details,
+            'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+        ];
+        $this->auditLogModel->writeToLog($log);
+
+        // Date identified entry
+        if (isset($details['dateIdentified'])) {
+            //log the day lead was identified
+            $log = [
+                'bundle'    => 'lead',
+                'object'    => 'lead',
+                'objectId'  => $lead->getId(),
+                'action'    => 'identified',
+                'details'   => [],
+                'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+            ];
+            $this->auditLogModel->writeToLog($log);
+        }
+
+        // IP added entry
+        if (isset($details['ipAddresses']) && !empty($details['ipAddresses'][1])) {
+            $log = [
+                'bundle'    => 'lead',
+                'object'    => 'lead',
+                'objectId'  => $lead->getId(),
+                'action'    => 'ipadded',
+                'details'   => $details['ipAddresses'],
+                'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+            ];
+            $this->auditLogModel->writeToLog($log);
+        }
+
+        $this->leadEventDispatcher->dispatchEvents($event, $details);
     }
 
     /**

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -98,9 +98,14 @@ class LeadSubscriber implements EventSubscriberInterface
         }
 
         // Unset dateLastActive and dateModified and ipAddress to prevent un-necessary audit log entries
-        unset($details['dateLastActive'], $details['dateModified'], $details['ipAddressList']);
+        unset($details['dateLastActive'], $details['dateModified'], $details['ipAddressList'], $details['manipulator']);
         if (empty($details)) {
             return;
+        }
+
+        if ($manipulator = $lead->getManipulator()) {
+            $details['manipulated_by']  = $manipulator->getManipulatedBy();
+            $details['manipulator_key'] = $manipulator->getManipulatorKey();
         }
 
         // Reset the loop prevention if processing a new contact to prevent a memory leak when manipulating large numbers of contacts

--- a/app/bundles/LeadBundle/Resources/views/Auditlog/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Auditlog/details.html.twig
@@ -3,7 +3,12 @@
     - event
     - lead
 #}
-{% set objects = {} %}
+{% if event.details.fields is defined %}
+    {% set objects = event.details.fields %}
+{% else %}
+    {% set objects = {} %}
+{% endif %}
+
 {% for key, value in event.details %}
     {% if 'fields' != key and 'dateIdentified' != key and 'dateModified' != key %}
         {% set objects = objects|merge({(key): value}) %}

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\OptimisticLockException;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
-use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -7,6 +7,9 @@ use Doctrine\ORM\OptimisticLockException;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
@@ -885,20 +888,22 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
     public function testManipulatorSetOnCampaignTriggerAction(): void
     {
+        $campaignEvent = new Event();
+        $campaign      = new Campaign();
+        $campaignEvent->setCampaign($campaign);
         $lead = new Lead();
+        $log  = new LeadEventLog();
+        $log->setEvent($campaignEvent);
+
         $args = [
-            'lead'  => $lead,
-            'event' => [
-                'campaign'   => ['id' => 1],
-                'properties' => ['integration' => 'vTiger', 'config' => ['campaigns' => 1]],
-                'type'       => 'test',
-            ],
+            'lead'            => $lead,
+            'event'           => $campaignEvent,
             'eventDetails'    => null,
             'systemTriggered' => false,
             'eventSettings'   => [],
         ];
 
-        $event           = new CampaignExecutionEvent($args, false);
+        $event           = new CampaignExecutionEvent($args, false, $log);
         $eventDispatcher = static::getContainer()->get('event_dispatcher');
         $eventDispatcher->dispatch($event, 'mautic.lead.on_campaign_trigger_action');
 

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Tests\CommonMocks;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
@@ -95,29 +96,29 @@ class LeadSubscriberTest extends CommonMocks
         $lead->setId(54);
 
         $changes = [
-            'title' => [
+            'title'          => [
                 '0' => 'sdf',
                 '1' => 'Mr.',
             ],
-            'fields' => [
+            'fields'         => [
                 'firstname' => [
                     '0' => 'Test',
                     '1' => 'John',
                 ],
-                'lastname' => [
+                'lastname'  => [
                     '0' => 'test',
                     '1' => 'Doe',
                 ],
-                'email' => [
+                'email'     => [
                     '0' => 'zrosa91@gmail.com',
                     '1' => 'john@gmail.com',
                 ],
-                'mobile' => [
+                'mobile'    => [
                     '0' => '345345',
                     '1' => '555555555',
                 ],
             ],
-            'dateModified' => [
+            'dateModified'   => [
                 '0' => '2017-08-21T15:50:57+00:00',
                 '1' => '2017-08-22T08:04:31+00:00',
             ],
@@ -240,5 +241,208 @@ class LeadSubscriberTest extends CommonMocks
         $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
+    }
+
+    public function testOnLeadPostSaveWillNotProcessTheSameContactMultipleTimesBetweenContacts()
+    {
+        $lead = new Lead();
+        $lead->setId(54);
+        $lead->addUpdatedField('title', 'Mr');
+        $lead->addUpdatedField('firstname', 'John');
+        $lead->addUpdatedField('lastname', 'Doe');
+
+        $lead2 = new Lead();
+        $lead2->setId(58);
+        $lead2->addUpdatedField('title', 'Mrs');
+        $lead2->addUpdatedField('firstname', 'Jane');
+        $lead2->addUpdatedField('lastname', 'Doe');
+
+        // Imitate a changed $lead2 but can't clone because it resets stuff in the __clone magic method
+        // namely just need same ID
+        $lead3 = new Lead();
+        $lead3->setId(58);
+        $lead3->addUpdatedField('lastname', 'Somebody');
+
+        $ipLookupHelper      = $this->createMock(IpLookupHelper::class);
+        $auditLogModel       = $this->createMock(AuditLogModel::class);
+        $leadEventDispatcher = $this->createMock(LeadChangeEventDispatcher::class);
+        $dncReasonHelper     = $this->createMock(DncReasonHelper::class);
+        $entityManager       = $this->createMock(EntityManager::class);
+        $translator          = $this->createMock(TranslatorInterface::class);
+        $router              = $this->createMock(RouterInterface::class);
+
+        // This method will be called exactly once per set of changes
+        $auditLogModel->expects($this->exactly(3))
+            ->method('writeToLog')
+            ->withConsecutive(
+                [
+                    [
+                        'bundle'    => 'lead',
+                        'object'    => 'lead',
+                        'objectId'  => $lead->getId(),
+                        'action'    => 'update',
+                        'details'   => [
+                            'title'     => [null, 'Mr'],
+                            'fields'    => [
+                                'title'     => [null, 'Mr'],
+                                'firstname' => [null, 'John'],
+                                'lastname'  => [null, 'Doe'],
+                            ],
+                            'firstname' => [null, 'John'],
+                            'lastname'  => [null, 'Doe'],
+                        ],
+                        'ipAddress' => null,
+                    ],
+                ],
+                [
+                    [
+                        'bundle'    => 'lead',
+                        'object'    => 'lead',
+                        'objectId'  => $lead2->getId(),
+                        'action'    => 'update',
+                        'details'   => [
+                            'title'     => [null, 'Mrs'],
+                            'fields'    => [
+                                'title'     => [null, 'Mrs'],
+                                'firstname' => [null, 'Jane'],
+                                'lastname'  => [null, 'Doe'],
+                            ],
+                            'firstname' => [null, 'Jane'],
+                            'lastname'  => [null, 'Doe'],
+                        ],
+                        'ipAddress' => null,
+                    ],
+                ],
+                [
+                    [
+                        'bundle'    => 'lead',
+                        'object'    => 'lead',
+                        'objectId'  => $lead3->getId(),
+                        'action'    => 'update',
+                        'details'   => [
+                            'fields'   => [
+                                'lastname' => [null, 'Somebody'],
+                            ],
+                            'lastname' => [null, 'Somebody'],
+                        ],
+                        'ipAddress' => null,
+                    ],
+                ]
+            );
+
+        $subscriber = new LeadSubscriber(
+            $ipLookupHelper,
+            $auditLogModel,
+            $leadEventDispatcher,
+            $dncReasonHelper,
+            $entityManager,
+            $translator,
+            $router
+        );
+
+        $leadEvent = $this->getMockBuilder(LeadEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadEvent->expects($this->exactly(6))
+            ->method('getLead')
+            ->willReturnOnConsecutiveCalls(
+                $lead,
+                $lead,
+                $lead2,
+                $lead2,
+                $lead3,
+                $lead3
+            );
+
+        $leadEvent->expects($this->exactly(6))
+            ->method('getChanges')
+            ->willReturnOnConsecutiveCalls(
+                $lead->getChanges(),
+                $lead->getChanges(),
+                $lead2->getChanges(),
+                $lead2->getChanges(),
+                $lead3->getChanges(),
+                $lead3->getChanges()
+            );
+
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+        $subscriber->onLeadPostSave($leadEvent);
+    }
+
+    public function testManipulatorLogged()
+    {
+        $lead = new Lead();
+        $lead->setId(54);
+
+        $lead->setManipulator(
+            new LeadManipulator('campaign', 'trigger-action', 1, 'Event Name (Campaign Name)')
+        );
+
+        $lead->addUpdatedField('title', 'Mr');
+        $lead->addUpdatedField('firstname', 'John');
+        $lead->addUpdatedField('lastname', 'Test');
+
+        $ipLookupHelper      = $this->createMock(IpLookupHelper::class);
+        $auditLogModel       = $this->createMock(AuditLogModel::class);
+        $leadEventDispatcher = $this->createMock(LeadChangeEventDispatcher::class);
+        $dncReasonHelper     = $this->createMock(DncReasonHelper::class);
+        $entityManager       = $this->createMock(EntityManager::class);
+        $translator          = $this->createMock(TranslatorInterface::class);
+        $router              = $this->createMock(RouterInterface::class);
+
+        // This method will be called exactly once
+        // even though the onLeadPostSave was called twice for the same lead
+        $auditLogModel->expects($this->once())
+            ->method('writeToLog')
+            ->with(
+                [
+                    'bundle'    => 'lead',
+                    'object'    => 'lead',
+                    'objectId'  => $lead->getId(),
+                    'action'    => 'update',
+                    'details'   => [
+                        'title'           => [null, 'Mr'],
+                        'fields'          => [
+                            'title'     => [null, 'Mr'],
+                            'firstname' => [null, 'John'],
+                            'lastname'  => [null, 'Test'],
+                        ],
+                        'firstname'       => [null, 'John'],
+                        'lastname'        => [null, 'Test'],
+                        'manipulated_by'  => 'Event Name (Campaign Name)',
+                        'manipulator_key' => 'campaign:trigger-action:1',
+                    ],
+                    'ipAddress' => null,
+                ]
+            );
+
+        $subscriber = new LeadSubscriber(
+            $ipLookupHelper,
+            $auditLogModel,
+            $leadEventDispatcher,
+            $dncReasonHelper,
+            $entityManager,
+            $translator,
+            $router
+        );
+
+        $leadEvent = $this->getMockBuilder(LeadEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $leadEvent->expects($this->once())
+            ->method('getLead')
+            ->will($this->returnValue($lead));
+
+        $leadEvent->expects($this->once())
+            ->method('getChanges')
+            ->will($this->returnValue($lead->getChanges()));
+
+        $subscriber->onLeadPostSave($leadEvent);
     }
 }

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -10,8 +10,8 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Tests\CommonMocks;
-use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
+use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
@@ -29,41 +29,41 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class LeadSubscriberTest extends CommonMocks
 {
     /**
-     * @var IpLookupHelper|MockObject
+     * @var IpLookupHelper&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $ipLookupHelper;
+    private MockObject $ipLookupHelper;
 
     /**
-     * @var AuditLogModel|MockObject
+     * @var AuditLogModel&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $auditLogModel;
+    private MockObject $auditLogModel;
 
     /**
-     * @var LeadChangeEventDispatcher|MockObject
+     * @var LeadChangeEventDispatcher&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $leadEventDispatcher;
+    private MockObject $leadEventDispatcher;
 
     private \Mautic\LeadBundle\Twig\Helper\DncReasonHelper $dncReasonHelper;
 
     /**
-     * @var EntityManager|MockObject
+     * @var EntityManager&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private MockObject $entityManager;
 
     /**
-     * @var TranslatorInterface|MockObject
+     * @var TranslatorInterface&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $translator;
+    private MockObject $translator;
 
     /**
-     * @var RouterInterface|MockObject
+     * @var RouterInterface&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $router;
+    private MockObject $router;
 
     /**
      * @var ModelFactory<object>&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $modelFacotry;
+    private MockObject $modelFacotry;
 
     /**
      * @var CoreParametersHelper
@@ -243,7 +243,7 @@ class LeadSubscriberTest extends CommonMocks
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }
 
-    public function testOnLeadPostSaveWillNotProcessTheSameContactMultipleTimesBetweenContacts()
+    public function testOnLeadPostSaveWillNotProcessTheSameContactMultipleTimesBetweenContacts(): void
     {
         $lead = new Lead();
         $lead->setId(54);
@@ -263,16 +263,8 @@ class LeadSubscriberTest extends CommonMocks
         $lead3->setId(58);
         $lead3->addUpdatedField('lastname', 'Somebody');
 
-        $ipLookupHelper      = $this->createMock(IpLookupHelper::class);
-        $auditLogModel       = $this->createMock(AuditLogModel::class);
-        $leadEventDispatcher = $this->createMock(LeadChangeEventDispatcher::class);
-        $dncReasonHelper     = $this->createMock(DncReasonHelper::class);
-        $entityManager       = $this->createMock(EntityManager::class);
-        $translator          = $this->createMock(TranslatorInterface::class);
-        $router              = $this->createMock(RouterInterface::class);
-
         // This method will be called exactly once per set of changes
-        $auditLogModel->expects($this->exactly(3))
+        $this->auditLogModel->expects($this->exactly(3))
             ->method('writeToLog')
             ->withConsecutive(
                 [
@@ -331,18 +323,20 @@ class LeadSubscriberTest extends CommonMocks
             );
 
         $subscriber = new LeadSubscriber(
-            $ipLookupHelper,
-            $auditLogModel,
-            $leadEventDispatcher,
-            $dncReasonHelper,
-            $entityManager,
-            $translator,
-            $router
+            $this->ipLookupHelper,
+            $this->auditLogModel,
+            $this->leadEventDispatcher,
+            $this->dncReasonHelper,
+            $this->entityManager,
+            $this->translator,
+            $this->router,
+            $this->modelFacotry,
+            $this->coreParametersHelper,
+            $this->companyLeadRepository,
+            true
         );
 
-        $leadEvent = $this->getMockBuilder(LeadEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $leadEvent = $this->createMock(LeadEvent::class);
 
         $leadEvent->expects($this->exactly(6))
             ->method('getLead')
@@ -374,7 +368,7 @@ class LeadSubscriberTest extends CommonMocks
         $subscriber->onLeadPostSave($leadEvent);
     }
 
-    public function testManipulatorLogged()
+    public function testManipulatorLogged(): void
     {
         $lead = new Lead();
         $lead->setId(54);
@@ -387,17 +381,9 @@ class LeadSubscriberTest extends CommonMocks
         $lead->addUpdatedField('firstname', 'John');
         $lead->addUpdatedField('lastname', 'Test');
 
-        $ipLookupHelper      = $this->createMock(IpLookupHelper::class);
-        $auditLogModel       = $this->createMock(AuditLogModel::class);
-        $leadEventDispatcher = $this->createMock(LeadChangeEventDispatcher::class);
-        $dncReasonHelper     = $this->createMock(DncReasonHelper::class);
-        $entityManager       = $this->createMock(EntityManager::class);
-        $translator          = $this->createMock(TranslatorInterface::class);
-        $router              = $this->createMock(RouterInterface::class);
-
         // This method will be called exactly once
         // even though the onLeadPostSave was called twice for the same lead
-        $auditLogModel->expects($this->once())
+        $this->auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with(
                 [
@@ -422,18 +408,20 @@ class LeadSubscriberTest extends CommonMocks
             );
 
         $subscriber = new LeadSubscriber(
-            $ipLookupHelper,
-            $auditLogModel,
-            $leadEventDispatcher,
-            $dncReasonHelper,
-            $entityManager,
-            $translator,
-            $router
+            $this->ipLookupHelper,
+            $this->auditLogModel,
+            $this->leadEventDispatcher,
+            $this->dncReasonHelper,
+            $this->entityManager,
+            $this->translator,
+            $this->router,
+            $this->modelFacotry,
+            $this->coreParametersHelper,
+            $this->companyLeadRepository,
+            true
         );
 
-        $leadEvent = $this->getMockBuilder(LeadEvent::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $leadEvent = $this->createMock(LeadEvent::class);
 
         $leadEvent->expects($this->once())
             ->method('getLead')


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | enhancement
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) |/
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
`manipulator` entries are written to the audit log which provide no value to the end user or to the audit log itself. Sometimes if no other changes are made, this is still written to the log cluttering up both the audit log tab in the UI and space in the database. 

<img width="981" alt="Screen Shot 2020-12-31 at 12 37 59" src="https://user-images.githubusercontent.com/63312/103424102-17a45c80-4b70-11eb-9ac3-db17d02da4ac.png">


While looking into this, I found there was code that could introduce a slow memory leak so patched that as well (plus use of static variables in methods is bad). 

This PR does 3 things:
1. It no longer records `manipulator` to the audit log. 
2. It adds `manipulated_by` and `manipulator_key` entries with data extracted from the LeadManipulator object if available. This is useful to know exactly what within the "System" modified the contact. 
3. It fixes the slow memory leak by resetting the "preventLoop" array between contacts. 

<img width="981" alt="Screen Shot 2020-12-31 at 12 49 51" src="https://user-images.githubusercontent.com/63312/103424110-1d9a3d80-4b70-11eb-8bb7-87589a5012d4.png">

[//]: # ( As applicable: )
#### Steps to test this PR:

2. Run a campaign that updates the contact
3. Check the contact's profile page and view the audit log tab
4. Note that there is not manipulator entry that shows changes from 0 to 1 or 1 to 0 and the addition of the two new keys

#### Other areas of Mautic that may be affected by the change:
1. None
2. 

#### List deprecations along with the new alternative:
1. None
2. 

#### List backwards compatibility breaks:
1. 
2. 
