### PR TITLE
Range processing of webhooks

### DIFF
--- a/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
+++ b/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
@@ -32,6 +32,20 @@ class ProcessWebhookQueuesCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 'Process payload for a specific webhook.  If not specified, all webhooks will be processed.',
                 null
+            )
+            ->addOption(
+                '--min-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Sets the minimum webhook queue ID to process (so called range mode).',
+                null
+            )
+            ->addOption(
+                '--max-id',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Sets the maximum webhook queue ID to process (so called range mode).',
+                null
             );
     }
 
@@ -44,11 +58,14 @@ class ProcessWebhookQueuesCommand extends Command
             return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
-        $id = $input->getOption('webhook-id');
+        $id    = $input->getOption('webhook-id');
+        $minId = (int) $input->getOption('min-id');
+        $maxId = (int) $input->getOption('max-id');
 
         if ($id) {
-            $webhook  = $this->webhookModel->getEntity($id);
-            $webhooks = (null !== $webhook && $webhook->isPublished()) ? [$id => $webhook] : [];
+            $webhook        = $this->webhookModel->getEntity($id);
+            $webhooks       = (null !== $webhook && $webhook->isPublished()) ? [$id => $webhook] : [];
+            $queueRangeMode = $minId && $maxId;
         } else {
             // make sure we only get published webhook entities
             $webhooks = $this->webhookModel->getEntities(
@@ -75,7 +92,23 @@ class ProcessWebhookQueuesCommand extends Command
         $output->writeLn('<info>Processing Webhooks</info>');
 
         try {
-            $this->webhookModel->processWebhooks($webhooks);
+            if ($queueRangeMode) {
+                $webhookLimit = $this->webhookModel->getWebhookLimit();
+
+                if (1 > $webhookLimit) {
+                    throw new \InvalidArgumentException('`webhook limit` parameter must be greater than zero.');
+                }
+
+                for (; $minId <= $maxId; $minId += $webhookLimit) {
+                    $this->webhookModel
+                        ->setMinQueueId($minId)
+                        ->setMaxQueueId(min($minId + $webhookLimit - 1, $maxId));
+
+                    $this->webhookModel->processWebhook(current($webhooks));
+                }
+            } else {
+                $this->webhookModel->processWebhooks($webhooks);
+            }
         } catch (\Exception $e) {
             $output->writeLn('<error>'.$e->getMessage().'</error>');
             $output->writeLn('<error>'.$e->getTraceAsString().'</error>');

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -633,6 +633,11 @@ class WebhookModel extends FormModel
         return 'webhook:webhooks';
     }
 
+    public function getWebhookLimit(): int
+    {
+        return $this->webhookLimit;
+    }
+
     public function setMinQueueId(int $minQueueId): self
     {
         $this->minQueueId = $minQueueId;

--- a/app/bundles/WebhookBundle/Tests/Functional/Command/ProcessWebhookQueuesCommandTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Command/ProcessWebhookQueuesCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\WebhookBundle\Tests\Functional\Command;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\WebhookBundle\Command\ProcessWebhookQueuesCommand;
+use Mautic\WebhookBundle\Entity\Event;
+use Mautic\WebhookBundle\Entity\Log;
+use Mautic\WebhookBundle\Entity\Webhook;
+use Mautic\WebhookBundle\Entity\WebhookQueue;
+use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Assert;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+final class ProcessWebhookQueuesCommandTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['queue_mode']    = WebhookModel::COMMAND_PROCESS;
+        $this->configParams['webhook_limit'] = 3;
+
+        parent::setUp();
+    }
+
+    public function testCommand(): void
+    {
+        $webhook      = $this->createWebhook('test', 'http://domain.tld', 'secret');
+        $event        = $this->createWebhookEvent($webhook, 'Type');
+        $handlerStack = static::getContainer()->get(MockHandler::class);
+        $queueIds     = [];
+
+        // Generate 10 queue records.
+        for ($i = 1; $i <= 10; ++$i) {
+            $addedLog = $this->createWebhookQueue($webhook, $event, "Some payload {$i}");
+            array_push($queueIds, $addedLog->getId());
+
+            $handlerStack->append(
+                function (RequestInterface $request) {
+                    Assert::assertSame('POST', $request->getMethod());
+                    Assert::assertSame('http://domain.tld', $request->getUri()->__toString());
+
+                    return new Response(SymfonyResponse::HTTP_OK);
+                }
+            );
+        }
+
+        // Process queue records from 4 to 9 including. 6 in total.
+        $output = $this->testSymfonyCommand(
+            ProcessWebhookQueuesCommand::COMMAND_NAME,
+            ['--webhook-id' => $webhook->getId(), '--min-id' => $queueIds[3], '--max-id' => $queueIds[8]]
+        );
+        Assert::assertStringContainsString('Webhook Processing Complete', $output->getDisplay());
+
+        // There will be 2 batches of webhook events sent. We've set we want to send 3 events per batch.
+        Assert::assertCount(2, $this->em->getRepository(Log::class)->findBy(['webhook' => $webhook]));
+
+        // And 4 out of 10 queue records will be left alone as they did not fit the ID range.
+        Assert::assertCount(4, $this->em->getRepository(WebhookQueue::class)->findBy(['webhook' => $webhook]));
+    }
+
+    private function createWebhook(string $name, string $url, string $secret): Webhook
+    {
+        $webhook = new Webhook();
+        $webhook->setName($name);
+        $webhook->setWebhookUrl($url);
+        $webhook->setSecret($secret);
+        $this->em->persist($webhook);
+
+        return $webhook;
+    }
+
+    private function createWebhookEvent(Webhook $webhook, string $type): Event
+    {
+        $event = new Event();
+        $event->setWebhook($webhook);
+        $event->setEventType($type);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createWebhookQueue(Webhook $webhook, Event $event, string $payload): WebhookQueue
+    {
+        $record = new WebhookQueue();
+        $record->setWebhook($webhook);
+        $record->setEvent($event);
+        $record->setPayload($payload);
+        $record->setDateAdded(new \DateTime());
+        $this->em->persist($record);
+        $this->em->flush();
+
+        return $record;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is adding these new options to the `mautic:webhooks:process` command:
- `--min-id` Sets the minimum webhook queue ID to process (so called range mode)
- `--max-id` Sets the maximum webhook queue ID to process (so called range mode)

It is a preparation for parallel processing once we move from cron to worker. The worker will split the work into multiple other jobs by webhook queue ID ranges. That enables parallel processing of the webhook queue.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure a webhook
3. Perform several events that you've sent in the webhook. For example if you've checked the **contact updated** event, update a bunch of contacts. That will create a bunch of records in the `webhook_queue` table.
4. Execute `bin/console mautic:webhooks:process --webhook-id=ID --min-id=5 --max-id=20`. Replace the `ID` with the actual webhook ID that you've created. And update the webhook queue range to whatever you have in your webhook_queue table.

Notice that the command processes only the webhook queue records from the ID range you've selected in the command. It won't touch others as that would cause an issue when multiple processes would be sending the same webhooks at the same time.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
