### PR TITLE
EntityValidateEvent introduced and attached to Email, Page and Sms entities

### DIFF
--- a/app/bundles/CoreBundle/Event/EntityValidateEvent.php
+++ b/app/bundles/CoreBundle/Event/EntityValidateEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Event;
+
+use Mautic\CoreBundle\Validator\EntityEvent;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class EntityValidateEvent extends Event
+{
+    public function __construct(private object $entity, private EntityEvent $constraint, private ExecutionContextInterface $context)
+    {
+    }
+
+    public function getEntity(): object
+    {
+        return $this->entity;
+    }
+
+    public function getConstraint(): EntityEvent
+    {
+        return $this->constraint;
+    }
+
+    public function getContext(): ExecutionContextInterface
+    {
+        return $this->context;
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Validator/EntityEventValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Validator/EntityEventValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Validator;
+
+use Mautic\CoreBundle\Event\EntityValidateEvent;
+use Mautic\CoreBundle\Validator\EntityEvent;
+use Mautic\CoreBundle\Validator\EntityEventValidator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class EntityEventValidatorTest extends TestCase
+{
+    private EventDispatcherInterface $dispatcher;
+    private ExecutionContextInterface $context;
+    private ConstraintValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        $this->context    = $this->createMock(ExecutionContextInterface::class);
+        $this->dispatcher = new EventDispatcher();
+        $this->validator  = new EntityEventValidator($this->dispatcher);
+        $this->validator->initialize($this->context);
+    }
+
+    public function testInvalidValue(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "object", "string" given');
+
+        $this->validator->validate('invalidType', new EntityEvent());
+    }
+
+    public function testInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessageMatches('/Expected argument of type "Mautic\\\CoreBundle\\\Validator\\\EntityEvent"/');
+
+        $this->validator->validate(new \stdClass(), new NotBlank());
+    }
+
+    public function testEventIsDispatched(): void
+    {
+        $dispatched = false;
+        $entity     = new \stdClass();
+        $constraint = new EntityEvent();
+
+        $this->dispatcher->addListener(EntityValidateEvent::class, function (EntityValidateEvent $event) use (&$dispatched, $entity, $constraint) {
+            $dispatched = true;
+
+            Assert::assertSame($entity, $event->getEntity());
+            Assert::assertSame($constraint, $event->getConstraint());
+            Assert::assertSame($this->context, $event->getContext());
+        });
+
+        $this->validator->validate($entity, $constraint);
+
+        Assert::assertTrue($dispatched);
+    }
+}

--- a/app/bundles/CoreBundle/Validator/EntityEvent.php
+++ b/app/bundles/CoreBundle/Validator/EntityEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+final class EntityEvent extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/app/bundles/CoreBundle/Validator/EntityEventValidator.php
+++ b/app/bundles/CoreBundle/Validator/EntityEventValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Validator;
+
+use Mautic\CoreBundle\Event\EntityValidateEvent;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class EntityEventValidator extends ConstraintValidator
+{
+    public function __construct(private EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!is_object($value)) {
+            throw new UnexpectedTypeException($value, 'object');
+        }
+
+        if (!$constraint instanceof EntityEvent) {
+            throw new UnexpectedTypeException($constraint, EntityEvent::class);
+        }
+
+        $this->dispatcher->dispatch(new EntityValidateEvent($value, $constraint, $this->context));
+    }
+}

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Entity\TranslationEntityTrait;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Entity\VariantEntityTrait;
 use Mautic\CoreBundle\Helper\UrlHelper;
+use Mautic\CoreBundle\Validator\EntityEvent;
 use Mautic\EmailBundle\Validator\EmailLists;
 use Mautic\EmailBundle\Validator\EmailOrEmailTokenList;
 use Mautic\FormBundle\Entity\Form;
@@ -373,6 +374,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         );
 
         $metadata->addConstraint(new EmailLists());
+        $metadata->addConstraint(new EntityEvent());
 
         $metadata->addConstraint(new Callback([
             'callback' => function (Email $email, ExecutionContextInterface $context): void {

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Entity\TranslationEntityInterface;
 use Mautic\CoreBundle\Entity\TranslationEntityTrait;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Entity\VariantEntityTrait;
+use Mautic\CoreBundle\Validator\EntityEvent;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -270,6 +271,8 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
                 }
             },
         ]));
+
+        $metadata->addConstraint(new EntityEvent());
     }
 
     /**

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
+use Mautic\CoreBundle\Validator\EntityEvent;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccess;
 use Symfony\Component\Validator\Constraints\Callback;
@@ -185,6 +186,8 @@ class Sms extends FormEntity
                 }
             },
         ]));
+
+        $metadata->addConstraint(new EntityEvent());
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR introduces `EntityValidateEvent` that is dispatched within `EntityEventValidator`. When the `EntityEventValidator` is attached to an entity, other parts of the codebase (plugins for example) can listen to the `EntityValidateEvent` and add their own validation rules.

In this PR `EntityEventValidator` was attached to Email, Page and Sms entities as we needed to add custom validation for those. There are no listeners listening to `EntityValidateEvent` in this PR.

Example subscriber method:
```php
    public function onEntityValidate(EntityValidateEvent $event): void
    {
        $email = $event->getEntity();

        if (!$email instanceof Email) {
            return;
        }

        $event->getContext()->buildViolation('some.message', ['%var%' => $this->getVar($email)])
            ->atPath('subject')
            ->addViolation();
    }
```


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Make sure that Emails, Pages and Smses can be created and updated via UI and API.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->