### PR TITLE
Adding regex operator validation

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -403,6 +403,11 @@ return [
                 'tag'       => 'validator.constraint_validator',
                 'alias'     => 'uniqueleadlist',
             ],
+            'mautic.lead.constraint.dbregex' => [
+                'class'     => \Mautic\LeadBundle\Form\Validator\Constraints\DbRegexValidator::class,
+                'arguments' => ['doctrine.dbal.default_connection'],
+                'tag'       => 'validator.constraint_validator',
+            ],
             'mautic.lead.validator.custom_field' => [
                 'class'     => Mautic\LeadBundle\Validator\CustomFieldValidator::class,
                 'arguments' => ['mautic.lead.model.field', 'translator'],

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -403,11 +403,6 @@ return [
                 'tag'       => 'validator.constraint_validator',
                 'alias'     => 'uniqueleadlist',
             ],
-            'mautic.lead.constraint.dbregex' => [
-                'class'     => \Mautic\LeadBundle\Form\Validator\Constraints\DbRegexValidator::class,
-                'arguments' => ['doctrine.dbal.default_connection'],
-                'tag'       => 'validator.constraint_validator',
-            ],
             'mautic.lead.validator.custom_field' => [
                 'class'     => Mautic\LeadBundle\Validator\CustomFieldValidator::class,
                 'arguments' => ['mautic.lead.model.field', 'translator'],

--- a/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Entity\OperatorListTrait;
 use Mautic\LeadBundle\Event\FormAdjustmentEvent;
 use Mautic\LeadBundle\Event\ListFieldChoicesEvent;
 use Mautic\LeadBundle\Event\TypeOperatorsEvent;
+use Mautic\LeadBundle\Form\Validator\Constraints\DbRegex;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -277,16 +278,22 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
 
     public function onSegmentFilterFormHandleDefault(FormAdjustmentEvent $event): void
     {
-        $form = $event->getForm();
+        $form        = $event->getForm();
+        $constraints = [];
+
+        if (in_array($event->getOperator(), [OperatorOptions::REGEXP, OperatorOptions::NOT_REGEXP], true)) {
+            $constraints[] = new DbRegex();
+        }
 
         $form->add(
             'filter',
             TextType::class,
             [
-                'label'    => false,
-                'attr'     => ['class' => 'form-control'],
-                'disabled' => $event->filterShouldBeDisabled(),
-                'data'     => $form->getData()['filter'] ?? '',
+                'label'       => false,
+                'attr'        => ['class' => 'form-control'],
+                'disabled'    => $event->filterShouldBeDisabled(),
+                'data'        => $form->getData()['filter'] ?? '',
+                'constraints' => $constraints,
             ]
         );
         $this->showOperatorsBasedAlertMessages($event);
@@ -297,6 +304,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
     {
         switch ($event->getOperator()) {
             case OperatorOptions::REGEXP:
+            case OperatorOptions::NOT_REGEXP:
                 $alertText = $this->translator->trans('mautic.lead_list.filter.alert.regexp');
                 break;
             case OperatorOptions::ENDS_WITH:
@@ -306,6 +314,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                 $alertText = $this->translator->trans('mautic.lead_list.filter.alert.contain');
                 break;
             case OperatorOptions::LIKE:
+            case OperatorOptions::NOT_LIKE:
                 $alertText = $this->translator->trans('mautic.lead_list.filter.alert.like');
                 break;
             default:

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+final class DbRegex extends Constraint
+{
+}

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
@@ -23,7 +23,7 @@ final class DbRegexValidator extends ConstraintValidator
         }
 
         try {
-            $result = $this->connection->executeQuery('SELECT "" REGEXP ? AS is_valid', [$regex]);
+            $result = $this->connection->executeQuery('SELECT 1 REGEXP ? AS is_valid', [$regex]);
 
             var_dump($result->fetchOne());
         } catch (Exception $e) {

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Form\Validator\Constraints;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class DbRegexValidator extends ConstraintValidator
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function validate($regex, Constraint $constraint): void
+    {
+        if (!$constraint instanceof DbRegex) {
+            throw new UnexpectedTypeException($constraint, DbRegex::class);
+        }
+
+        try {
+            $this->connection->executeQuery('SELECT "" REGEXP ? AS is_valid', [$regex]);
+        } catch (Exception $e) {
+            $this->context->buildViolation(
+                $this->stripUglyPartOfTheErrorMessage($e->getPrevious()->getMessage())
+            )->addViolation();
+        }
+    }
+
+    private function stripUglyPartOfTheErrorMessage(string $message): string
+    {
+        return preg_replace('/^SQLSTATE\[HY000\]: General error: \d+ /', '', $message);
+    }
+}

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
@@ -23,9 +23,7 @@ final class DbRegexValidator extends ConstraintValidator
         }
 
         try {
-            $result = $this->connection->executeQuery('SELECT 1 REGEXP ? AS is_valid', [$regex]);
-
-            var_dump($result->fetchOne());
+            $this->connection->executeQuery('SELECT 1 REGEXP ? AS is_valid', [$regex]);
         } catch (Exception $e) {
             $this->context->buildViolation(
                 $this->stripUglyPartOfTheErrorMessage($e->getPrevious()->getMessage())

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
@@ -23,7 +23,9 @@ final class DbRegexValidator extends ConstraintValidator
         }
 
         try {
-            $this->connection->executeQuery('SELECT "" REGEXP ? AS is_valid', [$regex]);
+            $result = $this->connection->executeQuery('SELECT "" REGEXP ? AS is_valid', [$regex]);
+
+            var_dump($result->fetchOne());
         } catch (Exception $e) {
             $this->context->buildViolation(
                 $this->stripUglyPartOfTheErrorMessage($e->getPrevious()->getMessage())

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegexValidator.php
@@ -33,6 +33,6 @@ final class DbRegexValidator extends ConstraintValidator
 
     private function stripUglyPartOfTheErrorMessage(string $message): string
     {
-        return preg_replace('/^SQLSTATE\[HY000\]: General error: \d+ /', '', $message);
+        return preg_replace('/SQLSTATE\[\d+\]: [\w ]+: \d+ /', '', $message);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -42,14 +42,14 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             'regexp',
             '^{Test|Test string)', // invalid regex: the first parantheses should not be curly
             Response::HTTP_BAD_REQUEST,
-            'filter: Incorrect description of a {min,max} interval.',
+            'filter: Got error \'unmatched parentheses at offset 18\' from regexp',
         ];
 
         yield [
             '!regexp',
             '^(Test|Test string))', // invalid regex: 2 ending parantheses
             Response::HTTP_BAD_REQUEST,
-            'filter: Mismatched parenthesis in regular expression.',
+            'filter: Got error \'unmatched parentheses at offset 19\' from regexp',
         ];
 
         yield [

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -65,6 +65,9 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testRegexOperatorValidation(string $operator, string $regex, int $expectedResponseCode, ?string $expectedErrorMessage): void
     {
+        $version = $this->connection->executeQuery('SELECT VERSION()')->fetchOne();
+        var_dump($version);
+
         $this->client->request(
             Request::METHOD_POST,
             '/api/segments/new',

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -7,6 +7,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -25,6 +26,72 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->listModel  = static::getContainer()->get('mautic.lead.model.list');
         $this->prefix     = static::getContainer()->getParameter('mautic.db_table_prefix');
         $this->translator = static::getContainer()->get('translator');
+    }
+
+    protected function beforeBeginTransaction(): void
+    {
+        $this->resetAutoincrement(['categories']);
+    }
+
+    /**
+     * @return iterable<array<string|int|null>>
+     */
+    public function regexOperatorProvider(): iterable
+    {
+        yield [
+            'regexp',
+            '^{Test|Test string)', // invalid regex: the first parantheses should not be curly
+            Response::HTTP_BAD_REQUEST,
+            'filter: Incorrect description of a {min,max} interval.',
+        ];
+
+        yield [
+            '!regexp',
+            '^(Test|Test string))', // invalid regex: 2 ending parantheses
+            Response::HTTP_BAD_REQUEST,
+            'filter: Mismatched parenthesis in regular expression.',
+        ];
+
+        yield [
+            'regexp',
+            '^(Test|Test string)', // valid regex
+            Response::HTTP_CREATED,
+            null,
+        ];
+    }
+
+    /**
+     * @dataProvider regexOperatorProvider
+     */
+    public function testRegexOperatorValidation(string $operator, string $regex, int $expectedResponseCode, ?string $expectedErrorMessage): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/segments/new',
+            [
+                'name'    => 'Regex test',
+                'filters' => [
+                    [
+                        'glue'       => 'and',
+                        'field'      => 'city',
+                        'object'     => 'lead',
+                        'type'       => 'text',
+                        'operator'   => $operator,
+                        'properties' => ['filter' => $regex],
+                    ],
+                ],
+            ]
+        );
+
+        Assert::assertSame($expectedResponseCode, $this->client->getResponse()->getStatusCode());
+
+        if ($expectedErrorMessage) {
+            Assert::assertSame(
+                $expectedErrorMessage,
+                json_decode($this->client->getResponse()->getContent(), true)['errors'][0]['message'],
+                $this->client->getResponse()->getContent()
+            );
+        }
     }
 
     public function testSingleSegmentWorkflow(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -66,7 +66,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testRegexOperatorValidation(string $operator, string $regex, int $expectedResponseCode, ?string $expectedErrorMessage): void
     {
         $version = $this->connection->executeQuery('SELECT VERSION()')->fetchOne();
-        var_dump($version);
+        version_compare($version, '8.0.0', '<') ? $this->markTestSkipped('MySQL 5.7.0 does not throw error for invalid REGEXP') : null;
 
         $this->client->request(
             Request::METHOD_POST,

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -508,10 +508,11 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
                 'filter',
                 TextType::class,
                 [
-                    'label'    => false,
-                    'attr'     => ['class' => 'form-control'],
-                    'disabled' => false,
-                    'data'     => '',
+                    'label'       => false,
+                    'attr'        => ['class' => 'form-control'],
+                    'disabled'    => false,
+                    'data'        => '',
+                    'constraints' => [],
                 ]
             );
 

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -508,11 +508,10 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
                 'filter',
                 TextType::class,
                 [
-                    'label'       => false,
-                    'attr'        => ['class' => 'form-control'],
-                    'disabled'    => false,
-                    'data'        => '',
-                    'constraints' => [],
+                    'label'    => false,
+                    'attr'     => ['class' => 'form-control'],
+                    'disabled' => false,
+                    'data'     => '',
                 ]
             );
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [enhancement]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We found that many segments that we host are failing due to invalid regex values. This PR is adding validation for the regex values in segment filters.

Technically, we execute the regex in a simple MySql query to be sure the MySql version supports that regex. It can be different in different versions. And validating any other way would be very difficult as Mysql's regexes are different from PHP's regexes.

I also noticed that the previous PR for alerts based on slow operators were missing some negative operators. Like `regexp` was supported but `!regexp` was not. So I added those.

⚠️ Warning: This feature doesn't work for old Mysql versions which our test suite uncovered. It works for MariaDB and for Mysql 8+. So I had to skip the tests for Mysql versions prior to v8. Hopefully, we'll remove the support for MySql 7.5 with Mautic 6 so this won't be an issue anymore. Still, it's better to validate on newer MySql rather than none.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a segment with some invalid regexp filter like `email regexp ^{Test|Test string)`

You will be able to save it and then when you execute the segment it will fail.

With this change you won't be able to save it and you will get the error from Mysql that should help identifying what's wrong:

![Screenshot 2024-06-28 at 13 26 16](https://github.com/mautic/mautic/assets/1235442/f31091db-f193-49b4-9626-c8fa8cebed5c)



#### Other areas of Mautic that may be affected by the change:
1. Just segment filters with regexp operators

#### List deprecations along with the new alternative:
1. none

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. Saving segments with regexp operators via API. Tested via UI manually.
