### PR TITLE
Dropping support for PHP 8.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: PHP version
       description: What PHP version are you using in your environment?
-      placeholder: ex. 8.0.20
+      placeholder: ex. 8.1.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.0
+        php-version: 8.1
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Get tag name
@@ -140,7 +140,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.0
+        php-version: 8.1
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Download full installation package from previous step
@@ -244,7 +244,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.0
+        php-version: 8.1
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         db-types: ['mysql', 'mariadb']
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}

--- a/app/bundles/CoreBundle/Session/Storage/Handler/RedisSentinelSessionHandler.php
+++ b/app/bundles/CoreBundle/Session/Storage/Handler/RedisSentinelSessionHandler.php
@@ -56,9 +56,9 @@ class RedisSentinelSessionHandler extends AbstractSessionHandler
         return true;
     }
 
-    public function gc($maxlifetime): bool
+    public function gc($maxlifetime): int|false
     {
-        return true;
+        return 1;
     }
 
     public function updateTimestamp($sessionId, $data): bool

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail;
 
+use IMAP\Connection;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\EmailBundle\Exception\MailboxException;
@@ -347,7 +348,7 @@ class Mailbox
     /**
      * Get IMAP mailbox connection stream.
      *
-     * @return resource|null
+     * @return Connection
      */
     public function getImapStream()
     {
@@ -361,7 +362,7 @@ class Mailbox
     }
 
     /**
-     * @return resource
+     * @return Connection
      *
      * @throws MailboxException
      */
@@ -392,7 +393,7 @@ class Mailbox
      */
     protected function isConnected(): bool
     {
-        return $this->isConfigured() && $this->imapStream && is_resource($this->imapStream) && @imap_ping($this->imapStream);
+        return $this->isConfigured() && $this->imapStream && @imap_ping($this->imapStream);
     }
 
     /**

--- a/app/composer.json
+++ b/app/composer.json
@@ -18,7 +18,7 @@
     ]
   },
   "require": {
-    "php": "~8.0",
+    "php": "~8.1",
     "ext-zlib": "*",
     "ext-zip": "*",
     "ext-imap": "*",

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,11 +1,11 @@
 {
   "version": "5.1.0",
   "stability": "stable",
-  "minimum_php_version": "8.0.2",
+  "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
-  "show_php_version_warning_if_under": "8.0.2",
+  "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "4.4.10",
   "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.1.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.0.2"
+      "php": "8.1.0"
     },
     "bin-dir": "bin",
     "component-dir": "media/assets",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbbaf3132fbdde013f5bdf260d429971",
+    "content-hash": "8208cc9a7622be9a2326b39dc563b6d2",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6003,7 +6003,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "ff04262752d9b0a30c80be568ceeb5a585fc3cda"
+                "reference": "a286e10cd5bf2b9467f7cd360c5222fef9d64e5c"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -6049,7 +6049,7 @@
                 "matthiasmullie/minify": "^1.3",
                 "noxlogic/ratelimit-bundle": "^1.19",
                 "oneup/uploader-bundle": "^3.1.0",
-                "php": "~8.0",
+                "php": "~8.1",
                 "php-amqplib/rabbitmq-bundle": "^2.5.1",
                 "php-http/guzzle7-adapter": "^1.0",
                 "phpoffice/phpspreadsheet": "^1.15 < 1.28",
@@ -18532,7 +18532,7 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.2"
+        "php": "8.1.0"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🟢
| BC breaks? (use the c.x branch)        | grey area
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

As PHP 8.0 doesn't get security updates for over 6 months now ([source](https://www.php.net/supported-versions.php)) and Mautic now supports PHP 8.1, 8.2 and 8.3 it's time to drop 8.0.

We've never done this step in a minor Mautic release AFAIK, but I can see it's very common in other projects and libraries. Composer won't allow to update if the PHP version is not up for it.

But I'm OK if the community decides to wait for Mautic 6 with this change. The main issues in my mind are:
- Lack of security support.
- Developers cannot use the [PHP 8.1 features](https://www.php.net/releases/8.1/en.php) until we drop the support for 8.0. So we are forced to write dated code that we'll have to update at some point. And developers would be more productive with those features.
- The Github Actions now run for 4 different PHP versions which is waste of resources.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Nothing to test as we are removing support, not adding anything new.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->