### PR TITLE
Prevent duplicate contacts or companies from being created during integration syncs when new objects are mapped to multiple integration object IDs

### DIFF
--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -139,26 +139,6 @@ return [
             'mautic.integrations.helper.sync_judge' => [
                 'class' => \Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudge::class,
             ],
-            'mautic.integrations.helper.contact_object' => [
-                'class'     => \Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\ContactObjectHelper::class,
-                'arguments' => [
-                    'mautic.lead.model.lead',
-                    'mautic.lead.repository.lead',
-                    'doctrine.dbal.default_connection',
-                    'mautic.lead.model.field',
-                    'mautic.lead.model.dnc',
-                    'mautic.lead.model.company',
-                ],
-            ],
-            'mautic.integrations.helper.company_object' => [
-                'class'     => \Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\CompanyObjectHelper::class,
-                'arguments' => [
-                    'mautic.lead.model.company',
-                    'mautic.lead.repository.company',
-                    'doctrine.dbal.default_connection',
-                    'mautic.lead.model.field',
-                ],
-            ],
             'mautic.integrations.sync.data_exchange.mautic.order_executioner' => [
                 'class'     => \Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\OrderExecutioner::class,
                 'arguments' => [

--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -156,6 +156,7 @@ return [
                     'mautic.lead.model.company',
                     'mautic.lead.repository.company',
                     'doctrine.dbal.default_connection',
+                    'mautic.lead.model.field',
                 ],
             ],
             'mautic.integrations.sync.data_exchange.mautic.order_executioner' => [

--- a/app/bundles/IntegrationsBundle/Config/services.php
+++ b/app/bundles/IntegrationsBundle/Config/services.php
@@ -32,4 +32,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.integrations.repository.field_change', \Mautic\IntegrationsBundle\Entity\FieldChangeRepository::class);
     $services->alias('mautic.integrations.repository.object_mapping', \Mautic\IntegrationsBundle\Entity\ObjectMappingRepository::class);
     $services->alias('mautic.plugin.integrations.repository.integration', \Mautic\PluginBundle\Entity\IntegrationRepository::class);
+    $services->alias('mautic.integrations.helper.contact_object', \Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\ContactObjectHelper::class);
+    $services->alias('mautic.integrations.helper.company_object', \Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\CompanyObjectHelper::class);
 };

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -14,7 +14,6 @@ use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
-use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
 
@@ -23,12 +22,12 @@ class CompanyObjectHelper implements ObjectHelperInterface
     /**
      * @var string[]|null
      */
-    private $uniqueIdentifierFields;
+    private ?array $uniqueIdentifierFields = null;
 
     /**
      * @var array<string,Company>
      */
-    private $companiesCreated = [];
+    private array $companiesCreated = [];
 
     public function __construct(
         private CompanyModel $model,

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -21,7 +21,7 @@ use Mautic\LeadBundle\Model\FieldModel;
 class CompanyObjectHelper implements ObjectHelperInterface
 {
     /**
-     * @var array
+     * @var string[]|null
      */
     private $uniqueIdentifierFields;
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -8,19 +8,33 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\UpdatedObjectMappingDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
 use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\FieldModel;
 
 class CompanyObjectHelper implements ObjectHelperInterface
 {
+    /**
+     * @var array
+     */
+    private $uniqueIdentifierFields;
+
+    /**
+     * @var array
+     */
+    private $companiesCreated = [];
+
     public function __construct(
         private CompanyModel $model,
         private CompanyRepository $repository,
-        private Connection $connection
+        private Connection $connection,
+        private FieldModel $fieldModel
     ) {
     }
 
@@ -33,15 +47,14 @@ class CompanyObjectHelper implements ObjectHelperInterface
     {
         $objectMappings = [];
         foreach ($objects as $object) {
-            $company = new Company();
             $fields  = $object->getFields();
+            $company = $this->getCompanyEntity($fields);
 
             foreach ($fields as $field) {
                 $company->addUpdatedField($field->getName(), $field->getValue()->getNormalizedValue());
             }
 
             $this->model->saveEntity($company);
-            $this->repository->detachEntity($company);
 
             DebugLogger::log(
                 MauticSyncDataExchange::NAME,
@@ -61,6 +74,14 @@ class CompanyObjectHelper implements ObjectHelperInterface
                 ->setInternalObjectId($company->getId());
             $objectMappings[] = $objectMapping;
         }
+
+        // Detach to free RAM after all companies are processed in case there are duplicates in the same batch
+        foreach ($this->companiesCreated as $company) {
+            $this->repository->detachEntity($company);
+        }
+
+        // Reset companies created for the next batch
+        $this->companiesCreated = [];
 
         return $objectMappings;
     }
@@ -209,5 +230,41 @@ class CompanyObjectHelper implements ObjectHelperInterface
     public function setFieldValues(Company $company): void
     {
         $this->model->setFieldValues($company, []);
+    }
+
+    private function getUniqueIdentifierFields(): array
+    {
+        if (null === $this->uniqueIdentifierFields) {
+            $uniqueIdentifierFields       = $this->fieldModel->getUniqueIdentifierFields(['object' => MauticSyncDataExchange::OBJECT_COMPANY]);
+            $this->uniqueIdentifierFields = array_keys($uniqueIdentifierFields);
+        }
+
+        return $this->uniqueIdentifierFields;
+    }
+
+    /**
+     * @var FieldDAO[] $fields
+     */
+    private function getCompanyEntity(array $fields): Company
+    {
+        $uniqueIdentifierFields = $this->getUniqueIdentifierFields();
+
+        // Create a key based on the concatenation of unique identifier values
+        $companyKey = '';
+        foreach ($uniqueIdentifierFields as $uniqueIdentifierField) {
+            if (isset($fields[$uniqueIdentifierField])) {
+                $companyKey .= strtolower($fields[$uniqueIdentifierField]->getValue()->getNormalizedValue());
+            }
+        }
+
+        // Check if a company with matching values was created in the same batch as another
+        if (!empty($companyKey) && isset($this->companiesCreated[$companyKey])) {
+            return $this->companiesCreated[$companyKey];
+        }
+
+        // Create a new company but ensure a unique key
+        $companyKey = $companyKey ?: uniqid();
+
+        return $this->companiesCreated[$companyKey] = new Company();
     }
 }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -26,7 +26,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
     private $uniqueIdentifierFields;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $companiesCreated = [];
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -26,7 +26,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
     private $uniqueIdentifierFields;
 
     /**
-     * @var string[]
+     * @var array<string,Company>
      */
     private $companiesCreated = [];
 
@@ -232,6 +232,9 @@ class CompanyObjectHelper implements ObjectHelperInterface
         $this->model->setFieldValues($company, []);
     }
 
+    /**
+     * @return string[]
+     */
     private function getUniqueIdentifierFields(): array
     {
         if (null === $this->uniqueIdentifierFields) {
@@ -243,7 +246,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
     }
 
     /**
-     * @var FieldDAO[]
+     * @param FieldDAO[] $fields
      */
     private function getCompanyEntity(array $fields): Company
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -14,8 +14,8 @@ use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Model\CompanyModel;
-use Mautic\LeadBundle\Model\FieldModel;
 
 class CompanyObjectHelper implements ObjectHelperInterface
 {
@@ -33,7 +33,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
         private CompanyModel $model,
         private CompanyRepository $repository,
         private Connection $connection,
-        private FieldModel $fieldModel
+        private FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier
     ) {
     }
 
@@ -237,7 +237,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
     private function getUniqueIdentifierFields(): array
     {
         if (null === $this->uniqueIdentifierFields) {
-            $uniqueIdentifierFields       = $this->fieldModel->getUniqueIdentifierFields(['object' => MauticSyncDataExchange::OBJECT_COMPANY]);
+            $uniqueIdentifierFields       = $this->fieldsWithUniqueIdentifier->getFieldsWithUniqueIdentifier(['object' => MauticSyncDataExchange::OBJECT_COMPANY]);
             $this->uniqueIdentifierFields = array_keys($uniqueIdentifierFields);
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -243,7 +243,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
     }
 
     /**
-     * @var FieldDAO[] $fields
+     * @var FieldDAO[]
      */
     private function getCompanyEntity(array $fields): Company
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -364,7 +364,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     }
 
     /**
-     * @var FieldDAO[] $fields
+     * @var FieldDAO[]
      */
     private function getContactEntity(array $fields): Lead
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -32,7 +32,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     private $uniqueIdentifierFields;
 
     /**
-     * @var string[]
+     * @var array<string,Lead>
      */
     private $contactsCreated = [];
 
@@ -305,6 +305,9 @@ class ContactObjectHelper implements ObjectHelperInterface
         return $this->availableFields;
     }
 
+    /**
+     * @return string[]
+     */
     private function getUniqueIdentifierFields(): array
     {
         if (null === $this->uniqueIdentifierFields) {
@@ -364,7 +367,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     }
 
     /**
-     * @var FieldDAO[]
+     * @param FieldDAO[] $fields
      */
     private function getContactEntity(array $fields): Lead
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -27,7 +27,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     private ?array $availableFields = null;
 
     /**
-     * @var array
+     * @var string[]|null
      */
     private $uniqueIdentifierFields;
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -29,12 +29,12 @@ class ContactObjectHelper implements ObjectHelperInterface
     /**
      * @var string[]|null
      */
-    private $uniqueIdentifierFields;
+    private ?array $uniqueIdentifierFields = null;
 
     /**
      * @var array<string,Lead>
      */
-    private $contactsCreated = [];
+    private array $contactsCreated = [];
 
     public function __construct(
         private LeadModel $model,

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -32,7 +32,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     private $uniqueIdentifierFields;
 
     /**
-     * @var array
+     * @var string[]
      */
     private $contactsCreated = [];
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -18,8 +18,9 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Exception\ImportFailedException;
+use Mautic\LeadBundle\Field\FieldList;
+use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
-use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 
 class ContactObjectHelper implements ObjectHelperInterface
@@ -40,8 +41,9 @@ class ContactObjectHelper implements ObjectHelperInterface
         private LeadModel $model,
         private LeadRepository $repository,
         private Connection $connection,
-        private FieldModel $fieldModel,
-        private DoNotContactModel $dncModel
+        private DoNotContactModel $dncModel,
+        private FieldList $fieldList,
+        private FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier
     ) {
     }
 
@@ -298,7 +300,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     private function getAvailableFields(): array
     {
         if (null === $this->availableFields) {
-            $availableFields       = $this->fieldModel->getFieldList(false, false);
+            $availableFields       = $this->fieldList->getFieldList(false, false);
             $this->availableFields = array_keys($availableFields);
         }
 
@@ -311,7 +313,7 @@ class ContactObjectHelper implements ObjectHelperInterface
     private function getUniqueIdentifierFields(): array
     {
         if (null === $this->uniqueIdentifierFields) {
-            $uniqueIdentifierFields       = $this->fieldModel->getUniqueIdentifierFields(['object' => MauticSyncDataExchange::OBJECT_CONTACT]);
+            $uniqueIdentifierFields       = $this->fieldsWithUniqueIdentifier->getFieldsWithUniqueIdentifier(['object' => MauticSyncDataExchange::OBJECT_CONTACT]);
             $this->uniqueIdentifierFields = array_keys($uniqueIdentifierFields);
         }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -5,13 +5,18 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncDataExchange\Internal\ObjectHelper;
 
 use Doctrine\DBAL\Connection;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company as CompanyObject;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\CompanyObjectHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CompanyObjectHelperTest extends TestCase
@@ -31,32 +36,133 @@ class CompanyObjectHelperTest extends TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $connection;
 
+    /**
+     * @var FieldModel|MockObject
+     */
+    private $fieldModel;
+
     protected function setUp(): void
     {
-        $this->model      = $this->createMock(CompanyModel::class);
+        $this->model = $this->createMock(CompanyModel::class);
         $this->repository = $this->createMock(CompanyRepository::class);
         $this->connection = $this->createMock(Connection::class);
+        $this->fieldModel = $this->createMock(FieldModel::class);
+
+        $this->fieldModel->method('getUniqueIdentifierFields')
+            ->with(['object' => CompanyObject::NAME])
+            ->willReturn(
+                [
+                    'companyemail' => [],
+                ]
+            );
     }
 
-    public function testCreate(): void
+    public function testCreateWithDuplicateUniqueIdentifiers(): void
     {
-        $this->model->expects($this->exactly(2))
-            ->method('saveEntity');
+        $idMap = [
+            'email1@email.com' => 127,
+            'email2@email.com' => 128,
+        ];
+
+        $this->model->expects($this->exactly(3))
+            ->method('saveEntity')
+            ->with(
+                $this->callback(function (Company $company) use ($idMap): bool {
+                    // Set ID
+                    $reflection = new \ReflectionClass($company);
+                    $property   = $reflection->getProperty('id');
+                    $property->setAccessible(true);
+                    $property->setValue($company, $idMap[$company->getEmail()]);
+
+                    return true;
+                })
+            );
+
         $this->repository->expects($this->exactly(2))
             ->method('detachEntity');
 
-        $objects = [
-            new ObjectChangeDAO('Test', MauticSyncDataExchange::OBJECT_COMPANY, null, 'MappedObject', 1, new \DateTime()),
-            new ObjectChangeDAO('Test', MauticSyncDataExchange::OBJECT_COMPANY, null, 'MappedObject', 2, new \DateTime()),
-        ];
+        // Test that two objects with the same unique identifier are merged into one
+        $object1 = $this->getObject(1, ['companyemail' => 'email1@email.com']);
+        $object2 = $this->getObject(2, ['companyemail' => 'email2@email.com']);
+        $object3 = $this->getObject(3, ['companyemail' => 'email1@email.com']);
+
+        $objects = [$object1, $object2, $object3];
 
         $objectMappings = $this->getObjectHelper()->create($objects);
 
         foreach ($objectMappings as $key => $objectMapping) {
             $this->assertEquals('Test', $objectMapping->getIntegration());
-            $this->assertEquals(MauticSyncDataExchange::OBJECT_COMPANY, $objectMapping->getInternalObjectName());
+            $this->assertEquals(CompanyObject::NAME, $objectMapping->getInternalObjectName());
             $this->assertEquals('MappedObject', $objectMapping->getIntegrationObjectName());
             $this->assertEquals($objects[$key]->getMappedObjectId(), $objectMapping->getIntegrationObjectId());
+
+            // Test that mapped ID matches internal ID
+            switch ($objects[$key]->getMappedObjectId()) {
+                case 1:
+                case 3:
+                    Assert::assertSame(127, $objectMapping->getInternalObjectId());
+                    break;
+                case 2:
+                    Assert::assertSame(128, $objectMapping->getInternalObjectId());
+                    break;
+            }
+        }
+    }
+
+    public function testCreateWithOneWithoutUniqueIdentifier(): void
+    {
+        $idMap = [
+            'email1@email.com' => 127,
+            'email2@email.com' => 128,
+            ''                 => 129,
+        ];
+
+        $this->model->expects($this->exactly(4))
+            ->method('saveEntity')
+            ->with(
+                $this->callback(function (Company $company) use ($idMap): bool {
+                    // Set ID
+                    $reflection = new \ReflectionClass($company);
+                    $property   = $reflection->getProperty('id');
+                    $property->setAccessible(true);
+                    $property->setValue($company, $idMap[$company->getEmail()]);
+
+                    return true;
+                })
+            );
+
+        $this->repository->expects($this->exactly(3))
+            ->method('detachEntity');
+
+        // Test that two objects with the same unique identifier are merged into one
+        $object1 = $this->getObject(1, ['companyemail' => 'email1@email.com']);
+        $object2 = $this->getObject(2, ['companyemail' => 'email2@email.com']);
+        $object3 = $this->getObject(3, ['companyemail' => 'email1@email.com']);
+        $object4 = $this->getObject(4, ['companyname' => 'Some Biz']);
+
+        $objects = [$object1, $object2, $object3, $object4];
+
+        $objectMappings = $this->getObjectHelper()->create($objects);
+
+        foreach ($objectMappings as $key => $objectMapping) {
+            $this->assertEquals('Test', $objectMapping->getIntegration());
+            $this->assertEquals(CompanyObject::NAME, $objectMapping->getInternalObjectName());
+            $this->assertEquals('MappedObject', $objectMapping->getIntegrationObjectName());
+            $this->assertEquals($objects[$key]->getMappedObjectId(), $objectMapping->getIntegrationObjectId());
+
+            // Test that mapped ID matches internal ID
+            switch ($objects[$key]->getMappedObjectId()) {
+                case 1:
+                case 3:
+                    Assert::assertSame(127, $objectMapping->getInternalObjectId());
+                    break;
+                case 2:
+                    Assert::assertSame(128, $objectMapping->getInternalObjectId());
+                    break;
+                case 4:
+                    Assert::assertSame(129, $objectMapping->getInternalObjectId());
+                    break;
+            }
         }
     }
 
@@ -140,6 +246,26 @@ class CompanyObjectHelperTest extends TestCase
      */
     private function getObjectHelper()
     {
-        return new CompanyObjectHelper($this->model, $this->repository, $this->connection);
+        return new CompanyObjectHelper($this->model, $this->repository, $this->connection, $this->fieldModel);
+    }
+
+    private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
+    {
+        $object = new ObjectChangeDAO(
+            'Test',
+            CompanyObject::NAME,
+            null,
+            'MappedObject',
+            $mappedId,
+            new \DateTime()
+        );
+
+        foreach ($fieldValues as $name => $value) {
+            $object->addField(
+                new FieldDAO($name, new NormalizedValueDAO('string', $value))
+            );
+        }
+
+        return $object;
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -250,7 +250,7 @@ class CompanyObjectHelperTest extends TestCase
     }
 
     /**
-     * @param array<string,string>
+     * @param array<string,string> $fieldValues
      */
     private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
     {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -22,24 +22,24 @@ use PHPUnit\Framework\TestCase;
 class CompanyObjectHelperTest extends TestCase
 {
     /**
-     * @var CompanyModel|\PHPUnit\Framework\MockObject\MockObject
+     * @var CompanyMod&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $model;
+    private MockObject $model;
 
     /**
-     * @var CompanyRepository|\PHPUnit\Framework\MockObject\MockObject
+     * @var CompanyRepository&ockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $repository;
+    private MockObject $repository;
 
     /**
-     * @var Connection|\PHPUnit\Framework\MockObject\MockObject
+     * @var Connecti&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $connection;
+    private MockObject $connection;
 
     /**
-     * @var FieldModel|MockObject
+     * @var FieldModel&MockObject
      */
-    private $fieldModel;
+    private MockObject $fieldModel;
 
     protected function setUp(): void
     {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -43,7 +43,7 @@ class CompanyObjectHelperTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->model = $this->createMock(CompanyModel::class);
+        $this->model      = $this->createMock(CompanyModel::class);
         $this->repository = $this->createMock(CompanyRepository::class);
         $this->connection = $this->createMock(Connection::class);
         $this->fieldModel = $this->createMock(FieldModel::class);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -13,8 +13,8 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\Compan
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
+use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Model\CompanyModel;
-use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -22,33 +22,33 @@ use PHPUnit\Framework\TestCase;
 class CompanyObjectHelperTest extends TestCase
 {
     /**
-     * @var CompanyMod&MockObject
+     * @var CompanyModel&MockObject
      */
     private MockObject $model;
 
     /**
-     * @var CompanyRepository&ockObject
+     * @var CompanyRepository&MockObject
      */
     private MockObject $repository;
 
     /**
-     * @var Connecti&MockObject
+     * @var Connection&MockObject
      */
     private MockObject $connection;
 
     /**
-     * @var FieldModel&MockObject
+     * @var FieldsWithUniqueIdentifier&MockObject
      */
-    private MockObject $fieldModel;
+    private MockObject $fieldsWithUniqueIdentifier;
 
     protected function setUp(): void
     {
-        $this->model      = $this->createMock(CompanyModel::class);
-        $this->repository = $this->createMock(CompanyRepository::class);
-        $this->connection = $this->createMock(Connection::class);
-        $this->fieldModel = $this->createMock(FieldModel::class);
+        $this->model                      = $this->createMock(CompanyModel::class);
+        $this->repository                 = $this->createMock(CompanyRepository::class);
+        $this->connection                 = $this->createMock(Connection::class);
+        $this->fieldsWithUniqueIdentifier = $this->createMock(FieldsWithUniqueIdentifier::class);
 
-        $this->fieldModel->method('getUniqueIdentifierFields')
+        $this->fieldsWithUniqueIdentifier->method('getFieldsWithUniqueIdentifier')
             ->with(['object' => CompanyObject::NAME])
             ->willReturn(
                 [
@@ -241,12 +241,9 @@ class CompanyObjectHelperTest extends TestCase
         Assert::assertSame([], $objectMappings);
     }
 
-    /**
-     * @return CompanyObjectHelper
-     */
-    private function getObjectHelper()
+    private function getObjectHelper(): CompanyObjectHelper
     {
-        return new CompanyObjectHelper($this->model, $this->repository, $this->connection, $this->fieldModel);
+        return new CompanyObjectHelper($this->model, $this->repository, $this->connection, $this->fieldsWithUniqueIdentifier);
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -249,6 +249,9 @@ class CompanyObjectHelperTest extends TestCase
         return new CompanyObjectHelper($this->model, $this->repository, $this->connection, $this->fieldModel);
     }
 
+    /**
+     * @param array<string,string>
+     */
     private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
     {
         $object = new ObjectChangeDAO(

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -363,6 +363,9 @@ class ContactObjectHelperTest extends TestCase
         $this->assertSame($objectName, $manipulator->getObjectName());
     }
 
+    /**
+     * @param array<string,string>
+     */
     private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
     {
         $object = new ObjectChangeDAO('Test', Contact::NAME, null, 'MappedObject', $mappedId, new DateTime());

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -364,7 +364,7 @@ class ContactObjectHelperTest extends TestCase
     }
 
     /**
-     * @param array<string,string>
+     * @param array<string,string> $fieldValues
      */
     private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
     {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -16,8 +16,9 @@ use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Exception\ImportFailedException;
+use Mautic\LeadBundle\Field\FieldList;
+use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Model\DoNotContact;
-use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -26,39 +27,45 @@ use PHPUnit\Framework\TestCase;
 class ContactObjectHelperTest extends TestCase
 {
     /**
-     * @var LeadModel|MockObject
+     * @var LeadModel&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $model;
+    private MockObject $model;
 
     /**
-     * @var LeadRepository|MockObject
+     * @var LeadRepository&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $repository;
+    private MockObject $repository;
 
     /**
-     * @var Connection|MockObject
+     * @var Connection&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $connection;
+    private MockObject $connection;
 
     /**
-     * @var FieldModel|MockObject
+     * @var DoNotContact&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $fieldModel;
+    private MockObject $doNotContactModel;
 
     /**
-     * @var DoNotContact|MockObject
+     * @var FieldList&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $doNotContactModel;
+    private MockObject $fieldList;
+
+    /**
+     * @var FieldsWithUniqueIdentifier&MockObject
+     */
+    private MockObject $fieldsWithUniqueIdentifier;
 
     protected function setUp(): void
     {
-        $this->model             = $this->createMock(LeadModel::class);
-        $this->repository        = $this->createMock(LeadRepository::class);
-        $this->connection        = $this->createMock(Connection::class);
-        $this->fieldModel        = $this->createMock(FieldModel::class);
-        $this->doNotContactModel = $this->createMock(DoNotContact::class);
+        $this->model                      = $this->createMock(LeadModel::class);
+        $this->repository                 = $this->createMock(LeadRepository::class);
+        $this->connection                 = $this->createMock(Connection::class);
+        $this->doNotContactModel          = $this->createMock(DoNotContact::class);
+        $this->fieldList                  = $this->createMock(FieldList::class);
+        $this->fieldsWithUniqueIdentifier = $this->createMock(FieldsWithUniqueIdentifier::class);
 
-        $this->fieldModel->method('getFieldList')
+        $this->fieldList->method('getFieldList')
             ->willReturn(
                 [
                     'email'   => [],
@@ -66,7 +73,7 @@ class ContactObjectHelperTest extends TestCase
                 ]
             );
 
-        $this->fieldModel->method('getUniqueIdentifierFields')
+        $this->fieldsWithUniqueIdentifier->method('getFieldsWithUniqueIdentifier')
             ->with(['object' => Contact::NAME])
             ->willReturn(
                 [
@@ -347,12 +354,9 @@ class ContactObjectHelperTest extends TestCase
         $this->getObjectHelper()->setFieldValues($contact);
     }
 
-    /**
-     * @return ContactObjectHelper
-     */
-    private function getObjectHelper()
+    private function getObjectHelper(): ContactObjectHelper
     {
-        return new ContactObjectHelper($this->model, $this->repository, $this->connection, $this->fieldModel, $this->doNotContactModel);
+        return new ContactObjectHelper($this->model, $this->repository, $this->connection, $this->doNotContactModel, $this->fieldList, $this->fieldsWithUniqueIdentifier);
     }
 
     private function assertManipulator(Lead $lead, string $objectName): void
@@ -368,7 +372,7 @@ class ContactObjectHelperTest extends TestCase
      */
     private function getObject(int $mappedId, array $fieldValues): ObjectChangeDAO
     {
-        $object = new ObjectChangeDAO('Test', Contact::NAME, null, 'MappedObject', $mappedId, new DateTime());
+        $object = new ObjectChangeDAO('Test', Contact::NAME, null, 'MappedObject', $mappedId, new \DateTime());
 
         foreach ($fieldValues as $name => $value) {
             $object->addField(


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | /
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

I found that duplicate contacts were getting created when running the sync command. The integration plugin syncs with Lead Gen forms. Each submission comes over as a mapped object ID. If the same person submitted multiple times within the same sync timeframe, the same contact would be in the batch multiple times but mapped to different form lead gen IDs. 

I traced this down to each integration object with mapped fields look to see if the object exists by unique identifiers and separated into found and not found. If the internal object has multiple mappings to different integration objects in the same batch, none of the objects are found in ACS and so each is created as a new object in ACS leading to duplicate contacts or companies.

This PR addresses this by creating keys based on unique identifier mapped values and re-using entities if matching keys are found before creating a new one. 

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
I'm not sure how to reproduce this is in other integrations and the LinkedIn one is not something that can be easily testable by anyone due to needing super admin access on Acquia's production LinkedIn company account. 

Maybe it can be replicated by creating duplicate leads in SF (if SF code doesn't account for this) and see if they create duplicates in ACS. 

#### Steps to test this PR:
Other integration syncs should be tested to ensure they still sync as expected. 

#### Other areas of Mautic that may be affected by the change:
1. Other integrations could be affected during syncing. 


[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The unit tests include mocks for multiple contacts and companies with matching unique identifiers but mapped to different integration objects to ensure that duplicates are not created. It also includes tests for scenarios where a unique identifier is not found at all to prevent mass merging. I'm also testing with LinkedIn to demo the background sync to LinkedIn for sign-off on the plugin. I can post a video of it working after I test this in development and record. 