### PR TITLE
DPMMA-2462 Fix Autowiring Dependency for PushToIntegrationTrait

### DIFF
--- a/app/bundles/PluginBundle/Config/services.php
+++ b/app/bundles/PluginBundle/Config/services.php
@@ -3,7 +3,11 @@
 declare(strict_types=1);
 
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
+use Mautic\PluginBundle\EventListener\CampaignSubscriber;
+use Mautic\PluginBundle\EventListener\FormSubscriber;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
@@ -24,4 +28,9 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.plugin.model.plugin', \Mautic\PluginBundle\Model\PluginModel::class);
     $services->alias('mautic.plugin.model.integration_entity', \Mautic\PluginBundle\Model\IntegrationEntityModel::class);
+
+    $services->set(FormSubscriber::class)
+        ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
+    $services->set(CampaignSubscriber::class)
+        ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
 };


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ N ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This PR fixes an issue when using integration plugins in Mautic campaigns, specifically with the "push to integration" action. The problem was caused by missing `integrationHelper` in `PluginBundle/EventListener/PushToIntegrationTrait.php`. To solve this, I've updated services.php to set `integrationHelper` in both `FormSubscriber` and `CampaignSubscriber` classes.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to reproduce this issue:
Steps to reproduce:
1. Open this PR on Gitpod or your local instance
2. Enable any plugin that adds the Push To Integration action. For example vTiger, you can fake credentials just to reproduce this autowiring issue. 
![image](https://github.com/mautic/mautic/assets/8580942/624c7ba3-767c-4ec1-80f3-1f491ea1565e)
3. Create campaign with Push to Integration action.
![image](https://github.com/mautic/mautic/assets/8580942/c7f5d3fc-2ba7-415f-93ab-7c1a0aa0a3bc)
4. Build the campaign `ddev exec php bin/console mautic:campaigns:update `
5. Run the campaign `ddev exec php bin/console mautic:campaigns:trigger `

The last command should result in an error:
```
Error: Call to a member function getIntegrationObjects() on null (uncaught exception) at /var/www/html/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php line 52 while running console command `mautic:campaigns:trigger`
[stack trace]
#0 /var/www/html/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php(40): Mautic\PluginBundle\EventListener\CampaignSubscriber::pushIt(Array, Object(Mautic\LeadBundle\Entity\Lead), Array)
#1 /var/www/html/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php(44): Mautic\PluginBundle\EventListener\CampaignSubscriber->pushToIntegration(Array, Object(Mautic\LeadBundle\Entity\Lead), Array)
#2 /var/www/html/vendor/symfony/event-dispatcher/Debug/WrappedListener.php(118): Mautic\PluginBundle\EventListener\CampaignSubscriber->onCampaignTriggerAction(Object(Mautic\CampaignBundle\Event\CampaignExecutionEvent), 'mautic.plugin.o...', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#3 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(Object(Mautic\CampaignBundle\Event\CampaignExecutionEvent), 'mautic.plugin.o...', Object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher))
#4 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\Component\EventDispatcher\EventDispatcher->callListeners(Array, 'mautic.plugin.o...', Object(Mautic\CampaignBundle\Event\CampaignExecutionEvent))
#5 /var/www/html/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php(154): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Mautic\CampaignBundle\Event\CampaignExecutionEvent), 'mautic.plugin.o...')
#6 /var/www/html/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php(165): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(Object(Mautic\CampaignBundle\Event\CampaignExecutionEvent), 'mautic.plugin.o...')
#7 /var/www/html/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php(63): Mautic\CampaignBundle\Executioner\Dispatcher\LegacyEventDispatcher->dispatchEventName('mautic.plugin.o...', Array, Object(Mautic\CampaignBundle\Entity\LeadEventLog))
#8 /var/www/html/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php(64): Mautic\CampaignBundle\Executioner\Dispatcher\LegacyEventDispatcher->dispatchCustomEvent(Object(Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor), Object(Doctrine\Common\Collections\ArrayCollection), NULL, Object(Mautic\CampaignBundle\Event\PendingEvent))
#9 /var/www/html/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php(46): Mautic\CampaignBundle\Executioner\Dispatcher\ActionDispatcher->dispatchEvent(Object(Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor), Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection))
#10 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(127): Mautic\CampaignBundle\Executioner\Event\ActionExecutioner->execute(Object(Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor), Object(Doctrine\Common\Collections\ArrayCollection))
#11 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(98): Mautic\CampaignBundle\Executioner\EventExecutioner->executeLogs(Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter))
#12 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(169): Mautic\CampaignBundle\Executioner\EventExecutioner->executeForContacts(Object(Mautic\CampaignBundle\Entity\Event), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter), false)
#13 /var/www/html/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(159): Mautic\CampaignBundle\Executioner\EventExecutioner->executeEventsForContacts(Object(Doctrine\Common\Collections\ArrayCollection), Object(Doctrine\Common\Collections\ArrayCollection), Object(Mautic\CampaignBundle\Executioner\Result\Counter))
#14 /var/www/html/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(60): Mautic\CampaignBundle\Executioner\KickoffExecutioner->executeOrScheduleEvent()
#15 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(332): Mautic\CampaignBundle\Executioner\KickoffExecutioner->execute(Object(Mautic\CampaignBundle\Entity\Campaign), Object(Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(285): Mautic\CampaignBundle\Command\TriggerCampaignCommand->executeKickoff()
#17 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(234): Mautic\CampaignBundle\Command\TriggerCampaignCommand->triggerCampaign(Object(Mautic\CampaignBundle\Entity\Campaign))
#18 /var/www/html/vendor/symfony/console/Command/Command.php(298): Mautic\CampaignBundle\Command\TriggerCampaignCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#19 /var/www/html/vendor/symfony/console/Application.php(1058): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#20 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(96): Symfony\Component\Console\Application->doRunCommand(Object(Mautic\CampaignBundle\Command\TriggerCampaignCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#21 /var/www/html/vendor/symfony/console/Application.php(301): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Mautic\CampaignBundle\Command\TriggerCampaignCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#22 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(82): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#23 /var/www/html/vendor/symfony/console/Application.php(171): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#24 /var/www/html/bin/console(16): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#25 {main} ["hostname" => "mautic-web","pid" => 4255]
10:07:45 CRITICAL  [console] Error thrown while running command "mautic:campaigns:trigger --campaign-limit=1". Message: "Call to a member function getIntegrationObjects() on null" ["exception" => Error { …},"command" => "mautic:campaigns:trigger --campaign-limit=1","message" => "Call to a member function getIntegrationObjects() on null"] ["hostname" => "mautic-web","pid" => 4255]
10:07:45 WARNING   [mautic] Command `mautic:campaigns:trigger` exited with status code 1 ["hostname" => "mautic-web","pid" => 4255]
```


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  Repeat steps to reproduce the issue

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
