### PR TITLE
[UI] Change navigation menu icons

### DIFF
--- a/app/assets/scaffold/files/package-lock.json
+++ b/app/assets/scaffold/files/package-lock.json
@@ -60,7 +60,7 @@
         "moment": "^2.29.4",
         "mousetrap": "^1.6.5",
         "multiselect": "^0.9.12",
-        "remixicon": "^4.1.0",
+        "remixicon": "^4.2.0",
         "shufflejs": "^5.4.1",
         "typeahead.js": "^0.11.1",
         "vimeo-froogaloop2": "^0.1.1"
@@ -5553,9 +5553,9 @@
       }
     },
     "node_modules/remixicon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.1.0.tgz",
-      "integrity": "sha512-N5dmpN6bjB7GyHi8RqhKp8Fy1cfOch0m75KZQv4ZNFa2ffpXJY2FQ4TdgigZulTdwOoTwLKjBQ7GCC+bEw8LHg=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.2.0.tgz",
+      "integrity": "sha512-MF5wApNveRh3n0iMVM+lr2nSWrj/rBbSD2eWapuD9ReYRGs5naAUR1BqVBCHGqm286FIS6zwwmUf96QjHQ9l4w=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/app/assets/scaffold/files/package.json
+++ b/app/assets/scaffold/files/package.json
@@ -61,7 +61,7 @@
     "moment": "^2.29.4",
     "mousetrap": "^1.6.5",
     "multiselect": "^0.9.12",
