### PR TITLE
[UX] Change Published to Available for use (Dynamic content)

### DIFF
--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/form.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/form.html.twig
@@ -125,7 +125,7 @@
             {{ form_row(form.language) }}
             {{ form_row(form.translationParent) }}
             <div id="publishStatus">
-                {{ form_row(form.isPublished) }}
+                {{ form_row(form.isPublished, {'label': 'mautic.dynamicContent.available'}) }}
             </div>
             {% if form.updateSelect is not defined %}
                 {{ form_row(form.isCampaignBased) }}

--- a/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
+++ b/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
@@ -1,5 +1,6 @@
 mautic.dynamicContent.dynamicContent="Dynamic Content"
 mautic.dynamicContent.dynamicContents="Dynamic Content"
+mautic.dynamicContent.available="Available for use"
 
 mautic.dynamicContent.campaign.event.form.dynamicContents="Limit to Pages"
 mautic.dynamicContent.campaign.event.form.dynamicContents.descr="Select the pages this trigger applies to. If none are selected, it'll apply to any page."

--- a/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
+++ b/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
@@ -15,10 +15,10 @@ mautic.dynamicContent.config.form.google.analytics="Analytics script (i.e. Googl
 mautic.dynamicContent.config.form.google.analytics.tooltip="Insert the analytics script to have it automatically included in the source of landing pages."
 
 mautic.dynamicContent.event.hit="Page Hit"
-mautic.dynamicContent.event.publish.down="Publish down %dwc%"
-mautic.dynamicContent.event.publish.down.description="Dynamic Content '%dwc%' is going to be unpublished."
-mautic.dynamicContent.event.publish.up="Publish up %dwc%"
-mautic.dynamicContent.event.publish.up.description="Page '%dwc%' is going to be published."
+mautic.dynamicContent.event.publish.down="Make %dwc% unavailable"
+mautic.dynamicContent.event.publish.down.description="Dynamic Content '%dwc%' will be set as unavailable."
+mautic.dynamicContent.event.publish.up="Make %dwc% available"
+mautic.dynamicContent.event.publish.up.description="Page '%dwc%' will be set as available."
 
 mautic.dynamicContent.form.internal.name="Internal Name"
 mautic.dynamicContent.form.confirmbatchdelete="Delete the selected items? WARNING - this will also delete all associated translations!"
@@ -36,8 +36,8 @@ mautic.dynamicContent.menu.view="View Page"
 
 mautic.dynamiccontent.permissions.header="Dynamic Content Permissions"
 mautic.dynamiccontent.permissions.dynamiccontents="Dynamic Content - User has access to"
-mautic.dynamicContent.publish.down="Publish Down"
-mautic.dynamicContent.publish.up="Publish Up"
+mautic.dynamicContent.publish.down="Set as unavailable"
+mautic.dynamicContent.publish.up="Set as available"
 mautic.dynamicContent.report.revision="Revision"
 
 mautic.dynamicContent.campaign.send_dwc="Push dynamic content"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This change updates the label from ‘Published’ to ‘Available for Use’ for dynamic content settings. This terminology shift better reflects the actual status of the content, indicating that it is ready for deployment rather than simply being in a published state. This enhancement promotes a clearer understanding of content status, aiding users in managing their dynamic content more effectively.
<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Dynamic Content
3. Create new
4. Look at the new label

![image](https://github.com/mautic/mautic/assets/116097999/0fc1456b-80d8-4893-afc2-be9a9c1ad17f)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
