### PR TITLE
Add the upload_dir to the DDEV config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,6 +10,7 @@ additional_fqdns: []
 mariadb_version: "10.3"
 mysql_version: ""
 provider: default
+upload_dir: "media/files, media/images" # Specify the directories containing user-generated uploads
 use_dns_when_possible: true
 composer_version: "2"
 webimage_extra_packages: [php8.2-imap]


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12244 ... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
When starting DDEV locally on a Mac, the following message is shown:

> You have mutagen enabled and your 'php' project type doesn't have an upload_dir set.
> For faster startup and less disk usage, set upload_dir to where your user-generated files are stored.
<img width="1023" alt="Screenshot 2024-03-13 at 11 58 46 PM" src="https://github.com/mautic/mautic/assets/95358802/d27cb544-b91a-4afc-a6de-ae335c54f516">

This PR addresses the warning message by adding the necessary `upload_dir` directives to the `config.yaml` file. It specifies the locations of user-uploaded materials (`media/files` and `media/images`).
<img width="1023" alt="Screenshot 2024-03-14 at 12 03 55 AM" src="https://github.com/mautic/mautic/assets/95358802/369c167d-a690-48cf-b82a-57a2f52d5254">

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Start DDEV locally on a Mac. Run `ddev start`
3. Verify that the warning message regarding the missing upload directory no longer appears.
4. Ensure that the specified upload directories (`media/files` and `media/images`) function as expected.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
