### PR TITLE
Upgrading composer-install from v2 to v3 to avoid NodeJS v16 warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Install dependencies
       # composer install cache - https://github.com/ramsey/composer-install
-      uses: "ramsey/composer-install@v2"
+      uses: "ramsey/composer-install@v3"
 
     - name: Run tests - database = ${{ matrix.db-types }}
       run: |
@@ -185,7 +185,7 @@ jobs:
 
     - name: Install dependencies
       # composer install cache - https://github.com/ramsey/composer-install
-      uses: "ramsey/composer-install@v2"
+      uses: "ramsey/composer-install@v3"
       env:
         NPM_CONFIG_CACHE: ./var/cache/js/npm
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [y]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

There are many NodeJS 16 warnings in our CI:
![Screenshot 2024-05-29 at 13 17 07](https://github.com/mautic/mautic/assets/1235442/02a80281-833e-4d29-b19a-e42dcc592f51)

Live example: https://github.com/mautic/mautic/actions/runs/9284756063

We are already using `actions/cache@v4` in our yml files, but this seem to be coming from `ramsey/composer-install@v2` and the [release note for v3](https://github.com/ramsey/composer-install/releases/tag/3.0.0) suggests the same.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. No production code was changed. Just CI dependency version. No need to test Mautic. Just check the CI output that there are no more warnings.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->
