### PR TITLE
IntegrationBundle bug fixes

### DIFF
--- a/app/bundles/CampaignBundle/Entity/FailedLeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/FailedLeadEventLogRepository.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity;
 
+use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
@@ -9,4 +10,20 @@ use Mautic\CoreBundle\Entity\CommonRepository;
  */
 class FailedLeadEventLogRepository extends CommonRepository
 {
+    /**
+     * @param array<string|int> $ids
+     */
+    public function deleteByIds(array $ids): void
+    {
+        if (!$ids) {
+            return;
+        }
+
+        $this->_em->getConnection()
+            ->createQueryBuilder()
+            ->delete(MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log')
+            ->where('log_id IN (:ids)')
+            ->setParameter('ids', $ids, Connection::PARAM_STR_ARRAY)
+            ->execute();
+    }
 }

--- a/app/bundles/CampaignBundle/Entity/FailedLeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/FailedLeadEventLogRepository.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ArrayParameterType;
 use Mautic\CoreBundle\Entity\CommonRepository;
 
 /**
@@ -23,7 +23,7 @@ class FailedLeadEventLogRepository extends CommonRepository
             ->createQueryBuilder()
             ->delete(MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log')
             ->where('log_id IN (:ids)')
-            ->setParameter('ids', $ids, Connection::PARAM_STR_ARRAY)
-            ->execute();
+            ->setParameter('ids', $ids, ArrayParameterType::STRING)
+            ->executeStatement();
     }
 }

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
@@ -12,11 +12,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CampaignEventLogCleanupSubscriber implements EventSubscriberInterface
 {
-    private FailedLeadEventLogRepository $failedLeadEventLogRepository;
-
-    public function __construct(FailedLeadEventLogRepository $failedLeadEventLogRepository)
+    public function __construct(private FailedLeadEventLogRepository $failedLeadEventLogRepository)
     {
-        $this->failedLeadEventLogRepository = $failedLeadEventLogRepository;
     }
 
     public static function getSubscribedEvents(): array

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
@@ -10,7 +10,7 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\ExecutedBatchEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignEventLogCleanupSubscriber implements EventSubscriberInterface
+final class CampaignEventLogCleanupSubscriber implements EventSubscriberInterface
 {
     public function __construct(private FailedLeadEventLogRepository $failedLeadEventLogRepository)
     {

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventLogCleanupSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\EventListener;
+
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Entity\FailedLeadEventLogRepository;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Event\ExecutedBatchEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CampaignEventLogCleanupSubscriber implements EventSubscriberInterface
+{
+    private FailedLeadEventLogRepository $failedLeadEventLogRepository;
+
+    public function __construct(FailedLeadEventLogRepository $failedLeadEventLogRepository)
+    {
+        $this->failedLeadEventLogRepository = $failedLeadEventLogRepository;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CampaignEvents::ON_EVENT_EXECUTED_BATCH => ['onEventBatchExecuted', -100],
+        ];
+    }
+
+    /**
+     * Deletes failed log entries for all successful event logs.
+     */
+    public function onEventBatchExecuted(ExecutedBatchEvent $event): void
+    {
+        $ids = $event->getExecuted()
+            ->map(fn (LeadEventLog $eventLog) => $eventLog->getId())
+            ->getValues();
+
+        if (!$ids) {
+            return;
+        }
+
+        $this->failedLeadEventLogRepository->deleteByIds($ids);
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/ArrayTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/ArrayTypeTest.php
@@ -102,6 +102,27 @@ class ArrayTypeTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testGivenObjectWithPrivatePropertyWhenConvertsToDatabaseValue(): void
+    {
+        $value = [
+            'fields' => [
+                'field_account_executive_o' => [
+                    null,
+                    new \Mautic\IntegrationsBundle\Sync\DAO\Value\ReferenceValueDAO(),
+                ],
+            ],
+            'dateModified' => [
+                '2022-05-02T21:39:27+00:00',
+                '2022-05-03T14:22:33+00:00',
+            ],
+        ];
+
+        $serialized   = $this->arrayType->convertToDatabaseValue($value, $this->platform);
+        $unserialized = $this->arrayType->convertToPHPValue($serialized, $this->platform);
+
+        $this->assertEquals($value, $unserialized);
+    }
+
     public function testGivenObjectWithPrivatePropertyWhenConvertsToPHPValueThenGetsArrayWithoutObject(): void
     {
         $array = [

--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -217,7 +217,7 @@ class FormSubscriber implements EventSubscriberInterface
             $matchedFields[$key] = $field['alias'];
 
             // decode html chars and quotes before posting to next form
-            $payload[$key]       = htmlspecialchars_decode($value, ENT_QUOTES);
+            $payload[$key]       = html_entity_decode(htmlspecialchars_decode($value, ENT_QUOTES), ENT_QUOTES);
         }
 
         $event->setPostSubmitPayload($payload);

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -54,8 +54,9 @@ class FormSubscriberTest extends TestCase
     public function testOnFormSubmitActionRepost(): void
     {
         $postData = [
-            'first_name' => "Test's Name",
-            'notes'      => 'A & B < dy >',
+            'first_name' => "Test's Name un être> and être",
+            'notes'      => 'A & B < dy >
+New line',
             'formId'     => '1',
             'return'     => '',
             'formName'   => 'form190122',
@@ -63,8 +64,8 @@ class FormSubscriberTest extends TestCase
         ];
 
         $resultData = [
-            'first_name' => 'Test&#39;s Name',
-            'notes'      => 'A &#38; B &#60; dy &#62;',
+            'first_name' => 'Test&#39;s Name un &ecirc;tre&gt; and être',
+            'notes'      => 'A &#38; B &#60; dy &#62;&#10;New line',
         ];
 
         $request         = new Request();

--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -287,6 +287,7 @@ return [
                     'mautic.integrations.sync.notification.handler_container',
                     'mautic.integrations.helper.sync_integrations',
                     'mautic.integrations.helper.config_integrations',
+                    'translator',
                 ],
             ],
             'mautic.integrations.sync.notification.writer' => [

--- a/app/bundles/IntegrationsBundle/Config/config.php
+++ b/app/bundles/IntegrationsBundle/Config/config.php
@@ -212,6 +212,7 @@ return [
                     'mautic.integrations.sync.data_exchange.mautic.full_object_report_builder',
                     'mautic.integrations.sync.data_exchange.mautic.partial_object_report_builder',
                     'mautic.integrations.sync.data_exchange.mautic.order_executioner',
+                    'mautic.integrations.helper.sync_date',
                 ],
             ],
             'mautic.integrations.sync.integration_process.object_change_generator' => [

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -111,12 +111,10 @@ class ConfigController extends AbstractFormController
         $oldApiKeys        = $this->integrationConfiguration->getApiKeys();
 
         // Submit the form
-        $form->handleRequest($this->request);
+        $form->handleRequest($request);
 
-        $eventDispatcher = $this->get('event_dispatcher');
-        \assert($eventDispatcher instanceof EventDispatcherInterface);
-        $configEvent     = new KeysSaveEvent($this->integrationConfiguration, $oldApiKeys);
-        $eventDispatcher->dispatch(IntegrationEvents::INTEGRATION_API_KEYS_BEFORE_SAVE, $configEvent);
+        $configEvent = new KeysSaveEvent($this->integrationConfiguration, $oldApiKeys);
+        $this->dispatcher->dispatch($configEvent, IntegrationEvents::INTEGRATION_API_KEYS_BEFORE_SAVE);
 
         if ($this->integrationObject instanceof ConfigFormSyncInterface) {
             $integration   = $this->integrationObject->getName();

--- a/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
@@ -39,7 +39,7 @@ class FieldChangeRepository extends CommonRepository
     /**
      * Takes an object id & type and deletes all entities that match.
      */
-    public function deleteEntitiesForObject(int $objectId, string $objectType, ?string $integration = null): void
+    public function deleteEntitiesForObject(int $objectId, string $objectType, ?string $integration = null, \DateTimeInterface $toDateTime = null): void
     {
         $qb = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
@@ -51,8 +51,13 @@ class FieldChangeRepository extends CommonRepository
             $qb->setParameter('integration', $integration);
         }
 
+        if (null !== $toDateTime) {
+            $expr = $expr->with($qb->expr()->lte('modified_at', ':toDateTime'));
+            $qb->setParameter('toDateTime', $toDateTime->format('Y-m-d H:i:s'));
+        }
+
         $qb->setParameter('objectType', $objectType)
-            ->setParameter('objectId', (int) $objectId);
+            ->setParameter('objectId', $objectId);
 
         $qb
             ->delete(MAUTIC_TABLE_PREFIX.'sync_object_field_change_report')

--- a/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/FieldChangeRepository.php
@@ -121,7 +121,9 @@ class FieldChangeRepository extends CommonRepository
             )
             ->setParameter('integration', $integration)
             ->setParameter('objectType', $objectType)
-            ->orderBy('f.modified_at'); // Newer updated fields must override older updated fields
+            // 1. We must sort by f.object_id. Otherwise values stored in PartialObjectReportBuilder::lastProcessedTrackedId will be incorrect.
+            // 2. Newer updated fields must override older updated fields
+            ->orderBy('f.object_id, f.modified_at', 'ASC');
 
         return $qb->executeQuery()->fetchAllAssociative();
     }

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
@@ -68,6 +68,7 @@ class ObjectMapping
             ->setCustomRepositoryClass(ObjectMappingRepository::class)
             ->addIndex(['integration', 'integration_object_name', 'integration_object_id', 'integration_reference_id'], 'integration_object')
             ->addIndex(['integration', 'integration_object_name', 'integration_reference_id', 'integration_object_id'], 'integration_reference')
+            ->addIndex(['integration', 'internal_object_name', 'last_sync_date'], 'integration_integration_object_name_last_sync_date')
             ->addIndex(['integration', 'last_sync_date'], 'integration_last_sync_date');
 
         $builder->addId();

--- a/app/bundles/IntegrationsBundle/Event/KeysSaveEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/KeysSaveEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\Event;
+
+use Mautic\PluginBundle\Entity\Integration;
+use Symfony\Component\EventDispatcher\Event;
+
+class KeysSaveEvent extends Event
+{
+    private Integration $integrationConfiguration;
+
+    /**
+     * @var array<mixed>
+     */
+    private array $oldKeys;
+
+    /**
+     * @var array<mixed>
+     */
+    private array $newKeys;
+
+    /**
+     * @param array<mixed> $keys
+     */
+    public function __construct(Integration $integrationConfiguration, array $keys)
+    {
+        $this->integrationConfiguration = $integrationConfiguration;
+        $this->oldKeys                  = $keys;
+        $this->newKeys                  = $integrationConfiguration->getApiKeys();
+    }
+
+    public function getIntegrationConfiguration(): Integration
+    {
+        return $this->integrationConfiguration;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getOldKeys(): array
+    {
+        return $this->oldKeys;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getNewKeys(): array
+    {
+        return $this->newKeys;
+    }
+}

--- a/app/bundles/IntegrationsBundle/Event/KeysSaveEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/KeysSaveEvent.php
@@ -5,30 +5,21 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Event;
 
 use Mautic\PluginBundle\Entity\Integration;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class KeysSaveEvent extends Event
+final class KeysSaveEvent extends Event
 {
-    private Integration $integrationConfiguration;
-
     /**
-     * @var array<mixed>
-     */
-    private array $oldKeys;
-
-    /**
-     * @var array<mixed>
+     * @var array<string,string>
      */
     private array $newKeys;
 
     /**
-     * @param array<mixed> $keys
+     * @param array<string,string> $oldKeys
      */
-    public function __construct(Integration $integrationConfiguration, array $keys)
+    public function __construct(private Integration $integrationConfiguration, private array $oldKeys)
     {
-        $this->integrationConfiguration = $integrationConfiguration;
-        $this->oldKeys                  = $keys;
-        $this->newKeys                  = $integrationConfiguration->getApiKeys();
+        $this->newKeys = $integrationConfiguration->getApiKeys();
     }
 
     public function getIntegrationConfiguration(): Integration
@@ -37,7 +28,7 @@ class KeysSaveEvent extends Event
     }
 
     /**
-     * @return array<mixed>
+     * @return array<string,string>
      */
     public function getOldKeys(): array
     {
@@ -45,7 +36,7 @@ class KeysSaveEvent extends Event
     }
 
     /**
-     * @return array<mixed>
+     * @return array<string,string>
      */
     public function getNewKeys(): array
     {

--- a/app/bundles/IntegrationsBundle/IntegrationEvents.php
+++ b/app/bundles/IntegrationsBundle/IntegrationEvents.php
@@ -205,4 +205,13 @@ final class IntegrationEvents
      * @var string
      */
     public const INTEGRATION_BATCH_SYNC_COMPLETED_MAUTIC_TO_INTEGRATION = 'mautic.integration.INTEGRATION_BATCH_SYNC_COMPLETED_MAUTIC_TO_INTEGRATION';
+
+    /**
+     * This event is dispatched when api keys is updated/inserted.
+     *
+     * The event listener receives a Mautic\IntegrationsBundle\Event\KeysSaveEvent instance.
+     *
+     * @var string
+     */
+    public const INTEGRATION_API_KEYS_BEFORE_SAVE = 'mautic.integration.INTEGRATION_API_KEYS_BEFORE_SAVE';
 }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
@@ -70,6 +70,9 @@ class ObjectIdsDAO
         return $this->objects[$objectType];
     }
 
+    /**
+     * @return string[]
+     */
     public function getObjectTypes(): array
     {
         return array_keys($this->objects);

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
@@ -69,4 +69,9 @@ class ObjectIdsDAO
 
         return $this->objects[$objectType];
     }
+
+    public function getObjectTypes(): array
+    {
+        return array_keys($this->objects);
+    }
 }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
@@ -180,12 +180,6 @@ class ObjectChangeDAO
         return $this;
     }
 
-    public function removeField(string $field): void
-    {
-        unset($this->fields[$field]);
-        unset($this->fieldsByState[ReportFieldDAO::FIELD_CHANGED][$field]);
-    }
-
     public function setObjectMapping(ObjectMapping $objectMapping): void
     {
         $this->objectMapping = $objectMapping;

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
@@ -180,6 +180,12 @@ class ObjectChangeDAO
         return $this;
     }
 
+    public function removeField(string $field): void
+    {
+        unset($this->fields[$field]);
+        unset($this->fieldsByState[ReportFieldDAO::FIELD_CHANGED][$field]);
+    }
+
     public function setObjectMapping(ObjectMapping $objectMapping): void
     {
         $this->objectMapping = $objectMapping;

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Request/ObjectDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Request/ObjectDAO.php
@@ -27,6 +27,9 @@ class ObjectDAO
          * Date/Time the sync started.
          */
         private ?\DateTimeInterface $toDateTime = null,
+        /**
+         * @deprecated Not used. To be removed in Mautic 6. Use SyncDateHelper instead
+         */
         private ?\DateTimeInterface $objectLastSyncDateTime = null
     ) {
     }
@@ -77,6 +80,9 @@ class ObjectDAO
         return $this->toDateTime;
     }
 
+    /**
+     * @deprecated Not used. To be removed in Mautic 6. Use SyncDateHelper instead
+     */
     public function getObjectLastSyncDateTime(): ?\DateTimeInterface
     {
         return $this->objectLastSyncDateTime;

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Value/ReferenceValueDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Value/ReferenceValueDAO.php
@@ -34,4 +34,20 @@ class ReferenceValueDAO implements \Stringable
     {
         return (string) $this->value;
     }
+
+    /** @return array<string, mixed> */
+    public function __serialize(): array
+    {
+        return [
+            'value' => $this->value,
+            'types' => $this->type,
+        ];
+    }
+
+    /** @param array<string, mixed> $data */
+    public function __unserialize(array $data): void
+    {
+        $this->value = $data['value'] ?? null;
+        $this->type  = $data['type'] ?? null;
+    }
 }

--- a/app/bundles/IntegrationsBundle/Sync/Helper/SyncDateHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Helper/SyncDateHelper.php
@@ -20,7 +20,7 @@ class SyncDateHelper
      */
     private array $lastObjectSyncDates = [];
 
-    private ?\DateTimeInterface $internalSyncStartDateTime;
+    private ?\DateTimeInterface $internalSyncStartDateTime = null;
 
     public function __construct(
         private Connection $connection
@@ -61,7 +61,7 @@ class SyncDateHelper
         return $this->lastObjectSyncDates[$key];
     }
 
-    public function getSyncToDateTime(): \DateTimeInterface
+    public function getSyncToDateTime(): ?\DateTimeInterface
     {
         if ($this->syncToDateTime) {
             return $this->syncToDateTime;
@@ -139,7 +139,9 @@ class SyncDateHelper
         $syncToDateTime = clone $this->getSyncToDateTime();
 
         // We should compare in UTC timezone
-        $syncToDateTime->setTimezone(new \DateTimeZone('UTC'));
+        if (method_exists($syncToDateTime, 'setTimezone')) {
+            $syncToDateTime->setTimezone(new \DateTimeZone('UTC'));
+        }
 
         // If syncToDate is less than now then use syncToDate, because otherwise we may delete
         // changes that aren't supposed to be deleted from the sync_object_field_change_report table

--- a/app/bundles/IntegrationsBundle/Sync/Helper/SyncDateHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Helper/SyncDateHelper.php
@@ -20,6 +20,8 @@ class SyncDateHelper
      */
     private array $lastObjectSyncDates = [];
 
+    private ?\DateTimeInterface $internalSyncStartDateTime;
+
     public function __construct(
         private Connection $connection
     ) {
@@ -109,5 +111,38 @@ class SyncDateHelper
         }
 
         return $lastSync;
+    }
+
+    public function getInternalSyncStartDateTime(): ?\DateTimeInterface
+    {
+        return $this->internalSyncStartDateTime;
+    }
+
+    public function setInternalSyncStartDateTime(): void
+    {
+        if ($this->internalSyncStartDateTime) {
+            return;
+        }
+
+        $this->internalSyncStartDateTime = $this->calculateInternalSyncStartDateTime();
+    }
+
+    private function calculateInternalSyncStartDateTime(): \DateTimeInterface
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        // If there is no syncToDateTime value use "now"
+        if (!$this->getSyncToDateTime()) {
+            return $now;
+        }
+
+        // Clone it so that we don't modify the initial object
+        $syncToDateTime = clone $this->getSyncToDateTime();
+
+        // We should compare in UTC timezone
+        $syncToDateTime->setTimezone(new \DateTimeZone('UTC'));
+
+        // If syncToDate is less than now then use syncToDate, because otherwise we may delete
+        // changes that aren't supposed to be deleted from the sync_object_field_change_report table
+        return min($now, $syncToDateTime);
     }
 }

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
@@ -53,7 +53,7 @@ class Notifier
         }
     }
 
