### PR TITLE
Fix campaign looping issue [backport]

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -349,7 +349,7 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @param      $campaignId
+     * @param int  $campaignId
      * @param bool $campaignCanBeRestarted
      *
      * @return CountResult
@@ -371,7 +371,7 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
-        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb, $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
@@ -405,7 +405,7 @@ class LeadRepository extends CommonRepository
             );
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
-        $this->updateQueryWithExistingMembershipExclusion($campaignId, $qb, $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
@@ -537,25 +537,31 @@ class LeadRepository extends CommonRepository
         return $segments;
     }
 
-    /**
-     * @param $campaignId
-     */
-    private function updateQueryWithExistingMembershipExclusion($campaignId, QueryBuilder $qb, $campaignCanBeRestarted = false)
+    private function updateQueryWithExistingMembershipExclusion(int $campaignId, QueryBuilder $qb, bool $campaignCanBeRestarted = false)
     {
-        $membershipConditions = [
+        $membershipConditions = $qb->expr()->and(
             $qb->expr()->eq('cl.lead_id', 'll.lead_id'),
-            $qb->expr()->eq('cl.campaign_id', (int) $campaignId),
-        ];
+            $qb->expr()->eq('cl.campaign_id', (int) $campaignId)
+        );
 
         if ($campaignCanBeRestarted) {
-            $membershipConditions[] = $qb->expr()->eq('cl.manually_removed', 0);
+            $alreadyInCampaign           = $qb->expr()->eq('cl.manually_removed', 0);
+            $removedFromCampaignManually = $qb->expr()->and(
+                $qb->expr()->eq('cl.manually_removed', 1),
+                $qb->expr()->isNull('cl.date_last_exited'),
+            );
+
+            $membershipConditions = $qb->expr()->and(
+                $membershipConditions,
+                $qb->expr()->or($alreadyInCampaign, $removedFromCampaignManually)
+            );
         }
 
         $subq = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'campaign_leads', 'cl')
             ->where(
-                $qb->expr()->andX(...$membershipConditions)
+                $qb->expr()->andX($membershipConditions)
             );
 
         $qb->andWhere(

--- a/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
@@ -11,6 +11,8 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
 
 class AbstractCampaignCommand extends MauticMysqlTestCase
 {
@@ -134,15 +136,27 @@ class AbstractCampaignCommand extends MauticMysqlTestCase
         return $campaign;
     }
 
-    protected function createCampaignLead(Campaign $campaign, Lead $lead): CampaignLead
+    protected function createCampaignLead(Campaign $campaign, Lead $lead, bool $manuallyRemoved = false): CampaignLead
     {
         $campaignLead = new CampaignLead();
         $campaignLead->setCampaign($campaign);
         $campaignLead->setLead($lead);
         $campaignLead->setDateAdded(new \DateTime());
+        $campaignLead->setManuallyRemoved($manuallyRemoved);
         $this->em->persist($campaignLead);
 
         return $campaignLead;
+    }
+
+    protected function createSegmentMember(LeadList $segment, Lead $lead): ListLead
+    {
+        $segmentMember = new ListLead();
+        $segmentMember->setLead($lead);
+        $segmentMember->setList($segment);
+        $segmentMember->setDateAdded(new \DateTime());
+        $this->em->persist($segmentMember);
+
+        return $segmentMember;
     }
 
     protected function createEvent(string $name, Campaign $campaign, string $type, string $eventType, array $property = null): Event

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -1,9 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Exception;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\Lead;
+use Mautic\CampaignBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\LeadBundle\Entity\ListLeadRepository;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
 use PHPUnit\Framework\Assert;
 
@@ -541,6 +548,53 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         Assert::assertTrue($campaignLeads[0]->getManuallyRemoved());
         Assert::assertSame($campaign2->getId(), $campaignLeads[1]->getCampaign()->getId());
         Assert::assertFalse($campaignLeads[1]->getManuallyRemoved());
+    }
+
+    /**
+     * @see https://github.com/mautic/mautic/issues/11061
+     *
+     * This test will not fail if the infinite loop returns and instead run indefinitelly until a PHPUNIT timeout is reached.
+     * I couldn't find an easy way to test for an infinite loop. But we'll know if it returns again.
+     * We'll just spend more time figuring out which test is taking so long.
+     */
+    public function testCampaignInfiniteLoop(): void
+    {
+        $campaignMemberRepo = $this->em->getRepository(Lead::class);
+        \assert($campaignMemberRepo instanceof LeadRepository);
+
+        $segmentMemberRepo = $this->em->getRepository(ListLead::class);
+        \assert($segmentMemberRepo instanceof ListLeadRepository);
+
+        $campaignRepo = $this->em->getRepository(Campaign::class);
+        \assert($campaignRepo instanceof CampaignRepository);
+
+        // Clear the campaign and segment members as those are manually_added.
+        $campaignMemberRepo->deleteEntities($campaignMemberRepo->findAll());
+        $segmentMemberRepo->deleteEntities($segmentMemberRepo->findAll());
+
+        $campaign = $campaignRepo->find(1); // Created in parent::setUp()
+        \assert($campaign instanceof Campaign);
+
+        $campaign->setAllowRestart(true);
+
+        $campaignRepo->saveEntity($campaign);
+
+        $john = $this->createLead('John');
+        $jane = $this->createLead('Jane');
+        $this->createSegmentMember($campaign->getLists()->first(), $john);
+        $this->createSegmentMember($campaign->getLists()->first(), $jane);
+        $this->createCampaignLead($campaign, $john);
+        $this->createCampaignLead($campaign, $jane, true); // Manually removed.
+        $this->em->flush();
+        $this->em->clear();
+
+        $tStart = microtime(true);
+
+        $this->runCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+
+        $tDiff = microtime(true) - $tStart;
+
+        $this->assertLessThan(10, $tDiff, 'The campaign rebuild takes more than 10 seconds, probably an infinite loop.');
     }
 
     /**


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ Y ]
| New feature/enhancement? (use the a.x branch)      | [ N ]
| Deprecations?                          | [ N ]
| BC breaks? (use the c.x branch)        | [ N ]
| Automated tests included?              | [ Y ]
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #12097, Fixes #11061

#### Description:

Backport of the "ugly looping issue while campaign rebuild use with Allow contacts to restart the campaign" that was fixed in #11318 for `5.x` to `4.4.x`.

#### Steps to test this PR:

See #11318
