### PR TITLE
Fix DDEV script permissions for Windows users

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -19,4 +19,5 @@ hooks:
     # Fix line endings on Windows
     - exec: sed -i -e 's/\r$//' ./.ddev/mautic-setup.sh
     - exec: sed -i -e 's/\r$//' ./.git/hooks/*
+    - exec: "chmod +x ./.ddev/mautic-setup.sh"
     - exec: "yes | ./.ddev/mautic-setup.sh"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force the use of LF for all text files for everyone
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Force the use of LF for all text files for everyone
-* text=auto eol=lf


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds an extra command for DDEV to fix file permission issues. 
Normally, you do:
1. `ddev config`
2. `ddev start`
At some point, DDEV tries to run the `mautic-setup.sh` (responsible for setting the admin account etc). The script fails. `composer install` doesn't happen. On Windows, it tends not to work and you need to change the permission every time and run manually again. This problem arises absolutely EVERY time you clone the repository.

It also saves time for devs on Windows, setting the Linux line endings (LF) to avoid conversions when cloning the repository.

This PR can reduce people asking the community why Mautic isn't working after running DDEV (because... `composer install` didn't run). Hope this helps new devs to have a trouble-free experience in the first contact with Mautic.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Pull down for testing locally on Windows
3. Run DDEV
4. No more wasted time

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->