### PR TITLE
Allow getting/setting publicPreview flag through API for Emails

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -23,6 +23,7 @@ use Mautic\LeadBundle\Controller\LeadAccessTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -213,5 +214,14 @@ class EmailApiController extends CommonApiController
         return $this->handleView(
             $this->view(['success' => true], Response::HTTP_CREATED)
         );
+    }
+
+    protected function prepareParametersFromRequest(FormInterface $form, array &$params, object $entity = null, array $masks = [], array $fields = []): void
+    {
+        if (isset($params['publicPreview']) && $entity instanceof Email) {
+            $entity->setPublicPreview(InputHelper::boolean($params['publicPreview']) ?? false);
+            unset($params['publicPreview']);
+        }
+        parent::prepareParametersFromRequest($form, $params, $entity, $masks, $fields);
     }
 }

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -426,6 +426,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
                     'emailType',
                     'publishUp',
                     'publishDown',
+                    'publicPreview',
                     'readCount',
                     'sentCount',
                     'revision',

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -97,11 +97,13 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertCount(1, $response['email']['lists']);
         $this->assertEquals($segmentAId, $response['email']['lists'][0]['id']);
         $this->assertEquals($payload['customHtml'], $response['email']['customHtml']);
+        $this->assertFalse($response['email']['publicPreview']);
 
         // Edit PATCH:
         $patchPayload = [
-            'name'  => 'API email renamed',
-            'lists' => [$segmentBId],
+            'name'          => 'API email renamed',
+            'lists'         => [$segmentBId],
+            'publicPreview' => true,
         ];
         $this->client->request('PATCH', "/api/emails/{$emailId}/edit", $patchPayload);
         $clientResponse = $this->client->getResponse();
@@ -115,11 +117,13 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($segmentBId, $response['email']['lists'][0]['id']);
         $this->assertEquals($payload['emailType'], $response['email']['emailType']);
         $this->assertEquals($payload['customHtml'], $response['email']['customHtml']);
+        $this->assertEquals($patchPayload['publicPreview'], $response['email']['publicPreview']);
 
         // Edit PUT:
         $payload['subject'] .= ' renamed';
-        $payload['lists']    = [$segmentAId, $segmentBId];
-        $payload['language'] = 'en'; // Must be present for PUT as all empty values are being cleared.
+        $payload['lists']         = [$segmentAId, $segmentBId];
+        $payload['language']      = 'en'; // Must be present for PUT as all empty values are being cleared.
+        $payload['publicPreview'] = false; // Must be present for PUT as all empty values are being cleared.
         $this->client->request('PUT', "/api/emails/{$emailId}/edit", $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
@@ -133,6 +137,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($segmentBId, $response['email']['lists'][0]['id']);
         $this->assertEquals($payload['emailType'], $response['email']['emailType']);
         $this->assertEquals($payload['customHtml'], $response['email']['customHtml']);
+        $this->assertEquals($payload['publicPreview'], $response['email']['publicPreview']);
 
         // Get:
         $this->client->request('GET', "/api/emails/{$emailId}");


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [X]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

This PR allow to get and set email flag publicPreview through API.

#### Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Send API request for an email: 
```
GET {{host}}/api/emails/{email_id}
Accept: application/json
Authorization: Bearer {{auth_token}}
```
the response will containt
```
"publicPreview": true,
```

update existing email by putting 
```
"publicPreview": true,
```
into payload body

the post value can be either:
true: true,"T","Y"
false: false,"F","N"

and verify it has been updated in UI
