### PR TITLE
Segment membership as a new filter for dynamic email content

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -195,6 +195,7 @@ return [
                 'class'     => Mautic\CoreBundle\Form\Type\DynamicContentFilterEntryFiltersType::class,
                 'arguments' => [
                     'translator',
+                    'mautic.lead.model.list',
                 ],
                 'methodCalls' => [
                     'setConnection' => [

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -3,6 +3,7 @@
 namespace Mautic\CoreBundle\Form\Type;
 
 use Mautic\LeadBundle\Form\Type\FilterTrait;
+use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -20,7 +21,8 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
     use FilterTrait;
 
     public function __construct(
-        private TranslatorInterface $translator
+        private TranslatorInterface $translator,
+        private ListModel $listModel
     ) {
     }
 
@@ -75,6 +77,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                 'stages',
                 'locales',
                 'fields',
+                'lists',
             ]
         );
 
@@ -82,6 +85,8 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
             [
                 'label'          => false,
                 'error_bubbling' => false,
+                // @see \Mautic\LeadBundle\Controller\AjaxController::loadSegmentFilterFormAction()
+                'lists'          => $this->listModel->getChoiceFields()['lead']['leadlist']['properties']['list'],
             ]
         );
     }

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -86,7 +86,7 @@ class DynamicContentFilterEntryFiltersType extends AbstractType
                 'label'          => false,
                 'error_bubbling' => false,
                 // @see \Mautic\LeadBundle\Controller\AjaxController::loadSegmentFilterFormAction()
