### PR TITLE
Fix migration generated columns

### DIFF
--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -25,7 +25,7 @@ class MigrationCommandSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ConsoleEvents::COMMAND => ['addGeneratedColumns'],
+            ConsoleEvents::TERMINATE => ['addGeneratedColumns'],
         ];
     }
 

--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\Doctrine\Provider\VersionProviderInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Stopwatch\Stopwatch;

--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -8,8 +8,7 @@ use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\Doctrine\Provider\VersionProviderInterface;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -29,7 +28,7 @@ class MigrationCommandSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function addGeneratedColumns(ConsoleCommandEvent $event): void
+    public function addGeneratedColumns(ConsoleTerminateEvent $event): void
     {
         $command = $event->getCommand();
         $output  = $event->getOutput();

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
@@ -13,7 +13,7 @@ use Mautic\CoreBundle\Doctrine\Provider\VersionProviderInterface;
 use Mautic\CoreBundle\EventListener\MigrationCommandSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -34,7 +34,7 @@ class MigrationCommandSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $connection;
 
-    private \Symfony\Component\Console\Event\ConsoleCommandEvent $event;
+    private ConsoleTerminateEvent $event;
 
     /**
      * @var MockObject|Command
@@ -77,7 +77,7 @@ class MigrationCommandSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $input = $this->createMock(InputInterface::class);
 
-        $this->event = new ConsoleCommandEvent($this->command, $input, $this->output);
+        $this->event = new ConsoleTerminateEvent($this->command, $input, $this->output, 0);
 
         $this->connection->method('createSchemaManager')->willReturn($this->schemaManager);
         $this->generatedColumns->add(new GeneratedColumn('page_hits', 'generated_hit_date', 'DATE', 'not important'));


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [N]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Migrations for generated columns run before the other doctrine migrations, causing table locks and copy that resulted in outages when deploying to production.

This PR changes the database migrations for generated columns to run after regular migrations are run according to https://symfony.com/blog/new-in-symfony-2-3-events-in-the-console-component

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here]Create a new mautic installation based off of deployed on your local.
Switch to this branch, then run migrations. You'll see that the generated column migrations are run after the regular migrations are run (after the googleplus field is deleted)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
