### PR TITLE
Allow replacing Symfony services within tests

### DIFF
--- a/app/AppTestKernel.php
+++ b/app/AppTestKernel.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class AppTestKernel extends AppKernel
+{
+    private bool $isTestContainerSet = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isInstalled(): bool
+    {
+        return true;
+    }
+
+    public function getCacheDir(): string
+    {
+        if ($dir = getenv('TEST_CACHE_DIR')) {
+            return dirname(__DIR__).'/'.$dir;
+        }
+
+        return parent::getCacheDir();
+    }
+
+    public function getLogDir(): string
+    {
+        if ($dir = getenv('TEST_LOG_DIR')) {
+            return dirname(__DIR__).'/'.$dir;
+        }
+
+        return parent::getLogDir();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getContainer(): ContainerInterface
+    {
+        if (!$this->container) {
+            $this->boot();
+        }
+
+        if ($this->isTestContainerSet) {
+            return $this->container;
+        }
+
+        $this->isTestContainerSet = true;
+
+        $testContainer = $this->container->get('test.service_container');
+        $testContainer->setPublicContainer($this->container);
+
+        return $this->container;
+    }
+}

--- a/app/bundles/CoreBundle/Test/Container/TestContainer.php
+++ b/app/bundles/CoreBundle/Test/Container/TestContainer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Test\Container;
+
+use Symfony\Bundle\FrameworkBundle\Test\TestContainer as BaseTestContainer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class TestContainer extends BaseTestContainer
+{
+    private ContainerInterface $publicContainer;
+
+    /**
+     * @param ?object $service
+     */
+    public function set(string $id, $service): void
+    {
+        $closure = static function (ContainerInterface $container) use ($id, $service) {
+            $container->services[$id] = $service; // @phpstan-ignore-line
+            $container->privates[$id] = $service; // @phpstan-ignore-line
+        };
+        \Closure::bind($closure, null, $this->publicContainer)($this->publicContainer);
+    }
+
+    public function setPublicContainer(ContainerInterface $container): void
+    {
+        $this->publicContainer = $container;
+    }
+}

--- a/app/composer.json
+++ b/app/composer.json
@@ -13,6 +13,7 @@
     },
     "files": [
       "AppKernel.php",
+      "AppTestKernel.php",
       "AppCache.php"
     ]
   },

--- a/app/config/config_test.php
+++ b/app/config/config_test.php
@@ -148,3 +148,8 @@ $container->register(GuzzleHttp\Handler\MockHandler::class)->setPublic(true);
 
 $container->register('http_client', Symfony\Component\HttpClient\MockHttpClient::class)
     ->setPublic(true);
+
+$container->register('test.service_container', Mautic\CoreBundle\Test\Container\TestContainer::class)
+    ->setArgument('$kernel', new Reference('kernel'))
+    ->setArgument('$privateServicesLocatorId', 'test.private_services_locator')
+    ->setPublic(true);

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -50,7 +50,7 @@
   <php>
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <env name="MAXMIND_LICENSE_KEY" value=""/>
-    <env name="KERNEL_CLASS" value="AppKernel" />
+    <env name="KERNEL_CLASS" value="AppTestKernel" />
     <const name="IS_PHPUNIT" value="true"/>
     <const name="MAUTIC_ENV" value="test"/>
     <server name="KERNEL_DIR" value="app"/>

--- a/composer.lock
+++ b/composer.lock
@@ -4703,12 +4703,12 @@
             "version": "v5.2.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "shasum": ""
             },
@@ -6003,7 +6003,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "d25d52459cb506b9997bcba8d16c6ee6870492fc"
+                "reference": "ff04262752d9b0a30c80be568ceeb5a585fc3cda"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -6144,6 +6144,7 @@
                 },
                 "files": [
                     "AppKernel.php",
+                    "AppTestKernel.php",
                     "AppCache.php"
                 ]
             },


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [❌]
| New feature/enhancement? (use the a.x branch)      | [✅]
| Deprecations?                          | [❌]
| BC breaks? (use the c.x branch)        | [❌]
| Automated tests included?              | [❌] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

This PR allows replacing of Symfony services within automated tests. Consider the following hypothetical test code.

```php
public function testSomething(): void
{
    static::getContainer()->set('session_listener', new \Symfony\Component\HttpKernel\EventListener\SessionListener());

    $this->client->request('GET', '/s/forms');
    $this->assertTrue($this->client->getResponse()->isOk());
}
```

Without this PR you will get an error like:
```
Symfony\Component\DependencyInjection\Exception\InvalidArgumentException : The "session_listener" service is private, you cannot replace it. /var/www/html/vendor/symfony/dependency-injection/Container.php:164
 /var/www/html/vendor/symfony/framework-bundle/Test/TestContainer.php:95
...
```


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
There is nothing to test as this PR just improves automated tests.
