### PR TITLE
Don't track downloads that came from non-requests

### DIFF
--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -124,6 +124,12 @@ class AssetModel extends FormModel
             $request = $this->requestStack->getCurrentRequest();
         }
 
+        if (null == $request) {
+            // likely this download came via a cron (no request), do not bother logging the download.
+            // https://github.com/mautic/mautic/issues/13577
+            return;
+        }
+
         $download = new Download();
         $download->setDateDownload(new \DateTime());
         $download->setUtmCampaign($request->get('utm_campaign'));

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -124,7 +124,7 @@ class AssetModel extends FormModel
             $request = $this->requestStack->getCurrentRequest();
         }
 
-        if (null == $request) {
+        if ($request !instanceof RequestInterface) {
             // likely this download came via a cron (no request), do not bother logging the download.
             // https://github.com/mautic/mautic/issues/13577
             return;


### PR DESCRIPTION


Branch: 5.x

| Q                                      | A
| -------------------------------------- | ---
| Bug fix?         | 🟢
| New feature/enhancement?     | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢
| Issue(s) addressed                     | Fixes #13577


## Description


As explained in #13577 - if a download event is triggered by a cron, the `request` object is null which throws an error. This proposed fix ignores tracking the download if it came from a non-request source (like a cron).

---
### 📋 Steps to test this PR:

See #13577:
1. Create email list with an attachment
2. Try to send using mautic:broadcasts:send