### PR TITLE
Update redis-commander to a newer image

### DIFF
--- a/.ddev/docker-compose.redis-commander.yaml
+++ b/.ddev/docker-compose.redis-commander.yaml
@@ -3,7 +3,7 @@ services:
   redis-commander:
     container_name: ddev-${DDEV_SITENAME}-redis-commander
     hostname: ${DDEV_SITENAME}-redis-commander
-    image: rediscommander/redis-commander
+    image: ghcr.io/joeferner/redis-commander:latest
     restart: always
     ports:
       - 1358


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:
Mautic is currently using an old version of the redis-commander (https://hub.docker.com/r/rediscommander/redis-commander) which hasn't been updated since last 3 years. This image is vulnerable and also doesn't support multiple platforms (For eg. It doesn't support linux/arm64) due to which docker has to emulate the image for different platforms causing performance issues and containers to fail due to health check.
We should use an updated redis-commander (https://github.com/joeferner/redis-commander) image which is widely adopted in the community and offers multiple-platform support with frequent updates.
For more details regarding the issue: https://forum.mautic.org/t/setting-up-mautic-on-mac-m1-health-check-failing/31253

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  Start the dev environment using `ddev start` and it will pull the updated redis-commander image.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

