### PR TITLE
Fix operators for text type report filters 

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -431,6 +431,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                                 $columnValue = (int) $filter['value'];
                                 break;
 
+                            case 'text':
                             case 'string':
                             case 'email':
                             case 'url':

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -329,6 +329,31 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(2, count($result));
     }
 
+    public function testUtmTagReportContainsExpression(): void
+    {
+        $report = new Report();
+        $report->setName('UTM tags report');
+        $report->setSource('lead.utmTag');
+        $coulmns = [
+            'utm.utm_campaign',
+        ];
+        $report->setColumns($coulmns);
+        $report->setFilters([
+            [
+                'column'    => 'utm.utm_campaign',
+                'glue'      => 'and',
+                'value'     => 'Test',
+                'condition' => 'contains',
+            ]]
+        );
+
+        $this->getContainer()->get('mautic.report.model.report')->saveEntity($report);
+
+        // Check the details page
+        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        Assert::assertTrue($this->client->getResponse()->isOk());
+    }
+
     /**
      * @dataProvider scheduleProvider
      *


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴🟢
| Deprecations?                          | 🔴🟢
| BC breaks? (use the c.x branch)        | 🔴🟢
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Some reports use text type columns  and then you cannot use  startsWith,endsWith, contain operators. PR fixed it

Related error

Related error log:

`[2020-11-27 10:28:53] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\UndefinedMethodException: "Attempted to call an undefined method named "contains" of class "Doctrine\DBAL\Query\Expression\ExpressionBuilder"." at .../app/bundles/ReportBundle/Builder/MauticReportBuilder.php line 487 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\UndefinedMethodException(code: 0): Attempted to call an undefined method named \"contains\" of class \"Doctrine\\DBAL\\Query\\Expression\\ExpressionBuilder\". at ...app/bundles/ReportBundle/Builder/MauticReportBuilder.php:487)"} []`


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create UTM codes report
3. Choose any columns and add to filter
UTM contains xxx
4. See error 500

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->