### PR TITLE
Replace reference to Mailhog with Mailpit

### DIFF
--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 # Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
-ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILHOG_URL=$(gp url 8025),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
+ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILPIT_URL=$(gp url 8025),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
 
 ddev get ddev/ddev-phpmyadmin
 

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 # Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
-ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILPIT_URL=$(gp url 8025),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
+ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILPIT_URL=$(gp url 8026),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
 
 ddev get ddev/ddev-phpmyadmin
 

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 # Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
-ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8036),MAILPIT_URL=$(gp url 8026),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
+ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8037),MAILPIT_URL=$(gp url 8026),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
 
 ddev get ddev/ddev-phpmyadmin
 

--- a/.ddev/gitpod-setup-ddev.sh
+++ b/.ddev/gitpod-setup-ddev.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # Misc housekeeping before start
 ddev config global --router-bind-all-interfaces
 # Pass the GITPOD_WORKSPACE_URL env variable to the web container for our setup script
-ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8037),MAILPIT_URL=$(gp url 8026),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
+ddev config global --web-environment="MAUTIC_URL=$(gp url 8080),PHPMYADMIN_URL=$(gp url 8037),MAILPIT_URL=$(gp url 8027),DRUSH_OPTIONS_URI=https://127.0.0.1:8080"
 
 ddev get ddev/ddev-phpmyadmin
 

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -3,7 +3,7 @@
 setup_mautic() {
     [ -z "${MAUTIC_URL}" ] && MAUTIC_URL="https://${DDEV_HOSTNAME}"
     [ -z "${PHPMYADMIN_URL}" ] && PHPMYADMIN_URL="https://${DDEV_HOSTNAME}:8037"
-    [ -z "${MAILHOG_URL}" ] && MAILHOG_URL="https://${DDEV_HOSTNAME}:8026"
+    [ -z "${MAILPIT_URL}" ] && MAILPIT_URL="https://${DDEV_HOSTNAME}:8026"
 
     printf "Installing Mautic Composer dependencies...\n"
     composer install
@@ -24,7 +24,7 @@ setup_mautic() {
     printf "🔒 The default login is admin / Maut1cR0cks!\n"
     printf "🌐 To open the Mautic instance, go to ${MAUTIC_URL} in your browser.\n"
     printf "🌐 To open PHPMyAdmin for managing the database, go to ${PHPMYADMIN_URL} in your browser.\n"
-    printf "🌐 To open Mailpit for seeing all emails that Mautic sent, go to ${MAILHOG_URL} in your browser.\n"
+    printf "🌐 To open Mailpit for seeing all emails that Mautic sent, go to ${MAILPIT_URL} in your browser.\n"
     printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
     printf "🚀 Run \"ddev exec bin/console COMMAND\" (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
     printf "🔴 If you want to stop the instance, simply run \"ddev stop\".\n"

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -24,7 +24,7 @@ setup_mautic() {
     printf "🔒 The default login is admin / Maut1cR0cks!\n"
     printf "🌐 To open the Mautic instance, go to ${MAUTIC_URL} in your browser.\n"
     printf "🌐 To open PHPMyAdmin for managing the database, go to ${PHPMYADMIN_URL} in your browser.\n"
-    printf "🌐 To open MailHog for seeing all emails that Mautic sent, go to ${MAILHOG_URL} in your browser.\n"
+    printf "🌐 To open Mailpit for seeing all emails that Mautic sent, go to ${MAILHOG_URL} in your browser.\n"
     printf "🚀 Run \"ddev exec composer test\" to run PHPUnit tests.\n"
     printf "🚀 Run \"ddev exec bin/console COMMAND\" (like mautic:segments:update) to use the Mautic CLI. For an overview of all available CLI commands, go to https://mau.tc/cli\n"
     printf "🔴 If you want to stop the instance, simply run \"ddev stop\".\n"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -24,7 +24,7 @@ ports:
   # phpmyadmin https port
   - port: 8027
     onOpen: ignore
-  # mailhog https port
+  # mailpit https port
   - port: 8036
     onOpen: ignore
   # Main web port


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

#### Description:

Mailhog has been abandoned and Mailpit is now [used by default by DDEV](https://github.com/ddev/ddev/pull/5313). I've just updated the copy printed out to avoid confusion, we might want to update the variables at some point in the future to replace mailhog with mailpit, perhaps? Can make that as a separate PR later if folks want that.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check that the output in green text now shows Mailpit instead of Mailhog
3. Check that Mailpit loads in Gitpod