### PR TITLE
Dispatch inject template event also for ajax responses.

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -156,22 +156,24 @@ class CommonController extends AbstractController implements MauticController
         $parameters = $args['viewParameters'] ?? [];
         $template   = $args['contentTemplate'];
 
+        $code     = $args['responseCode'] ?? 200;
+        $response = new Response('', $code);
+
         if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
             $event = $this->dispatcher->dispatch(
                 new CustomTemplateEvent($request, $template, $parameters),
                 CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
             );
 
-            $template   = $event->getTemplate();
-            $parameters = $event->getVars();
+            $template                = $event->getTemplate();
+            $parameters              = $event->getVars();
+            $args['viewParameters']  = $parameters;
+            $args['contentTemplate'] = $template;
         }
 
         if ($request->isXmlHttpRequest() && !$request->get('ignoreAjax', false)) {
             return $this->ajaxAction($request, $args);
         }
-
-        $code     = $args['responseCode'] ?? 200;
-        $response = new Response('', $code);
 
         $parameters['mauticTemplateVars'] = $parameters;
 

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -153,15 +153,8 @@ class CommonController extends AbstractController implements MauticController
             $args['viewParameters']['mauticContent'] = $mauticContent;
         }
 
-        if ($request->isXmlHttpRequest() && !$request->get('ignoreAjax', false)) {
-            return $this->ajaxAction($request, $args);
-        }
-
         $parameters = $args['viewParameters'] ?? [];
         $template   = $args['contentTemplate'];
-
-        $code     = $args['responseCode'] ?? 200;
-        $response = new Response('', $code);
 
         if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
             $event = $this->dispatcher->dispatch(
@@ -172,6 +165,13 @@ class CommonController extends AbstractController implements MauticController
             $template   = $event->getTemplate();
             $parameters = $event->getVars();
         }
+
+        if ($request->isXmlHttpRequest() && !$request->get('ignoreAjax', false)) {
+            return $this->ajaxAction($request, $args);
+        }
+
+        $code     = $args['responseCode'] ?? 200;
+        $response = new Response('', $code);
 
         $parameters['mauticTemplateVars'] = $parameters;
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ X ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When an ajax request is done, the CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE is not  dispatched. This causes for example that you can inject a template on a page (example mail overview) when going directly to the page (or reload it), but not when you access it from the menu. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

Set a breakpoint on the place the event is dispatched. (CommonController). See that event is dispatched on page load, but not when accessing page from the menu for example. 

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
