### PR TITLE
FIX leak checked attribute in cycle

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
@@ -19,7 +19,7 @@
             'mappedFields': mappedFields|default([]),
     })|replace({
             '<input': '<input value="' ~ field.defaultValue ~ '"',
-    }) -}}
+    })|raw -}}
 {% endif %}
 {#
     This field relies on the `group.html.twig` implementation.

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -229,21 +229,21 @@
   {% for listValue, listLabel in list|default([]) %}
     {% set id = field.alias ~ '_' ~ inputAlphanum(inputTransliterate(listValue)) ~ loop.index0 %}
     {% set checkboxBrackets = ('checkbox' == type) ? '[]' : '' %}
-    {% set inputAttributes = inputAttributes|merge({
+    {% set listInputAttributes = inputAttributes|merge({
             'name': 'mauticform[' ~ field.alias ~ ']' ~ checkboxBrackets,
             'id': 'mauticform_' ~ containerType ~ '_' ~ type ~ '_' ~ id,
             'type': type,
             'value': listValue|e,
     }) %}
     {% if field.defaultValue == listValue %}
-      {% set inputAttributes = inputAttributes|merge({
+      {% set listInputAttributes = listInputAttributes|merge({
               'checked': 'checked',
       }) %}
     {% endif %}
 
     {% if wrapDiv %}<div class="mauticform-{{ containerType }}-row">{% endif %}
 
-    <input {% for attrName, attrValue in inputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %} />
+    <input {% for attrName, attrValue in listInputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %} />
     {% set optionLabelAttr = optionLabelAttr|merge({
             'id': 'mauticform_' ~ containerType ~ '_label_' ~ id,
             'for': 'mauticform_' ~ containerType ~ '_' ~ type ~ '_' ~ id,


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [X ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In case of definition form checkboxes/radios with default value, mautic render form "checked" attribute on every input below "matched" checkbox/radio.

In twig template there is a cycle through `list` possible value. For each listItem top-level defined variable `inputAttributes` is extended (by merge) with mandatory attributes - in every iteration. But there is a condition for default value - when condition is met, variable `inputAttributes` was extended by merge again, with `checked` attribute. This action keep persisted through iteration.

I suggest just rename variable in cycle, for prevent overwrite top-level `inputAttributes`.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to "Components" > "Forms" and create new "Form object"
3. Under "Fields" tab add new field "checkbox groups" or "radio groups"
4. In tab "properties" fill in at least 5 pairs
5. Return to 1st tab ("general") and fill "Default value" by value of your first property <- this is important - filll in 1st value
6. Now save the form, go to preview => you will see last radio is checked (or all checkboxes are checked)

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
