### PR TITLE
Add possibility to stop sending in EmailSendEvent.

### DIFF
--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -47,6 +47,8 @@ class EmailSendEvent extends CommonEvent
 
     private bool $stopSending = false;
 
+    private string|\Exception $stopSendingError = '';
+
     /**
      * @param array $args
      * @param bool  $isDynamicContentParsing
@@ -345,5 +347,21 @@ class EmailSendEvent extends CommonEvent
     public function getStopSending(): bool
     {
         return $this->stopSending;
+    }
+
+    /**
+     * Set stop sending errror.
+     */
+    public function setStopSendingError(string|\Exception $error): void
+    {
+        $this->stopSendingError = $error;
+    }
+
+    /**
+     * Get stop sending errror.
+     */
+    public function getStopSendingError(): string|\Exception
+    {
+        return $this->stopSendingError;
     }
 }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -45,6 +45,8 @@ class EmailSendEvent extends CommonEvent
 
     private array $textHeaders = [];
 
+    private bool $stopSending = false;
+
     /**
      * @param array $args
      * @param bool  $isDynamicContentParsing
@@ -327,5 +329,21 @@ class EmailSendEvent extends CommonEvent
         $content .= $this->getEmail() ? $this->getEmail()->getCustomHtml() : '';
 
         return $content.implode(' ', $this->getTextHeaders());
+    }
+
+    /**
+     * Set stop sending.
+     */
+    public function setStopSending(bool $stopSending): void
+    {
+        $this->stopSending = $stopSending;
+    }
+
+    /**
+     * Get stop sending.
+     */
+    public function getStopSending(): bool
+    {
+        return $this->stopSending;
     }
 }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -374,7 +374,9 @@ class MailHelper
             }
 
             try {
-                $this->mailer->send($this->message);
+                if (empty($this->fatal)) {
+                    $this->mailer->send($this->message);
+                }
             } catch (TransportExceptionInterface $exception) {
                 /*
                     The nature of symfony/mailer is working with transactional emails only
@@ -1463,7 +1465,10 @@ class MailHelper
         $this->dispatcher->dispatch($event, EmailEvents::EMAIL_ON_SEND);
 
         $this->eventTokens = array_merge($this->eventTokens, $event->getTokens(false));
-
+        if ($event->getStopSending()) {
+            $this->logError('Event said to stop sending.');
+            $this->fatal = true;
+        }
         unset($event);
     }
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1466,7 +1466,9 @@ class MailHelper
 
         $this->eventTokens = array_merge($this->eventTokens, $event->getTokens(false));
         if ($event->getStopSending()) {
-            $this->logError('Event said to stop sending.');
+            $this->logError($event->getStopSendingError());
+            // When a string is used for logging the error, fatal is not set
+            // and therefore mail sending is not stopped.
             $this->fatal = true;
         }
         unset($event);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ X]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I would like the possibility to stop the sending of an Email through an eventsubscriber. There is already the EmailSendEvent so this looks the logical place to add this. 

Creating an eventsubscriber like below can now with this PR stop sending of the mail. 

```
    public static function getSubscribedEvents(): array
    {
        return [
            EmailEvents::EMAIL_ON_SEND    => ['stopMailSending', 0],
        ];
    }
    public function stopMailSending(EmailSendEvent $event): void
    {
      $event->setStopSending(TRUE);
     $event->setStopSendingError('Sending was stopped because subscriber said so.')
    }
```

This allows plugin developers to stop mail sending based on certain criteria. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create plugin with above EventListener, and see mails are not sent. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
