### PR TITLE
fix: avoid page reload on Remote Asset Browser

### DIFF
--- a/app/bundles/AssetBundle/Resources/views/Remote/browse.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Remote/browse.html.twig
@@ -29,7 +29,7 @@
                 <ul class="list-group list-group-tabs">
                     {% for integration in integrations %}
                         <li class="list-group-item{% if loop.index0 is same as(0) %} active{% endif %}" id="tab{{ integration.getName() }}">
-                            <a href="#" class="steps" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}');">
+                            <a href="javascript: void(0);" class="steps" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}');">
                                 {{ integration.getDisplayName() }}
                             </a>
                         </li>

--- a/app/bundles/AssetBundle/Resources/views/Remote/list.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Remote/list.html.twig
@@ -6,23 +6,23 @@
             <div class="list-group remote-file-list">
                 {% if items.dirs is defined %}
                     {% for item in items.dirs %}
-                        <a class="list-group-item" href="#" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}', '/{{ item|trim('/','right') }}');">
+                        <a class="list-group-item" href="javascript: void(0);" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}', '/{{ item|trim('/','right') }}');">
                             {{ item }}
                         </a>
                     {% endfor %}
                     {% for item in items.keys %}
-                        <a class="list-group-item" href="#" onclick="Mautic.selectRemoteFile('{{ integration.getPublicUrl(item) }}');">
+                        <a class="list-group-item" href="javascript: void(0);" onclick="Mautic.selectRemoteFile('{{ integration.getPublicUrl(item) }}');">
                             {{ item }}
                         </a>
                     {% endfor %}
                 {% else %}
                     {% for item in items %}
                         {% if connector.getAdapter().isDirectory(item) %}
-                            <a class="list-group-item" href="#" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}', '/{{ item|trim('/', 'right') }}');">
+                            <a class="list-group-item" href="javascript: void(0);" onclick="Mautic.updateRemoteBrowser('{{ integration.getName() }}', '/{{ item|trim('/', 'right') }}');">
                                 {{ item }}
                             </a>
                         {% else %}
-                            <a class="list-group-item" href="#" onclick="Mautic.selectRemoteFile('{{ integration.getPublicUrl(item) }}');">
+                            <a class="list-group-item" href="javascript: void(0);" onclick="Mautic.selectRemoteFile('{{ integration.getPublicUrl(item) }}');">
                                 {{ item }}
                             </a>
                         {% endif %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13091  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Closes issue https://github.com/mautic/mautic/issues/13091

Clicking the "Amazon S3" under Browse Remote Files causes a page refresh, along with any subsequent file selection. This is because the user clicks on a `<a href="#" onclick="Mautic.updateRemoteBrowser(...)">` element without any `event.preventDefault()`. Anchor elements with an onclick handler will refresh the page even though the `href` attribute is `"#"`.

<img width="947" alt="Screenshot 2024-02-22 at 10 20 38 AM" src="https://github.com/mautic/mautic/assets/12927717/c647f853-8f57-4e39-94b0-1506cf265b00">

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to the Plugins page, configure S3 and publish it
3. Navigate to Components > Assets > New
4. Under **Storage Location**, select **Remote** and then click **Browse Remote Files**
5. In the modal, select **Amazon S3**
6. (page should not refresh)
7. Select a file
8. (page should not refresh)
