### PR TITLE
Fix email validation and exception handling in CampaignConditionSubscriber and EmailValidator (#13728)

### DIFF
--- a/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
@@ -9,6 +9,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 class CampaignConditionSubscriber implements EventSubscriberInterface
 {
@@ -41,7 +42,7 @@ class CampaignConditionSubscriber implements EventSubscriberInterface
     {
         try {
             $this->validator->validate($event->getLead()->getEmail(), true);
-        } catch (InvalidEmailException) {
+        } catch (UnexpectedValueException|InvalidEmailException) {
             return $event->setResult(false);
         }
 

--- a/app/bundles/EmailBundle/Helper/EmailValidator.php
+++ b/app/bundles/EmailBundle/Helper/EmailValidator.php
@@ -27,7 +27,7 @@ class EmailValidator
     public function validate($address, $doDnsCheck = false): void
     {
         if (!$this->isValidFormat($address)) {
-            throw new InvalidEmailException($address, $this->translator->trans('mautic.email.address.invalid_format', ['%email%' => $address ?: '?']));
+            throw new InvalidEmailException($address ?: '?', $this->translator->trans('mautic.email.address.invalid_format', ['%email%' => $address ?: '?']));
         }
 
         if ($this->hasValidCharacters($address)) {

--- a/app/bundles/EmailBundle/Helper/EmailValidator.php
+++ b/app/bundles/EmailBundle/Helper/EmailValidator.php
@@ -6,6 +6,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailValidationEvent;
 use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EmailValidator
@@ -26,8 +27,12 @@ class EmailValidator
      */
     public function validate($address, $doDnsCheck = false): void
     {
+        if (!is_string($address)) {
+            throw new UnexpectedValueException($address, 'string');
+        }
+
         if (!$this->isValidFormat($address)) {
-            throw new InvalidEmailException($address ?: '?', $this->translator->trans('mautic.email.address.invalid_format', ['%email%' => $address ?: '?']));
+            throw new InvalidEmailException($address, $this->translator->trans('mautic.email.address.invalid_format', ['%email%' => $address ?: '?']));
         }
 
         if ($this->hasValidCharacters($address)) {

--- a/app/bundles/EmailBundle/Helper/EmailValidator.php
+++ b/app/bundles/EmailBundle/Helper/EmailValidator.php
@@ -23,6 +23,7 @@ class EmailValidator
      *
      * @param bool $doDnsCheck
      *
+     * @throws UnexpectedValueException
      * @throws InvalidEmailException
      */
     public function validate($address, $doDnsCheck = false): void

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
@@ -53,6 +53,8 @@ class CampaignConditionSubscriberTest extends TestCase
             'systemTriggered' => true,
             'eventSettings'   => [],
         ];
+
+        // @phpstan-ignore-next-line (CampaignExecutionEvent is deprecated but needed for this test)
         $event = new CampaignExecutionEvent($eventArgs, true);
 
         // Call the onCampaignTriggerCondition method
@@ -84,6 +86,8 @@ class CampaignConditionSubscriberTest extends TestCase
             'systemTriggered' => true,
             'eventSettings'   => [],
         ];
+
+        // @phpstan-ignore-next-line (CampaignExecutionEvent is deprecated but needed for this test)
         $event = new CampaignExecutionEvent($eventArgs, true);
 
         // Call the onCampaignTriggerCondition method
@@ -117,6 +121,8 @@ class CampaignConditionSubscriberTest extends TestCase
             'systemTriggered' => true,
             'eventSettings'   => [],
         ];
+
+        // @phpstan-ignore-next-line (CampaignExecutionEvent is deprecated but needed for this test)
         $event = new CampaignExecutionEvent($eventArgs, true);
 
         // Call the onCampaignTriggerCondition method

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\EmailBundle\EventListener\CampaignConditionSubscriber;
+use Mautic\EmailBundle\Exception\InvalidEmailException;
+use Mautic\EmailBundle\Helper\EmailValidator;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class CampaignConditionSubscriberTest extends TestCase
+{
+    /**
+     * @var MockObject&EmailValidator
+     */
+    private MockObject $validator;
+
+    private CampaignConditionSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a mock EmailValidator (not the real object)
+        $this->validator = $this->createMock(EmailValidator::class);
+
+        // Initialize the CampaignConditionSubscriber with the mock validator
+        $this->subscriber = new CampaignConditionSubscriber($this->validator);
+    }
+
+    public function testOnCampaignTriggerConditionReturnsFalseForNullEmail(): void
+    {
+        // Create a Lead object and set the email to null
+        $lead = new Lead();
+        $lead->setEmail(null);
+
+        // Expect the validate method to throw an UnexpectedValueException for the null email
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with(null, true)
+            ->willThrowException(new UnexpectedValueException(null, 'string'));
+
+        // Prepare the CampaignExecutionEvent with the lead and required event details
+        $eventArgs = [
+            'lead'            => $lead,
+            'event'           => [
+                'type' => 'email.validate.address',
+            ],
+            'eventDetails'    => [],
+            'systemTriggered' => true,
+            'eventSettings'   => [],
+        ];
+        $event = new CampaignExecutionEvent($eventArgs, true);
+
+        // Call the onCampaignTriggerCondition method
+        $this->subscriber->onCampaignTriggerCondition($event);
+
+        // Assert that the result is false due to the exception
+        $this->assertFalse($event->getResult());
+    }
+
+    public function testOnCampaignTriggerConditionReturnsFalseForInvalidEmail(): void
+    {
+        // Create a Lead object and set an invalid email
+        $lead = new Lead();
+        $lead->setEmail('invalid-email');
+
+        // Expect the validate method to throw an InvalidEmailException for the invalid email
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with($lead->getEmail(), true)
+            ->willThrowException(new InvalidEmailException($lead->getEmail(), 'Invalid email format'));
+
+        // Prepare the CampaignExecutionEvent with the lead and required event details
+        $eventArgs = [
+            'lead'            => $lead,
+            'event'           => [
+                'type' => 'email.validate.address',
+            ],
+            'eventDetails'    => [],
+            'systemTriggered' => true,
+            'eventSettings'   => [],
+        ];
+        $event = new CampaignExecutionEvent($eventArgs, true);
+
+        // Call the onCampaignTriggerCondition method
+        $this->subscriber->onCampaignTriggerCondition($event);
+
+        // Assert that the result is false due to the exception
+        $this->assertFalse($event->getResult());
+    }
+
+    public function testOnCampaignTriggerConditionReturnsTrueForValidEmail(): void
+    {
+        // Create a Lead object and set a valid email
+        $lead = new Lead();
+        $lead->setEmail('john.doe@example.com');
+
+        // Expect the validate method to validate the email without throwing any exceptions
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with($lead->getEmail(), true)
+            ->willReturnCallback(function () {
+                // Do nothing, as the method is void
+            });
+
+        // Prepare the CampaignExecutionEvent with the lead and required event details
+        $eventArgs = [
+            'lead'            => $lead,
+            'event'           => [
+                'type' => 'email.validate.address',
+            ],
+            'eventDetails'    => [],
+            'systemTriggered' => true,
+            'eventSettings'   => [],
+        ];
+        $event = new CampaignExecutionEvent($eventArgs, true);
+
+        // Call the onCampaignTriggerCondition method
+        $this->subscriber->onCampaignTriggerCondition($event);
+
+        // Assert that the result is true for a valid email
+        $this->assertTrue($event->getResult());
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
@@ -10,6 +10,7 @@ use Mautic\EmailBundle\Tests\Helper\EventListener\EmailValidationSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EmailValidatorTest extends \PHPUnit\Framework\TestCase
@@ -99,6 +100,12 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase
 
         // hopefully this domain remains intact
         $this->emailValidator->validate('john@mail.email');
+    }
+
+    public function testValidateNull(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->emailValidator->validate(null);
     }
 
     public function testValidateEmailWithoutTld(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13728  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR addresses an issue where the `EmailValidator` class could pass a null value to the `InvalidEmailException` constructor, causing a type error. The changes ensure that the email address passed to the `InvalidEmailException` is always a string.

When the `validate` method of the `EmailValidator` class receives a null value for the `$address` parameter, it leads to a type error in the `InvalidEmailException` constructor. The constructor expects a string but is given null instead, resulting in an error.

Change:
* Modified the `validate` method in `EmailValidator` to handle null or empty email addresses using the null coalescing operator (?:).

_Had to close previous PR as it was based on 5.0 instead of 5.1 - too many merge conflicts._

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create new segment
4. Add new contact without e-mail address
5. Add newly created contact to new segment
6. Create new campaign, select contact source, add condition check ("has valid e-mail address")
7. Publish new campaign
8. Execute `mautic:campaign:rebuild`
9. Execute `mautic:campaign:trigger` (should not throw any errors)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->