### PR TITLE
FIX: Removes onConfigSave which invokes htmlspecialchars and escapes tracking HTML

### DIFF
--- a/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\PageBundle\EventListener;
 
 use Mautic\ConfigBundle\ConfigEvents;
 use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
-use Mautic\ConfigBundle\Event\ConfigEvent;
 use Mautic\PageBundle\Form\Type\ConfigTrackingPageType;
 use Mautic\PageBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -61,15 +60,5 @@ class ConfigSubscriber implements EventSubscriberInterface
                 'do_not_track_404_anonymous'            => false,
             ],
         ]);
-    }
-
-    public function onConfigSave(ConfigEvent $event): void
-    {
-        $values = $event->getConfig();
-
-        if (!empty($values['pageconfig']['google_analytics'])) {
-            $values['pageconfig']['google_analytics'] = htmlspecialchars($values['pageconfig']['google_analytics']);
-            $event->setConfig($values);
-        }
     }
 }


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13355

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description


This fixes #13355



---
### 📋 Steps to test this PR:


This removes the HTML escaping logic in the onConfigSave method of `ConfigSubscriber`. This change prevents the UI from displaying escaped HTML in the custom tracking JS field after saving the form.

Previously, the form erroneously escaped HTML entities. By removing this code, users will now see the original HTML as expected when they revisit the form.

The main issue, however, was that re-saving  meant saving escaped HTML which would break inserting the tracking HTML code.

### Steps to test

**Before**
1. Add custom HTML in `Configuration > Landing Page Settings > Analytics script (i.e. Google Analytics) `
2. Save
3. Open this view again → see escaped HTML
4. Save again
5. Open a landing page and see escaped HTML tracking code injected.

**After**
1. Add custom HTML in `Configuration > Landing Page Settings > Analytics script (i.e. Google Analytics) `
2. Save
3. Open this view again → see unescaped HTML
4. Save again
5. Open a landing page and see correct HTML tracking code injected.

**Sample Script**
```html
<script>
(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
  ga('create', 'UA-xxxxxx-1', 'auto');
  ga('send', 'pageview');
</script>
```