### PR TITLE
[UX] “Score” and “Company owner” fields on New Company looks inconsistent since both are not part of either “Core” nor “Professional” sections

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Company/form_fields.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/form_fields.html.twig
@@ -66,7 +66,7 @@
                                         </div>
                                     {% endif %}
                                 </div>
-                                <div class="row">
+                                <div class="row mb-md">
                                     {% if form.companyzipcode is defined %}
                                         <div class="col-sm-{{ halfSize }}">
                                             {{ form_widget(form.companyzipcode, {'attr': {'placeholder': form.companyzipcode.vars.label}}) }}
@@ -77,6 +77,14 @@
                                             {{ form_widget(form.companycountry, {'attr': {'placeholder': form.companycountry.vars.label}}) }}
                                         </div>
                                     {% endif %}
+                                </div>
+                                <div class="row">
+                                    <div  class="col-sm-{{ halfSize }}">
+                                        {{ form_row(form.score) }}
+                                    </div>
+                                    <div  class="col-sm-{{ halfSize }}">
+                                        {{ form_row(form.owner) }}
+                                    </div>
                                 </div>
                             </div>
                         {% endif %}

--- a/app/bundles/LeadBundle/Resources/views/Company/form_standalone.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/form_standalone.html.twig
@@ -38,13 +38,7 @@
                     {% endfor %}
                 </ul>
                 <hr/>
-                <div>
-                    {{ form_row(form.score) }}
-                </div>
-                <hr/>
-                <div>
-                    {{ form_row(form.owner) }}
-                </div>
+
             </div>
         </div>
         <div class="col-md-9 bg-auto height-auto bdr-l">


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This update repositions the ‘Score’ and ‘Company owner’ fields within the New Company section to align with the existing ‘Core’ and ‘Professional’ categories. The change aims to eliminate inconsistencies in the field layout, thereby improving the logical flow and visual coherence of the interface. This adjustment will benefit users by providing a more intuitive and organized structure, facilitating easier navigation and data entry.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Companies
3. Create a new
4. Look at the new fields location

![image](https://github.com/mautic/mautic/assets/116097999/cb804ae2-2735-4aed-a6cd-30b74c21f88f)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