-    private function getObjectDisplayName(string $integration, string $object)
+    private function getObjectDisplayName(string $integration, string $object): string
     {
         try {
             $configIntegration = $this->configIntegrationsHelper->getIntegration($integration);

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
@@ -12,13 +12,15 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\NotificationDAO;
 use Mautic\IntegrationsBundle\Sync\Exception\HandlerNotSupportedException;
 use Mautic\IntegrationsBundle\Sync\Notification\Handler\HandlerContainer;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Notifier
 {
     public function __construct(
         private HandlerContainer $handlerContainer,
         private SyncIntegrationsHelper $syncIntegrationsHelper,
-        private ConfigIntegrationsHelper $configIntegrationsHelper
+        private ConfigIntegrationsHelper $configIntegrationsHelper,
+        private TranslatorInterface $translator
     ) {
     }
 
@@ -51,9 +53,6 @@ class Notifier
         }
     }
 
-    /**
-     * @return string
-     */
     private function getObjectDisplayName(string $integration, string $object)
     {
         try {
@@ -72,6 +71,6 @@ class Notifier
             return ucfirst($object);
         }
 
-        return $objects[$object];
+        return $this->translator->trans($objects[$object]);
     }
 }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolver.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolver.php
@@ -9,9 +9,11 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\ReferenceValueDAO;
+use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\Exception\ReferenceNotFoundException;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
+use MauticPlugin\SalesforceBundle\Integration\Salesforce2Integration;
 
 final class ReferenceResolver implements ReferenceResolverInterface
 {
@@ -26,7 +28,16 @@ final class ReferenceResolver implements ReferenceResolverInterface
     public function resolveReferences(string $objectName, array $changedObjects): void
     {
         if (Contact::NAME !== $objectName) {
-            // references are currently resolved only for contacts
+            DebugLogger::log(
+                Salesforce2Integration::NAME,
+                sprintf(
+                    'references are currently resolved only for %s. Given %s',
+                    Contact::NAME,
+                    $objectName
+                ),
+                __CLASS__.':'.__FUNCTION__
+            );
+
             return;
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolver.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolver.php
@@ -13,7 +13,6 @@ use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\Exception\ReferenceNotFoundException;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
-use MauticPlugin\SalesforceBundle\Integration\Salesforce2Integration;
 
 final class ReferenceResolver implements ReferenceResolverInterface
 {
@@ -29,7 +28,7 @@ final class ReferenceResolver implements ReferenceResolverInterface
     {
         if (Contact::NAME !== $objectName) {
             DebugLogger::log(
-                Salesforce2Integration::NAME,
+                'N/A',
                 sprintf(
                     'references are currently resolved only for %s. Given %s',
                     Contact::NAME,

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilder.php
@@ -35,7 +35,7 @@ class FullObjectReportBuilder
 
     public function buildReport(RequestDAO $requestDAO): ReportDAO
     {
-        $syncReport       = new ReportDAO(MauticSyncDataExchange::NAME);
+        $syncReport       = new ReportDAO($requestDAO->getSyncToIntegration());
         $requestedObjects = $requestDAO->getObjects();
         $limit            = 200;
         $start            = $limit * ($requestDAO->getSyncIteration() - 1);
@@ -43,7 +43,7 @@ class FullObjectReportBuilder
         foreach ($requestedObjects as $requestedObjectDAO) {
             try {
                 DebugLogger::log(
-                    MauticSyncDataExchange::NAME,
+                    $requestDAO->getSyncToIntegration(),
                     sprintf(
                         'Searching for %s objects between %s and %s (%d,%d)',
                         $requestedObjectDAO->getObject(),
@@ -110,7 +110,7 @@ class FullObjectReportBuilder
                 !empty($object['date_modified']) ? $object['date_modified'] : $object['date_added'],
                 new \DateTimeZone('UTC')
             );
-            $reportObjectDAO  = new ReportObjectDAO($requestedObjectDAO->getObject(), $object['id'], $modifiedDateTime);
+            $reportObjectDAO = new ReportObjectDAO($requestedObjectDAO->getObject(), $object['id'], $modifiedDateTime);
             $syncReport->addObject($reportObjectDAO);
 
             if (isset($event)) {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
@@ -17,7 +17,6 @@ use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
-use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class PartialObjectReportBuilder
@@ -27,15 +26,9 @@ class PartialObjectReportBuilder
      */
     private $reportObjects = [];
 
-    /**
-     * @var array
-     */
-    private $lastProcessedTrackedId = [];
+    private array $lastProcessedTrackedId = [];
 
-    /**
-     * @var array
-     */
-    private $objectsWithMissingFields = [];
+    private array $objectsWithMissingFields = [];
 
     private ?\Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO $syncReport = null;
 
@@ -50,7 +43,7 @@ class PartialObjectReportBuilder
 
     public function buildReport(RequestDAO $requestDAO): ReportDAO
     {
-        $this->syncReport = new ReportDAO(MauticSyncDataExchange::NAME);
+        $this->syncReport = new ReportDAO($requestDAO->getSyncToIntegration());
         $requestedObjects = $requestDAO->getObjects();
 
         foreach ($requestedObjects as $objectDAO) {
@@ -77,14 +70,14 @@ class PartialObjectReportBuilder
                 } catch (ObjectNotFoundException $exception) {
                     // Process the others
                     DebugLogger::log(
-                        MauticSyncDataExchange::NAME,
+                        $requestDAO->getSyncToIntegration(),
                         $exception->getMessage(),
                         self::class.':'.__FUNCTION__
                     );
                 }
             } catch (ObjectNotFoundException $exception) {
                 DebugLogger::log(
-                    MauticSyncDataExchange::NAME,
+                    $requestDAO->getSyncToIntegration(),
                     $exception->getMessage(),
                     self::class.':'.__FUNCTION__
                 );
@@ -189,7 +182,7 @@ class PartialObjectReportBuilder
                 } catch (FieldNotFoundException $exception) {
                     // Field is not supported so keep going
                     DebugLogger::log(
-                        MauticSyncDataExchange::NAME,
+                        $this->syncReport->getIntegration(),
                         $exception->getMessage(),
                         self::class.':'.__FUNCTION__
                     );

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/MauticSyncDataExchange.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/MauticSyncDataExchange.php
@@ -16,6 +16,7 @@ use Mautic\IntegrationsBundle\Sync\Exception\ObjectDeletedException;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotSupportedException;
 use Mautic\IntegrationsBundle\Sync\Helper\MappingHelper;
+use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
 use Mautic\IntegrationsBundle\Sync\Logger\DebugLogger;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\OrderExecutioner;
@@ -36,7 +37,8 @@ class MauticSyncDataExchange implements SyncDataExchangeInterface
         private MappingHelper $mappingHelper,
         private FullObjectReportBuilder $fullObjectReportBuilder,
         private PartialObjectReportBuilder $partialObjectReportBuilder,
-        private OrderExecutioner $orderExecutioner
+        private OrderExecutioner $orderExecutioner,
+        private SyncDateHelper $syncDateHelper
     ) {
     }
 
@@ -95,7 +97,12 @@ class MauticSyncDataExchange implements SyncDataExchangeInterface
                 $object   = $this->fieldHelper->getFieldObjectName($changedObjectDAO->getMappedObject());
                 $objectId = $changedObjectDAO->getMappedObjectId();
 
-                $this->fieldChangeRepository->deleteEntitiesForObject((int) $objectId, $object, $changedObjectDAO->getIntegration());
+                $this->fieldChangeRepository->deleteEntitiesForObject(
+                    (int) $objectId,
+                    $object,
+                    $changedObjectDAO->getIntegration(),
+                    $this->syncDateHelper->getInternalSyncStartDateTime()
+                );
             } catch (ObjectNotSupportedException $exception) {
                 DebugLogger::log(
                     self::NAME,

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcess.php
@@ -56,7 +56,7 @@ class IntegrationSyncProcess
                 $mappedInternalObjectsNames = [];
                 try {
                     $mappedInternalObjectsNames = $this->mappingManualDAO->getMappedInternalObjectsNames($integrationObjectName);
-                } catch (ObjectNotFoundException $e) {
+                } catch (ObjectNotFoundException) {
                 }
 
                 if (1 > count(array_intersect($mauticObjectTypes, $mappedInternalObjectsNames))) {

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcess.php
@@ -89,14 +89,12 @@ class IntegrationSyncProcess
 
             $objectSyncFromDateTime = $this->syncDateHelper->getSyncFromDateTime($this->mappingManualDAO->getIntegration(), $integrationObjectName);
             $objectSyncToDateTime   = $this->syncDateHelper->getSyncToDateTime();
-            $lastObjectSyncDateTime = $this->syncDateHelper->getLastSyncDateForObject($this->mappingManualDAO->getIntegration(), $integrationObjectName);
             DebugLogger::log(
                 $this->mappingManualDAO->getIntegration(),
                 sprintf(
-                    "Integration to Mautic; syncing from %s to %s for the %s object with %d fields but giving the option to sync from the object's last sync date of %s",
+                    'Integration to Mautic; syncing from %s to %s for the %s object with %d fields',
                     $objectSyncFromDateTime->format('Y-m-d H:i:s'),
                     $objectSyncToDateTime->format('Y-m-d H:i:s'),
-                    $lastObjectSyncDateTime ? $lastObjectSyncDateTime->format('Y-m-d H:i:s') : 'null',
                     $integrationObjectName,
                     count($integrationObjectFields)
                 ),
@@ -106,8 +104,7 @@ class IntegrationSyncProcess
             $integrationRequestObject = new RequestObjectDAO(
                 $integrationObjectName,
                 $objectSyncFromDateTime,
-                $objectSyncToDateTime,
-                $lastObjectSyncDateTime
+                $objectSyncToDateTime
             );
 
             foreach ($integrationObjectFields as $integrationObjectField) {

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/MauticSyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/MauticSyncProcess.php
@@ -53,7 +53,7 @@ class MauticSyncProcess
             if ($hasMauticObjectIDs) {
                 try {
                     $internalRequestDAO->getInputOptionsDAO()->getMauticObjectIds()->getObjectIdsFor($internalObjectName);
-                } catch (ObjectNotFoundException $e) {
+                } catch (ObjectNotFoundException) {
                     DebugLogger::log(
                         $this->mappingManualDAO->getIntegration(),
                         sprintf(

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/MauticSyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/MauticSyncProcess.php
@@ -43,10 +43,29 @@ class MauticSyncProcess
      */
     public function getSyncReport(int $syncIteration): ReportDAO
     {
-        $internalRequestDAO = new RequestDAO($this->mappingManualDAO->getIntegration(), $syncIteration, $this->inputOptionsDAO);
+        $internalRequestDAO     = new RequestDAO($this->mappingManualDAO->getIntegration(), $syncIteration, $this->inputOptionsDAO);
+        $mauticObjectTypes      = $internalRequestDAO->getInputOptionsDAO()->getMauticObjectIds() ?
+            $internalRequestDAO->getInputOptionsDAO()->getMauticObjectIds()->getObjectTypes() : [];
+        $hasMauticObjectIDs = 0 < count($mauticObjectTypes);
 
         $internalObjectsNames = $this->mappingManualDAO->getInternalObjectNames();
         foreach ($internalObjectsNames as $internalObjectName) {
+            if ($hasMauticObjectIDs) {
+                try {
+                    $internalRequestDAO->getInputOptionsDAO()->getMauticObjectIds()->getObjectIdsFor($internalObjectName);
+                } catch (ObjectNotFoundException $e) {
+                    DebugLogger::log(
+                        $this->mappingManualDAO->getIntegration(),
+                        sprintf(
+                            'Mautic to integration; skipping sync for the %s object because certain object IDs are specified for other object(s)',
+                            $internalObjectName
+                        ),
+                        __CLASS__.':'.__FUNCTION__
+                    );
+                    continue;
+                }
+            }
+
             $internalObjectFields = $this->mappingManualDAO->getInternalObjectFieldsToSyncToIntegration($internalObjectName);
             if (0 === count($internalObjectFields)) {
                 // No fields configured for a sync

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
@@ -65,6 +65,7 @@ class SyncProcess
         }
 
         if ($this->inputOptionsDAO->pushIsEnabled()) {
+            $this->syncDateHelper->setInternalSyncStartDateTime();
             $this->executeInternalSync();
         }
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\Tests\Functional\Entity;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\IntegrationsBundle\Entity\FieldChange;
+use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+final class FieldChangeRepositoryTest extends MauticMysqlTestCase
+{
+    const INTEGRATION = 'someIntegration';
+    const COLUMN_NAME = 'some_column';
+    const OBJECT_ID   = 100;
+
+    private FieldChangeRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->em->getRepository(FieldChange::class);
+    }
+
+    public function testThatFindChangesBeforeMethodReturnsChangesInCorrectOrder(): void
+    {
+        $fieldChanges = $this->generateFieldChanges(3);
+        $fieldChanges[0]->setObjectId(3);
+        $fieldChanges[1]->setObjectId(1);
+        $fieldChanges[2]->setObjectId(2);
+
+        foreach ($fieldChanges as $fieldChange) {
+            $this->em->persist($fieldChange);
+        }
+
+        $this->em->flush();
+
+        $changes = $this->repository->findChangesBefore(
+            static::INTEGRATION,
+            Lead::class,
+            $this->getNow()->modify('+30 seconds'),
+            null,
+            2
+        );
+
+        Assert::assertSame(1, (int) $changes[0]['object_id']);
+        Assert::assertSame(2, (int) $changes[1]['object_id']);
+    }
+
+    public function testThatItDoesntDeleteObjectsThatCameDuringInternalSynchronization(): void
+    {
+        $now          = $this->getNow();
+        $fieldChanges = $this->generateFieldChanges(2);
+        $aDayLater    = (clone $now)->modify('+1 day'); // Don't use \DateTimeImmutable because entity expects \DateTime
+        $fieldChanges[1]->setModifiedAt($aDayLater);
+
+        foreach ($fieldChanges as $fieldChange) {
+            $this->em->persist($fieldChange);
+        }
+
+        $this->em->flush();
+
+        $this->repository->deleteEntitiesForObject(
+            static::OBJECT_ID,
+            Lead::class,
+            static::INTEGRATION,
+            $now->modify('+30 seconds')
+        );
+
+        $remainingChanges = $this->repository->findAll();
+        Assert::assertCount(1, $remainingChanges);
+        Assert::assertSame($fieldChanges[1]->getId(), $remainingChanges[0]->getId());
+    }
+
+    /**
+     * @return FieldChange[]
+     */
+    private function generateFieldChanges(int $quantity): array
+    {
+        $fieldChanges = [];
+        $now          = $this->getNow();
+        for ($i = 1; $i <= $quantity; ++$i) {
+            $fieldChange = new FieldChange();
+            $fieldChange->setIntegration(static::INTEGRATION);
+            $fieldChange->setObjectId(static::OBJECT_ID);
+            $fieldChange->setObjectType(Lead::class);
+            $fieldChange->setModifiedAt($now);
+            $fieldChange->setColumnName(static::COLUMN_NAME);
+            $fieldChange->setColumnType('string');
+            $fieldChange->setColumnValue((string) $i);
+
+            $fieldChanges[] = $fieldChange;
+        }
+
+        return $fieldChanges;
+    }
+
+    private function getNow(): \DateTime
+    {
+        return new \DateTime('now', new \DateTimeZone('UTC'));
+    }
+}

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
@@ -12,9 +12,9 @@ use PHPUnit\Framework\Assert;
 
 final class FieldChangeRepositoryTest extends MauticMysqlTestCase
 {
-    const INTEGRATION = 'someIntegration';
-    const COLUMN_NAME = 'some_column';
-    const OBJECT_ID   = 100;
+    private const INTEGRATION = 'someIntegration';
+    private const COLUMN_NAME = 'some_column';
+    private const OBJECT_ID   = 100;
 
     private FieldChangeRepository $repository;
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\Tests\Unit\Event;
+
+use Mautic\IntegrationsBundle\Event\KeysSaveEvent;
+use Mautic\PluginBundle\Entity\Integration;
+use PHPUnit\Framework\TestCase;
+
+class KeysSaveEventTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $integration = $this->createMock(Integration::class);
+        $keys        = [
+            'apikey' => 'test',
+        ];
+        $integration->expects(self::once())
+            ->method('getApiKeys')
+            ->willReturn($keys);
+
+        $event       = new KeysSaveEvent($integration, $keys);
+
+        self::assertSame($integration, $event->getIntegrationConfiguration());
+        self::assertSame($keys, $event->getOldKeys());
+        self::assertSame($keys, $event->getNewKeys());
+    }
+}

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
@@ -13,14 +13,12 @@ class KeysSaveEventTest extends TestCase
     public function testGetters(): void
     {
         $integration = $this->createMock(Integration::class);
-        $keys        = [
-            'apikey' => 'test',
-        ];
+        $keys        = ['apikey' => 'test'];
         $integration->expects(self::once())
             ->method('getApiKeys')
             ->willReturn($keys);
 
-        $event       = new KeysSaveEvent($integration, $keys);
+        $event = new KeysSaveEvent($integration, $keys);
 
         self::assertSame($integration, $event->getIntegrationConfiguration());
         self::assertSame($keys, $event->getOldKeys());

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/ObjectChangeDAOTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/DAO/Sync/Order/ObjectChangeDAOTest.php
@@ -36,4 +36,17 @@ class ObjectChangeDAOTest extends TestCase
 
         Assert::assertSame($objectMapping, $objectChangeDAO->getObjectMapping());
     }
+
+    public function testThatFieldCanBeRemoved(): void
+    {
+        $objectChangeDAO = new ObjectChangeDAO('foo', 'bar', 1, 'contact', 1);
+        $value           = new NormalizedValueDAO('type', 1);
+        $field           = new FieldDAO('fieldName', $value);
+
+        Assert::assertCount(0, $objectChangeDAO->getFields());
+        $objectChangeDAO->addField($field);
+        Assert::assertCount(1, $objectChangeDAO->getFields());
+        $objectChangeDAO->removeField('fieldName');
+        Assert::assertCount(0, $objectChangeDAO->getFields());
+    }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\Helper;
 
 use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class SyncDateHelperTest extends TestCase
@@ -28,7 +29,7 @@ class SyncDateHelperTest extends TestCase
 
         $this->syncDateHelper->setSyncDateTimes($syncFromDateTime);
 
-        $this->assertEquals($syncFromDateTime, $this->syncDateHelper->getSyncFromDateTime('Test', 'Object'));
+        Assert::assertEquals($syncFromDateTime, $this->syncDateHelper->getSyncFromDateTime('Test', 'Object'));
     }
 
     public function testLastSyncDateForIntegrationSyncObjectIsReturned(): void
@@ -38,7 +39,7 @@ class SyncDateHelperTest extends TestCase
         $this->syncDateHelper->method('getLastSyncDateForObject')
             ->willReturn($objectLastSyncDate);
 
-        $this->assertEquals($objectLastSyncDate, $this->syncDateHelper->getSyncFromDateTime('Test', 'Object'));
+        Assert::assertEquals($objectLastSyncDate, $this->syncDateHelper->getSyncFromDateTime('Test', 'Object'));
     }
 
     public function testSyncToDateTimeIsReturnedIfSpecified(): void
@@ -47,13 +48,39 @@ class SyncDateHelperTest extends TestCase
 
         $this->syncDateHelper->setSyncDateTimes(null, $syncToDateTime);
 
-        $this->assertEquals($syncToDateTime, $this->syncDateHelper->getSyncToDateTime());
+        Assert::assertEquals($syncToDateTime, $this->syncDateHelper->getSyncToDateTime());
     }
 
     public function testSyncDateTimeIsReturnedForSyncToDateTimeIfNotSpecified(): void
     {
         $this->syncDateHelper->setSyncDateTimes();
 
-        $this->assertInstanceOf(\DateTimeImmutable::class, $this->syncDateHelper->getSyncToDateTime());
+        Assert::assertInstanceOf(\DateTimeImmutable::class, $this->syncDateHelper->getSyncToDateTime());
+    }
+
+    public function testThatSetInternalSyncStartDateTimeMethodUsesSyncToDateValueIfItIsEarlier(): void
+    {
+        // Although $fiveSecondsBefore value is expected to be in UTC timezone let's use another timezone
+        // to check how the method handles such cases.
+        $fiveSecondsBefore = new \DateTime('-5 seconds', new \DateTimeZone('Etc/GMT-5'));
+        $this->syncDateHelper->setSyncDateTimes(null, $fiveSecondsBefore);
+        $this->syncDateHelper->setInternalSyncStartDateTime();
+        $internalSyncStartDateTime = $this->syncDateHelper->getInternalSyncStartDateTime();
+        Assert::assertSame($fiveSecondsBefore->getTimestamp(), $internalSyncStartDateTime->getTimestamp());
+    }
+
+    public function testThatSetInternalSyncStartDateTimeMethodUsesNowIfItIsEarlier(): void
+    {
+        // Although $fiveSecondsAfter value is expected to be in UTC timezone let's use another timezone
+        // to check how the method handles such cases.
+        $fiveSecondsAfter = new \DateTime('+5 seconds', new \DateTimeZone('Etc/GMT+5'));
+        $this->syncDateHelper->setSyncDateTimes(null, $fiveSecondsAfter);
+        $this->syncDateHelper->setInternalSyncStartDateTime();
+        $now                       = new \DateTime('now', new \DateTimeZone('UTC'));
+        $internalSyncStartDateTime = $this->syncDateHelper->getInternalSyncStartDateTime();
+        $difference                = $internalSyncStartDateTime->getTimestamp() - $now->getTimestamp();
+
+        // Add a 1 second buffer in case there is some delay
+        Assert::assertTrue((1 >= $difference) && (-1 < $difference));
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
@@ -31,6 +31,8 @@ class FullObjectReportBuilderTest extends TestCase
 {
     private const INTEGRATION_NAME = 'Test';
 
+    private const TEST_EMAIL = 'test@test.com';
+
     /**
      * @var ObjectProvider|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -71,9 +73,9 @@ class FullObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, $requestDAO->getSyncToIntegration())
             ->willReturn(
-                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
+                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, self::TEST_EMAIL))
             );
 
         $internalObject = new Contact();
@@ -97,7 +99,7 @@ class FullObjectReportBuilderTest extends TestCase
                     $event->setFoundObjects([
                         [
                             'id'            => 1,
-                            'email'         => 'test@test.com',
+                            'email'         => self::TEST_EMAIL,
                             'date_modified' => '2018-10-08 00:30:00',
                         ],
                     ]);
@@ -111,7 +113,7 @@ class FullObjectReportBuilderTest extends TestCase
         $objects = $report->getObjects(Contact::NAME);
 
         $this->assertTrue(isset($objects[1]));
-        $this->assertEquals('test@test.com', $objects[1]->getField('email')->getValue()->getNormalizedValue());
+        $this->assertEquals(self::TEST_EMAIL, $objects[1]->getField('email')->getValue()->getNormalizedValue());
     }
 
     public function testBuildingCompanyReport(): void
@@ -125,9 +127,9 @@ class FullObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, $requestDAO->getSyncToIntegration())
             ->willReturn(
-                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
+                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, self::TEST_EMAIL))
             );
 
         $internalObject = new Company();
@@ -151,7 +153,7 @@ class FullObjectReportBuilderTest extends TestCase
                     $event->setFoundObjects([
                         [
                             'id'            => 1,
-                            'email'         => 'test@test.com',
+                            'email'         => self::TEST_EMAIL,
                             'date_modified' => '2018-10-08 00:30:00',
                         ],
                     ]);
@@ -165,7 +167,7 @@ class FullObjectReportBuilderTest extends TestCase
         $objects = $report->getObjects(MauticSyncDataExchange::OBJECT_COMPANY);
 
         $this->assertTrue(isset($objects[1]));
-        $this->assertEquals('test@test.com', $objects[1]->getField('email')->getValue()->getNormalizedValue());
+        $this->assertEquals(self::TEST_EMAIL, $objects[1]->getField('email')->getValue()->getNormalizedValue());
     }
 
     /**
@@ -183,9 +185,9 @@ class FullObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, $requestDAO->getSyncToIntegration())
             ->willReturn(
-                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
+                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, self::TEST_EMAIL))
             );
 
         $internalObject = new Contact();
@@ -231,7 +233,7 @@ class FullObjectReportBuilderTest extends TestCase
                                 [
                                     [
                                         'id'            => 1,
-                                        'email'         => 'test@test.com',
+                                        'email'         => self::TEST_EMAIL,
                                         'date_modified' => '2018-10-08 00:30:00',
                                     ],
                                 ]
@@ -270,7 +272,7 @@ class FullObjectReportBuilderTest extends TestCase
         $objects = $report->getObjects(Contact::NAME);
 
         $this->assertTrue(isset($objects[1]));
-        $this->assertEquals('test@test.com', $objects[1]->getField('email')->getValue()->getNormalizedValue());
+        $this->assertEquals(self::TEST_EMAIL, $objects[1]->getField('email')->getValue()->getNormalizedValue());
     }
 
     /**
@@ -288,9 +290,9 @@ class FullObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, $requestDAO->getSyncToIntegration())
             ->willReturn(
-                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
+                new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, self::TEST_EMAIL))
             );
 
         $internalObject = new Company();
@@ -336,7 +338,7 @@ class FullObjectReportBuilderTest extends TestCase
                                 [
                                     [
                                         'id'            => 1,
-                                        'email'         => 'test@test.com',
+                                        'email'         => self::TEST_EMAIL,
                                         'date_modified' => '2018-10-08 00:30:00',
                                     ],
                                 ]
@@ -375,6 +377,6 @@ class FullObjectReportBuilderTest extends TestCase
         $objects = $report->getObjects(MauticSyncDataExchange::OBJECT_COMPANY);
 
         $this->assertTrue(isset($objects[1]));
-        $this->assertEquals('test@test.com', $objects[1]->getField('email')->getValue()->getNormalizedValue());
+        $this->assertEquals(self::TEST_EMAIL, $objects[1]->getField('email')->getValue()->getNormalizedValue());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -13,6 +13,8 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\RequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\EncodedValueDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
+use Mautic\IntegrationsBundle\Sync\Exception\FieldNotFoundException;
+use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company as InternalCompany;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
@@ -88,7 +90,7 @@ class PartialObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, self::INTEGRATION_NAME)
             ->willReturn(
                 new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
             );
@@ -179,7 +181,7 @@ class PartialObjectReportBuilderTest extends TestCase
 
         $this->fieldBuilder->expects($this->once())
             ->method('buildObjectField')
-            ->with('email', $this->anything(), $requestObject, MauticSyncDataExchange::NAME)
+            ->with('email', $this->anything(), $requestObject, self::INTEGRATION_NAME)
             ->willReturn(
                 new FieldDAO('email', new NormalizedValueDAO(NormalizedValueDAO::EMAIL_TYPE, 'test@test.com'))
             );
@@ -256,5 +258,143 @@ class PartialObjectReportBuilderTest extends TestCase
         $this->assertTrue(isset($objects[1]));
         $this->assertEquals('test@test.com', $objects[1]->getField('email')->getValue()->getNormalizedValue());
         $this->assertEquals('Bob and Cat', $objects[1]->getField('companyname')->getValue()->getNormalizedValue());
+    }
+
+    public function testTrackedContactChangesThrowsObjectNotFoundException(): void
+    {
+        $requestDAO    = new RequestDAO(self::INTEGRATION_NAME, 1, new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]));
+        $fromDateTime  = new \DateTimeImmutable('2018-10-08 00:00:00');
+        $toDateTime    = new \DateTimeImmutable('2018-10-08 00:01:00');
+        $requestObject = new ObjectDAO(Contact::NAME, $fromDateTime, $toDateTime);
+        $requestObject->addField('email');
+        $requestObject->addField('firstname');
+        $requestDAO->addObject($requestObject);
+
+        $fieldChange = [
+            'object_type'  => Lead::class,
+            'object_id'    => 1,
+            'modified_at'  => '2018-10-08 00:30:00',
+            'column_name'  => 'firstname',
+            'column_type'  => EncodedValueDAO::STRING_TYPE,
+            'column_value' => 'Bob',
+        ];
+
+        $this->fieldHelper->expects($this->once())
+            ->method('getFieldObjectName')
+            ->with(Contact::NAME)
+            ->willReturn(Lead::class);
+
+        // Find and return tracked changes
+        $this->fieldChangeRepository->expects($this->once())
+            ->method('findChangesBefore')
+            ->with(
+                'Test',
+                Lead::class,
+                $toDateTime,
+                0
+            )
+            ->willReturn([$fieldChange]);
+
+        $this->objectProvider->expects($this->once())
+            ->method('getObjectByEntityName')
+            ->with(Lead::class)
+            ->willThrowException(new ObjectNotFoundException(Contact::NAME));
+
+        $report  = $this->reportBuilder->buildReport($requestDAO);
+        $objects = $report->getObjects(Contact::NAME);
+
+        $this->assertEmpty($objects);
+    }
+
+    public function testTrackedContactChangesFieldNotFoundException(): void
+    {
+        $exception = new FieldNotFoundException('email', 'company');
+        $this->expectExceptionObject($exception);
+
+        $requestDAO    = new RequestDAO(self::INTEGRATION_NAME, 1, new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]));
+        $fromDateTime  = new \DateTimeImmutable('2018-10-08 00:00:00');
+        $toDateTime    = new \DateTimeImmutable('2018-10-08 00:01:00');
+        $requestObject = new ObjectDAO(MauticSyncDataExchange::OBJECT_COMPANY, $fromDateTime, $toDateTime);
+        $requestObject->addField('email');
+        $requestObject->addField('companyname');
+        $requestDAO->addObject($requestObject);
+
+        $this->fieldBuilder->expects($this->once())
+            ->method('buildObjectField')
+            ->with('email', $this->anything(), $requestObject, self::INTEGRATION_NAME)
+            ->willThrowException(new FieldNotFoundException('email', $requestObject->getObject()));
+
+        $fieldChange = [
+            'object_type'  => Company::class,
+            'object_id'    => 1,
+            'modified_at'  => '2018-10-08 00:30:00',
+            'column_name'  => 'firstname',
+            'column_type'  => EncodedValueDAO::STRING_TYPE,
+            'column_value' => 'Bob',
+        ];
+
+        $this->fieldHelper->expects($this->once())
+            ->method('getFieldChangeObject')
+            ->with($fieldChange)
+            ->willReturn(
+                new FieldDAO('companyname', new NormalizedValueDAO(NormalizedValueDAO::TEXT_TYPE, 'Bob and Cat'))
+            );
+
+        $this->fieldHelper->expects($this->once())
+            ->method('getFieldObjectName')
+            ->with(InternalCompany::NAME)
+            ->willReturn(Company::class);
+
+        // Find and return tracked changes
+        $this->fieldChangeRepository->expects($this->once())
+            ->method('findChangesBefore')
+            ->with(
+                'Test',
+                Company::class,
+                $toDateTime,
+                0
+            )
+            ->willReturn([$fieldChange]);
+
+        $internalObject = new InternalCompany();
+
+        $this->objectProvider->expects($this->once())
+            ->method('getObjectByEntityName')
+            ->with(Company::class)
+            ->willReturn($internalObject);
+
+        $this->objectProvider->expects($this->once())
+            ->method('getObjectByName')
+            ->with(InternalCompany::NAME)
+            ->willReturn($internalObject);
+
+        // Find the complete object
+        $this->dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS,
+                 $this->callback(function (InternalObjectFindEvent $event) use ($internalObject) {
+                     $this->assertSame([1], $event->getIds());
+                     $this->assertSame($internalObject, $event->getObject());
+
+                     // Mock a subscriber:
+                     $event->setFoundObjects([
+                         [
+                             'id'          => 1,
+                             'email'       => 'test@test.com',
+                             'companyname' => 'Bob and Cat',
+                         ],
+                     ]);
+
+                     return true;
+                 })
+            );
+
+        $report  = $this->reportBuilder->buildReport($requestDAO);
+        $objects = $report->getObjects(InternalCompany::NAME);
+
+        $this->assertTrue(isset($objects[1]));
+        // trying to access non-existent object
+        $objects[1]->getField('email');
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -372,8 +372,7 @@ class PartialObjectReportBuilderTest extends TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS,
-                 $this->callback(function (InternalObjectFindEvent $event) use ($internalObject) {
+                $this->callback(function (InternalObjectFindEvent $event) use ($internalObject) {
                      $this->assertSame([1], $event->getIds());
                      $this->assertSame($internalObject, $event->getObject());
 
@@ -387,7 +386,8 @@ class PartialObjectReportBuilderTest extends TestCase
                      ]);
 
                      return true;
-                 })
+                 }),
+                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -373,20 +373,20 @@ class PartialObjectReportBuilderTest extends TestCase
             ->method('dispatch')
             ->with(
                 $this->callback(function (InternalObjectFindEvent $event) use ($internalObject) {
-                     $this->assertSame([1], $event->getIds());
-                     $this->assertSame($internalObject, $event->getObject());
+                    $this->assertSame([1], $event->getIds());
+                    $this->assertSame($internalObject, $event->getObject());
 
-                     // Mock a subscriber:
-                     $event->setFoundObjects([
-                         [
-                             'id'          => 1,
-                             'email'       => 'test@test.com',
-                             'companyname' => 'Bob and Cat',
-                         ],
-                     ]);
+                    // Mock a subscriber:
+                    $event->setFoundObjects([
+                        [
+                            'id'          => 1,
+                            'email'       => 'test@test.com',
+                            'companyname' => 'Bob and Cat',
+                        ],
+                    ]);
 
-                     return true;
-                 }),
+                    return true;
+                }),
                 IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
             );
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
@@ -12,6 +12,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\RequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\Helper\MappingHelper;
+use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\OrderExecutioner;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ReportBuilder\FullObjectReportBuilder;
@@ -56,6 +57,11 @@ class MauticSyncDataExchangeTest extends TestCase
 
     private \Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange $mauticSyncDataExchange;
 
+    /**
+     * @var SyncDateHelper&MockObject
+     */
+    private MockObject $syncDateHelper;
+
     protected function setUp(): void
     {
         $this->fieldChangeRepository      = $this->createMock(FieldChangeRepository::class);
@@ -64,6 +70,7 @@ class MauticSyncDataExchangeTest extends TestCase
         $this->fullObjectReportBuilder    = $this->createMock(FullObjectReportBuilder::class);
         $this->partialObjectReportBuilder = $this->createMock(PartialObjectReportBuilder::class);
         $this->orderExecutioner           = $this->createMock(OrderExecutioner::class);
+        $this->syncDateHelper             = $this->createMock(SyncDateHelper::class);
 
         $this->mauticSyncDataExchange = new MauticSyncDataExchange(
             $this->fieldChangeRepository,
@@ -71,7 +78,8 @@ class MauticSyncDataExchangeTest extends TestCase
             $this->mappingHelper,
             $this->fullObjectReportBuilder,
             $this->partialObjectReportBuilder,
-            $this->orderExecutioner
+            $this->orderExecutioner,
+            $this->syncDateHelper
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
@@ -17,6 +17,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\RequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\Helper\MappingHelper;
 use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\SyncDataExchangeInterface;
@@ -48,12 +49,24 @@ class IntegrationSyncProcessTest extends TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $syncDataExchange;
 
+    /**
+     * @var InputOptionsDAO
+     */
+    private $inputOptionsDAO;
+
+    /**
+     * @var IntegrationSyncProcess
+     */
+    private $integrationSyncProcess;
+
     protected function setUp(): void
     {
-        $this->syncDateHelper        = $this->createMock(SyncDateHelper::class);
-        $this->mappingHelper         = $this->createMock(MappingHelper::class);
-        $this->objectChangeGenerator = $this->createMock(ObjectChangeGenerator::class);
-        $this->syncDataExchange      = $this->createMock(SyncDataExchangeInterface::class);
+        $this->syncDateHelper         = $this->createMock(SyncDateHelper::class);
+        $this->mappingHelper          = $this->createMock(MappingHelper::class);
+        $this->objectChangeGenerator  = $this->createMock(ObjectChangeGenerator::class);
+        $this->syncDataExchange       = $this->createMock(SyncDataExchangeInterface::class);
+        $this->inputOptionsDAO        = new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]);
+        $this->integrationSyncProcess = new IntegrationSyncProcess($this->syncDateHelper, $this->mappingHelper, $this->objectChangeGenerator);
     }
 
     public function testThatIntegrationGetSyncReportIsCalledBasedOnRequest(): void
@@ -161,15 +174,68 @@ class IntegrationSyncProcessTest extends TestCase
         $this->assertEquals([$objectName => [2 => $objectChangeDAO]], $syncOrder->getIdentifiedObjects());
     }
 
-    /**
-     * @return IntegrationSyncProcess
-     */
-    private function getSyncProcess(MappingManualDAO $mappingManualDAO)
+    private function getSyncProcess(MappingManualDAO $mappingManualDAO): IntegrationSyncProcess
     {
-        $syncProcess = new IntegrationSyncProcess($this->syncDateHelper, $this->mappingHelper, $this->objectChangeGenerator);
+        $this->integrationSyncProcess->setupSync($this->inputOptionsDAO, $mappingManualDAO, $this->syncDataExchange);
 
-        $syncProcess->setupSync(new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]), $mappingManualDAO, $this->syncDataExchange);
+        return $this->integrationSyncProcess;
+    }
 
-        return $syncProcess;
+    public function testThatItDoesntSyncOtherEntityTypesWhenIDsForSomeEntityAreSpecified(): void
+    {
+        $mappingManual         = new MappingManualDAO(self::INTEGRATION_NAME);
+        $this->inputOptionsDAO = new InputOptionsDAO([
+            'integration'      => self::INTEGRATION_NAME,
+            'mautic-object-id' => ['contact:1'],
+        ]);
+
+        $contactMapping = new ObjectMappingDAO(Contact::NAME, 'Contact');
+        $contactMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($contactMapping);
+
+        $leadMapping = new ObjectMappingDAO(Contact::NAME, 'Lead');
+        $leadMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($leadMapping);
+
+        $companyMapping = new ObjectMappingDAO(Company::NAME, 'Account');
+        $companyMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($companyMapping);
+
+        $fromSyncDateTime = new \DateTimeImmutable();
+        $this->syncDateHelper->expects($this->exactly(2))
+            ->method('getSyncFromDateTime')
+            ->withConsecutive([self::INTEGRATION_NAME, 'Contact'], [self::INTEGRATION_NAME, 'Lead'])
+            ->willReturn($fromSyncDateTime);
+
+        $toSyncDateTime   = new \DateTimeImmutable();
+        $this->syncDateHelper->expects($this->exactly(2))
+            ->method('getSyncToDateTime')
+            ->willReturn($toSyncDateTime);
+
+        $this->syncDateHelper->expects($this->exactly(2))
+            ->method('getLastSyncDateForObject')
+            ->withConsecutive([self::INTEGRATION_NAME, 'Contact'], [self::INTEGRATION_NAME, 'Lead'])
+            ->willReturn(null);
+
+        // SyncDateExchangeInterface::getSyncReport should sync because an object was added to the report
+        $this->syncDataExchange->expects($this->once())
+            ->method('getSyncReport')
+            ->willReturnCallback(
+                function (RequestDAO $requestDAO): ReportDAO {
+                    $requestObjects = $requestDAO->getObjects();
+                    $this->assertCount(2, $requestObjects);
+
+                    /** @var RequestObjectDAO $requestObject */
+                    $requestObject = $requestObjects[0];
+                    $this->assertEquals(['email'], $requestObject->getRequiredFields());
+                    $this->assertEquals(['email'], $requestObject->getFields());
+                    $this->assertEquals('Contact', $requestObject->getObject());
+
+                    return new ReportDAO(self::INTEGRATION_NAME);
+                }
+            );
+
+        $syncReport = $this->getSyncProcess($mappingManual)->getSyncReport(1);
+        $this->assertEquals(self::INTEGRATION_NAME, $syncReport->getIntegration());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
@@ -89,11 +89,6 @@ class IntegrationSyncProcessTest extends TestCase
             ->method('getSyncToDateTime')
             ->willReturn($toSyncDateTime);
 
-        $this->syncDateHelper->expects($this->once())
-            ->method('getLastSyncDateForObject')
-            ->with(self::INTEGRATION_NAME, $objectName)
-            ->willReturn(null);
-
         // SyncDateExchangeInterface::getSyncReport should sync because an object was added to the report
         $this->syncDataExchange->expects($this->once())
             ->method('getSyncReport')
@@ -211,11 +206,6 @@ class IntegrationSyncProcessTest extends TestCase
         $this->syncDateHelper->expects($this->exactly(2))
             ->method('getSyncToDateTime')
             ->willReturn($toSyncDateTime);
-
-        $this->syncDateHelper->expects($this->exactly(2))
-            ->method('getLastSyncDateForObject')
-            ->withConsecutive([self::INTEGRATION_NAME, 'Contact'], [self::INTEGRATION_NAME, 'Lead'])
-            ->willReturn(null);
 
         // SyncDateExchangeInterface::getSyncReport should sync because an object was added to the report
         $this->syncDataExchange->expects($this->once())

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
@@ -23,7 +23,6 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\MauticSyncProcess;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\ObjectChangeGenerator;
 use PHPUnit\Framework\TestCase;
-use Rector\CodingStyle\Tests\Rector\Use_\RemoveUnusedAliasRector\Source\Mapping;
 
 class MauticSyncProcessTest extends TestCase
 {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
@@ -12,15 +12,18 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO as ReportFieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
+use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO as RequestObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\RequestDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Value\NormalizedValueDAO;
 use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
+use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\MauticSyncProcess;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\ObjectChangeGenerator;
 use PHPUnit\Framework\TestCase;
+use Rector\CodingStyle\Tests\Rector\Use_\RemoveUnusedAliasRector\Source\Mapping;
 
 class MauticSyncProcessTest extends TestCase
 {
@@ -41,11 +44,23 @@ class MauticSyncProcessTest extends TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $syncDataExchange;
 
+    /**
+     * @var InputOptionsDAO
+     */
+    private $inputOptionsDAO;
+
+    /**
+     * @var MauticSyncProcess
+     */
+    private $mauticSyncProcess;
+
     protected function setUp(): void
     {
         $this->syncDateHelper        = $this->createMock(SyncDateHelper::class);
         $this->objectChangeGenerator = $this->createMock(ObjectChangeGenerator::class);
         $this->syncDataExchange      = $this->createMock(MauticSyncDataExchange::class);
+        $this->inputOptionsDAO       = new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]);
+        $this->mauticSyncProcess     = new MauticSyncProcess($this->syncDateHelper, $this->objectChangeGenerator);
     }
 
     public function testThatMauticGetSyncReportIsCalledBasedOnRequest(): void
@@ -86,7 +101,7 @@ class MauticSyncProcessTest extends TestCase
                 }
             );
 
-        $this->getSyncProcess($mappingManual)->getSyncReport(1);
+        $this->createMauticSyncProcess($mappingManual)->getSyncReport(1);
     }
 
     public function testThatMauticGetSyncReportIsNotCalledBasedOnRequest(): void
@@ -102,7 +117,7 @@ class MauticSyncProcessTest extends TestCase
         $this->syncDataExchange->expects($this->never())
             ->method('getSyncReport');
 
-        $report = $this->getSyncProcess($mappingManual)->getSyncReport(1);
+        $report = $this->createMauticSyncProcess($mappingManual)->getSyncReport(1);
 
         $this->assertEquals(MauticSyncDataExchange::NAME, $report->getIntegration());
     }
@@ -142,21 +157,67 @@ class MauticSyncProcessTest extends TestCase
             ->method('getSyncObjectChange')
             ->willReturn($objectChangeDAO);
 
-        $syncOrder = $this->getSyncProcess($mappingManual)->getSyncOrder($syncReport);
+        $syncOrder = $this->createMauticSyncProcess($mappingManual)->getSyncOrder($syncReport);
 
         // The change should have been added to the order as an identified object
         $this->assertEquals([Contact::NAME => [1 => $objectChangeDAO]], $syncOrder->getIdentifiedObjects());
     }
 
-    /**
-     * @return MauticSyncProcess
-     */
-    private function getSyncProcess(MappingManualDAO $mappingManualDAO)
+    private function createMauticSyncProcess(MappingManualDAO $mappingManualDAO): MauticSyncProcess
     {
-        $syncProcess = new MauticSyncProcess($this->syncDateHelper, $this->objectChangeGenerator);
+        $this->mauticSyncProcess->setupSync($this->inputOptionsDAO, $mappingManualDAO, $this->syncDataExchange);
 
-        $syncProcess->setupSync(new InputOptionsDAO(['integration' => self::INTEGRATION_NAME]), $mappingManualDAO, $this->syncDataExchange);
+        return $this->mauticSyncProcess;
+    }
 
-        return $syncProcess;
+    public function testThatItDoesntSyncOtherEntityTypesWhenIDsForSomeEntityAreSpecified(): void
+    {
+        $mappingManual         = new MappingManualDAO(self::INTEGRATION_NAME);
+        $this->inputOptionsDAO = new InputOptionsDAO([
+            'integration'      => self::INTEGRATION_NAME,
+            'mautic-object-id' => ['contact:1'],
+        ]);
+
+        $contactMapping = new ObjectMappingDAO(Contact::NAME, 'Contact');
+        $contactMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($contactMapping);
+
+        $leadMapping = new ObjectMappingDAO(Contact::NAME, 'Lead');
+        $leadMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($leadMapping);
+
+        $companyMapping = new ObjectMappingDAO(Company::NAME, 'Account');
+        $companyMapping->addFieldMapping('email', 'email', ObjectMappingDAO::SYNC_BIDIRECTIONALLY, true);
+        $mappingManual->addObjectMapping($companyMapping);
+
+        $fromSyncDateTime = new \DateTimeImmutable();
+        $this->syncDateHelper->expects($this->once())
+            ->method('getSyncFromDateTime')
+            ->with(MauticSyncDataExchange::NAME, Contact::NAME)
+            ->willReturn($fromSyncDateTime);
+
+        $toSyncDateTime   = new \DateTimeImmutable();
+        $this->syncDateHelper->expects($this->once())
+            ->method('getSyncToDateTime')
+            ->willReturn($toSyncDateTime);
+
+        $this->syncDataExchange->expects($this->once())
+            ->method('getSyncReport')
+            ->willReturnCallback(
+                function (RequestDAO $requestDAO): ReportDAO {
+                    $requestObjects = $requestDAO->getObjects();
+                    $this->assertCount(1, $requestObjects);
+
+                    /** @var ObjectDAO $requestObject */
+                    $requestObject = $requestObjects[0];
+                    $this->assertEquals(['email'], $requestObject->getRequiredFields());
+                    $this->assertEquals(Contact::NAME, $requestObject->getObject());
+
+                    return new ReportDAO(self::INTEGRATION_NAME);
+                }
+            );
+
+        $syncReport = $this->createMauticSyncProcess($mappingManual)->getSyncReport(1);
+        $this->assertEquals(self::INTEGRATION_NAME, $syncReport->getIntegration());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
@@ -135,6 +135,9 @@ class SyncProcessTest extends TestCase
             ->method('pushIsEnabled')
             ->willReturn(true);
 
+        $this->syncDateHelper->expects($this->once())
+            ->method('setInternalSyncStartDateTime');
+
         // Integration to Mautic
 
         // fetch the report from the integration

--- a/app/migrations/Version20210112162046.php
+++ b/app/migrations/Version20210112162046.php
@@ -2,13 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic Contributors. All rights reserved.
- * @author      Mautic
- * @link        https://mautic.org
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20210112162046.php
+++ b/app/migrations/Version20210112162046.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        https://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20210112162046 extends AbstractMauticMigration
+{
+    private const TABLE_NAME = 'sync_object_mapping';
+    private const INDEX_NAME = 'integration_integration_object_name_last_sync_date';
+
+    public function preUp(Schema $schema): void
+    {
+        $this->skipIf(
+            $this->indexExists($schema),
+            sprintf('Index `%s` already exists. Skipping the migration', static::INDEX_NAME)
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(sprintf(
+            'ALTER TABLE `%s` ADD INDEX `%s` (`integration`, `internal_object_name`, `last_sync_date`);',
+            $this->getTableName(),
+            static::INDEX_NAME
+        ));
+    }
+
+    public function preDown(Schema $schema): void
+    {
+        $this->skipIf(
+            !$this->indexExists($schema),
+            sprintf('Index `%s` doesn\'t exist. Skipping reverting the migration', static::INDEX_NAME)
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(sprintf(
+            'ALTER TABLE `%s` DROP INDEX `%s`;',
+            $this->getTableName(),
+            static::INDEX_NAME
+        ));
+    }
+
+    private function getTableName(): string
+    {
+        return $this->prefix.static::TABLE_NAME;
+    }
+
+    private function indexExists(Schema $schema): bool
+    {
+        return $schema->getTable($this->getTableName())->hasIndex(static::INDEX_NAME);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR contains a bunch of PRs regarding the IntegrationsBundle improvement from our fork. It's adding an index which is a performance improvement. 

Since there is no plugin the community can test with yet and the changes are covered by tests, let's get this reviewed twice and merge.

## Bug fix 1

[//]: # ( Required: )
#### Description:
We only have to synchronize particular objects if object IDs are specified.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create a lead and an account in Salesforce.
2. Make sure they are synced back to Campaign Studio (Salesforce plugin has to be configured on your instance and bi-directional sync should be enabled for leads, contacts and accounts).
Alternatively, run this command to sync the changes:
```bash
php bin/console mautic:integrations:sync Salesforce2
```
3. Open the contact that was synced back to Campaign Studio in Campaign Studio. Note its ID in the URL (that will be the number part of the URL).
4. Change lead's URL or Last Name (or both). Change company's name as well. You should edit these objects in Campaign Studio (not in Salesforce).
5. Run the following command in the console (you have to have access to the command console). Replace `7345` with ID of the contact you noted on the step 3.
```bash
php bin/console mautic:integrations:sync Salesforce2 --mautic-object-id=contact:7345
```
6. Open your account in Salesforce. Although you specified contact id when you executed the sync command in the console, account (company) changes were also synced back to SF. It shouldn't sync company changes in this case because we specified contact IDs in the command.

I don't know how to test it from UI only.


#### Steps to test this PR:
1. Repeat steps 1-5 from `Steps to reproduce the bug` section.
2. Open your account in Salesforce. Only lead related changes should be synced back to Salesforce. Account(company) changes should not be synced back to Salesforce.
3. This also works vice versa. If you specify ID during the sync, changes from Integration should not be synced back to Campaign Studio. Only objects that are explicitly specified in the command should be synced back to Campaign Studio.

#### Other areas of Mautic that may be affected by the change:
1. All integrations that use IntegrationsBundle are affected by this PR (e.g. MParticle bundle).
See `List backwards compatibility breaks` section to understand how they are affected. It would be good to test them too using the similar testing steps described in `Steps to test this PR` section.
I haven't tested this with other plugins/bundles that use IntegrationsBundle, I only tested it with Salesforce plugin.

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. This PR breaks backwards compatibility. It changes behaviour of the Integrations bundle so that we only sync IDs of the objects that are specified in the console (if they are specified of course). We don't sync other kinds of objects.
We used to sync other kinds of objects if IDs for some objects were specified.
E.g. if we specified contact IDs we used to sync accounts (companies) as well.
If we don't specify IDs of the objects it will sync all pending changes. This works as it used to work before.

## Bug fix 2

#### Description:
In the process of synchronization IntegrationsBundle module deletes changes that happen after the sync started. 
We may delete changes that haven't been synchronized with integrations. We must delete entities according to the timestamp instead.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Make sure you have Salesforce plugin installed and authorized. Make sure it syncs contacts and leads.
2. Modify some lead, e.g. change its last name. Save it.
3. Modify the same lead again. But this time modify another field, e.g. `City`.
4. Go go the `sync_object_field_change_report` and verify that there are 2 records that belong to that lead (these records should be the changes you've just made).
5. Change `modified_at` column for **one** of the leads. Add a 1 year to the value (you can add 1 day or 1 hour, it doesn't really matter).
6. Run the sync or wait until sync job is executed.
You can manually run the sync with this command:
```bash
bin/console mautic:integrations:sync Salesforce2
```
7. Go to the `sync_object_field_change_report table`.
Expected result: the record with the modified `modified_at` value should stay because that change happened in the future. The IntegrationsBundle doesn't have to delete changes with `modified_at` value >= `now`.
Actual result: 2 records will be deleted.

#### Steps to test this PR:
1. Checkout this branch.
2. Repeat steps 2-7 from `Steps to reproduce the bug`.
This time 1 record should stay.

#### Other areas of Mautic that may be affected by the change:
1. All modules that use IntegrationsBundle will be affected by this (e.g. Magento plugin).

## Bug fix 3:

#### Description:
There is a bug that is leaving a number of contacts left over in the mautic_sync_object_field_change_report table after a sync when the expectation is that the entire queue is processed assuming there are no sync issues or validations.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. You have to have Salesforce2 plugin configured and working.
2. Create a segment.
3. Create a campaign based on your segment. It should update 2 contact fields (choose `update contact` campaign action).
4. Import 2000 contacts into your segment. You can generate contacts using https://github.com/dongilbert/contact-generator (as a `.csv` file).
5. Check the `mautic_sync_object_field_change_report` table and note the changes logged (should be 4000 entries).
6. Run the command to sync for example bin/console mautic:integrations:sync -e prod Salesforce2 --start-datetime="2020-10-23 17:41:30" --end-datetime="2020-10-23 17:53:00" (use a relative time range that has a start datetime for before the changes and the end date/time of after.
7. Let the command finish and check the `mautic_sync_object_field_change_report` table. It still has some left over entries.

Expected result: All the changes in the `mautic_sync_object_field_change_report` table  must be processed after the first run.
Actual result: some changes are not processed after the first run.

#### Steps to test this PR:
1. Repeat steps 2-6 from `Steps to reproduce` section.
2. All the changes in the `mautic_sync_object_field_change_report` table  must be processed after the first run.

#### Other areas of Mautic that may be affected by the change:
1. All plugins that use IntegrationsBundle are affected by this change.

## Bug fix 4

#### Description:
This PR has only few comments to satisfy PHPSTAN
<!--
If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:
1. Load up [this PR](https://m3.mautibox.com)
2. Enable Salesforce2 plugin
3. Create a campaign and an action as send to salesforce
4. Sync is not always success at first attempt, when failes to sync any contact, it is added to mautic_failed_lead_event_log along with mautic_lead_event_log table. 
5. It will be rescheduled, But when it get succeed in next attempts, the row from mautic_failed_lead_event_log table is not deleted.
6. After this PR, it will be deleted and stats will be fine.

#### Other areas of Mautic that may be affected by the change:
1. campaign view page tabs (stats)

## Bug fix 5

#### Description:
Reference fields were not serializing correctly and causing an error because of the private fields.

#### Steps to test this PR:
##### SF to ACS
1. Create a lookup field in SF for account type object
2. create a lookup field in CS for company
3. configure SF and map above created fields in `Account` tab
4. In SF, create/update account and add value in newly added lookup field
5. Run a sync. Sync should fail with an error similar to `references are currently resolved only for %s. Given %s` instead of the serialization error.

##### ACS to SF
1. Create a lookup field in SF for account type object
2. create a lookup field in CS for company
3. configure SF and map above created fields in `Account` tab
4. In ACS, create/update company with the account ID of another account in SF
5. Run a sync. Sync should should work but I don't think this should be considered an officially supported feature because the sync will not work in the other direction.

#### List of areas covered by the unit and/or functional tests:
1. Added test case using the data that was causing an error

## Bug fix 6

#### Description:
"Contact timeline URL" generated is incorrect which gives 404 page when clicked on link from SF.

#### Steps to test this PR:
1. Load this PR
2. configure SF plugin.
3. Create a custom field in Salesforce called Campaign Studio timeline. Campaign Studio sends the data to Salesforce as a link.
4. In Campaign Studio, navigate to the field mapping section (under Settings > Plugins), map the custom field that you’ve created in the first step to the Contact timeline URL field and set the direction to sync only to the integration.
5. Unpublish and re-publish the Salesforce plugin.
6. Check the Campaign Studio timeline field on lead which is synced to SF.
7. It should be "https://<instance_url>/s/plugin/Salesforce2/timeline/view/<contact_id>" currently it is "https://<instance_url>/s/plugin/mautic/timeline/view/<contact_id>"

#### Other areas of Mautic that may be affected by the change:
1. Other Plugins might be affected as well, Drift Plugin to be verified

## Bug fix 7

#### Description:

When the record is transferred to SFDC using Campaign Studio integration, some special characters are sent with the encoded. The customers see the encoded value in SFDC, which they cannot read.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Setup SF plugin
2. Setup Web-to-case on SF https://help.salesforce.com/s/articleView?id=sf.setting_up_web-to-case.htm&type=5
3. Generate Web Form https://help.salesforce.com/s/articleView?id=sf.web_to_case_html.htm&type=5
3. Create a form in ACS and use action "Post result to another form"
4. Submit a form with multiple line data in description
5. You will see the new line characters in description on SF on "Cases" in SF