### PR TITLE
Add provision for merge filters | Custom Objects

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -53,6 +53,8 @@ class ContactSegmentFilterFactory
                     $factorSegmentFilter                    = $this->factorSegmentFilter($nestedFilter, $batchLimiters);
                     $mergedProperty[$index]['filter_value'] = $factorSegmentFilter->getParameterValue();
                     $mergedProperty[$index]['operator']     = $factorSegmentFilter->getOperator();
+                    $mergedProperty[$index]['field']        = $factorSegmentFilter->getField();
+                    $mergedProperty[$index]['type']         = $factorSegmentFilter->getType();
                 }
                 if ($factorSegmentFilter) {
                     $factorSegmentFilter->contactSegmentFilterCrate->setMergedProperty($mergedProperty);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [✅]
| New feature/enhancement? (use the a.x branch)      | [❌]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [✅] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | https://acquia.atlassian.net/browse/MAUT-11028 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
This PR fixes the way CO filters are used in segments. When multiple custom items are linked to a contact, it didn't use to account a single custom object row while considering segment filter query. This fix can be enabled by setting `custom_object_merge_filter` key to true and also `custom_object_item_value_to_contact_relation_limit` key to 0.

If the following contacts have custom items associated and consider today's date is *2024-02-12*:
| Contact ID | Custom Item Text | Custom Item Date |
| --- | --- | --- |
| 1 | Tiger | 2024-02-01 |
| 1 | Lion | 2024-02-01 |
| **2** | **Tiger** | **2024-02-15** |
| 2 | Lion | 2024-02-15 |
| 3 | Tiger | 2024-03-15 |
| 3 | Lion | 2024-03-15 |

Segment filters are:
1. Custom Item Text = 'Tiger'
2. Custom Item Date > '2024-02-13 23:59:59'
3. Custom Item Date <= '2024-03-12'

### Before PR:
```sql
SELECT l.id
FROM mautic_leads l
WHERE (EXISTS(SELECT contact_id
              FROM mautic_custom_field_value_text cfwq_2_value
                       INNER JOIN mautic_custom_item_xref_contact cfwq_2_contact
                                  ON cfwq_2_value.custom_item_id = cfwq_2_contact.custom_item_id
              WHERE (cfwq_2_value.custom_field_id = 2)
                AND (cfwq_2_value.value = 'Tiger')
                AND (cfwq_2_contact.contact_id = l.id)))
  AND (EXISTS(SELECT contact_id
              FROM mautic_custom_field_value_date cfwq_1_value
                       INNER JOIN mautic_custom_item_xref_contact cfwq_1_contact
                                  ON cfwq_1_value.custom_item_id = cfwq_1_contact.custom_item_id
              WHERE (cfwq_1_value.custom_field_id = 1)
                AND (cfwq_1_value.value > '2024-02-13 23:59:59')
                AND (cfwq_1_value.value <= '2024-03-12')
                AND (cfwq_1_contact.contact_id = l.id)))
  AND (l.id NOT IN (SELECT par5.lead_id FROM mautic_lead_lists_leads par5 WHERE par5.leadlist_id = 1))

```
The segment should only consider contact ID 2 has a valid contact but since the SQL generated individually executed consider contact IDs 1 and 3 as valid contacts.

### After PR:
```sql
SELECT l.id
FROM mautic_leads l
WHERE (EXISTS(SELECT 1
              FROM mautic_custom_item_xref_contact cix
                       INNER JOIN mautic_custom_field_value_text cix_2_text_value
                                  ON cix_2_text_value.custom_item_id = cix.custom_item_id AND
                                     cix_2_text_value.custom_field_id = 2
                       INNER JOIN mautic_custom_field_value_date cix_1_date_value
                                  ON cix_1_date_value.custom_item_id = cix.custom_item_id AND
                                     cix_1_date_value.custom_field_id = 1
              WHERE (cix.contact_id = l.id)
                AND (cix_2_text_value.value = 'Tiger')
                AND (cix_1_date_value.value > '2024-02-13 23:59:59')
                AND (cix_1_date_value.value <= '2024-03-12')))
  AND (l.id NOT IN (SELECT par4.lead_id FROM mautic_lead_lists_leads par4 WHERE par4.leadlist_id = 4))
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Try above scenario and it should consider only contact 2

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->