### PR TITLE
Display UI warnings when a segment that is used in campaign gets unpublished

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CommandListEvent;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Event\UpgradeEvent;
-use Mautic\CoreBundle\Exception\RecordCanNotUnpublishException;
+use Mautic\CoreBundle\Exception\RecordNotUnpublishedException;
 use Mautic\CoreBundle\Factory\IpLookupFactory;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -18,6 +18,7 @@ use Mautic\CoreBundle\IpLookup\AbstractLocalDataLookup;
 use Mautic\CoreBundle\IpLookup\AbstractLookup;
 use Mautic\CoreBundle\IpLookup\IpLookupFormInterface;
 use Mautic\CoreBundle\Model\FormModel;
+use Mautic\CoreBundle\Service\FlashBag;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -297,8 +298,8 @@ class AjaxController extends CommonController
                         );
                         $dataArray['statusHtml'] = $html;
                     }
-                } catch (RecordCanNotUnpublishException $e) {
-                    $this->addFlashMessage($e->getMessage());
+                } catch (RecordNotUnpublishedException $exception) {
+                    $this->addFlash(FlashBag::LEVEL_ERROR, $exception->getMessage());
                     $status = Response::HTTP_UNPROCESSABLE_ENTITY;
                 }
             } else {

--- a/app/bundles/CoreBundle/Exception/RecordCanNotUnpublishException.php
+++ b/app/bundles/CoreBundle/Exception/RecordCanNotUnpublishException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Mautic\CoreBundle\Exception;
-
-class RecordCanNotUnpublishException extends \Exception
-{
-}

--- a/app/bundles/CoreBundle/Exception/RecordNotUnpublishedException.php
+++ b/app/bundles/CoreBundle/Exception/RecordNotUnpublishedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Mautic\CoreBundle\Exception;
+
+class RecordNotUnpublishedException extends RecordException
+{
+}

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -195,7 +195,7 @@ class FormModel extends AbstractCommonModel
                 case 'published':
                 case 'expired':
                 case 'pending':
-                    $event = $this->dispatchEvent('pre_unpublish', $entity);
+                    $this->dispatchEvent('pre_unpublish', $entity);
                     $entity->setIsPublished(false);
                     break;
             }

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -414,6 +414,20 @@ return [
                 'tag'   => 'validator.constraint_validator',
                 'alias' => 'segment_in_use',
             ],
+            'mautic.lead.validator.lead.list.campaign' => [
+                'class'     => \Mautic\LeadBundle\Validator\SegmentUsedInCampaignsValidator::class,
+                'arguments' => [
+                    'mautic.lead.repository.lead_list',
+                    'translator',
+                ],
+            ],
+            'mautic.lead.constraint.validator.lead.list.campaign' => [
+                'class'     => \Mautic\LeadBundle\Validator\Constraints\SegmentUsedInCampaignsValidator::class,
+                'arguments' => [
+                    'mautic.lead.validator.lead.list.campaign',
+                ],
+                'tag'       => 'validator.constraint_validator',
+            ],
             'mautic.lead.event.dispatcher' => [
                 'class'     => \Mautic\LeadBundle\Helper\LeadChangeEventDispatcher::class,
                 'arguments' => [

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Form\Validator\Constraints\SegmentInUse;
 use Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAlias;
+use Mautic\LeadBundle\Validator\Constraints\SegmentUsedInCampaigns;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -140,6 +141,7 @@ class LeadList extends FormEntity
             'message' => 'mautic.lead.list.alias.unique',
         ]));
 
+        $metadata->addConstraint(new SegmentUsedInCampaigns());
         $metadata->addConstraint(new SegmentInUse());
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -509,4 +509,28 @@ class LeadListRepository extends CommonRepository
 
         return 1 === $result;
     }
+
+    /**
+     * Returns array of campaigns related to this segment.
+     */
+    public function getSegmentCampaigns(int $segmentId): array
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
+            ->select('clx.campaign_id, c.name')
+            ->distinct()
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_leadlist_xref', 'clx')
+            ->join('clx', MAUTIC_TABLE_PREFIX.'campaigns', 'c', 'c.id = clx.campaign_id');
+        $q->where(
+            $q->expr()->eq('clx.leadlist_id', $segmentId)
+        );
+
+        $lists   = [];
+        $results = $q->execute()->fetchAll();
+
+        foreach ($results as $row) {
+            $lists[$row['campaign_id']] = $row['name'];
+        }
+
+        return $lists;
+    }
 }

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -512,6 +512,8 @@ class LeadListRepository extends CommonRepository
 
     /**
      * Returns array of campaigns related to this segment.
+     *
+     * @return array<int, string>
      */
     public function getSegmentCampaigns(int $segmentId): array
     {
@@ -525,7 +527,7 @@ class LeadListRepository extends CommonRepository
         );
 
         $lists   = [];