-                'lists'          => $this->listModel->getChoiceFields()['lead']['leadlist']['properties']['list'],
+                'lists'          => $this->listModel->getChoiceFields()['lead']['leadlist']['properties']['list'] ?? [],
             ]
         );
     }

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
@@ -134,7 +134,6 @@ class DynamicContentFilterEntryType extends AbstractType
                 $key,
                 [
                     'company',
-                    'leadlist',
                     'campaign',
                     'device_type',
                     'device_brand',

--- a/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
+++ b/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Test\Event;
+
+use Mautic\CoreBundle\Event\TokenReplacementEvent;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\TestCase;
+
+class TokenReplacementEventTest extends TestCase
+{
+    public function testGetPassthrough(): void
+    {
+        $passthrough = ['passthrough'];
+        $event       = new TokenReplacementEvent('', null, [], $passthrough);
+        self::assertSame($passthrough, $event->getPassthrough());
+    }
+
+    public function testGetSetContent(): void
+    {
+        $content = 'content';
+        $event   = new TokenReplacementEvent($content);
+        self::assertSame($content, $event->getContent());
+    }
+
+    public function testAddGetTokens(): void
+    {
+        $token  = 'token';
+        $value  = 'value';
+        $token1 = 'token1';
+        $value1 = 'value1';
+        $event  = new TokenReplacementEvent('');
+        self::assertSame([], $event->getTokens());
+        $event->addToken($token, $value);
+        self::assertSame([$token => $value], $event->getTokens());
+        $event->addToken($token1, $value1);
+        self::assertSame(
+            [
+                $token  => $value,
+                $token1 => $value1,
+            ],
+            $event->getTokens()
+        );
+    }
+
+    public function testGetClickthrough(): void
+    {
+        $leadId           = 1;
+        $leadEntity['id'] = $leadId;
+        $clickthrough     = ['lead' => $leadEntity];
+        $event            = new TokenReplacementEvent('', $leadEntity, $clickthrough);
+        self::assertSame(
+            ['lead' => 1],
+            $event->getClickthrough()
+        );
+
+        $leadEntity   = new Lead();
+
+        $clickthrough = ['lead', $leadEntity];
+        $event        = new TokenReplacementEvent('', $leadEntity, $clickthrough);
+        self::assertSame(
+            $clickthrough,
+            $event->getClickthrough()
+        );
+
+        $leadEntity->setId($leadId);
+        $clickthrough = ['lead' => $leadEntity];
+        $event        = new TokenReplacementEvent('', $leadEntity, $clickthrough);
+        self::assertSame(
+            ['lead' => 1],
+            $event->getClickthrough()
+        );
+    }
+
+    public function testGetEntity(): void
+    {
+        $lead  = new Lead();
+        $event = new TokenReplacementEvent($lead);
+        self::assertSame(
+            $lead,
+            $event->getEntity()
+        );
+    }
+
+    public function testSetClickthrough(): void
+    {
+        $lead         = new Lead();
+        $event        = new TokenReplacementEvent($lead);
+        $clickthrough = ['clickthrough'];
+        $event->setClickthrough($clickthrough);
+
+        self::assertSame($clickthrough, $event->getClickthrough());
+    }
+
+    public function testGetLead(): void
+    {
+        $lead  = null;
+        $event = new TokenReplacementEvent('', $lead);
+        self::assertSame($lead, $event->getLead());
+        $lead  = new Lead();
+        $event = new TokenReplacementEvent('', $lead);
+        self::assertSame($lead, $event->getLead());
+    }
+
+    public function testSetContent(): void
+    {
+        $content1 = 'content1';
+        $event    = new TokenReplacementEvent('');
+        $event->setContent($content1);
+        self::assertSame($content1, $event->getContent());
+    }
+}

--- a/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
+++ b/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\CoreBundle\Test\Event;
 
 use Mautic\CoreBundle\Event\TokenReplacementEvent;

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Tests\Unit\Form\Type;
+
+use Mautic\CoreBundle\Form\Type\DynamicContentFilterEntryFiltersType;
+use Mautic\LeadBundle\Model\ListModel;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class DynamicContentFilterEntryFiltersTypeTest extends TestCase
+{
+    /**
+     * @var MockObject|TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var ListModel|MockObject
+     */
+    private $listModel;
+
+    /**
+     * @var DynamicContentFilterEntryFiltersType
+     */
+    private $form;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->listModel  = $this->createMock(ListModel::class);
+
+        $this->form =  new DynamicContentFilterEntryFiltersType($this->translator, $this->listModel);
+    }
+
+    public function testBuildForm(): void
+    {
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects(self::exactly(4))
+            ->method('add')
+            ->withConsecutive(
+                [
+                    'glue',
+                    ChoiceType::class,
+                    [
+                        'label'             => false,
+                        'choices'           => [
+                            'mautic.lead.list.form.glue.and' => 'and',
+                            'mautic.lead.list.form.glue.or'  => 'or',
+                        ],
+                        'attr'              => [
+                            'class'    => 'form-control not-chosen glue-select',
+                            'onchange' => 'Mautic.updateFilterPositioning(this)',
+                        ],
+                    ],
+                ],
+                [
+                    'field',
+                    HiddenType::class,
+                ],
+                [
+                    'object',
+                    HiddenType::class,
+                ],
+                [
+                    'type',
+                    HiddenType::class,
+                ]
+            );
+
+        $builder->expects($this->exactly(2))
+            ->method('addEventListener')
+            ->withConsecutive(
+                [
+                    FormEvents::PRE_SET_DATA,
+                    function (FormEvent $event) use ($formModifier) {
+                        $formModifier($event, FormEvents::PRE_SET_DATA);
+                    },
+                ],
+                [
+                    FormEvents::PRE_SUBMIT,
+                    function (FormEvent $event) use ($formModifier) {
+                        $formModifier($event, FormEvents::PRE_SUBMIT);
+                    },
+                ]
+            );
+
+        $this->form->buildForm($builder, []);
+    }
+
+    public function testGetBlockPrefix(): void
+    {
+        self::assertSame('dynamic_content_filter_entry_filters', $this->form->getBlockPrefix());
+    }
+
+    public function testConfigureOptions(): void
+    {
+        $resolver = $this->createMock(OptionsResolver::class);
+        $resolver->expects(self::once())
+            ->method('setRequired')
+            ->with([
+                'countries',
+                'regions',
+                'timezones',
+                'stages',
+                'locales',
+                'fields',
+                'lists',
+            ]);
+
+        $this->form->configureOptions($resolver);
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -78,6 +78,8 @@ class DynamicContentFilterEntryFiltersTypeTest extends TestCase
                 ]
             );
 
