### PR TITLE
Removing Merge button from Add New Company View

### DIFF
--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -209,7 +209,7 @@ class CompanyController extends FormController
         $leadFieldModel = $this->getModel('lead.field');
         \assert($leadFieldModel instanceof FieldModel);
         $fields = $leadFieldModel->getPublishedFieldArrays('company');
-        $form   = $model->createForm($entity, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
+        $form   = $model->createForm($entity, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect, 'hide_extra_buttons' => true]);
 
         $viewParameters = ['page' => $page];
         $returnUrl      = $this->generateUrl('mautic_company_index', $viewParameters);

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -209,7 +209,7 @@ class CompanyController extends FormController
         $leadFieldModel = $this->getModel('lead.field');
         \assert($leadFieldModel instanceof FieldModel);
         $fields = $leadFieldModel->getPublishedFieldArrays('company');
-        $form   = $model->createForm($entity, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect, 'hide_extra_buttons' => true]);
+        $form   = $model->createForm($entity, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
 
         $viewParameters = ['page' => $page];
         $returnUrl      = $this->generateUrl('mautic_company_index', $viewParameters);

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -91,7 +91,7 @@ class CompanyType extends AbstractType
             );
         }
 
-        if (null === $options['data']->id) {
+        if (null === $options['data']->getId()) {
             $builder->add(
                 'buttons',
                 FormButtonsType::class

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -132,10 +132,9 @@ class CompanyType extends AbstractType
     {
         $resolver->setDefaults(
             [
-                'data_class'         => Company::class,
-                'isShortForm'        => false,
-                'update_select'      => false,
-                'hide_extra_buttons' => false,
+                'data_class'    => Company::class,
+                'isShortForm'   => false,
+                'update_select' => false,
             ]
         );
 

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -91,7 +91,7 @@ class CompanyType extends AbstractType
             );
         }
 
-        if (!empty($options['hide_extra_buttons'])) {
+        if (null === $options['data']->id) {
             $builder->add(
                 'buttons',
                 FormButtonsType::class

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -90,32 +90,40 @@ class CompanyType extends AbstractType
                 FormButtonsType::class
             );
         }
-        $builder->add(
-            'buttons',
-            FormButtonsType::class,
-            [
-                'post_extra_buttons' => [
-                    [
-                        'name'  => 'merge',
-                        'label' => 'mautic.lead.merge',
-                        'attr'  => [
-                            'class'       => 'btn btn-default btn-dnd',
-                            'icon'        => 'ri-exchange-2-line',
-                            'data-toggle' => 'ajaxmodal',
-                            'data-target' => '#MauticSharedModal',
-                            'data-header' => $this->translator->trans('mautic.lead.company.header.merge'),
-                            'href'        => $this->router->generate(
-                                'mautic_company_action',
-                                [
-                                    'objectId'     => $options['data']->getId(),
-                                    'objectAction' => 'merge',
-                                ]
-                            ),
+
+        if (!empty($options['hide_extra_buttons'])) {
+            $builder->add(
+                'buttons',
+                FormButtonsType::class
+            );
+        } else {
+            $builder->add(
+                'buttons',
+                FormButtonsType::class,
+                [
+                    'post_extra_buttons' => [
+                        [
+                            'name'  => 'merge',
+                            'label' => 'mautic.lead.merge',
+                            'attr'  => [
+                                'class'       => 'btn btn-default btn-dnd',
+                                'icon'        => 'fa fa-building',
+                                'data-toggle' => 'ajaxmodal',
+                                'data-target' => '#MauticSharedModal',
+                                'data-header' => $this->translator->trans('mautic.lead.company.header.merge'),
+                                'href'        => $this->router->generate(
+                                    'mautic_company_action',
+                                    [
+                                        'objectId'     => $options['data']->getId(),
+                                        'objectAction' => 'merge',
+                                    ]
+                                ),
+                            ],
                         ],
                     ],
-                ],
-            ]
-        );
+                ]
+            );
+        }
 
         $builder->addEventSubscriber(new CleanFormSubscriber($cleaningRules));
     }
@@ -124,9 +132,10 @@ class CompanyType extends AbstractType
     {
         $resolver->setDefaults(
             [
-                'data_class'    => Company::class,
-                'isShortForm'   => false,
-                'update_select' => false,
+                'data_class'         => Company::class,
+                'isShortForm'        => false,
+                'update_select'      => false,
+                'hide_extra_buttons' => false,
             ]
         );
 

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -145,4 +145,26 @@ class CompanyControllerTest extends MauticMysqlTestCase
         );
         $this->assertEquals(true, $this->client->getResponse()->isRedirect('/s/companies'));
     }
+
+    public function testCompanyMergeButtonVisible (): void
+    {
+        $this->client->request('GET', '/s/companies/new/');
+        $clientResponse         = $this->client->getResponse();
+        $clientResponseContent  = $clientResponse->getContent();
+        $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
+
+        // Use the Crawler to parse the HTML content
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($clientResponseContent);
+
+        // Check for specific buttons by their IDs
+        $applyButton = $crawler->filter('#company_buttons_apply_toolbar');
+        $saveButton = $crawler->filter('#company_buttons_save_toolbar');
+        $cancelButton = $crawler->filter('#company_buttons_cancel_toolbar');
+        $mergeButton = $crawler->filter('#company_buttons_merge_toolbar');
+
+        $this->assertCount(1, $applyButton, 'Apply button not found');
+        $this->assertCount(1, $saveButton, 'Save button not found');
+        $this->assertCount(1, $cancelButton, 'Cancel button not found');
+        $this->assertCount(0, $mergeButton, 'Merge button found');
+    }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -146,7 +146,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $this->assertEquals(true, $this->client->getResponse()->isRedirect('/s/companies'));
     }
 
-    public function testCompanyMergeButtonVisible (): void
+    public function testNewCompanyMergeButtonVisible(): void
     {
         $this->client->request('GET', '/s/companies/new/');
         $clientResponse         = $this->client->getResponse();
@@ -157,10 +157,10 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $crawler = new \Symfony\Component\DomCrawler\Crawler($clientResponseContent);
 
         // Check for specific buttons by their IDs
-        $applyButton = $crawler->filter('#company_buttons_apply_toolbar');
-        $saveButton = $crawler->filter('#company_buttons_save_toolbar');
-        $cancelButton = $crawler->filter('#company_buttons_cancel_toolbar');
-        $mergeButton = $crawler->filter('#company_buttons_merge_toolbar');
+        $applyButton  = $crawler->filter('#company_buttons_apply');
+        $saveButton   = $crawler->filter('#company_buttons_save');
+        $cancelButton = $crawler->filter('#company_buttons_cancel');
+        $mergeButton  = $crawler->filter('#company_buttons_merge');
 
         $this->assertCount(1, $applyButton, 'Apply button not found');
         $this->assertCount(1, $saveButton, 'Save button not found');


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13416  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR removes the redundant **Merge** button when creating a new company, which makes sure the incorrect modal with "New" button (as mentioned in the issue) is not displayed.
![image](https://github.com/mautic/mautic/assets/97207366/ecfaaf91-e7bf-48ec-b085-882498da6970)

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to `Companies` and click on `New`.
3. In the top-right toolbar, verify that the `Merge` button is not displayed when creating a new company, but, it is visible once the company is saved, showing the correct modal on clicking it.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
