### PR TITLE
Allow form_help for form elements

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/FormTheme/mautic_form_layout.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/FormTheme/mautic_form_layout.html.twig
@@ -540,7 +540,7 @@ id="{{ id|escape }}" name="{{ full_name|escape }}"
                 {%- if help_html is same as(false) -%}
                     {{- help|trans(help_translation_parameters, translation_domain) -}}
                 {%- else -%}
-                    {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
+                    {{- help|trans(help_translation_parameters, translation_domain)|purify -}}
                 {%- endif -%}
         </p>
     {%- endif -%}

--- a/app/bundles/CoreBundle/Resources/views/FormTheme/mautic_form_layout.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/FormTheme/mautic_form_layout.html.twig
@@ -532,3 +532,16 @@ id="{{ id|escape }}" name="{{ full_name|escape }}"
         {%- endif -%}
     {%- endfor -%}
 {%- endblock attributes -%}
+
+{% block form_help -%}
+    {%- if help is not empty -%}
+        {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' help-text')|trim}) -%}
+        <p id="{{ id }}_help"{% with { attr: help_attr } %}{{ block('attributes') }}{% endwith %}>
+                {%- if help_html is same as(false) -%}
+                    {{- help|trans(help_translation_parameters, translation_domain) -}}
+                {%- else -%}
+                    {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
+                {%- endif -%}
+        </p>
+    {%- endif -%}
+{%- endblock form_help %}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR allows to add a help element to a form element. 
This would allow us to add more contextuel help teks, even with links to the documentation. 
Example for redirect types. 
![image](https://github.com/mautic/mautic/assets/1926222/8b1429fe-0ef5-43a6-9c94-7899784178ea)
It is related to https://github.com/mautic/mautic/pull/13535 but now adds support for the symfony form_help function. 
See https://symfony.com/doc/current/reference/forms/types/form.html#help

It provides support for the 4 possible options. 
* help
* help_attr
* help_html
* help_translation_parameters

Example is when a form element is defined like. 

```php
        $builder->add(
            'subject',
            TextType::class,
            [
                'label'      => 'mautic.email.subject',
                'label_attr' => ['class' => 'control-label'],
                'label_html' => true,
                'attr'       => [
                    'class'   => 'form-control',
                    'onBlur'  => 'Mautic.copySubjectToName(mQuery(this))',
                ],
                'help' => 'mautic.email.help',
                'help_translation_parameters' => [
                  '%company%' => 'param',
                ],
                'help_attr'       => [
                  'class'   => 'HELP',
                ],
                'help_html' => true,
            ]
        );
```

It renders the help text below. 
![image](https://github.com/mautic/mautic/assets/1926222/2b1a1903-3267-4257-85de-9136eb11d3fa)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add the above example to a field, and see the help text below. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
