### PR TITLE
Fixing custom content variables for plugins

### DIFF
--- a/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
@@ -128,7 +128,7 @@
             <!--/ stats -->
         </div>
 
-        {{ customContent('details.stats.graph.below', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+        {{ customContent('details.stats.graph.below', _context) }}
 
         <!-- start: tab-content -->
         <div class="tab-content pa-md preview-detail">

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
@@ -85,7 +85,7 @@
             </div>
             <!--/ campaign detail collapseable toggler -->
 
-            {{ customContent('left.section.top', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+            {{ customContent('left.section.top', _context) }}
             <!-- some stats -->
             <div class="pa-md">
                 <div class="row">
@@ -118,7 +118,7 @@
             </div>
             <!--/ stats -->
 
-            {{ customContent('details.stats.graph.below', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+            {{ customContent('details.stats.graph.below', _context) }}
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">
@@ -153,7 +153,7 @@
                         {{ 'mautic.lead.leads'|trans }}
                     </a>
                 </li>
-                {{ customContent('tabs', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+                {{ customContent('tabs', _context) }}
             </ul>
             <!--/ tabs controls -->
         </div>
@@ -193,21 +193,21 @@
                 <div class="spinner"><i class="fa fa-spin fa-spinner"></i></div>
                 <div class="clearfix"></div>
             </div>
-            {{ customContent('tabs.content', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+            {{ customContent('tabs.content', _context) }}
         </div>
         <!--/ end: tab-content -->
 
-        {{ customContent('left.section.bottom', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+        {{ customContent('left.section.bottom', _context) }}
     </div>
     <!--/ left section -->
 
     <!-- right section -->
     <div class="col-md-3 bg-white bdr-l height-auto">
-        {{ customContent('right.section.top', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+        {{ customContent('right.section.top', _context) }}
 
         {{ include('@MauticCore/Helper/recentactivity.html.twig', {'logs': logs}) }}
 
-        {{ customContent('right.section.bottom', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+        {{ customContent('right.section.bottom', _context) }}
     </div>
     <!--/ right section -->
 </div>

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
@@ -32,7 +32,7 @@
                 'filters': filters|default([]),
         }) -}}
         <div class="page-list">
-            {{- customContent('content.above', mauticTemplateVars|default({})) -}}
+            {{- customContent('content.above', _context) -}}
   {% endif %}
 
   {% if items|length > 0 %}
@@ -95,7 +95,6 @@
           </thead>
           <tbody>
             {% for item in items %}
-                {% set mauticTemplateVars = {'item': item} %}
                 <tr>
                     <td>
                       {{- include('@MauticCore/Helper/list_actions.html.twig', {
@@ -127,7 +126,7 @@
                           }) -}}
                             <a href="{{ path('mautic_campaign_action', {'objectAction': 'view', 'objectId': item.id}) }}" data-toggle="ajax">
                                 {{- item.name -}}
-                                {{- customContent('campaign.name', mauticTemplateVars) -}}
+                                {{- customContent('campaign.name', _context|merge({'item': item})) -}}
                             </a>
                         </div>
                         {%- if item.description -%}
@@ -167,7 +166,7 @@
   {% endif %}
 
   {% if isIndex %}
-            {{- customContent('content.below', mauticTemplateVars|default({})) -}}
+            {{- customContent('content.below', _context) -}}
         </div>
     </div>
   {% endif %}

--- a/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
+++ b/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
@@ -81,7 +81,7 @@
                     </div>
                 </div>
                 <!--/ stats -->
-                {{ customContent('details.stats.graph.below', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+                {{ customContent('details.stats.graph.below', _context) }}
 
                 <!-- tabs controls -->
                 <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/ChannelBundle/Resources/views/Message/form.html.twig
+++ b/app/bundles/ChannelBundle/Resources/views/Message/form.html.twig
@@ -4,7 +4,7 @@
     {% if form.children.channel is defined %}
         {% set channel = form.children.channel.vars.data %}
         {% set enabled = form.children.isEnabled.vars.data %}
-        {% set channelContent = customContent('channel.right', mauticTemplateVars is defined ? mauticTemplateVars : []) %}
+        {% set channelContent = customContent('channel.right', _context) %}
         {% set leftCol = channelContent ? 6 : 12 %}
         {% set enableCol = channelContent ? '' : 'col-md-2' %}
         {% set propsCol = channelContent ? '' : 'col-md-10' %}

--- a/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
@@ -5,7 +5,7 @@
 			<div class="col-xs-2 text-right pull-left">
 					{{ publishStatus|purify }}
 			</div>
-			{{ customContent('page.header.left', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+			{{ customContent('page.header.left', _context) }}
 		</div>
 		<div class="col-xs-7 col-sm-6 col-md-7 va-m">
 			<div class="toolbar text-right" id="toolbar">
@@ -24,7 +24,7 @@
 						<ul class="dropdown-menu dropdown-menu-right" role="menu"></ul>
 					</div>
 				</div>
-				{{ customContent('page.header.right', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+				{{ customContent('page.header.right', _context) }}
 			</div>
 			<div class="clearfix"></div>
 		</div>

--- a/app/bundles/CoreBundle/Resources/views/FormTheme/form_tabbed.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/FormTheme/form_tabbed.html.twig
@@ -1,4 +1,3 @@
-{% set mauticTemplateVars = mauticTemplateVars is defined ? mauticTemplateVars : [] %}
 {% extends "@MauticCore/FormTheme/form.html.twig" %}
 {% set hasRightColumn = block('rightFormContent') is defined %}
 {% block mainFormContent %}
@@ -9,7 +8,7 @@
                 <div class="col-xs-12">
                     {{ form_errors(form) }}
                     {% block aboveTabsContent %}{% endblock %}
-                    {{ customContent('tabs.above', mauticTemplateVars) }}
+                    {{ customContent('tabs.above', _context) }}
                     {{- include('@MauticCore/Helper/tabs.html.twig', {'tabs' : formTabs }) -}}
                     <div class="pr-md pl-md">
                         {% if block('_content') is defined %}
@@ -19,7 +18,7 @@
                         {% endif %}
                     </div>
                     {% block belowTabsContent %}{% endblock %}
-                    {{ customContent('tabs.below', mauticTemplateVars) }}
+                    {{ customContent('tabs.below', _context) }}
                 </div>
             </div>
         </div>

--- a/app/bundles/CoreBundle/Resources/views/Helper/details.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/details.html.twig
@@ -1,5 +1,4 @@
-{% set mauticTemplateVars = mauticTemplateVars is defined ? mauticTemplateVars : [] %}
-{{ customContent('details.top', mauticTemplateVars) }}
+{{ customContent('details.top', _context) }}
 {% if attribute(entity, 'getCategory') is defined and method_exists(entity, 'getCategory') %}
 <tr>
     <td width="20%"><span class="fw-b textTitle">{% trans %}mautic.core.category{% endtrans %}</span></td>
@@ -48,4 +47,4 @@
         <td>{{ entity.getId() }}</td>
     </tr>
 {% endif %}
-{{ customContent('details.bottom', mauticTemplateVars) }}
+{{ customContent('details.bottom', _context) }}

--- a/app/bundles/CoreBundle/Resources/views/LeftPanel/index.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/LeftPanel/index.html.twig
@@ -58,7 +58,7 @@
     <div class="scroll-content slimscroll">
         <!-- start: navigation -->
         <nav class="nav-sidebar">
-            {{ customContent('menu.above', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+            {{ customContent('menu.above', _context) }}
             {{ menuRender('main') }}
 
             <!-- start: left nav -->

--- a/app/bundles/CoreBundle/Resources/views/Standard/list.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Standard/list.html.twig
@@ -1,4 +1,3 @@
-{% set mauticTemplateVars = mauticTemplateVars is defined ? mauticTemplateVars : [] %}
 {% set ignoreStandardColumns = ignoreStandardColumns is defined ? ignoreStandardColumns : [] %}
 {% set isIndex = tmpl == 'index' ? true : false %}
 {% set tmpl = 'list' %}
@@ -57,9 +56,9 @@
             }) -}}
 
             <div class="page-list">
-                {{ customContent('content.above', mauticTemplateVars) }}
+                {{ customContent('content.above', _context) }}
                 {{ block('mainContent') }}
-                {{ customContent('content.below', mauticTemplateVars) }}
+                {{ customContent('content.below', _context) }}
             </div>
         </div>
     {% else %}
@@ -141,7 +140,7 @@
                         }) -}}
                         {% endif %}
 
-                        {{ customContent('list.headers', mauticTemplateVars) }}
+                        {{ customContent('list.headers', _context) }}
                 </tr>
                 </thead>
                 <tbody>
@@ -193,7 +192,7 @@
                                         {'objectId' : item.getId(), 'objectAction' : nameAction}
                                     ) }}">
                                         {{ item.getName() }}
-                                        {{ customContent('list.name', mauticTemplateVars) }}
+                                        {{ customContent('list.name', _context) }}
                                     </a>
                                 </div>
                                 {% if attribute(item, 'getDescription') is defined and item.getDescription() %}
@@ -220,7 +219,7 @@
                             <td class="visible-md visible-lg">{{ item.getId() }}</td>
                         {% endif %}
 
-                        {{ customContent('list.columns', mauticTemplateVars) }}
+                        {{ customContent('list.columns', _context) }}
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
@@ -123,7 +123,7 @@
               </div>
               <!--/ stats -->
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+              {{ customContent('details.stats.graph.below', _context) }}
 
               <!-- tabs controls -->
               <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
@@ -63,7 +63,7 @@
                 {% set hasVariants  = item.isVariant() %}
                 {% set hasTranslations  = item.isTranslation() %}
                 {% set type = item.getEmailType() %}
-                {% set mauticTemplateVars = mauticTemplateVars|default([])|merge({'item' : item}) %}
+                {% set mauticTemplateVars = _context|merge({'item' : item}) %}
                 <tr>
                     <td>
                         {% set edit = securityHasEntityAccess(

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -248,7 +248,7 @@
                   </div>
               </div>
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+              {{ customContent('details.stats.graph.below', _context) }}
 
               <!-- tabs controls -->
               <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/EmailBundle/Resources/views/Email/form.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/form.html.twig
@@ -21,7 +21,6 @@
 } %}
 {% set isCodeMode = (email.getTemplate() is same as 'mautic_code_mode') %}
 {% set previewUrl = previewUrl|default('') %}
-{% set mauticTemplateVars = mauticTemplateVars|default({'mauticTemplate': '@MauticEmail/Email/form.html.twig', 'email': email}) %}
 
 {% block headerTitle %}
   {% if email.id is not empty %}
@@ -53,7 +52,7 @@
                         <li id="dynamic-content-tab" {{ (isCodeMode) ? '' : 'class="hidden"' }}>
                             <a href="#dynamic-content-container" role="tab" data-toggle="tab">{{ 'mautic.core.dynamicContent'|trans }}</a>
                         </li>
-                        {{ customContent('email.tabs', mauticTemplateVars) }}
+                        {{ customContent('email.tabs', _context) }}
                     </ul>
                     <!--/ tabs controls -->
 
@@ -75,7 +74,7 @@
                                     {{ form_row(form.fromAddress) }}
                                     {{ form_row(form.replyToAddress) }}
                                     {{ form_row(form.bccAddress) }}
-                                    {{ customContent('email.settings.advanced', mauticTemplateVars) }}
+                                    {{ customContent('email.settings.advanced', _context) }}
                                     <div>
                                         <div class="pull-left">
                                             {{ form_label(form.assetAttachments) }}
@@ -146,7 +145,7 @@
                                 </div>
                             </div>
                         </div>
-                        {{ customContent('email.tabs.content', mauticTemplateVars) }}
+                        {{ customContent('email.tabs.content', _context) }}
                     </div>
                 </div>
             </div>

--- a/app/bundles/FormBundle/Resources/views/Form/details.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Form/details.html.twig
@@ -133,7 +133,7 @@
             </div>
             <!--/ stats -->
 
-            {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+            {{ customContent('details.stats.graph.below', _context) }}
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
@@ -51,7 +51,7 @@
                             <img src="{{ flag }}" style="max-height: 24px;" class="ml-sm" />
                         </div>
                     {% endif %}
-                    {{ customContent('lead.grid', mauticTemplateVars|default([])) }}
+                    {{ customContent('lead.grid', _context) }}
                 </div>
             </div>
         </div>

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -307,7 +307,7 @@
                         </a>
                     </li>
                 {% endif %}
-                {{ customContent('tabs', mauticTemplateVars|default([])) }}
+                {{ customContent('tabs', _context) }}
             </ul>
             <!--/ tabs controls -->
         </div>
@@ -357,7 +357,7 @@
             <!--/ #auditlog-container -->
 
             <!-- custom content -->
-            {{ customContent('tabs.content', mauticTemplateVars|default([])) }}
+            {{ customContent('tabs.content', _context) }}
             <!-- end: custom content -->
 
             <!-- #place-container -->

--- a/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
@@ -10,7 +10,7 @@
     {% set diffInSeconds = now.timestamp - lastBuiltDate.timestamp %}
     {% set hoursSinceLastBuilt = diffInSeconds / 3600 | round %}
 {% endif %}
-{% set mauticTemplateVars = mauticTemplateVars|default([])|merge([{'item': item}]) %}
+{% set mauticTemplateVars = _context|merge([{'item': item}]) %}
 <tr>
     <td>
         {{ include('@MauticCore/Helper/list_actions.html.twig', {
@@ -62,7 +62,7 @@
                        data-original-title="{{ 'mautic.lead.list.form.config.segment_build_time.message'|trans({'%count%': item.lastBuiltTime}) }}">
                     <i class="fa text-danger fa-clock-o"></i></label>
             {% endif %}
-            {{ customContent('segment.name', mauticTemplateVars|default([])) }}
+            {{ customContent('segment.name', mauticTemplateVars) }}
         </div>
         {% if item.description %}
             <div class="text-muted mt-4">

--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -120,7 +120,7 @@
                 </div>
             </div>
 
-            {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+            {{ customContent('details.stats.graph.below', _context) }}
 
             <!-- tabs controls -->
             <!-- search bar-->

--- a/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
@@ -87,7 +87,7 @@
             </div>
             <!--/ stats -->
 
-            {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+            {{ customContent('details.stats.graph.below', _context) }}
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/PageBundle/Resources/views/Page/details.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Page/details.html.twig
@@ -145,7 +145,7 @@
               </div>
               <!--/ stats -->
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+              {{ customContent('details.stats.graph.below', _context) }}
 
               <!-- tabs controls -->
               <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/PageBundle/Resources/views/Trackable/click_counts.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Trackable/click_counts.html.twig
@@ -1,4 +1,3 @@
-{% set mauticTemplateVars = mauticTemplateVars is defined ? mauticTemplateVars : [] %}
 {% set showConversionRate = showConversionRate is defined ? showConversionRate : false %}
 {% if trackables is not empty %}
     <div class="table-responsive">
@@ -9,7 +8,7 @@
                 <td>{{ 'mautic.trackable.click_url'|trans }}</td>
                 <td>{{ 'mautic.trackable.click_count'|trans }}</td>
                 <td>{{ 'mautic.trackable.click_unique_count'|trans }}</td>
-                {{ customContent('click_counts_headers', mauticTemplateVars) }}
+                {{ customContent('click_counts_headers', _context) }}
                 {% if showConversionRate %}
                     <td>{{ 'mautic.trackable.click_conversion_rate'|trans }}</td>
                 {% endif %}
@@ -38,7 +37,7 @@
                         {% endif %}
                         </span>
                             </td>
-                            {{ customContent('click_counts', mauticTemplateVars|merge({'redirect_id' : link.redirect_id})) }}
+                            {{ customContent('click_counts', _context|merge({'redirect_id' : link.redirect_id})) }}
                             {% if showConversionRate %}
                                 <td data-conversion-rate-cell data-unique-hits="{{ link.unique_hits }}"><div class="spinner"><i class="fa fa-spin fa-spinner"></i></div></td>
                             {% endif %}

--- a/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
@@ -114,7 +114,7 @@
             </div>
             <!--/ stats -->
 
-            {{ customContent('details.stats.graph.below', mauticTemplateVars is defined ? mauticTemplateVars : []) }}
+            {{ customContent('details.stats.graph.below', _context) }}
 
             <!-- tabs controls -->
             <ul class="nav nav-tabs pr-md pl-md">

--- a/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
@@ -1,6 +1,6 @@
 <!-- Recent activity block(audit_log table) -->
 <div class="col-md-3 bg-white height-auto">
-	{{ customContent('right.section.top', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+	{{ customContent('right.section.top', _context) }}
 	<div class="panel bg-white shd-none bdr-rds-0 bdr-w-0 mb-0">
 		<div class="panel-heading">
 			<div class="panel-title">{% trans %}mautic.core.recent.activity{% endtrans %}</div>
@@ -190,6 +190,6 @@
 			{% endif %}
 		</div>
 	</div>
-	{{ customContent('right.section.bottom', mauticTemplateVars is defined ? mauticTemplateVars : {}) }}
+	{{ customContent('right.section.bottom', _context) }}
 </div>
 <!-- Recent activity block(audit_log table) -->

--- a/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
@@ -105,7 +105,7 @@
               </div>
               <!--/ stats -->
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+              {{ customContent('details.stats.graph.below', _context) }}
 
               {% if trackables is defined and trackables is not empty %}
                   <!-- tabs controls -->

--- a/plugins/MauticSocialBundle/Resources/views/Monitoring/details.html.twig
+++ b/plugins/MauticSocialBundle/Resources/views/Monitoring/details.html.twig
@@ -84,7 +84,7 @@
               </div>
               <!--/ stats -->
 
-              {{ customContent('details.stats.graph.below', mauticTemplateVars|default([])) }}
+              {{ customContent('details.stats.graph.below', _context) }}
 
               <!-- tabs controls -->
               <ul class="nav nav-tabs pr-md pl-md">


### PR DESCRIPTION
Now it's empty, so let's use Twig's _context which holds all tha vars now

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I'm porting a M4 plugin to M5 and found that all the customContent calls are broken because the template vars are empty. This was quite badly missed during the Twig refactoring and the developers (me included) still thought that the `mauticTemplateVars` still works as it did with PHP templates. But during testing we found that it's mostly empty and so we added it a default value of an empty array. Which means the core code works but the plugins are missing all the variables.

This PR fixes it by using Twig's [`_context`](https://twig.symfony.com/doc/3.x/templates.html#:~:text=_context%3A%20references%20the%20current%20context%3B) which holds all the template vars for the current template.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. There is no simple way how to test this without a plugin that's using it, but please make sure you can still browse list, detail and form views for:
3. assets
4. campaigns
5. marketing messages
6. dynamic content
7. emails
8. forms
9. contacts
10. segments
11. sms
12. users
13. focus items

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
