### PR TITLE
Fixing link with ampersands in email click tracking

### DIFF
--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -303,8 +303,12 @@ class TrackableModel extends AbstractCommonModel
         if ('html' == $type) {
             // For HTML, replace only the links; leaving the link text (if a URL) intact
             foreach ($this->contentReplacements['second_pass'] as $search => $replace) {
+                // Make the search regular expression match both "&" and "&amp;".
+                $search  = preg_quote($search, '/');
+                $search  = str_replace('&amp;', '&', $search);
+                $search  = str_replace('&', '(?:&|&amp;)', $search);
                 $content = preg_replace(
-                    '/<(.*?) href=(["\'])'.preg_quote($search, '/').'(.*?)\\2(.*?)>/i',
+                    '/<(.*?) href=(["\'])'.$search.'(.*?)\\2(.*?)>/i',
                     '<$1 href=$2'.$replace.'$3$2$4>',
                     $content
                 );

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -152,7 +152,7 @@ class TrackableModelTest extends TestCase
      */
     public function testStandardLinkWithStandardQuery(?bool $useMap): void
     {
-        $url   = 'https://foo-bar.com?foo=bar';
+        $url   = 'https://foo-bar.com?foo=bar&amp;one=two&three=four&amp;five=six';
         $model = $this->getModel();
 
         if (null !== $useMap) {
@@ -182,7 +182,7 @@ class TrackableModelTest extends TestCase
 
         // Assert that the URL redirect equals $url
         $redirect = $trackables[$match[0]]->getRedirect();
-        Assert::assertEquals($url, $redirect->getUrl());
+        Assert::assertEquals(str_replace('&amp;', '&', $url), $redirect->getUrl());
     }
 
     /**


### PR DESCRIPTION


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Make the search regular expression match both "&" and "&amp;" for link replacement within an email body

This PR fixes the issue with email URLs containing `&amp;`. If there is a link like `https://www.google.com?foo=1&amp;bar=2` within an email, the link is not replaced with a trackable link. See the screen recording below.

https://github.com/mautic/mautic/assets/6388925/23f5f57d-3164-48b9-ba8c-0052f1f07d53

| Before                                 | After
| -------------------------------------- | ---
| ![Screenshot 2024-06-18 at 13 46 56](https://github.com/mautic/mautic/assets/6388925/e8b90fc9-fc86-4754-9698-bc88ac94ddf5)                                       | ![Screenshot 2024-06-18 at 13 23 15](https://github.com/mautic/mautic/assets/6388925/afa58a1f-90d6-434b-90a7-2d47b893d74f)



---
### 📋 Steps to test this PR:

1. Follow the steps shown in the screen recording above.
2. If you hover the link within the email body as shown at the end of the video, the link should be replaced with a trackable link (e.g. `https://mautic-community.ddev.site/r/c6d3df7e8cef5f58e9046abcd?ct=YTo1OntzOjY6InNvdXJjZSI7YTowOnt9czo1OiJlbWFpb...`) as you can see in the "After" screenshot.


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->