-        $results = $q->execute()->fetchAll();
+        $results = $q->executeQuery()->fetchAllAssociative();
 
         foreach ($results as $row) {
             $lists[$row['campaign_id']] = $row['name'];

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -8,24 +8,15 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ListApiControllerFunctionalTest extends MauticMysqlTestCase
 {
-    /**
-     * @var ListModel
-     */
-    protected $listModel;
+    protected ListModel $listModel;
 
-    /**
-     * @var string
-     */
-    private $prefix;
+    private string $prefix;
 
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
+    private TranslatorInterface $translator;
 
     protected function setUp(): void
     {
@@ -316,6 +307,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $segmentName = 'Segment1';
         $segment     = new LeadList();
         $segment->setName($segmentName);
+        $segment->setPublicName($segmentName);
         $segment->setAlias(mb_strtolower($segmentName));
         $segment->setIsPublished(true);
         $this->em->persist($segment);
@@ -338,10 +330,10 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         Assert::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $clientResponse->getStatusCode());
         Assert::assertArrayHasKey('errors', $response);
-        $errorMessage = $this->translator->transChoice(
+        $errorMessage = $this->translator->trans(
             'mautic.lead.lists.used_in_campaigns',
-            1,
             [
+                '%count%'         => '1',
                 '%campaignNames%' => '"'.$campaignName.'"',
             ],
             'validators'
@@ -354,6 +346,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $segmentName = 'Segment1';
         $segment     = new LeadList();
         $segment->setName($segmentName);
+        $segment->setPublicName($segmentName);
         $segment->setAlias(mb_strtolower($segmentName));
         $segment->setIsPublished(true);
         $this->em->persist($segment);
@@ -493,7 +486,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
     private function saveSegment(string $name, string $alias, array $filters = [], LeadList $segment = null): LeadList
     {
         $segment ??= new LeadList();
-        $segment->setName($name)->setAlias($alias)->setFilters($filters);
+        $segment->setName($name)->setPublicName($name)->setAlias($alias)->setFilters($filters);
         $this->listModel->saveEntity($segment);
 
         return $segment;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -10,23 +10,59 @@ use Mautic\LeadBundle\EventListener\SegmentSubscriber;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Mautic\LeadBundle\Validator\SegmentUsedInCampaignsValidator;
+use PHPUnit\Framework\TestCase;
 
-class SegmentSubscriberTest extends \PHPUnit\Framework\TestCase
+class SegmentSubscriberTest extends TestCase
 {
+    /**
+     * @var IpLookupHelper
+     */
+    private $ipLookupHelper;
+
+    /**
+     * @var AuditLogModel
+     */
+    private $auditLogModel;
+
+    /**
+     * @var ListModel
+     */
+    private $listModel;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var SegmentUsedInCampaignsValidator
+     */
+    private $segmentUsedInCampaignsValidator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ipLookupHelper                  = $this->createMock(IpLookupHelper::class);
+        $this->auditLogModel                   = $this->createMock(AuditLogModel::class);
+        $this->listModel                       = $this->createMock(ListModel::class);
+        $this->segmentUsedInCampaignsValidator = $this->createMock(SegmentUsedInCampaignsValidator::class);
+        $this->translator                      = $this->createMock(TranslatorInterface::class);
+    }
+
     public function testGetSubscribedEvents(): void
     {
-        $ipLookupHelper   = $this->createMock(IpLookupHelper::class);
-        $auditLogModel    = $this->createMock(AuditLogModel::class);
-        $listModel        = $this->createMock(ListModel::class);
-        $translatorModel  = $this->createMock(TranslatorInterface::class);
-
-        $subscriber     = new SegmentSubscriber($ipLookupHelper, $auditLogModel, $listModel, $translatorModel);
+        $subscriber  = new SegmentSubscriber($this->ipLookupHelper, $this->auditLogModel, $this->listModel, $this->segmentUsedInCampaignsValidator, $this->translator);
 
         $this->assertEquals(
             [
-                LeadEvents::LIST_PRE_UNPUBLISH => ['onSegmentPreUnpublish', 0],
                 LeadEvents::LIST_POST_SAVE     => ['onSegmentPostSave', 0],
                 LeadEvents::LIST_POST_DELETE   => ['onSegmentDelete', 0],
+                LeadEvents::LIST_PRE_UNPUBLISH => [
+                    ['validateSegmentFilters', 0],
+                    ['validateSegmentsUsedInCampaigns', 0],
+                ],
             ],
             $subscriber->getSubscribedEvents()
         );
@@ -52,20 +88,15 @@ class SegmentSubscriberTest extends \PHPUnit\Framework\TestCase
             'ipAddress' => $ip,
         ];
 
-        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
-        $ipLookupHelper->expects($this->once())
+        $this->ipLookupHelper->expects($this->once())
             ->method('getIpAddressFromRequest')
             ->will($this->returnValue($ip));
 
-        $auditLogModel = $this->createMock(AuditLogModel::class);
-        $auditLogModel->expects($this->once())
+        $this->auditLogModel->expects($this->once())
             ->method('writeToLog')
             ->with($log);
 
-        $listModel        = $this->createMock(ListModel::class);
-        $translatorModel  = $this->createMock(TranslatorInterface::class);
-
-        $subscriber     = new SegmentSubscriber($ipLookupHelper, $auditLogModel, $listModel, $translatorModel);
+        $subscriber  = new SegmentSubscriber($this->ipLookupHelper, $this->auditLogModel, $this->listModel, $this->segmentUsedInCampaignsValidator, $this->translator);
 
         $segment            = $this->createMock(LeadList::class);
         $segment->deletedId = $segmentId;
@@ -111,10 +142,7 @@ class SegmentSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('writeToLog')
             ->with($log);
 
-        $listModel        = $this->createMock(ListModel::class);
-        $translatorModel  = $this->createMock(TranslatorInterface::class);
-
-        $subscriber     = new SegmentSubscriber($ipLookupHelper, $auditLogModel, $listModel, $translatorModel);
+        $subscriber  = new SegmentSubscriber($ipLookupHelper, $auditLogModel, $this->listModel, $this->segmentUsedInCampaignsValidator, $this->translator);
 
         $segment = $this->createMock(LeadList::class);
         $segment->expects($this->once())

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -9,36 +9,37 @@ use Mautic\LeadBundle\Event\LeadListEvent as SegmentEvent;
 use Mautic\LeadBundle\EventListener\SegmentSubscriber;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\ListModel;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Mautic\LeadBundle\Validator\SegmentUsedInCampaignsValidator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SegmentSubscriberTest extends TestCase
 {
     /**
-     * @var IpLookupHelper
+     * @var IpLookupHelper&MockObject
      */
-    private $ipLookupHelper;
+    private MockObject $ipLookupHelper;
 
     /**
-     * @var AuditLogModel
+     * @var AuditLogModel&MockObject
      */
-    private $auditLogModel;
+    private MockObject $auditLogModel;
 
     /**
-     * @var ListModel
+     * @var ListModel&MockObject
      */
-    private $listModel;
+    private MockObject $listModel;
 
     /**
-     * @var TranslatorInterface
+     * @var TranslatorInterface&MockObject
      */
-    private $translator;
+    private MockObject $translator;
 
     /**
-     * @var SegmentUsedInCampaignsValidator
+     * @var SegmentUsedInCampaignsValidator&MockObject
      */
-    private $segmentUsedInCampaignsValidator;
+    private MockObject $segmentUsedInCampaignsValidator;
 
     public function setUp(): void
     {

--- a/app/bundles/LeadBundle/Translations/en_US/validators.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/validators.ini
@@ -38,3 +38,4 @@ mautic.lead_list.is_in_use="This segment is used in %segments%, please go back a
 mautic.import.file.required="Please select a CSV file to upload"
 mautic.lead.segment.date_invalid="Date field filter value \"%value%\" is invalid. It must be on format YYYY-MM-DD or using keywords from the validated this you will find in documentation. Please be careful not using uppercase character."
 mautic.lead.field.unique.is_used="This field must be unique."
+mautic.lead.lists.used_in_campaigns="{1}This segment is used in %campaignNames% campaign. Please check it before unpublishing.|[2,Inf]This segment is used in the following campaigns: %campaignNames%. Please check them before unpublishing."

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class SegmentUsedInCampaigns extends Constraint
+{
+    public function getTargets()
+    {
+        return static::CLASS_CONSTRAINT;
+    }
+}

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaignsValidator.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaignsValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Validator\Constraints;
+
+use Mautic\CoreBundle\Exception\RecordNotUnpublishedException;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Validator\SegmentUsedInCampaignsValidator as InternalValidator;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class SegmentUsedInCampaignsValidator extends ConstraintValidator
+{
+    /**
+     * @var InternalValidator
+     */
+    private $internalValidator;
+
+    public function __construct(InternalValidator $internalValidator)
+    {
+        $this->internalValidator = $internalValidator;
+    }
+
+    public function validate($segment, Constraint $constraint): void
+    {
+        try {
+            /** @var LeadList $segment */
+            if ($segment->getIsPublished()) {
+                return;
+            }
+
+            $this->internalValidator->validate($segment);
+        } catch (RecordNotUnpublishedException $exception) {
+            $this->context->buildViolation($exception->getMessage())
+                ->atPath('isPublished')
+                ->setCode(Response::HTTP_UNPROCESSABLE_ENTITY)
+                ->addViolation();
+        }
+    }
+}

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaignsValidator.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaignsValidator.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2021 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\LeadBundle\Validator\Constraints;
 
 use Mautic\CoreBundle\Exception\RecordNotUnpublishedException;
@@ -22,14 +13,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class SegmentUsedInCampaignsValidator extends ConstraintValidator
 {
-    /**
-     * @var InternalValidator
-     */
-    private $internalValidator;
-
-    public function __construct(InternalValidator $internalValidator)
+    public function __construct(private InternalValidator $internalValidator)
     {
-        $this->internalValidator = $internalValidator;
     }
 
     public function validate($segment, Constraint $constraint): void
@@ -44,7 +29,7 @@ class SegmentUsedInCampaignsValidator extends ConstraintValidator
         } catch (RecordNotUnpublishedException $exception) {
             $this->context->buildViolation($exception->getMessage())
                 ->atPath('isPublished')
-                ->setCode(Response::HTTP_UNPROCESSABLE_ENTITY)
+                ->setCode((string) Response::HTTP_UNPROCESSABLE_ENTITY)
                 ->addViolation();
         }
     }

--- a/app/bundles/LeadBundle/Validator/SegmentUsedInCampaignsValidator.php
+++ b/app/bundles/LeadBundle/Validator/SegmentUsedInCampaignsValidator.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\LeadBundle\Validator;
+
+use Mautic\CoreBundle\Exception\RecordNotUnpublishedException;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class SegmentUsedInCampaignsValidator
+{
+    /**
+     * @var LeadListRepository
+     */
+    private $leadListRepository;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(LeadListRepository $leadListRepository, TranslatorInterface $translator)
+    {
+        $this->leadListRepository = $leadListRepository;
+        $this->translator         = $translator;
+    }
+
+    /**
+     * @throws RecordNotUnpublishedException
+     */
+    public function validate(LeadList $segment): void
+    {
+        if (!$segment->getId()) {
+            return;
+        }
+
+        $segments = $this->leadListRepository->getSegmentCampaigns($segment->getId());
+        if (1 > count($segments)) {
+            return;
+        }
+
+        $campaignNames = array_map([$this, 'decorateCampaignName'], $segments);
+        $campaignNames = implode(', ', $campaignNames);
+
+        $errorMessage = $this->translator->transChoice(
+            'mautic.lead.lists.used_in_campaigns',
+            count($segments),
+            [
+                '%campaignNames%' => $campaignNames,
+            ],
+            'validators'
+        );
+
+        throw new RecordNotUnpublishedException($errorMessage);
+    }
+
+    private function decorateCampaignName($campaignName): string
+    {
+        return sprintf('"%s"', $campaignName);
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | /
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Currently if a campaign is based on a segment as the source of contacts, and that segment gets unpublished, the campaign will fail.
If a user tries to unpublish a segment that is being used in another campaign as a source, we must not allow to do it and display an error message.

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
This is not a bug so there is nothing to reproduce.

#### Steps to test this PR:
1. Create a segment, publish it.
2. Create a segment and used the segment as the source of the contacts.
3. Go to a segment edit page and try to unpublish it. You should see a warning message. Your segment should not be unpublished.
4. Go to a segment list page (with the list of all available segments) and try to unpublish it from there. You should also see an error message.

You can also test API if you know how to do it, but we have a functional test that does it. 
1. Make sure you followed steps 1-2.
2. Send an API request (your API user have to be configured appropriately) that modifies the segment and unpublishes it.
3. You should see a error in the response and the response must have 422 code.

#### Other areas of Mautic that may be affected by the change:
1. Only segments should be affected.

#### List deprecations along with the new alternative:
No

#### List backwards compatibility breaks:
No