### PR TITLE
Fixing form attribute

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
@@ -32,7 +32,7 @@
     .mauticform-field-hidden { display:none }
 </style>
 <div id="mauticform_wrapper{{ formName }}" class="mauticform_wrapper">
-    <form autocomplete="false" role="form" method="post" action="{{ action }}" id="mauticform{{ formName }}" {% if isAjax %}data-mautic-form="{{ formName|trim('_', 'left') }}"{% endif %} enctype="multipart/form-data" {{ form.formAttributes }}>
+    <form autocomplete="false" role="form" method="post" action="{{ action }}" id="mauticform{{ formName }}" {% if isAjax %}data-mautic-form="{{ formName|trim('_', 'left') }}"{% endif %} enctype="multipart/form-data" {{ form.formAttributes|raw }}>
         {%- if successfulSubmitAction == 'top' -%}
             <div class="mauticform-error" id="mauticform{{ formName }}_error"></div>
             <div class="mauticform-message" id="mauticform{{ formName }}_message"></div>

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -43,7 +43,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
                     'type'  => 'button',
                 ],
             ],
-            'postAction'  => 'return',
+            'postAction'     => 'return',
+            'formAttributes' => 'class="foobar"',
         ];
 
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
@@ -85,6 +86,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
         $formCrawler = $crawler->filter('form[id=mauticform_submissiontestform]');
         $this->assertSame(1, $formCrawler->count());
+        $this->assertStringContainsString(' class="foobar"', $crawler->html());
         $form = $formCrawler->form();
         $form->setValues([
             'mauticform[country]' => 'Australia',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/13715, https://github.com/mautic/mautic/issues/13645

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

The form attribute value is being escaped as that's the default Twig behavior. So this bug came in with the Twig refactoring. It should be a raw value instead.  

It's about this field:
![Screenshot 2024-05-07 at 09 26 09](https://github.com/mautic/mautic/assets/1235442/c6286601-838b-40ed-aadc-56ffd5f9b5fe)

⚠️ as this change is adding the `|raw` filter, it allows users to add also JS as an attribute. Like `onclick="alert('hello')"`. That's how I think it suppose to be and that's how it works for field attributes as well. This JS will not be executed anywhere in the administration but wherever the form is embedded. I'm open for discussion on this topic.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a form with any field.
3. Fill in `class="foobar"` to the form attribute field as shown above.
4. Open the form. The simplest way is to duplicate the form tab and instead of `/s/forms/edit/1` change this part of URL to `/form/1`.
5. Inspect the HTML source code to see that the class is quoted twice as the linked issues suggest.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
