### PR TITLE
New event for plugins INTEGRATION_CONFIG_ON_GENERATE_AUTH_URL

### DIFF
--- a/app/bundles/IntegrationsBundle/Event/ConfigAuthUrlEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/ConfigAuthUrlEvent.php
@@ -2,36 +2,15 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic contributors. All rights reserved
- * @author      Acquia
- *
- * @link        https://www.mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\IntegrationsBundle\Event;
 
 use Mautic\PluginBundle\Entity\Integration;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class ConfigAuthUrlEvent extends Event
 {
-    /**
-     * @var Integration
-     */
-    private $integrationConfiguration;
-
-    /**
-     * @var string
-     */
-    private $authUrl;
-
-    public function __construct(Integration $integrationConfiguration, string $authUrl)
+    public function __construct(private Integration $integrationConfiguration, private string $authUrl)
     {
-        $this->integrationConfiguration = $integrationConfiguration;
-        $this->authUrl                  = $authUrl;
     }
 
     public function getIntegrationConfiguration(): Integration

--- a/app/bundles/IntegrationsBundle/Event/ConfigAuthUrlEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/ConfigAuthUrlEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic contributors. All rights reserved
+ * @author      Acquia
+ *
+ * @link        https://www.mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\IntegrationsBundle\Event;
+
+use Mautic\PluginBundle\Entity\Integration;
+use Symfony\Component\EventDispatcher\Event;
+
+final class ConfigAuthUrlEvent extends Event
+{
+    /**
+     * @var Integration
+     */
+    private $integrationConfiguration;
+
+    /**
+     * @var string
+     */
+    private $authUrl;
+
+    public function __construct(Integration $integrationConfiguration, string $authUrl)
+    {
+        $this->integrationConfiguration = $integrationConfiguration;
+        $this->authUrl                  = $authUrl;
+    }
+
+    public function getIntegrationConfiguration(): Integration
+    {
+        return $this->integrationConfiguration;
+    }
+
+    public function getIntegration(): string
+    {
+        return $this->integrationConfiguration->getName();
+    }
+
+    public function getAuthUrl(): string
+    {
+        return $this->authUrl;
+    }
+
+    public function setAuthUrl(string $authUrl): void
+    {
+        $this->authUrl = $authUrl;
+    }
+}

--- a/app/bundles/IntegrationsBundle/IntegrationEvents.php
+++ b/app/bundles/IntegrationsBundle/IntegrationEvents.php
@@ -43,6 +43,15 @@ final class IntegrationEvents
     public const INTEGRATION_CONFIG_AFTER_SAVE = 'mautic.integration.config_after_save';
 
     /**
+     * The mautic.integration.config_before_save event is dispatched prior to an integration's configuration is saved.
+     *
+     * The event listener receives a Mautic\IntegrationsBundle\Event\ConfigAuthUrlEvent instance.
+     *
+     * @var string
+     */
+    public const INTEGRATION_CONFIG_ON_GENERATE_AUTH_URL = 'mautic.integration.INTEGRATION_CONFIG_ON_GENERATE_AUTH_URL';
+
+    /**
      * The mautic.integration.keys_before_encryption event is dispatched prior to encrypting keys to be stored into the database.
      *
      * The event listener receives a Mautic\IntegrationsBundle\Event\KeysEncryptionEvent instance.


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Provide a way for hosts to rewrite the auth URL for a plugin built on the IntegrationBundle's OAuth2 http client to be able to proxy requests through a single point of entry

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. This cannot be tested as it only allow plugins to hook into existing functionality

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
