### PR TITLE
[UX] Place the tip modal (the one that asks the website to generate preview) more below for Focus Items

### DIFF
--- a/plugins/MauticFocusBundle/Assets/css/focus.css
+++ b/plugins/MauticFocusBundle/Assets/css/focus.css
@@ -15,6 +15,7 @@
 }
 .focus-builder .website-preview .website-placeholder {
   z-index: 1020;
+  margin-top: 10%;
 }
 .focus-builder #websiteScreenshot {
   position: absolute;

--- a/plugins/MauticFocusBundle/Assets/css/focus.less
+++ b/plugins/MauticFocusBundle/Assets/css/focus.less
@@ -19,6 +19,7 @@
 
     .website-placeholder {
       z-index: 1020;
+      margin-top: 10%;
     }
   }
 

--- a/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/form.html.twig
@@ -48,7 +48,7 @@
             <div class="website-preview">
 
                 <!-- Form to get preview URL -->
-                <div class="website-placeholder hide well well-lg col-md-6 col-md-offset-3 mt-lg">
+                <div class="website-placeholder hide well well-lg col-md-6 col-md-offset-3">
                     <div class="row">
                         <div class="mautibot-image col-xs-3 text-center">
                             <img class="img-responsive" style="max-height: 125px; margin-left: auto; margin-right: auto;" src="{{ mautibotGetImage('wave') }}"/>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
This enhancement optimizes the positioning of the tip modal related to website preview generation. By shifting it further down, it avoids interference with any top-placed navigation bars, respecting the user’s layout choices. This improvement caters to diverse design preferences and ensures a seamless user experience by maintaining clear visibility of all interface elements.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Focus Items
3. Create new
4. Open the builder
5. Select Display a notice
6. Select Bar style
7. Tip will be below


![Captura de tela 2024-02-28 125107](https://github.com/mautic/mautic/assets/116097999/f34b0e84-9865-48db-ad00-475fc7b4e2f8)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