+        $formModifier = function (FormEvent $event, $eventName) {};
+
         $builder->expects($this->exactly(2))
             ->method('addEventListener')
             ->withConsecutive(

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * @copyright   2020 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\CoreBundle\Tests\Unit\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\DynamicContentFilterEntryFiltersType;
@@ -23,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DynamicContentFilterEntryFiltersTypeTest extends TestCase
 {
@@ -42,7 +33,7 @@ class DynamicContentFilterEntryFiltersTypeTest extends TestCase
      */
     private $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -19,19 +19,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class DynamicContentFilterEntryFiltersTypeTest extends TestCase
 {
     /**
-     * @var MockObject|TranslatorInterface
+     * @var MockObject&TranslatorInterface
      */
-    private $translator;
+    private MockObject $translator;
 
     /**
-     * @var ListModel|MockObject
+     * @var ListModel&MockObject
      */
-    private $listModel;
+    private MockObject $listModel;
 
-    /**
-     * @var DynamicContentFilterEntryFiltersType
-     */
-    private $form;
+    private DynamicContentFilterEntryFiltersType $form;
 
     protected function setUp(): void
     {
@@ -39,8 +36,7 @@ class DynamicContentFilterEntryFiltersTypeTest extends TestCase
 
         $this->translator = $this->createMock(TranslatorInterface::class);
         $this->listModel  = $this->createMock(ListModel::class);
-
-        $this->form =  new DynamicContentFilterEntryFiltersType($this->translator, $this->listModel);
+        $this->form       =  new DynamicContentFilterEntryFiltersType($this->translator, $this->listModel);
     }
 
     public function testBuildForm(): void
@@ -53,12 +49,12 @@ class DynamicContentFilterEntryFiltersTypeTest extends TestCase
                     'glue',
                     ChoiceType::class,
                     [
-                        'label'             => false,
-                        'choices'           => [
+                        'label'   => false,
+                        'choices' => [
                             'mautic.lead.list.form.glue.and' => 'and',
                             'mautic.lead.list.form.glue.or'  => 'or',
                         ],
-                        'attr'              => [
+                        'attr' => [
                             'class'    => 'form-control not-chosen glue-select',
                             'onchange' => 'Mautic.updateFilterPositioning(this)',
                         ],

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -746,3 +746,28 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
     // Convert based on first option in list
     Mautic.convertDwcFilterInput('#' + filterIdBase + '_operator', mQuery);
 };
+
+Mautic.copySubjectToName = function(elemSubject) {
+    let elemName = mQuery("#emailform_name");
+    if (elemName.val() === "") {
+        elemName.val(elemSubject.val());
+    }
+};
+
+Mautic.loadEmailDeliveredStat = function($el) {
+    var emailId = $el.data('email-stat-delivered-for');
+    Mautic.ajaxActionRequest('email:getEmailDeliveredCount', {id: emailId}, function(response){
+        if (response.success) {
+            var delivered = response.delivered;
+            $el.html(delivered);
+        }
+    }, false, true, "GET");
+};
+
+Mautic.loadEmailUsages = function($el) {
+    var emailId = $el.data('fetch-email-usages');
+    Mautic.ajaxActionRequest('email:getEmailUsages', {id: emailId}, function(response){
+        var usagesHtml = response.usagesHtml;
+        $el.html(usagesHtml);
+    }, false, true, "GET");
+};

--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -532,7 +532,7 @@ Mautic.toggleMailerIsOwnerWarningMessage = function(radioSelector) {
     let checkedRadio = mQuery(radioSelector+':checked');
     let globalMailerIsOwnerValue = checkedRadio.attr('data-global-mailer-is-onwer') ? '1' : '0';
     let warningMessageId = 'mailer-is-owner-waring';
-    
+
     mQuery('#'+warningMessageId).remove();
 
     if (checkedRadio.val() !== globalMailerIsOwnerValue) {
@@ -630,7 +630,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
 
     if (isSpecial) {
         var templateField = fieldType;
-        if (fieldType == 'boolean' || fieldType == 'multiselect') {
+        if (fieldType == 'boolean' || fieldType == 'multiselect' || fieldType == 'leadlist') {
             templateField = 'select';
         }
         var template = mQuery('#templates .' + templateField + '-template').clone();
@@ -668,7 +668,7 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
     var fieldOptions = fieldCallback = '';
     //activate fields
     if (isSpecial) {
-        if (fieldType == 'select' || fieldType == 'boolean' || fieldType == 'multiselect') {
+        if (fieldType == 'select' || fieldType == 'boolean' || fieldType == 'multiselect' || fieldType == 'leadlist') {
             // Generate the options
             fieldOptions = selectedOption.data("field-list");
 
@@ -744,107 +744,5 @@ Mautic.addDynamicContentFilter = function (selectedFilter, jQueryVariant) {
     });
 
     // Convert based on first option in list
-    Mautic.convertDynamicContentFilterInput('#' + filterIdBase + '_operator', mQuery);
-};
-
-Mautic.convertDynamicContentFilterInput = function(el, jQueryVariant) {
-    var mQuery = (typeof jQueryVariant != 'undefined') ? jQueryVariant : window.mQuery;
-    var operator = mQuery(el).val();
-    // Extract the filter number
-    var regExp    = /emailform_dynamicContent_(\d+)_filters_(\d+)_filters_(\d+)_operator/;
-    var matches   = regExp.exec(mQuery(el).attr('id'));
-
-    var dynamicContentIndex       = matches[1];
-    var dynamicContentFilterIndex = matches[2];
-    var filterNum                 = matches[3];
-
-    var filterId       = '#emailform_dynamicContent_' + dynamicContentIndex + '_filters_' + dynamicContentFilterIndex + '_filters_' + filterNum + '_filter';
-    var filterEl       = mQuery(filterId);
-    var filterElParent = filterEl.parent();
-
-    // Reset has-error
-    if (filterElParent.hasClass('has-error')) {
-        filterElParent.find('div.help-block').hide();
-        filterElParent.removeClass('has-error');
-    }
-
-    var disabled = (operator == 'empty' || operator == '!empty');
-    filterEl.prop('disabled', disabled);
-
-    if (disabled) {
-        filterEl.val('');
-    }
-
-    var newName = '';
-    var lastPos;
-
-    if (filterEl.is('select')) {
-        var isMultiple  = filterEl.attr('multiple');
-        var multiple    = (operator == 'in' || operator == '!in');
-        var placeholder = filterEl.attr('data-placeholder');
-
-        if (multiple && !isMultiple) {
-            filterEl.attr('multiple', 'multiple');
-
-            // Update the name
-            newName =  filterEl.attr('name') + '[]';
-            filterEl.attr('name', newName);
-
-            placeholder = mauticLang['chosenChooseMore'];
-        } else if (!multiple && isMultiple) {
-            filterEl.removeAttr('multiple');
-
-            // Update the name
-            newName = filterEl.attr('name');
-            lastPos = newName.lastIndexOf('[]');
-            newName = newName.substring(0, lastPos);
-
-            filterEl.attr('name', newName);
-
-            placeholder = mauticLang['chosenChooseOne'];
-        }
-
-        if (multiple) {
-            // Remove empty option
-            filterEl.find('option[value=""]').remove();
-
-            // Make sure none are selected
-            filterEl.find('option:selected').removeAttr('selected');
-        } else {
-            // Add empty option
-            filterEl.prepend("<option value='' selected></option>");
-        }
-
-        // Destroy the chosen and recreate
-        Mautic.destroyChosen(filterEl);
-
-        filterEl.attr('data-placeholder', placeholder);
-
-        Mautic.activateChosenSelect(filterEl, false, mQuery);
-    }
-};
-
-Mautic.copySubjectToName = function(elemSubject) {
-    let elemName = mQuery("#emailform_name");
-    if (elemName.val() === "") {
-        elemName.val(elemSubject.val());
-    }
-};
-
-Mautic.loadEmailDeliveredStat = function($el) {
-    var emailId = $el.data('email-stat-delivered-for');
-    Mautic.ajaxActionRequest('email:getEmailDeliveredCount', {id: emailId}, function(response){
-        if (response.success) {
-            var delivered = response.delivered;
-            $el.html(delivered);
-        }
-    }, false, true, "GET");
-};
-
-Mautic.loadEmailUsages = function($el) {
-    var emailId = $el.data('fetch-email-usages');
-    Mautic.ajaxActionRequest('email:getEmailUsages', {id: emailId}, function(response){
-        var usagesHtml = response.usagesHtml;
-        $el.html(usagesHtml);
-    }, false, true, "GET");
+    Mautic.convertDwcFilterInput('#' + filterIdBase + '_operator', mQuery);
 };

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 
 /**
@@ -206,27 +205,12 @@ trait MatchFilterForLeadTrait
      */
     private function isContactSegmentRelationshipValid(int $contactId, string $operator, array $segmentIds = null): bool
     {
-        switch ($operator) {
-            case OperatorOptions::EMPTY:
-                // Contact is not in any segment
-                $return = $this->segmentRepository->isNotContactInAnySegment($contactId);
-                break;
-            case OperatorOptions::NOT_EMPTY:
-                // Contact is in any segment
-                $return = $this->segmentRepository->isContactInAnySegment($contactId);
-                break;
-            case OperatorOptions::IN:
-                // Contact is in all segments provided in $segmentsIds
-                $return = $this->segmentRepository->isContactInSegments($contactId, $segmentIds);
-                break;
-            case OperatorOptions::NOT_IN:
-                // Contact is not in all segments provided in $segmentsIds
-                $return = $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds);
-                break;
-            default:
-                throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator));
-        }
-
-        return $return;
+        return match ($operator) {
+            OperatorOptions::EMPTY     => $this->segmentRepository->isNotContactInAnySegment($contactId),
+            OperatorOptions::NOT_EMPTY => $this->segmentRepository->isContactInAnySegment($contactId),
+            OperatorOptions::IN        => $this->segmentRepository->isContactInSegments($contactId, $segmentIds),
+            OperatorOptions::NOT_IN    => $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds),
+            default                    => throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator)),
+        };
     }
 }

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -199,7 +199,7 @@ trait MatchFilterForLeadTrait
      *
      * @see \Mautic\LeadBundle\EventListener\DynamicContentSubscriber::isContactSegmentRelationshipValid
      *
-     * @param string $operator empty, !empty, in, !in
+     * @param string $operator   empty, !empty, in, !in
      * @param int[]  $segmentIds
      */
     private function isContactSegmentRelationshipValid(LeadListRepository $segmentRepository, int $contactId, string $operator, array $segmentIds = null): bool

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -206,10 +206,10 @@ trait MatchFilterForLeadTrait
     private function isContactSegmentRelationshipValid(int $contactId, string $operator, array $segmentIds = null): bool
     {
         return match ($operator) {
-            OperatorOptions::EMPTY     => $this->segmentRepository->isNotContactInAnySegment($contactId),
-            OperatorOptions::NOT_EMPTY => $this->segmentRepository->isContactInAnySegment($contactId),
-            OperatorOptions::IN        => $this->segmentRepository->isContactInSegments($contactId, $segmentIds),
-            OperatorOptions::NOT_IN    => $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds),
+            OperatorOptions::EMPTY     => $this->segmentRepository->isNotContactInAnySegment($contactId), // Contact is not in any segment
+            OperatorOptions::NOT_EMPTY => $this->segmentRepository->isContactInAnySegment($contactId), // Contact is in any segment
+            OperatorOptions::IN        => $this->segmentRepository->isContactInSegments($contactId, $segmentIds), // Contact is in one of the segment provided in $segmentsIds
+            OperatorOptions::NOT_IN    => $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds), // Contact is not in all segments provided in $segmentsIds
             default                    => throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator)),
         };
     }

