### PR TITLE
draft: refs #13801 Remove render hidden field when defaultValue present

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
@@ -1,5 +1,5 @@
 {% if field.defaultValue is defined and field.defaultValue is not empty %}
-
+{% set hiddenField = field|merge({inputAttributes: "value='#{ field.defaultValue }'"}) %}
 {#
     This field relies on the `hidden.html.twig` implementation.
 
@@ -9,7 +9,7 @@
     This eliminates the need to copy twig templates into themes that just rely on one base template file.
 #}
     {{- include([theme|default('') ~ 'hidden.html.twig', '@MauticForm/Field/hidden.html.twig'], {
-            'field': field,
+            'field': hiddenField,
             'fields': fields|default([]),
             'inForm': inForm|default(false),
             'id': id,
@@ -17,8 +17,6 @@
             'type': 'checkbox',
             'formName': formName|default(''),
             'mappedFields': mappedFields|default([]),
-    })|replace({
-            '<input': '<input value="' ~ field.defaultValue ~ '"',
     }) -}}
 {% endif %}
 {#

--- a/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
@@ -1,3 +1,26 @@
+{% if field.defaultValue is defined and field.defaultValue is not empty %}
+
+{#
+    This field relies on the `hidden.html.twig` implementation.
+
+    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/hidden.html.twig`
+    and falls back to the standard template '@MauticForm/Field/hidden.html.twig'.
+
+    This eliminates the need to copy twig templates into themes that just rely on one base template file.
+#}
+    {{- include([theme|default('') ~ 'hidden.html.twig', '@MauticForm/Field/hidden.html.twig'], {
+            'field': field,
+            'fields': fields|default([]),
+            'inForm': inForm|default(false),
+            'id': id,
+            'formId': formId|default(0),
+            'type': 'checkbox',
+            'formName': formName|default(''),
+            'mappedFields': mappedFields|default([]),
+    })|replace({
+            '<input': '<input value="' ~ field.defaultValue ~ '"',
+    }) -}}
+{% endif %}
 {#
     This field relies on the `group.html.twig` implementation.
 

--- a/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/checkboxgrp.html.twig
@@ -1,26 +1,3 @@
-{% if field.defaultValue is defined and field.defaultValue is not empty %}
-
-{#
-    This field relies on the `hidden.html.twig` implementation.
-
-    Mautic tries to render `@themes/{{theme}}/html/MauticFormBundle/Field/hidden.html.twig`
-    and falls back to the standard template '@MauticForm/Field/hidden.html.twig'.
-
-    This eliminates the need to copy twig templates into themes that just rely on one base template file.
-#}
-    {{- include([theme|default('') ~ 'hidden.html.twig', '@MauticForm/Field/hidden.html.twig'], {
-            'field': field,
-            'fields': fields|default([]),
-            'inForm': inForm|default(false),
-            'id': id,
-            'formId': formId|default(0),
-            'type': 'checkbox',
-            'formName': formName|default(''),
-            'mappedFields': mappedFields|default([]),
-    })|replace({
-            '<input': '<input value="' ~ field.defaultValue ~ '"',
-    }) -}}
-{% endif %}
 {#
     This field relies on the `group.html.twig` implementation.
 


### PR DESCRIPTION
Related to #13801

If `checkbox` has default value set, there is rendered hidden field tag (`hidden.twig`), which is populated by "value" attribute => this not working - `replace` function broke html probably. Also in edit of form, HTML markup is show above checkboxes optionsList.

see https://github.com/mautic/mautic/issues/13801

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new form (Components > Form > New)
3. Got to tab "Fields" and add new field `Checkbox group`
4. Popup dialog apper, type `name` "boolean"; `default value` "no"; then go to tab `properties` and add 1 item "yes" and submit dialog. <= this field should be for test default "no" value submitted if checkbox is not checked.
5. Add another `Checkbox group` > type `name` to "list"; `default value` "item2"; then go to tab `properties` and add 3 items (item1..item4) and submit dialog
6. Go to preview of form => if you submit with check "boolean" => results contains value "yes"; if you submit with unchecked "boolean" => results contain "no".

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->