### PR TITLE
FEAT: Adds WHERE filter to ForeignFuncFilterQueryBuilder

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -26,6 +26,10 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
 
         $filterParameters = $filter->getParameterValue();
 
+        // allow custom Lead::id foreign key columns like `contact_id`
+        // instead of the deprecated `lead_id`
+        $foreignContactColumn = $filter->getForeignContactColumn();
+
         if (is_array($filterParameters)) {
             $parameters = [];
             foreach ($filterParameters as $filterParameter) {
@@ -61,7 +65,7 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
                         $leadsTableAlias,
                         $filter->getTable(),
                         $tableAlias,
-                        sprintf('%s.id = %s.lead_id', $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads'), $tableAlias)
+                        sprintf('%s.id = %s.%s', $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads'), $tableAlias, $foreignContactColumn)
                     );
                 }
             }
@@ -122,7 +126,7 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
         } else {
             if ($filterAggr) {
                 $expression = $queryBuilder->expr()->exists('SELECT '.$expressionArg.' FROM '.$filter->getTable().' '.
-                    $tableAlias.' WHERE '.$leadsTableAlias.'.id='.$tableAlias.'.lead_id HAVING '.$expression);
+                $tableAlias.' WHERE '.$leadsTableAlias.'.id='.$tableAlias.'.'.$foreignContactColumn.' HAVING '.$expression);
             } else { // This should never happen
                 $queryBuilder->addGroupBy($leadsTableAlias.'.id');
             }

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -132,7 +132,7 @@ class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
                     ->andHaving($expression);
 
                 if ($where = $filter->getWhere()) {
-                    $subQueryBuilder->andWhere(str_replace(str_replace(MAUTIC_TABLE_PREFIX, '', $filter->getTable()).'.', $tableAlias.'.', $where));
+                    $subQueryBuilder->andWhere(str_replace(str_replace(MAUTIC_TABLE_PREFIX ?? '', '', $filter->getTable()).'.', $tableAlias.'.', $where));
                 }
 
                 $expression = $queryBuilder->expr()->exists($subQueryBuilder->getSQL());

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
@@ -22,7 +22,8 @@ class ForeignValueFilterQueryBuilder extends BaseFilterQueryBuilder
         $batchLimiters    = $filter->getBatchLimiters();
         $filterParameters = $filter->getParameterValue();
 