--- a/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TokenSubscriber.php
@@ -7,6 +7,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -17,7 +18,8 @@ class TokenSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private EventDispatcherInterface $dispatcher,
-        private PrimaryCompanyHelper $primaryCompanyHelper
+        private PrimaryCompanyHelper $primaryCompanyHelper,
+        private LeadListRepository $segmentRepository
     ) {
     }
 

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -124,6 +124,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
     {
         $segment = new LeadList();
         $segment->setName($name);
+        $segment->setPublicName($name);
         $segment->setAlias(strtolower($name));
         $segment->isPublished(true);
         $this->em->persist($segment);

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -136,7 +136,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $listLead = new ListLead();
         $listLead->setLead($lead);
         $listLead->setList($segment);
-        $listLead->setDateAdded(new DateTime());
+        $listLead->setDateAdded(new \DateTime());
         $this->em->persist($listLead);
         $this->em->flush();
 

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -7,6 +7,8 @@ namespace Mautic\EmailBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -62,5 +64,82 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
 
         return $lead;
+    }
+
+    public function testPreviewEmailWithCorrectDCVariationFilterSegmentMembership(): void
+    {
+        $segment1 = $this->createSegment('Segment 1');
+        $segment2 = $this->createSegment('Segment 2');
+        $lead     = $this->createLead();
+        $this->addLeadToSegment($lead, $segment1);
+        $email = $this->createEmail();
+
+        $email->setDynamicContent([
+            0 => [
+                    'tokenName' => 'Dynamic Content 1',
+                    'content'   => '<p>Default Dynamic Content</p>',
+                    'filters'   => [
+                            0 => [
+                                    'content' => '<p>Variation 1</p>',
+                                    'filters' => [
+                                            0 => [
+                                                    'glue'   => 'and',
+                                                    'field'  => 'leadlist',
+                                                    'object' => 'lead',
+                                                    'type'   => 'leadlist',
+                                                    'filter' => [
+                                                            0 => $segment1->getId(),
+                                                            1 => $segment2->getId(),
+                                                        ],
+                                                    'display'  => 'Segment Membership',
+                                                    'operator' => 'in',
+                                                ],
+                                        ],
+                                ],
+                        ],
+                ],
+        ]);
+        $email->setCustomHtml('{dynamiccontent="Dynamic Content 1"}');
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $url                    = "/email/preview/{$email->getId()}";
+        $urlWithContact         = "{$url}?contactId={$lead->getId()}";
+        $contentNoContactInfo   = 'Default Dynamic Content';
+        $contentWithContactInfo = 'Variation 1';
+
+        // Anonymous visitor
+        $this->assertPageContent($url, $contentNoContactInfo);
+        $this->assertPageContent($urlWithContact, $contentNoContactInfo);
+
+        $this->loginUser('admin');
+
+        // Admin user
+        $this->assertPageContent($url, $contentNoContactInfo);
+        $this->assertPageContent($urlWithContact, $contentWithContactInfo);
+    }
+
+    private function createSegment(string $name = 'Segment 1'): LeadList
+    {
+        $segment = new LeadList();
+        $segment->setName($name);
+        $segment->setAlias(strtolower($name));
+        $segment->isPublished(true);
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        return $segment;
+    }
+
+    private function addLeadToSegment(Lead $lead, LeadList $segment): ListLead
+    {
+        $listLead = new ListLead();
+        $listLead->setLead($lead);
+        $listLead->setList($segment);
+        $listLead->setDateAdded(new DateTime());
+        $this->em->persist($listLead);
+        $this->em->flush();
+
+        return $listLead;
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -71,33 +71,34 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $segment1 = $this->createSegment('Segment 1');
         $segment2 = $this->createSegment('Segment 2');
         $lead     = $this->createLead();
+        $email    = $this->createEmail();
+
         $this->addLeadToSegment($lead, $segment1);
-        $email = $this->createEmail();
 
         $email->setDynamicContent([
-            0 => [
-                    'tokenName' => 'Dynamic Content 1',
-                    'content'   => '<p>Default Dynamic Content</p>',
-                    'filters'   => [
-                            0 => [
-                                    'content' => '<p>Variation 1</p>',
-                                    'filters' => [
-                                            0 => [
-                                                    'glue'   => 'and',
-                                                    'field'  => 'leadlist',
-                                                    'object' => 'lead',
-                                                    'type'   => 'leadlist',
-                                                    'filter' => [
-                                                            0 => $segment1->getId(),
-                                                            1 => $segment2->getId(),
-                                                        ],
-                                                    'display'  => 'Segment Membership',
-                                                    'operator' => 'in',
-                                                ],
-                                        ],
+            [
+                'tokenName' => 'Dynamic Content 1',
+                'content'   => '<p>Default Dynamic Content</p>',
+                'filters'   => [
+                    [
+                        'content' => '<p>Variation 1</p>',
+                        'filters' => [
+                            [
+                                'glue'   => 'and',
+                                'field'  => 'leadlist',
+                                'object' => 'lead',
+                                'type'   => 'leadlist',
+                                'filter' => [
+                                    $segment1->getId(),
+                                    $segment2->getId(),
                                 ],
+                                'display'  => 'Segment Membership',
+                                'operator' => 'in',
+                            ],
                         ],
+                    ],
                 ],
+            ],
         ]);
         $email->setCustomHtml('{dynamiccontent="Dynamic Content 1"}');
         $this->em->persist($email);

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\EmailBundle\EventListener\MatchFilterForLeadTrait;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\TestCase;
 
@@ -131,19 +132,50 @@ class MatchFilterForLeadTraitTest extends TestCase
     public function testCheckLeadValueIsInFilter(array $fieldDetails, array $filterDetails, bool $expected): void
     {
         $lead = [
-            'id'                    => 1,
-            $fieldDetails['name']   => $fieldDetails['value'],
+            'id'                  => 1,
+            $fieldDetails['name'] => $fieldDetails['value'],
         ];
 
         $filter = [
             0 => [
-                'display'   => null,
-                'field'     => $fieldDetails['name'],
-                'filter'    => $filterDetails['value'],
-                'glue'      => 'and',
-                'object'    => 'lead',
-                'operator'  => $filterDetails['operator'],
-                'type'      => $fieldDetails['type'],
+                'display'  => null,
+                'field'    => $fieldDetails['name'],
+                'filter'   => $filterDetails['value'],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $filterDetails['operator'],
+                'type'     => $fieldDetails['type'],
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+
+        $this->assertSame($expected, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidEmpty(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::EMPTY;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isNotContactInAnySegment')
+            ->with($lead['id'])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
             ],
         ];
 
@@ -245,12 +277,146 @@ class MatchFilterForLeadTraitTest extends TestCase
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidNotEmpty(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::NOT_EMPTY;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isContactInAnySegment')
+            ->with($lead['id'])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidIn(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::IN;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isContactInSegments')
+            ->with($lead['id'], [0 => $segmentId])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidNotIn(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = OperatorOptions::NOT_IN;
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+        $segmentRepository->expects(self::once())
+            ->method('isNotContactInSegments')
+            ->with($lead['id'], [0 => $segmentId])
+            ->willReturn(true);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        self::assertSame(true, $trait->match($filter, $lead));
+    }
+
+    public function testIsContactSegmentRelationshipValidInvalidOperator(): void
+    {
+        $lead['id'] = 1;
+        $segmentId  = 1;
+        $operator   = 'invalid';
+
+        $segmentRepository = $this->createMock(LeadListRepository::class);
+
+        $filter = [
+            0 => [
+                'display' => 'Segment Membership',
+                'field'   => 'leadlist',
+                'filter'  => [
+                    0 => $segmentId,
+                ],
+                'glue'     => 'and',
+                'object'   => 'lead',
+                'operator' => $operator,
+                'type'     => 'leadlist',
+            ],
+        ];
+
+        $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $trait->match($filter, $lead);
     }
 }
 
 class MatchFilterForLeadTraitTestable
 {
     use MatchFilterForLeadTrait;
+
+    public function setRepository($segmentRepository): void
+    {
+        $this->segmentRepository = $segmentRepository;
+    }
 
     public function match(array $filter, array $lead): bool
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -153,7 +153,19 @@ class MatchFilterForLeadTraitTest extends TestCase
         $this->assertSame($expected, $trait->match($filter, $lead));
     }
 
-    public function testIsContactSegmentRelationshipValidEmpty(): void
+    /**
+     * @return iterable<string, string[]>
+     */
+    public function segmentMembershipFilterProvider(): iterable
+    {
+        yield 'Classic Segment Membership Filter' => ['leadlist'];
+        yield 'Static Segment Membership Filter' => ['leadlist_static'];
+    }
+
+    /**
+     * @dataProvider segmentMembershipFilterProvider
+     */
+    public function testIsContactSegmentRelationshipValidEmpty(string $filterField): void
     {
         $lead['id'] = 1;
         $segmentId  = 1;
@@ -168,7 +180,7 @@ class MatchFilterForLeadTraitTest extends TestCase
         $filter = [
             0 => [
                 'display' => 'Segment Membership',
-                'field'   => 'leadlist',
+                'field'   => $filterField,
                 'filter'  => [
                     0 => $segmentId,
                 ],
@@ -180,8 +192,9 @@ class MatchFilterForLeadTraitTest extends TestCase
         ];
 
         $trait = new MatchFilterForLeadTraitTestable();
+        $trait->setRepository($segmentRepository);
 
-        $this->assertSame($expected, $trait->match($filter, $lead));
+        self::assertTrue($trait->match($filter, $lead));
     }
 
     /**
@@ -277,9 +290,6 @@ class MatchFilterForLeadTraitTest extends TestCase
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
-        $trait->setRepository($segmentRepository);
-
-        self::assertSame(true, $trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidNotEmpty(): void
@@ -311,7 +321,7 @@ class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertSame(true, $trait->match($filter, $lead));
+        self::assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidIn(): void
@@ -343,7 +353,7 @@ class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertSame(true, $trait->match($filter, $lead));
+        self::assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidNotIn(): void
@@ -375,7 +385,7 @@ class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertSame(true, $trait->match($filter, $lead));
+        self::assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidInvalidOperator(): void
@@ -413,7 +423,9 @@ class MatchFilterForLeadTraitTestable
 {
     use MatchFilterForLeadTrait;
 
-    public function setRepository($segmentRepository): void
+    private LeadListRepository $segmentRepository;
+
+    public function setRepository(LeadListRepository $segmentRepository): void
     {
         $this->segmentRepository = $segmentRepository;
     }

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -116,10 +117,11 @@ CONTENT
         $primaryCompanyHelper = $this->createMock(PrimaryCompanyHelper::class);
         $primaryCompanyHelper->method('getProfileFieldsWithPrimaryCompany')
             ->willReturn(['email' => 'hello@someone.com']);
+        $segmentRepository    = $this->createMock(LeadListRepository::class);
 
         /** @var TokenSubscriber $subscriber */
         $subscriber = $this->getMockBuilder(TokenSubscriber::class)
-            ->setConstructorArgs([$dispatcher, $primaryCompanyHelper])
+            ->setConstructorArgs([$dispatcher, $primaryCompanyHelper, $segmentRepository])
             ->onlyMethods([])
             ->getMock();
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -253,7 +253,7 @@ class LeadListRepository extends CommonRepository
     /**
      * Get a count of leads that belong to the list.
      *
-     * @param int|int[] $listIds
+     * @param $listIds
      *
      * @return array|int
      *

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -253,7 +253,7 @@ class LeadListRepository extends CommonRepository
     /**
      * Get a count of leads that belong to the list.
      *
-     * @param $listIds
+     * @param int|int[] $listIds
      *
      * @return array|int
      *

--- a/app/bundles/LeadBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DynamicContentSubscriber.php
@@ -48,10 +48,10 @@ final class DynamicContentSubscriber implements EventSubscriberInterface
         $contactId = (int) $contact->getId();
 
         return match ($operator) {
-            OperatorOptions::EMPTY     => $this->segmentRepository->isNotContactInAnySegment($contactId),
-            OperatorOptions::NOT_EMPTY => $this->segmentRepository->isContactInAnySegment($contactId),
-            OperatorOptions::IN        => $this->segmentRepository->isContactInSegments($contactId, $segmentIds),
-            OperatorOptions::NOT_IN    => $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds),
+            OperatorOptions::EMPTY     => $this->segmentRepository->isNotContactInAnySegment($contactId), // Contact is not in any segment
+            OperatorOptions::NOT_EMPTY => $this->segmentRepository->isContactInAnySegment($contactId), // Contact is in any segment
+            OperatorOptions::IN        => $this->segmentRepository->isContactInSegments($contactId, $segmentIds), // Contact is in one of the segment provided in $segmentsIds
+            OperatorOptions::NOT_IN    => $this->segmentRepository->isNotContactInSegments($contactId, $segmentIds), // Contact is not in all segments provided in $segmentsIds
             default                    => throw new \InvalidArgumentException(sprintf("Unexpected operator '%s'", $operator)),
         };
     }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
Add ability to use segment filters in email dynamic content.

#### Steps to test this PR:

1. Create a contact with email address `contact@a.email`
2. Create another contact with email address `contact@b.email`
3. Create "Segment A" with no filters
4. Create "Segment B" with no filters
5. Add the first contact to Segment A and the second contact to Segment B
7. Create email in `Channels > Emails`
    - Click on segment email
    - Choose both segments
    - Click builder
    - Drag dynamic content to email content 
    - Customize slot content with some default text
![Snímek obrazovky 2020-10-29 v 12 55 38](https://user-images.githubusercontent.com/12815758/97565518-715c9f00-19e6-11eb-8ee9-022953e6e205.png)
    - Click green `Add variant button` - and `Variation 1` will be added
    - Fill custom content for segment contacts
    - select Segment Membership 
 ![Snímek obrazovky 2020-10-29 v 12 47 23](https://user-images.githubusercontent.com/12815758/97565718-80435180-19e6-11eb-9996-2a14e7277c2d.png)
    - Save the email and send
    - The contact from Segment A will have content from Variant 1 and the other will see the default content