### PR TITLE
Adding support for PHP 8.3

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,6 +1,6 @@
 type: php
 docroot: ""
-php_version: "8.2"
+php_version: "8.3"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -13,7 +13,7 @@ provider: default
 upload_dir: "media/files, media/images" # Specify the directories containing user-generated uploads
 use_dns_when_possible: true
 composer_version: "2"
-webimage_extra_packages: [php8.2-imap]
+webimage_extra_packages: [php8.3-imap]
 hooks:
   post-start:
     # Fix line endings on Windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
         db-types: ['mysql', 'mariadb']
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -22,7 +22,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
     {
         $reflectionProperty = new \ReflectionProperty(TokenHelper::class, 'parameters');
         $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue([
+        $reflectionProperty->setValue(null, [
             'date_format_dateonly' => 'F j, Y',
             'date_format_timeonly' => 'g:i a',
         ]);

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -2,7 +2,7 @@
   "version": "5.1.0",
   "stability": "stable",
   "minimum_php_version": "8.0.2",
-  "maximum_php_version": "8.2.99",
+  "maximum_php_version": "8.3.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.0.2",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Adding support for PHP 8.3. 

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Everything should work on PHP 8.3 the same way as on 8.0, 8.1, 8.2. But ideally, our test suite should catch the issues.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->