### PR TITLE
[UI] Replaces table action button `arrow-down` with `more-2` icon

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
@@ -21,7 +21,7 @@
 
     <div class="input-group-btn">
         <button type="button" class="btn btn-default btn-sm dropdown-toggle btn-nospin" data-toggle="dropdown">
-            <i class="ri-arrow-down-s-line"></i>
+            <i class="ri-more-2-line"></i>
         </button>
         {% if tooltip is defined and tooltip is not empty %}<i class="ri-question-line"></i>{% endif %}
         <ul class="pull-{{ pull }} page-list-actions dropdown-menu" role="menu">

--- a/app/bundles/CoreBundle/Resources/views/Helper/page_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/page_actions.html.twig
@@ -27,7 +27,7 @@
 
     {{ buttonsRender(
         (
-            '<button type="button" class="btn btn-default btn-nospin dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="ri-arrow-down-s-line"></i></button>\n'
+            '<button type="button" class="btn btn-default btn-nospin dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="ri-more-2-line"></i></button>\n'
             ~ '<ul class="dropdown-menu dropdown-menu-right" role="menu">'
         )
         , '</ul>'

--- a/app/bundles/CoreBundle/Resources/views/Helper/page_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/page_actions.html.twig
@@ -27,7 +27,7 @@
 
     {{ buttonsRender(
         (
-            '<button type="button" class="btn btn-default btn-nospin dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="ri-more-2-line"></i></button>\n'
+            '<button type="button" class="btn btn-default btn-nospin dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><i class="ri-arrow-down-s-line"></i></button>\n'
             ~ '<ul class="dropdown-menu dropdown-menu-right" role="menu">'
         )
         , '</ul>'

--- a/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
@@ -30,7 +30,7 @@
 
         <div class="input-group-btn">
             <button type="button" disabled class="btn btn-default btn-sm dropdown-toggle btn-nospin" data-toggle="dropdown">
-                <i class="ri-arrow-down-s-line"></i>
+                <i class="ri-more-2-line"></i>
             </button>
             <ul class="pull-{{ pull }} page-list-actions dropdown-menu" role="menu">
                 {{ buttonsRender() }}


### PR DESCRIPTION
This replaces the icon for the action toggle button in tables (e.g. contact list table or segment list table) with a 3 dot icon.

The previous arrow down icon indicates that an collapsed element would get unfolded/shown. This is not the case in these tables. The button shows more actions. In any UI that I know a 3 dot icon is used for that.

The arrow down icon would be more suitable if it would show more details on click. Hence, this PR.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This replaces the icon for the action toggle button in tables (e.g. contact list table or segment list table) with a 3 dot icon.

The previous arrow down icon indicates that an collapsed element would get unfolded/shown. This is not the case in these tables. The button shows more actions. In any UI that I know a 3 dot icon is used for that.

The arrow down icon would be more suitable if it would show more details on click (which it doesn't).


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->

| Before                                 | After |
| -------------------------------------- | --- |
| ![image](https://github.com/mautic/mautic/assets/26040044/a245f4d3-6c49-4c6b-9c4a-4ea9fa983ba9) | ![image](https://github.com/mautic/mautic/assets/26040044/9d2b1272-3dd7-40e4-9ece-d237aaa33ef6) |



---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. See that the icons got replaced in any table that shows the "more action" button.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->