### PR TITLE
Updated CommonController::delegateView to include "mauticTemplate" value in "mauticTemplateVars" for rendering

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -173,6 +173,8 @@ class CommonController extends AbstractController implements MauticController
             $parameters = $event->getVars();
         }
 
+        $parameters['mauticTemplate'] = $template;
+
         $parameters['mauticTemplateVars'] = $parameters;
 
         return $this->render($template, $parameters, $response);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

When working with the `CoreEvents::VIEW_INJECT_CUSTOM_CONTENT` event, the template name, `mauticTemplate,` was missing, which led to a failing check.

The changes in the PR are brought back from M4 https://github.com/mautic/mautic/blob/4.4/app/bundles/CoreBundle/Templating/Engine/PhpEngine.php#L113.

#### Steps to test this PR:

**This is a technical task.**

