### PR TITLE
fix to make sure the excerption is handled properly according to #13554

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
@@ -57,8 +57,23 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
     {
         $package   = $this->getRemoteDateStoreDownloadUrl();
 
+        // try {
+        //     $data = $this->client->get($package);
+        // } catch (\Exception $exception) {
+        //     $this->logger->error('Failed to fetch remote IP data: '.$exception->getMessage());
+        // }
+
         try {
             $data = $this->client->get($package);
+            // check if response is 200 before storing value in $data
+            if ($data->getStatusCode() === 200)
+            {
+                $data = $data;
+            }
+            else
+            {
+                return false;
+            }
         } catch (\Exception $exception) {
             $this->logger->error('Failed to fetch remote IP data: '.$exception->getMessage());
         }


### PR DESCRIPTION
Fix:#13554

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes ##13554

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The main problem here is that the response is stored in the $data variable irrespective of the 
response being successful (200 status) or not.
In other words, the catch block which is supposed to handle your suggestion("I think we should handle this more elegantly and show an error message / warning that there's an issue with the key?")
is not running, as the $data variable was assigned a null value , so instead of this previous implementation below
```php
      try {
            $data = $this->client->get($package);
        } catch (\Exception $exception) {
            $this->logger->error('Failed to fetch remote IP data: '.$exception->getMessage());
        }
```

I updated it to this
```php

           try {
            $data = $this->client->get($package);
            // check if response is 200 before storing value in $data
            if ($data->getStatusCode() === 200)
            {
                $data = $data;
            }
            else
            {
                return false;
            }
        } catch (\Exception $exception) {
            $this->logger->error('Failed to fetch remote IP data: '.$exception->getMessage());
        }
```
This update would make sure the response is 200 , before storing the data in the $data variable
else it will return false( this will make sure the catch block executes)

Note: this implementation was done in the directory : **/mautic/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php**

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
