### PR TITLE
fix: correct mime types for embedded images

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -835,7 +835,8 @@ class MailHelper
         $this->message->html($content);
     }
 
-    private function resolveMimeType(string $data): ?string {
+    private function resolveMimeType(string $data): ?string
+    {
         $mimeType = null;
         if (extension_loaded('fileinfo')) {
             if (($info = finfo_open(\FILEINFO_MIME)) !== false) {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -840,7 +840,7 @@ class MailHelper
         $mimeType = null;
         if (extension_loaded('fileinfo')) {
             if (($info = finfo_open(\FILEINFO_MIME)) !== false) {
-                $mimeType = finfo_buffer($info, $data) ?? null;
+                $mimeType = finfo_buffer($info, $data) ?: null;
                 finfo_close($info);
             }
         }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -825,7 +825,7 @@ class MailHelper
                 }
 
                 if ($imageContent = file_get_contents($path)) {
-                    $this->message->embed($imageContent, md5($match));
+                    $this->message->embed($imageContent, md5($match), $this->resolveMimeType($imageContent));
                     $this->embedImagesReplaces[$match] = 'cid:'.md5($match);
                 }
             }
@@ -833,6 +833,18 @@ class MailHelper
         }
 
         $this->message->html($content);
+    }
+
+    private function resolveMimeType(string $data): ?string {
+        $mimeType = null;
+        if (extension_loaded('fileinfo')) {
+            if (($info = finfo_open(\FILEINFO_MIME)) !== false) {
+                $mimeType = finfo_buffer($info, $data) ?? null;
+                finfo_close($info);
+            }
+        }
+
+        return $mimeType;
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -1076,7 +1076,7 @@ class MailHelperTest extends TestCase
 
         // We should use a local image to avoid network requests.
         $sampleImagePath = __DIR__.'/../../../../assets/images/avatar.svg';
-        $sampleImage = \file_get_contents($sampleImagePath);
+        $sampleImage     = \file_get_contents($sampleImagePath);
 
         $mailer->setIdHash('IDHASH');
         $email->setSubject('Test');
@@ -1100,8 +1100,11 @@ class MailHelperTest extends TestCase
         $this->assertStringContainsString('<img height="1" width="1" src="http://tracking.url" alt="" />', $body);
 
         $embeddedImages = [];
-        $matchCount = preg_match_all('/"cid:([^"]+?)"/', $body, $embeddedImages);
+        $matchCount     = preg_match_all('/"cid:([^"]+?)"/', $body, $embeddedImages);
         $this->assertSame(2, $matchCount);
+
+        $resolveMimeTypeMethod  = $reflectionMailerObject->getMethod('resolveMimeType');
+        $resolveMimeTypeMethod->setAccessible(true);
 
         foreach ($embeddedImages[1] as $cid) {
             $attachment = null;
@@ -1118,11 +1121,11 @@ class MailHelperTest extends TestCase
                 }
             }
 
-            $this->assertNotNull($attachment, "Cannot find the embedded image in attachments");
+            $this->assertNotNull($attachment, 'Cannot find the embedded image in attachments');
+
             $this->assertEquals(
                 implode('/', [$attachment->getMediaType(), $attachment->getMediaSubtype()]),
-                $reflectionMailerObject->getMethod('resolveMimeType')
-                    ->invoke($mailer, $sampleImage)
+                $resolveMimeTypeMethod->invoke($mailer, $sampleImage)
             );
         }
     }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -26,6 +26,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Component\Mime\Header\MailboxListHeader;
+use Symfony\Component\Mime\Part\TextPart;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -1075,6 +1076,7 @@ class MailHelperTest extends TestCase
 
         // We should use a local image to avoid network requests.
         $sampleImagePath = __DIR__.'/../../../../assets/images/avatar.svg';
+        $sampleImage = \file_get_contents($sampleImagePath);
 
         $mailer->setIdHash('IDHASH');
         $email->setSubject('Test');
@@ -1096,7 +1098,33 @@ class MailHelperTest extends TestCase
         $body = $mauticMessage->getHtmlBody();
 
         $this->assertStringContainsString('<img height="1" width="1" src="http://tracking.url" alt="" />', $body);
-        $this->assertSame(2, substr_count($body, 'cid:'));
+
+        $embeddedImages = [];
+        $matchCount = preg_match_all('/"cid:([^"]+?)"/', $body, $embeddedImages);
+        $this->assertSame(2, $matchCount);
+
+        foreach ($embeddedImages[1] as $cid) {
+            $attachment = null;
+            foreach ($mauticMessage->getAttachments() as $i) {
+                // Symfony currently replaces our content-ids with its own,
+                // and the original is stored in $name, however, there's no clean way to access it
+                $nameReflection = new \ReflectionProperty(TextPart::class, 'name');
+                $nameReflection->setAccessible(true);
+                $originalCid = $nameReflection->getValue($i);
+
+                if ($originalCid === $cid) {
+                    $attachment = $i;
+                    break;
+                }
+            }
+
+            $this->assertNotNull($attachment, "Cannot find the embedded image in attachments");
+            $this->assertEquals(
+                implode('/', [$attachment->getMediaType(), $attachment->getMediaSubtype()]),
+                $reflectionMailerObject->getMethod('resolveMimeType')
+                    ->invoke($mailer, $sampleImage)
+            );
+        }
     }
 
     public function testThatWeDontEmbedAlreadyEmbeddedImages(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | see description <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This commit 8669bd16f3a3255830314655f080a4fa3a0c77d5 did a very important change for mail portability - embedding images in mime parts. However, this is not enough. Each part needs to contain correct Content-Type to be accepted by clients like gmail or thunderbird. Without this change, email is broken, images are not shown and are placed in attachments instead as generic data.

This change uses php's fileinfo extension to determine the correct mime type for each image and uses it for the mime part.

| Before                                 | After
| -------------------------------------- | ---
|  Image mime-parts did not contain content-type header                                      | They do



---
### 📋 Steps to test this PR:

Use embed images as base64 in mautic and send an email with images