-        // allow use of `contact_id` column instead of deprecated `lead_id`
+        // allow custom Lead::id foreign key columns like `contact_id`
+        // instead of the deprecated `lead_id`
         $foreignContactColumn = $filter->getForeignContactColumn();
 
         if (is_array($filterParameters)) {

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignFuncFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignFuncFilterQueryBuilderTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Segment\Query\Filter;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Test\Doctrine\MockedConnectionTrait;
+use Mautic\LeadBundle\Event\SegmentDictionaryGenerationEvent;
+use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Provider\FilterOperatorProvider;
+use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
+use Mautic\LeadBundle\Segment\ContactSegmentFilterOperator;
+use Mautic\LeadBundle\Segment\Decorator\CustomMappedDecorator;
+use Mautic\LeadBundle\Segment\Query\Filter\ForeignFuncFilterQueryBuilder;
+use Mautic\LeadBundle\Segment\Query\QueryBuilder;
+use Mautic\LeadBundle\Segment\RandomParameterName;
+use Mautic\LeadBundle\Segment\TableSchemaColumnsCache;
+use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ForeignFuncFilterQueryBuilderTest extends TestCase
+{
+    use MockedConnectionTrait;
+    private RandomParameterName $randomParameter;
+
+    /**
+     * @var EventDispatcherInterface&MockObject
+     */
+    private MockObject $dispatcher;
+
+    private ForeignFuncFilterQueryBuilder $queryBuilder;
+
+    /**
+     * @var Connection&MockObject
+     */
+    private MockObject $connectionMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->randomParameter     = new RandomParameterName();
+        $this->dispatcher          = $this->createMock(EventDispatcherInterface::class);
+        $this->connectionMock      = $this->getMockedConnection();
+        $this->queryBuilder        = new ForeignFuncFilterQueryBuilder(
+            $this->randomParameter,
+            $this->dispatcher
+        );
+
+        $this->connectionMock->method('getDatabase')->willReturn('test_mautic');
+        $this->dispatcher->addListener(LeadEvents::SEGMENT_DICTIONARY_ON_GENERATE, [$this, 'onSegmentDictionaryGenerate']);
+    }
+
+    public function testGetServiceId(): void
+    {
+        $this->assertEquals(
+            'mautic.lead.query.builder.foreign.func',
+            $this->queryBuilder::getServiceId()
+        );
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function dataApplyQuery(): iterable
+    {
+        yield ['gt', '2', 'SELECT count(DISTINCT par1.id) FROM test_table par1 WHERE (l.id=par1.contact_id) AND (some_bool = 1) HAVING count(DISTINCT par1.id) > 0'];
+    }
+
+    /**
+     * @dataProvider dataApplyQuery
+     */
+    public function testApplyQuery(string $operator, string $parameterValue, string $expectedQuery): void
+    {
+        $expectedQuery = str_replace('__PREFIX__', MAUTIC_TABLE_PREFIX, $expectedQuery);
+        $queryBuilder  = new QueryBuilder($this->connectionMock);
+        $queryBuilder->select('1');
+        $queryBuilder->from(MAUTIC_TABLE_PREFIX.'leads', 'l');
+
+        $filter = $this->getContactSegmentFilter([
+            'glue'       => 'and',
+            'field'      => 'contact_id',
+            'object'     => 'lead',
+            'type'       => 'number',
+            'operator'   => $operator,
+            'properties' => [
+                'filter' => $parameterValue,
+            ],
+            'filter'  => '0',
+            'display' => null,
+        ]);
+
+        $this->queryBuilder->applyQuery($queryBuilder, $filter);
+
+        Assert::assertSame($expectedQuery, $queryBuilder->getDebugOutput());
+    }
+
+    /**
+     * @param array<string, mixed> $filter
+     * @param array<string, mixed> $batchLimiters
+     */
+    private function getContactSegmentFilter(array $filter, array $batchLimiters = []): ContactSegmentFilter
+    {
+        $emMock = $this->createMock(EntityManager::class);
+        $emMock->method('getConnection')->willReturn($this->connectionMock);
+        /**
+         * @var \Mautic\LeadBundle\Segment\TableSchemaColumnsCache&\PHPUnit\Framework\MockObject\MockObject $tableSchemaColumnsCacheMock
+         */
+        $tableSchemaColumnsCacheMock = $this->getMockBuilder(TableSchemaColumnsCache::class)
+            ->setConstructorArgs([$emMock])
+            ->getMock();
+        $tableSchemaColumnsCacheMock->method('getColumns')->willReturn(['contact_id' => []]);
+
+        return new ContactSegmentFilter(
+            new ContactSegmentFilterCrate($filter),
+            new CustomMappedDecorator(
+                new ContactSegmentFilterOperator(
+                    new FilterOperatorProvider($this->dispatcher, $this->createMock(TranslatorInterface::class))
+                ),
+                new ContactSegmentFilterDictionary($this->dispatcher)
+            ),
+            $tableSchemaColumnsCacheMock,
+            $this->queryBuilder,
+            $batchLimiters
+        );
+    }
+
+    public function onSegmentDictionaryGenerate(SegmentDictionaryGenerationEvent $event): void
+    {
+        $event->addTranslation('mautic.lead.query.builder.foreign.func.test.translation', [
+            'type'                => ForeignFuncFilterQueryBuilder::getServiceId(),
+            'foreign_table'       => 'test_table',
+            'foreign_table_field' => 'contact_id',
+            'table'               => 'leads',
+            'table_field'         => 'id',
+            'func'                => 'count',
+            'field'               => 'id',
+            'where'               => 'some_bool = 1',
+        ]);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->




## Description

This PR adds the possibility to use [ForeignFuncFilterQueryBuilder](https://github.com/mautic/mautic/blob/b30170e7711ebebcce4297699bbe107a2d29473f/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php#L10) with a custom `WHERE` clause.

This makes it possible to create more sophisticated segment filters more easily. The [SegmentFilterSubscriber](https://github.com/mautic/mautic/blob/b30170e7711ebebcce4297699bbe107a2d29473f/app/bundles/PointBundle/EventListener/SegmentFilterSubscriber.php#L74) in the PointBundle is an example for this (but it uses `ForeignFuncFilterQueryBuilder`).

This is already possible in [ForeignValueFilterQueryBuilder (L44)](https://github.com/mautic/mautic/blob/b30170e7711ebebcce4297699bbe107a2d29473f/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php#L44), but not in ForeignFuncFilterQueryBuilder. This PR makes both filter "behave" similarly.

Under the hood: [CustomMappedDecorator::getForeignContactColumn()](https://github.com/mautic/mautic/blob/b30170e7711ebebcce4297699bbe107a2d29473f/app/bundles/LeadBundle/Segment/Decorator/CustomMappedDecorator.php#L83) looks for the `ContactSegmentFilterCrate` field `foreign_table_field`.

NOTE: This PR builds on #13851 (this PR's branch is based on that PR).

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add a custom table to your database for a custom segment filter. Use this SQL (it creates the table `test_table` and adds 4 rows of data to it):
    ```sql
	/*!40101 SET NAMES utf8mb4 */;

	--
	-- Database: `mautic`
	--

	-- --------------------------------------------------------

	--
	-- Table structure for table `test_table`
	--

	CREATE TABLE `test_table` (
	  `id` int(11) NOT NULL,
	  `contact_id` int(11) NOT NULL,
	  `some_value` varchar(255) NOT NULL,
	  `some_bool` tinyint(1) NOT NULL
	);

	--
	-- Dumping data for table `test_table`
	--

	INSERT INTO `test_table` (`id`, `contact_id`, `some_value`, `some_bool`) VALUES
	(1, 1, 'foo', 1),
	(2, 1, 'bar', 1),
	(3, 2, 'lorem', 1),
	(4, 3, 'ipsum', 0);

	--
	-- Indexes for table `test_table`
	--
	ALTER TABLE `test_table`
	  ADD PRIMARY KEY (`id`);

	--
	-- AUTO_INCREMENT for table `test_table`
	--
	ALTER TABLE `test_table`
	  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
    ```
3. Create a test segment filter subscriber. Create the file `app/bundles/CoreBundle/EventListener/TestSegmentFilterSubscriber.php` in your CoreBundle's event listener directory.
    ````php
	<?php

	declare(strict_types=1);

	namespace Mautic\CoreBundle\EventListener;

	use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
	use Mautic\LeadBundle\Event\SegmentDictionaryGenerationEvent;
	use Mautic\LeadBundle\LeadEvents;
	use Mautic\LeadBundle\Provider\TypeOperatorProviderInterface;
	use Mautic\LeadBundle\Segment\OperatorOptions;
	use Mautic\LeadBundle\Segment\Query\Filter\ForeignFuncFilterQueryBuilder;
	use Symfony\Component\EventDispatcher\EventSubscriberInterface;
	use Symfony\Contracts\Translation\TranslatorInterface;

	class TestSegmentFilterSubscriber implements EventSubscriberInterface
	{
		public function __construct(
			private TypeOperatorProviderInterface $typeOperatorProvider,
			private TranslatorInterface $translator,
		) {
		}

		public static function getSubscribedEvents(): array
		{
			return [
				LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE => [
					['onGenerateSegmentFiltersAddPointGroups', -10],
				],
				LeadEvents::SEGMENT_DICTIONARY_ON_GENERATE   => [
					['onSegmentDictionaryGenerate', 0],
				],
			];
		}

		public function onGenerateSegmentFiltersAddPointGroups(LeadListFiltersChoicesEvent $event): void
		{
			// Only show for segments and not dynamic content addressed by https://github.com/mautic/mautic/pull/9260
			if (!$event->isForSegmentation()) {
				return;
			}

			$event->addChoice('lead', 'test_segment_filter', [
				'label'      => 'Test Filter',
				'properties' => ['type' => 'number'],
				'operators'  =>  $this->typeOperatorProvider->getOperatorsIncluding([
					OperatorOptions::EQUAL_TO,
					OperatorOptions::GREATER_THAN,
					OperatorOptions::LESS_THAN,
					OperatorOptions::GREATER_THAN_OR_EQUAL,
					OperatorOptions::LESS_THAN_OR_EQUAL,
				]),
				'object'     => 'lead',
			]);
		}

		public function onSegmentDictionaryGenerate(SegmentDictionaryGenerationEvent $event): void
		{
			$event->addTranslation('test_segment_filter', [
				'type'                => ForeignFuncFilterQueryBuilder::getServiceId(),
				'foreign_table'       => 'test_table',
				'foreign_table_field' => 'contact_id',
				'table'               => 'leads',
				'table_field'         => 'id',
				'func'                => 'count',
				'field'               => 'id',
				'where'               => 'some_bool = 1'
			]);
		}
	}

    ````
    This creates a new custom filter. This filter counts how many times a lead is referenced in the new `test_table` **IF the column `some_bool` is `true`** (Note: WHERE can be any filter condition, though).
4. Clear the cache.
5. Create a new segment and use the new filter:
    ![image](https://github.com/mautic/mautic/assets/26040044/1ac73872-aa10-4949-9956-67588f785da3)

6. Run `php bin/console mautic:segments:rebuild`
7. Contact with ID 1 gets added to your new segment.