-    "remixicon": "^4.1.0",
+    "remixicon": "^4.2.0",
     "shufflejs": "^5.4.1",
     "typeahead.js": "^0.11.1",
     "vimeo-froogaloop2": "^0.1.1"

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -90,7 +90,7 @@ return [
     'menu' => [
         'main' => [
             'mautic.campaign.menu.index' => [
-                'iconClass' => 'fa-clock-o',
+                'iconClass' => 'ri-megaphone-fill',
                 'route'     => 'mautic_campaign_index',
                 'access'    => 'campaign:campaigns:view',
                 'priority'  => 50,

--- a/app/bundles/CategoryBundle/Config/config.php
+++ b/app/bundles/CategoryBundle/Config/config.php
@@ -41,7 +41,7 @@ return [
             'mautic.category.menu.index' => [
                 'route'     => 'mautic_category_index',
                 'access'    => 'category:categories:view',
-                'iconClass' => 'fa-folder',
+                'iconClass' => 'ri-folder-settings-fill',
                 'id'        => 'mautic_category_index',
             ],
         ],

--- a/app/bundles/ConfigBundle/Config/config.php
+++ b/app/bundles/ConfigBundle/Config/config.php
@@ -19,13 +19,13 @@ return [
             'mautic.config.menu.index' => [
                 'route'           => 'mautic_config_action',
                 'routeParameters' => ['objectAction' => 'edit'],
-                'iconClass'       => 'fa-cogs',
+                'iconClass'       => 'ri-settings-5-line',
                 'id'              => 'mautic_config_index',
                 'access'          => 'admin',
             ],
             'mautic.sysinfo.menu.index' => [
                 'route'     => 'mautic_sysinfo_index',
-                'iconClass' => 'fa-life-ring',
+                'iconClass' => 'ri-information-2-fill',
                 'id'        => 'mautic_sysinfo_index',
                 'access'    => 'admin',
                 'checks'    => [

--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -4835,3 +4835,6 @@ ul.media-list.media-list-feed div.media-object {
 .ui-sortable-handle:active {
   cursor: grabbing;
 }
+.flip-vertically {
+  transform: scaleY(-1);
+}

--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -729,11 +729,12 @@ body > #app-wrapper {
   padding-top: 20px;
 }
 .app-sidebar .nav-sidebar .sidebar-minimizer > .direction:after {
-  font-family: 'FontAwesome';
-  content: '\f053';
+  font-family: 'remixicon';
+  font-size: 18px;
+  content: '\EA64';
 }
 .app-sidebar .nav-sidebar .sidebar-minimizer.active .direction:after {
-  content: '\f054';
+  content: '\EA6E';
 }
 @media (min-width: 768px) {
   .app-sidebar.sidebar-left {

--- a/app/bundles/CoreBundle/Assets/css/app/less/custom.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/custom.less
@@ -343,3 +343,7 @@ ul.media-list.media-list-feed div.media-object
 .ui-sortable-handle:active {
   cursor: grabbing;
 }
+
+.flip-vertically {
+  transform: scaleY(-1);
+}

--- a/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
@@ -319,14 +319,15 @@
     .sidebar-minimizer {
       > .direction {
         &:after {
-          font-family: 'FontAwesome';
-          content: '\f053';
+          font-family: 'remixicon';
+          font-size: 18px;
+          content: '\EA64';
         }
       }
       &.active {
         .direction {
           &:after {
-            content: '\f054';
+            content: '\EA6E';
           }
         }
       }

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -107,19 +107,19 @@ return [
         'main' => [
             'mautic.core.components' => [
                 'id'        => 'mautic_components_root',
-                'iconClass' => 'fa-puzzle-piece',
+                'iconClass' => 'ri-puzzle-fill',
                 'priority'  => 60,
             ],
             'mautic.core.channels' => [
                 'id'        => 'mautic_channels_root',
-                'iconClass' => 'fa-rss',
+                'iconClass' => 'ri-rss-fill',
                 'priority'  => 40,
             ],
         ],
         'admin' => [
             'mautic.theme.menu.index' => [
                 'route'     => 'mautic_themes_index',
-                'iconClass' => 'fa-newspaper-o',
+                'iconClass' => 'ri-palette-fill',
                 'id'        => 'mautic_themes_index',
                 'access'    => 'core:themes:view',
             ],

--- a/app/bundles/DashboardBundle/Config/config.php
+++ b/app/bundles/DashboardBundle/Config/config.php
@@ -34,7 +34,7 @@ return [
             'items'    => [
                 'mautic.dashboard.menu.index' => [
                     'route'     => 'mautic_dashboard_index',
-                    'iconClass' => 'fa-th-large',
+                    'iconClass' => 'ri-funds-fill',
                 ],
             ],
         ],

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -285,19 +285,19 @@ return [
         'main' => [
             'items' => [
                 'mautic.lead.leads' => [
-                    'iconClass' => 'fa-user',
+                    'iconClass' => 'ri-user-6-fill',
                     'access'    => ['lead:leads:viewown', 'lead:leads:viewother'],
                     'route'     => 'mautic_contact_index',
                     'priority'  => 80,
                 ],
                 'mautic.companies.menu.index' => [
                     'route'     => 'mautic_company_index',
-                    'iconClass' => 'fa-building-o',
+                    'iconClass' => 'ri-building-2-fill',
                     'access'    => ['lead:leads:viewother'],
                     'priority'  => 75,
                 ],
                 'mautic.lead.list.menu.index' => [
-                    'iconClass' => 'fa-pie-chart',
+                    'iconClass' => 'ri-pie-chart-fill',
                     'access'    => ['lead:lists:viewown', 'lead:lists:viewother'],
                     'route'     => 'mautic_segment_index',
                     'priority'  => 70,
@@ -309,7 +309,7 @@ return [
             'items'    => [
                 'mautic.lead.field.menu.index' => [
                     'id'        => 'mautic_lead_field',
-                    'iconClass' => 'fa-list',
+                    'iconClass' => 'ri-input-field',
                     'route'     => 'mautic_contactfield_index',
                     'access'    => 'lead:fields:full',
                 ],

--- a/app/bundles/MarketplaceBundle/EventListener/MenuSubscriber.php
+++ b/app/bundles/MarketplaceBundle/EventListener/MenuSubscriber.php
@@ -38,7 +38,7 @@ final class MenuSubscriber implements EventSubscriberInterface
                     'marketplace.title' => [
                         'id'        => 'marketplace',
                         'route'     => RouteProvider::ROUTE_LIST,
-                        'iconClass' => 'fa-plus',
+                        'iconClass' => 'ri-shopping-bag-3-fill',
                         'access'    => MarketplacePermissions::CAN_VIEW_PACKAGES,
                     ],
                 ],

--- a/app/bundles/PluginBundle/Config/config.php
+++ b/app/bundles/PluginBundle/Config/config.php
@@ -49,7 +49,7 @@ return [
             'items'    => [
                 'mautic.plugin.plugins' => [
                     'id'        => 'mautic_plugin_root',
-                    'iconClass' => 'fa-plus-circle',
+                    'iconClass' => 'ri-plug-fill',
                     'access'    => 'plugin:plugins:manage',
                     'route'     => 'mautic_plugin_index',
                 ],

--- a/app/bundles/PointBundle/Config/config.php
+++ b/app/bundles/PointBundle/Config/config.php
@@ -70,7 +70,7 @@ return [
         'main' => [
             'mautic.points.menu.root' => [
                 'id'        => 'mautic_points_root',
-                'iconClass' => 'fa-calculator',
+                'iconClass' => 'ri-focus-2-fill',
                 'access'    => ['point:points:view', 'point:triggers:view', 'point:groups:view'],
                 'priority'  => 30,
                 'children'  => [

--- a/app/bundles/ReportBundle/Config/config.php
+++ b/app/bundles/ReportBundle/Config/config.php
@@ -64,7 +64,7 @@ return [
         'main' => [
             'mautic.report.reports' => [
                 'route'     => 'mautic_report_index',
-                'iconClass' => 'fa-line-chart',
+                'iconClass' => 'ri-file-chart-fill',
                 'access'    => [
                     'report:reports:viewown',
                     'report:reports:viewother',

--- a/app/bundles/StageBundle/Config/config.php
+++ b/app/bundles/StageBundle/Config/config.php
@@ -36,7 +36,7 @@ return [
         'main' => [
             'mautic.stages.menu.index' => [
                 'route'     => 'mautic_stage_index',
-                'iconClass' => 'fa-tachometer',
+                'iconClass' => 'ri-barricade-fill flip-vertically',
                 'access'    => ['stage:stages:view'],
                 'priority'  => 25,
             ],

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -6,12 +6,12 @@ return [
             'mautic.user.users' => [
                 'access'    => 'user:users:view',
                 'route'     => 'mautic_user_index',
-                'iconClass' => 'fa-users',
+                'iconClass' => 'ri-user-settings-fill',
             ],
             'mautic.user.roles' => [
                 'access'    => 'user:roles:view',
                 'route'     => 'mautic_role_index',
-                'iconClass' => 'fa-lock',
+                'iconClass' => 'ri-shield-user-fill',
             ],
         ],
     ],

--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -31,7 +31,7 @@ return [
             'items' => [
                 'mautic.webhook.webhooks' => [
                     'id'        => 'mautic_webhook_root',
-                    'iconClass' => 'fa-exchange',
+                    'iconClass' => 'ri-webhook-fill',
                     'access'    => ['webhook:webhooks:viewown', 'webhook:webhooks:viewother'],
                     'route'     => 'mautic_webhook_index',
                 ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "moment": "^2.29.4",
         "mousetrap": "^1.6.5",
         "multiselect": "^0.9.12",
-        "remixicon": "^4.1.0",
+        "remixicon": "^4.2.0",
         "shufflejs": "^5.4.1",
         "typeahead.js": "^0.11.1",
         "vimeo-froogaloop2": "^0.1.1"
@@ -5553,9 +5553,9 @@
       }
     },
     "node_modules/remixicon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.1.0.tgz",
-      "integrity": "sha512-N5dmpN6bjB7GyHi8RqhKp8Fy1cfOch0m75KZQv4ZNFa2ffpXJY2FQ4TdgigZulTdwOoTwLKjBQ7GCC+bEw8LHg=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.2.0.tgz",
+      "integrity": "sha512-MF5wApNveRh3n0iMVM+lr2nSWrj/rBbSD2eWapuD9ReYRGs5naAUR1BqVBCHGqm286FIS6zwwmUf96QjHQ9l4w=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "moment": "^2.29.4",
     "mousetrap": "^1.6.5",
     "multiselect": "^0.9.12",
-    "remixicon": "^4.1.0",
+    "remixicon": "^4.2.0",
     "shufflejs": "^5.4.1",
     "typeahead.js": "^0.11.1",
     "vimeo-froogaloop2": "^0.1.1"

--- a/plugins/MauticTagManagerBundle/Config/config.php
+++ b/plugins/MauticTagManagerBundle/Config/config.php
@@ -48,7 +48,7 @@ return [
                 'id'        => 'mautic_tagmanager_index',
                 'route'     => 'mautic_tagmanager_index',
                 'access'    => 'tagManager:tagManager:view',
-                'iconClass' => 'fa-tag',
+                'iconClass' => 'ri-hashtag',
                 'priority'  => 1,
             ],
         ],


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR started with the discussion here:
[UX] Improve the comparison between the two form type options https://github.com/mautic/mautic/pull/13381

This discussion generated another PR:
[UI] Change Form, SMS and Email types header https://github.com/mautic/mautic/pull/13582

Then the second PR raised needs:

> I like that we have the goal to make this more clean and we remove the "new". Great idea.
> 
> The goal of this screen is for the user to decide quickly which one of the two options to choose.
> 
> So for the icons, we should use the same icons across Mautic. So a user can quickly see that this is a segment email. So anything segment is always a segment icon, and a campaign icon is always a campaign icon.

So this PR aims to solve the need to see standard icons across the entire UI.
This move is backed by the addition of Remix icon pack https://github.com/mautic/mautic/pull/13318, where we need to replace FontAwesome icons until it's completely removed and the code clean.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Look at both sidebars

![image](https://github.com/mautic/mautic/assets/116097999/1f2400d3-4a35-4395-8d71-3ce349665e9a)

![image](https://github.com/mautic/mautic/assets/116097999/eab3c5b0-1bc8-444f-8636-0492eea7f958)


<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
