### PR TITLE
Send example email as a specified contact

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -39,8 +39,8 @@ class ContentPreviewSettingsType extends AbstractType
         $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_TRANSLATION, $translations, $objectId);
         $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_VARIANT, $variants, $objectId);
 
-        if ($this->security->isAdmin() ||
-            $this->security->hasEntityAccess(
+        if ($this->security->isAdmin()
+            || $this->security->hasEntityAccess(
                 'lead:leads:viewown',
                 'lead:leads:viewother',
                 $this->userHelper->getUser()->getId()

--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Form\Type;
 
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\PageBundle\Entity\Page;
@@ -25,22 +26,25 @@ class ContentPreviewSettingsType extends AbstractType
     private const CHOICE_TYPE_TRANSLATION = 'translation';
     private const CHOICE_TYPE_VARIANT     = 'variant';
 
-    public function __construct(private TranslatorInterface $translator, private CorePermissions $security)
+    public function __construct(private TranslatorInterface $translator, private CorePermissions $security, private UserHelper $userHelper)
     {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $objectId              = $options['objectId'];
-        $translations          = $options['translations'];
-        $variants              = $options['variants'];
+        $objectId     = $options['objectId'];
+        $translations = $options['translations'];
+        $variants     = $options['variants'];
 
         $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_TRANSLATION, $translations, $objectId);
         $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_VARIANT, $variants, $objectId);
 
-        if ($this->security->isAdmin()
-            || $this->security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother')
-        ) {
+        if ($this->security->isAdmin() ||
+            $this->security->hasEntityAccess(
+                'lead:leads:viewown',
+                'lead:leads:viewother',
+                $this->userHelper->getUser()->getId()
+            )) {
             $builder->add(
                 'contact',
                 LookupType::class,

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -200,7 +200,7 @@ abstract class AbstractPermissions
             return true;
         }
 
-        //otherwise test for specific level
+        // otherwise test for specific level
         $result = ($this->permissions[$name][$level] & $userPermissions[$name]);
 
         return (bool) $result;

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -186,24 +186,24 @@ abstract class AbstractPermissions
      * @param array  $userPermissions
      * @param string $name
      * @param string $level
-     *
-     * @return bool
      */
-    public function isGranted($userPermissions, $name, $level)
+    public function isGranted($userPermissions, $name, $level): bool
     {
         [$name, $level] = $this->getSynonym($name, $level);
 
         if (!isset($userPermissions[$name])) {
             // the user doesn't have implicit access
             return false;
-        } elseif (isset($this->permissions[$name]['full']) && $this->permissions[$name]['full'] & $userPermissions[$name]) {
-            return true;
-        } else {
-            // otherwise test for specific level
-            $result = ($this->permissions[$name][$level] & $userPermissions[$name]);
-
-            return ($result) ? true : false;
         }
+
+        if (isset($this->permissions[$name]['full']) && ($this->permissions[$name]['full'] & $userPermissions[$name])) {
+            return true;
+        }
+
+        //otherwise test for specific level
+        $result = ($this->permissions[$name][$level] & $userPermissions[$name]);
+
+        return (bool) $result;
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -19,25 +19,22 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ContentPreviewSettingsTypeTest extends TestCase
 {
-    /**
-     * @var ContentPreviewSettingsType
-     */
-    private $form;
+    private ContentPreviewSettingsType $form;
 
     /**
-     * @var MockObject|TranslatorInterface
+     * @var MockObject&TranslatorInterface
      */
-    private $translator;
+    private MockObject $translator;
 
     /**
-     * @var CorePermissions|MockObject
+     * @var CorePermissions&MockObject
      */
-    private $security;
+    private MockObject $security;
 
     /**
-     * @var UserHelper|MockObject
+     * @var UserHelper&MockObject
      */
-    private $userHelperMock;
+    private MockObject $userHelperMock;
 
     protected function setUp(): void
     {

--- a/app/bundles/EmailBundle/Assets/js/send.example.js
+++ b/app/bundles/EmailBundle/Assets/js/send.example.js
@@ -1,0 +1,33 @@
+/**
+ * Used in data-lookup-callback attr of form field in ExampleSendType
+ * Take a look at https://github.com/twitter/typeahead.js/
+ */
+Mautic.activateContactLookupField = function(fieldOptions, filterId) {
+
+    const lookupElementId = 'example_send_contact';
+    const action          = mQuery('#'+ lookupElementId).attr('data-chosen-lookup');
+
+    const options = {
+        limit: 20,
+        'searchKey': 'lead.lead',
+    };
+
+    Mautic.activateFieldTypeahead(lookupElementId, filterId, options, action);
+
+    mQuery('#'+ lookupElementId).on("change",function(event) {
+        if (event.target.value === '') {
+            // Delete selected contact ID from hidden field
+            mQuery('#example_send_contact_id').val('');
+        }
+    });
+};
+
+/**
+ * Used in data-lookup-callback attr of form field in ExampleSendType
+ */
+Mautic.updateContactLookupListFilter = function(field, item) {
+    if (item && item.id) {
+        mQuery('#example_send_contact_id').val(item.id);
+        mQuery(field).val(item.value);
+    }
+};

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1518,13 +1518,17 @@ class EmailController extends FormController
             $isValid     = $this->isFormValid($form);
             if (!$isCancelled && $isValid) {
                 $emails              = $form['emails']->getData()['list'];
-                // Use this contact data to fill email body content
-                $previewForContactId = (int) $form->getData()['contact_id'];
+                $previewForContactId = null;
 
-                if ($previewForContactId && (
-                    !$security->isAdmin()
-                    || !$security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother')
-                )
+                // Use this contact data to fill email body content
+                if ($form->has('contact_id')) {
+                    $previewForContactId = (int) $form->getData()['contact_id'];
+                }
+
+                if ($previewForContactId &&
+                    (!$security->isAdmin() ||
+                        !$security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $user->getId())
+                    )
                 ) {
                     // disallow displaying contact information
                     $previewForContactId = null;

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1540,10 +1540,10 @@ class EmailController extends FormController
 
                 if (!isset($fields)) {
                     // Prepare a fake lead
-                    $fields     = $fieldModel->getFieldList(false, false);
+                    $fields = $fieldModel->getFieldList(false, false);
                     array_walk(
                         $fields,
-                        function (&$field) {
+                        function (&$field): void {
                             $field = "[$field]";
                         }
                     );

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1525,9 +1525,9 @@ class EmailController extends FormController
                     $previewForContactId = (int) $form->getData()['contact_id'];
                 }
 
-                if ($previewForContactId &&
-                    (!$security->isAdmin() ||
-                        !$security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $user->getId())
+                if ($previewForContactId
+                    && (!$security->isAdmin()
+                        || !$security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $user->getId())
                     )
                 ) {
                     // disallow displaying contact information

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1536,10 +1536,7 @@ class EmailController extends FormController
 
                 if ($previewForContactId) {
                     // We have one from request parameter
-                    $contact = $leadModel->getEntity($previewForContactId);
-                    if ($contact && $contact->getId()) {
-                        $fields = $contact->convertToArray();
-                    }
+                    $fields = $leadModel->getRepository()->getLead($previewForContactId);
                 }
 
                 if (!isset($fields)) {

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -441,11 +441,9 @@ class PublicController extends CommonFormController
      *
      * @return Response
      */
-    public function previewAction(AnalyticsHelper $analyticsHelper, Request $request, string $objectId, string $objectType = null)
+    public function previewAction(AnalyticsHelper $analyticsHelper, Request $request, string $objectId, string $objectType = null, EmailModel $model)
     {
-        $contactId = (int) $request->query->get('contactId');
-        /** @var EmailModel $model */
-        $model       = $this->getModel('email');
+        $contactId   = (int) $request->query->get('contactId');
         $emailEntity = $model->getEntity($objectId);
 
         if (null === $emailEntity) {
@@ -515,9 +513,7 @@ class PublicController extends CommonFormController
             // We have one from request parameter
             /** @var LeadModel $leadModel */
             $leadModel = $this->getModel('lead.lead');
-            /** @var Lead $contact */
-            $contact = $leadModel->getEntity($contactId);
-            $contact = $contact->convertToArray();
+            $contact   = $leadModel->getRepository()->getLead($contactId);
         } else {
             // Generate faked one
             /** @var \Mautic\LeadBundle\Model\FieldModel $fieldModel */

--- a/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
@@ -5,6 +5,7 @@ namespace Mautic\EmailBundle\Form\Type;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\LookupType;
 use Mautic\CoreBundle\Form\Type\SortableListType;
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -17,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ExampleSendType extends AbstractType
 {
-    public function __construct(private TranslatorInterface $translator, private CorePermissions $security)
+    public function __construct(private TranslatorInterface $translator, private CorePermissions $security, private UserHelper $userHelper)
     {
     }
 
@@ -34,9 +35,12 @@ class ExampleSendType extends AbstractType
             ]
         );
 
-        if ($this->security->isAdmin()
-            || $this->security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother')
-        ) {
+        if ($this->security->isAdmin() ||
+            $this->security->hasEntityAccess(
+                'lead:leads:viewown',
+                'lead:leads:viewother',
+                $this->userHelper->getUser()->getId()
+            )) {
             $builder->add(
                 'contact',
                 LookupType::class,

--- a/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
@@ -35,8 +35,8 @@ class ExampleSendType extends AbstractType
             ]
         );
 
-        if ($this->security->isAdmin() ||
-            $this->security->hasEntityAccess(
+        if ($this->security->isAdmin()
+            || $this->security->hasEntityAccess(
                 'lead:leads:viewown',
                 'lead:leads:viewother',
                 $this->userHelper->getUser()->getId()

--- a/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
@@ -3,16 +3,24 @@
 namespace Mautic\EmailBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\CoreBundle\Form\Type\LookupType;
 use Mautic\CoreBundle\Form\Type\SortableListType;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends AbstractType<mixed>
  */
 class ExampleSendType extends AbstractType
 {
+    public function __construct(private TranslatorInterface $translator, private CorePermissions $security)
+    {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add(
@@ -25,6 +33,35 @@ class ExampleSendType extends AbstractType
                 'option_notblank'  => false,
             ]
         );
+
+        if ($this->security->isAdmin()
+            || $this->security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother')
+        ) {
+            $builder->add(
+                'contact',
+                LookupType::class,
+                [
+                    'attr' => [
+                        'class'                => 'form-control',
+                        'data-callback'        => 'activateContactLookupField',
+                        'data-toggle'          => 'field-lookup',
+                        'data-lookup-callback' => 'updateContactLookupListFilter',
+                        'data-chosen-lookup'   => 'lead:contactList',
+                        'placeholder'          => $this->translator->trans(
+                            'mautic.lead.list.form.startTyping'
+                        ),
+                        'data-no-record-message' => $this->translator->trans(
+                            'mautic.core.form.nomatches'
+                        ),
+                    ],
+                ]
+            );
+
+            $builder->add(
+                'contact_id',
+                HiddenType::class
+            );
+        }
 
         $builder->add(
             'buttons',

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2165,8 +2165,14 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    public function sendSampleEmailToUser($email, $users, $leadFields = null, $tokens = [], $assetAttachments = [], $saveStat = true)
-    {
+    public function sendSampleEmailToUser(
+        $email,
+        $users,
+        $leadFields = null,
+        $tokens = [],
+        $assetAttachments = [],
+        $saveStat = true
+    ) {
         if (!$emailId = $email->getId()) {
             return false;
         }
@@ -2183,6 +2189,20 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         if (empty($users)) {
             return false;
         }
+
+        // Generate and replace tokens
+        $event = new EmailSendEvent(
+            null,
+            [
+                'content'      => $email->getCustomHtml(),
+                'email'        => $email,
+                'idHash'       => 'xxxxxxxxxxxxxx', // bogus ID
+                'tokens'       => ['{tracking_pixel}' => ''], // Override tracking_pixel
+                'internalSend' => true,
+                'lead'         => $leadFields,
+            ]
+        );
+        $this->dispatcher->dispatch(EmailEvents::EMAIL_ON_DISPLAY, $event);
 
         $mailer = $this->mailHelper->getSampleMailer();
         $mailer->setLead($leadFields, true);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2202,7 +2202,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
                 'lead'         => $leadFields,
             ]
         );
-        $this->dispatcher->dispatch(EmailEvents::EMAIL_ON_DISPLAY, $event);
+        $this->dispatcher->dispatch($event, EmailEvents::EMAIL_ON_DISPLAY);
 
         $mailer = $this->mailHelper->getSampleMailer();
         $mailer->setLead($leadFields, true);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -16,6 +16,8 @@ use Mautic\EmailBundle\Controller\EmailController;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Helper\FormFieldHelper;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
@@ -227,11 +229,6 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
         $this->containerMock->method('has')->willReturnCallback($serviceExists);
         $this->containerMock->method('get')->willReturnMap($services);
 
-        $this->modelFactoryMock->expects($this->once())
-            ->method('getModel')
-            ->with('email')
-            ->willReturn($this->modelMock);
-
         $this->modelMock->expects($this->once())
             ->method('getEntity')
             ->with(1)
@@ -272,6 +269,6 @@ class EmailControllerTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request();
         $this->requestStack->push($request);
-        $this->controller->sendExampleAction($request, 1);
+        $this->controller->sendExampleAction($request, 1, $this->corePermissionsMock, $this->modelMock, $this->createMock(LeadModel::class), $this->createMock(FieldModel::class));
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 {
+    protected $useCleanupRollback = false;
+
     protected function setUp(): void
     {
         $this->configParams['mailer_spool_type'] = 'file';
@@ -129,7 +131,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $form = $formCrawler->form();
         $form->setValues(['example_send[emails][list][0]' => 'admin@yoursite.com']);
         $this->client->submit($form);
-        
+
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
@@ -220,7 +222,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $form = $formCrawler->form();
         $form->setValues([
             'example_send[emails][list][0]' => 'admin@yoursite.com',
-            'example_send[contact]'         => $contacts['contacts'][0]['firstname'],
+            'example_send[contact]'         => $contacts['contacts'][0]['fields']['core']['firstname']['value'],
             'example_send[contact_id]'      => $contacts['contacts'][0]['id'],
         ]);
         $this->client->submit($form);
@@ -315,11 +317,11 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $form = $formCrawler->form();
         $form->setValues([
             'example_send[emails][list][0]' => 'admin@yoursite.com',
-            'example_send[contact]'         => $contacts['contacts'][0]['firstname'],
+            'example_send[contact]'         => $contacts['contacts'][0]['fields']['core']['firstname']['value'],
             'example_send[contact_id]'      => $contacts['contacts'][0]['id'],
         ]);
         $this->client->submit($form);
-        
+
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -39,7 +39,6 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
-        // Asserting email data
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString(
             'Contact emails is test@domain.tld',
@@ -62,16 +61,10 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
-        // Asserting email data
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Contact emails is [Email]', $message->getBody()->toString());
     }
 
-    /**
-     * @throws MappingException
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
     public function testSendExampleEmailForDynamicContentVariantsWithCustomFieldWithNoContact(): void
     {
         // Create custom field
@@ -132,25 +125,17 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        self::assertSame(1, $formCrawler->count());
+        Assert::assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues(['example_send[emails][list][0]' => 'admin@yoursite.com']);
         $this->client->submit($form);
-        self::assertCount(1, $this->transport->messages);
-        $message = $this->transport->messages[0];
+        
+        $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
-        // Asserting email data
-        self::assertInstanceOf('Swift_Message', $message);
-        self::assertSame('admin@yoursite.com', key($message->getTo()));
-        self::assertStringContainsString('Email subject', $message->getSubject());
-        self::assertStringContainsString('Default Dynamic Content', $message->getBody());
+        Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
+        Assert::assertStringContainsString('Default Dynamic Content', $message->getBody()->toString());
     }
 
-    /**
-     * @throws MappingException
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
     public function testSendExampleEmailForDynamicContentVariantsWithCustomFieldWithMatchFilterContact(): void
     {
         // Create custom field
@@ -231,7 +216,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        self::assertSame(1, $formCrawler->count());
+        Assert::assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues([
             'example_send[emails][list][0]' => 'admin@yoursite.com',
@@ -239,21 +224,13 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
             'example_send[contact_id]'      => $contacts['contacts'][0]['id'],
         ]);
         $this->client->submit($form);
-        self::assertCount(1, $this->transport->messages);
-        $message = $this->transport->messages[0];
 
-        // Asserting email data
-        self::assertInstanceOf('Swift_Message', $message);
-        self::assertSame('admin@yoursite.com', key($message->getTo()));
-        self::assertStringContainsString('Email subject', $message->getSubject());
-        self::assertStringContainsString('Variant 1 Dynamic Content', $message->getBody());
+        $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
+
+        Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
+        Assert::assertStringContainsString('Variant 1 Dynamic Content', $message->getBody()->toString());
     }
 
-    /**
-     * @throws MappingException
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
     public function testSendExampleEmailForDynamicContentVariantsWithCustomFieldWithNoMatchFilterContact(): void
     {
         // Create custom field
@@ -334,7 +311,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        self::assertSame(1, $formCrawler->count());
+        Assert::assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues([
             'example_send[emails][list][0]' => 'admin@yoursite.com',
@@ -342,14 +319,11 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
             'example_send[contact_id]'      => $contacts['contacts'][0]['id'],
         ]);
         $this->client->submit($form);
-        self::assertCount(1, $this->transport->messages);
-        $message = $this->transport->messages[0];
+        
+        $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
 
-        // Asserting email data
-        self::assertInstanceOf('Swift_Message', $message);
-        self::assertSame('admin@yoursite.com', key($message->getTo()));
-        self::assertStringContainsString('Email subject', $message->getSubject());
-        self::assertStringContainsString('Default Dynamic Content', $message->getBody());
+        Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
+        Assert::assertStringContainsString('Default Dynamic Content', $message->getBody()->toString());
     }
 
     private function createEmail(): Email

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright   2021 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Controller;
+
+use DateTime;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\Lead;
+use Swift_Events_EventListener;
+use Swift_Mime_SimpleMessage;
+use Swift_Transport;
+use Symfony\Component\HttpFoundation\Request;
+
+class EmailExampleFunctionalTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['mailer_spool_type'] = 'file';
+
+        parent::setUp();
+    }
+
+    public function testSendEmail(): void
+    {
+        $this->container->set('swiftmailer.transport.real', $transport = $this->createTransportFake());
+
+        $lead  = $this->createLead();
+        $email = $this->createEmail();
+        $this->em->flush();
+
+        $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
+        $formCrawler = $crawler->filter('form[name=example_send]');
+        self::assertSame(1, $formCrawler->count());
+        $form = $formCrawler->form();
+        $form->setValues([
+            'example_send[emails][list][0]' => 'admin@yoursite.com',
+            'example_send[contact]'         => 'somebody',
+            'example_send[contact_id]'      => $lead->getId(),
+        ]);
+        $this->client->submit($form);
+
+        self::assertCount(1, $transport->messages);
+
+        $message = $transport->messages[0];
+
+        // Asserting email data
+        self::assertInstanceOf('Swift_Message', $message);
+        self::assertSame('admin@yoursite.com', key($message->getTo()));
+        self::assertContains('Email subject', $message->getSubject());
+        self::assertContains(
+            'Contact emails is test@domain.tld',
+            $message->getBody()
+        );
+    }
+
+    private function createEmail(): Email
+    {
+        $email = new Email();
+        $email->setDateAdded(new DateTime());
+        $email->setName('Email name');
+        $email->setSubject('Email subject');
+        $email->setTemplate('Blank');
+        $email->setCustomHtml('Contact emails is {contactfield=email}');
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setEmail('test@domain.tld');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createTransportFake(): Swift_Transport
+    {
+        return new class() implements Swift_Transport {
+            /**
+             * @var array
+             */
+            public $messages = [];
+
+            public function isStarted(): bool
+            {
+                return true;
+            }
+
+            public function start(): void
+            {
+            }
+
+            public function stop(): void
+            {
+            }
+
+            public function ping(): bool
+            {
+                return true;
+            }
+
+            public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null): int
+            {
+                $this->messages[] = clone $message;
+
+                return count((array) $message->getTo())
+                    + count((array) $message->getCc())
+                    + count((array) $message->getBcc());
+            }
+
+            public function registerPlugin(Swift_Events_EventListener $plugin): void
+            {
+            }
+        };
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -27,7 +27,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        Assert::assertSame(1, $formCrawler->count());
+        Assert::assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues([
             'example_send[emails][list][0]' => 'admin@yoursite.com',

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Controller;
 
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
@@ -118,6 +120,132 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         // Admin user
         $this->assertPageContent($url, $contentNoContactInfo);
         $this->assertPageContent($urlWithContact, $contentWithContactInfo);
+    }
+
+    /**
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function testPreviewEmailForDynamicContentVariantsWithCustomField(): void
+    {
+        // Create custom field
+        $this->client->request(
+            'POST',
+            '/api/fields/contact/new',
+            [
+                'label'      => 'bool',
+                'type'       => 'boolean',
+                'properties' => [
+                    'no'  => 'No',
+                    'yes' => 'Yes',
+                ],
+            ]
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode());
+        self::assertJson($this->client->getResponse()->getContent());
+
+        // Create some contacts
+        $this->client->request(
+            'POST',
+            '/api/contacts/batch/new',
+            [
+                [
+                    'firstname' => 'John',
+                    'lastname'  => 'A',
+                    'email'     => 'john.a@email.com',
+                    'bool'      => true,
+                ],
+                [
+                    'firstname' => 'John',
+                    'lastname'  => 'B',
+                    'email'     => 'john.b@email.com',
+                    'bool'      => false,
+                ],
+                [
+                    'firstname' => 'John',
+                    'lastname'  => 'C',
+                    'email'     => 'john.c@email.com',
+                    'bool'      => null,
+                ],
+            ]
+        );
+        self::assertSame(
+            201,
+            $this->client->getResponse()->getStatusCode(),
+            $this->client->getResponse()->getContent()
+        );
+        $contacts = json_decode($this->client->getResponse()->getContent(), true);
+
+        // Create email with dynamic content variant
+        $email          = $this->createEmail();
+        $dynamicContent = [
+            [
+                'tokenName' => 'Dynamic Content 1',
+                'content'   => '<p>Default Dynamic Content</p>',
+                'filters'   => [
+                    [
+                        'content' => null,
+                        'filters' => [],
+                    ],
+                ],
+            ],
+            [
+                'tokenName' => 'Dynamic Content 2',
+                'content'   => '<p>Default Dynamic Content</p>',
+                'filters'   => [
+                    [
+                        'content' => '<p>Variant 1 Dynamic Content</p>',
+                        'filters' => [
+                            [
+                                'glue'     => 'and',
+                                'field'    => 'bool',
+                                'object'   => 'lead',
+                                'type'     => 'boolean',
+                                'filter'   => '1',
+                                'display'  => null,
+                                'operator' => '=',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $email->setCustomHtml('<div>{dynamiccontent="Dynamic Content 2"}</div>');
+        $email->setDynamicContent($dynamicContent);
+        $this->em->flush();
+
+        $url            = "/email/preview/{$email->getId()}";
+        $defaultContent = 'Default Dynamic Content';
+        $variantContent = 'Variant 1 Dynamic Content';
+
+        // Non admin user - show default content
+        $this->assertPageContent($url, $defaultContent);
+
+        // Non admin user with contact preview - show default content
+        $urlWithContact1 = "{$url}?contactId={$contacts['contacts'][0]['id']}";
+        $this->assertPageContent($urlWithContact1, $defaultContent);
+
+        // Login admin user
+        $this->loginUser('admin');
+
+        // Admin user with contact preview - show variant content - true filter matches
+        $urlWithContact1 = "{$url}?contactId={$contacts['contacts'][0]['id']}";
+        $this->assertPageContent($urlWithContact1, $variantContent);
+
+        // Admin user with contact preview - show variant content - false filter doesn't matches
+        $urlWithContact2 = "{$url}?contactId={$contacts['contacts'][1]['id']}";
+        $this->assertPageContent($urlWithContact2, $defaultContent);
+
+        // Admin user with contact preview - show variant content - null filter doesn't matches
+        $urlWithContact3 = "{$url}?contactId={$contacts['contacts'][2]['id']}";
+        $this->assertPageContent($urlWithContact3, $defaultContent);
+    }
+
+    public function testPreviewEmailWithInvalidIdThrows404Error(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/preview/5009');
+        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertStringContainsString('404 Not Found - Requested URL not found: /email/preview/5009', $crawler->text());
     }
 
     private function createSegment(string $name = 'Segment 1'): LeadList

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\Controller;
 
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\ORMException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
@@ -16,6 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PreviewFunctionalTest extends MauticMysqlTestCase
 {
+    protected $useCleanupRollback = false;
+
     public function testPreviewPage(): void
     {
         $lead  = $this->createLead();
@@ -122,10 +122,6 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->assertPageContent($urlWithContact, $contentWithContactInfo);
     }
 
-    /**
-     * @throws ORMException
-     * @throws OptimisticLockException
-     */
     public function testPreviewEmailForDynamicContentVariantsWithCustomField(): void
     {
         // Create custom field

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -126,7 +126,7 @@ class ExampleSendTypeTest extends TestCase
                     [
                         'apply_text' => false,
                         'save_text'  => 'mautic.email.send',
-                        'save_icon'  => 'fa fa-send',
+                        'save_icon'  => 'ri-send-plane-line',
                     ],
                 ]
             );

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -70,7 +70,7 @@ class ExampleSendTypeTest extends TestCase
                     [
                         'apply_text' => false,
                         'save_text'  => 'mautic.email.send',
-                        'save_icon'  => 'fa fa-send',
+                        'save_icon'  => 'ri-send-plane-line',
                     ],
                 ]
             );

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * @copyright   2020 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Form\Type;
+
+use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\CoreBundle\Form\Type\LookupType;
+use Mautic\CoreBundle\Form\Type\SortableListType;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\EmailBundle\Form\Type\ExampleSendType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ExampleSendTypeTest extends TestCase
+{
+    /**
+     * @var ExampleSendType
+     */
+    private $form;
+
+    /**
+     * @var MockObject|TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var CorePermissions|MockObject
+     */
+    private $security;
+
+    public function setUp(): void
+    {
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->security   = $this->createMock(CorePermissions::class);
+        $this->form       = new ExampleSendType($this->translator, $this->security);
+
+        parent::setUp();
+    }
+
+    public function testBuildFormWithoutContact(): void
+    {
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects(self::exactly(2))
+            ->method('add')
+            ->withConsecutive(
+                [
+                    'emails',
+                    SortableListType::class,
+                    [
+                        'entry_type'       => EmailType::class,
+                        'label'            => 'mautic.email.example_recipients',
+                        'add_value_button' => 'mautic.email.add_recipient',
+                        'option_notblank'  => false,
+                    ],
+                ],
+                [
+                    'buttons',
+                    FormButtonsType::class,
+                    [
+                        'apply_text' => false,
+                        'save_text'  => 'mautic.email.send',
+                        'save_icon'  => 'fa fa-send',
+                    ],
+                ]
+            );
+
+        $this->security->expects(self::once())
+            ->method('isAdmin')
+            ->willReturn(false);
+        $this->security->expects(self::once())
+            ->method('hasEntityAccess')
+            ->with('lead:leads:viewown', 'lead:leads:viewother')
+            ->willReturn(false);
+
+        $this->form->buildForm($builder, []);
+    }
+
+    public function testBuildFormWithContact(): void
+    {
+        $this->translator->expects(self::exactly(2))
+            ->method('trans')
+            ->withConsecutive(
+                ['mautic.lead.list.form.startTyping'],
+                ['mautic.core.form.nomatches']
+            )->willReturnOnConsecutiveCalls(
+                'startTyping',
+                'nomatches'
+            );
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects(self::exactly(4))
+            ->method('add')
+            ->withConsecutive(
+                [
+                    'emails',
+                    SortableListType::class,
+                    [
+                        'entry_type'       => EmailType::class,
+                        'label'            => 'mautic.email.example_recipients',
+                        'add_value_button' => 'mautic.email.add_recipient',
+                        'option_notblank'  => false,
+                    ],
+                ],
+                [
+                    'contact',
+                    LookupType::class,
+                    [
+                        'attr' => [
+                            'class'                  => 'form-control',
+                            'data-callback'          => 'activateContactLookupField',
+                            'data-toggle'            => 'field-lookup',
+                            'data-lookup-callback'   => 'updateContactLookupListFilter',
+                            'data-chosen-lookup'     => 'lead:contactList',
+                            'placeholder'            => 'startTyping',
+                            'data-no-record-message' => 'nomatches',
+                        ],
+                    ],
+                ],
+                [
+                    'contact_id',
+                    HiddenType::class,
+                ],
+                [
+                    'buttons',
+                    FormButtonsType::class,
+                    [
+                        'apply_text' => false,
+                        'save_text'  => 'mautic.email.send',
+                        'save_icon'  => 'fa fa-send',
+                    ],
+                ]
+            );
+
+        $this->security->expects(self::once())
+            ->method('isAdmin')
+            ->willReturn(false);
+        $this->security->expects(self::once())
+            ->method('hasEntityAccess')
+            ->with('lead:leads:viewown', 'lead:leads:viewother')
+            ->willReturn(true);
+
+        $this->form->buildForm($builder, []);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * @copyright   2020 Mautic Contributors. All rights reserved
- * @author      Mautic
- *
- * @link        https://mautic.org
- *
- * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
- */
-
 namespace Mautic\EmailBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
@@ -21,24 +12,21 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ExampleSendTypeTest extends TestCase
 {
-    /**
-     * @var ExampleSendType
-     */
-    private $form;
+    private ExampleSendType $form;
 
     /**
-     * @var MockObject|TranslatorInterface
+     * @var MockObject&TranslatorInterface
      */
-    private $translator;
+    private MockObject $translator;
 
     /**
-     * @var CorePermissions|MockObject
+     * @var CorePermissions&MockObject
      */
-    private $security;
+    private MockObject $security;
 
     public function setUp(): void
     {

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\Tree\JsPlumbFormatter;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\UtmTag;
@@ -53,10 +54,16 @@ class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function contactListAction(Request $request, LeadModel $model): JsonResponse
+    public function contactListAction(Request $request, LeadModel $model, CorePermissions $corePermissions): JsonResponse
     {
-        $filter    = InputHelper::clean($request->query->get('filter'));
-        $results   = $model->getLookupResults('contact', $filter);
+        $filter['string'] = InputHelper::clean($request->query->get('filter'));
+
+        // Do not show other's contacts if do not have permission.
+        if (!$corePermissions->isGranted(['lead:leads:viewother'], 'MATCH_ONE')) {
+            $filter['force'] = ' '.$this->translator->trans('mautic.core.searchcommand.ismine');
+        }
+
+        $results = $model->getLookupResults('contact', $filter);
 
         $results['success'] = 1;
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -643,11 +643,7 @@ class LeadModel extends FormModel
                 $results = $this->em->getRepository(User::class)->getUserList($filter, $limit, $start, ['lead' => 'leads']);
                 break;
             case 'contact':
-                $fetchResults = $this->getEntities([
-                    'start'          => $start,
-                    'limit'          => $limit,
-                    'filter'         => ['string' => $filter],
-                ]);
+                $fetchResults = $this->getEntities(['start' => $start, 'limit' => $limit, 'filter' => $filter]);
 
                 $results = [];
 

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\LeadBundle\Entity\Company;
-use Mautic\LeadBundle\Entity\LeadList;
-use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
-use PHPUnit\Framework\Assert;
-use Doctrine\Common\Persistence\Mapping\MappingException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
+use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -5,17 +5,12 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
-use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\HttpFoundation\Request;
 use Doctrine\Common\Persistence\Mapping\MappingException;
-use Mautic\CampaignBundle\DataFixtures\ORM\CampaignData;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\UserBundle\Entity\Role;
@@ -23,7 +18,6 @@ use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class AjaxControllerFunctionalTest extends MauticMysqlTestCase
@@ -392,7 +386,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $updatedLead = $this->em->getRepository(Lead::class)->find($lead->getId());
         $this->assertFalse(in_array($tag, $updatedLead->getTags()->toArray()));
     }
-    
+
     public function testContactListActionSuggestionsByAdminUser(): void
     {
         /** @var UserRepository $userRepository */
@@ -441,9 +435,6 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         }
     }
 
-    /**
-     * @throws MappingException
-     */
     public function testContactListActionSuggestionsByNonAdminUser(): void
     {
         /** @var UserRepository $userRepository */

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -475,7 +475,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         /** @var PasswordEncoderInterface $encoder */
-        $encoder = $this->container->get('security.encoder_factory')->getEncoder($user);
+        $encoder = $this->getContainer()->get('security.encoder_factory')->getEncoder($user);
 
         $user->setPassword($encoder->encodePassword('mautic', null));
         $userRepository->saveEntity($user);

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -12,6 +12,19 @@ use Mautic\LeadBundle\Entity\LeadList;
 use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
+use Doctrine\Common\Persistence\Mapping\MappingException;
+use Mautic\CampaignBundle\DataFixtures\ORM\CampaignData;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\UserBundle\Entity\Role;
+use Mautic\UserBundle\Entity\RoleRepository;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
 class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -378,6 +391,137 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         // Assert the tag is removed from the lead
         $updatedLead = $this->em->getRepository(Lead::class)->find($lead->getId());
         $this->assertFalse(in_array($tag, $updatedLead->getTags()->toArray()));
+    }
+    
+    public function testContactListActionSuggestionsByAdminUser(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->em->getRepository(User::class);
+
+        /** @var User $adminUser */
+        $adminUser = $userRepository->findOneBy(['username' => 'admin']);
+        self::assertInstanceOf(User::class, $adminUser);
+
+        $salesUser = $userRepository->findOneBy(['username' => 'sales']);
+        self::assertInstanceOf(User::class, $salesUser);
+
+        $leads = [];
+
+        // Create 4 leads with two owned by admin and sales users respectively.
+        for ($i = 1; $i <= 4; ++$i) {
+            $owner = $adminUser;
+
+            if ($i > 2) {
+                $owner = $salesUser;
+            }
+
+            $lead = new Lead();
+            $lead->setFirstname("User $i");
+            $lead->setOwner($owner);
+            $leads[] = $lead;
+        }
+
+        /** @var LeadRepository $leadRepository */
+        $leadRepository = $this->em->getRepository(Lead::class);
+        $leadRepository->saveEntities($leads);
+        $this->em->clear();
+
+        // Check suggestions for admin user.
+        $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:contactList&field=undefined&filter=user');
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isOk());
+
+        $data       = json_decode($response->getContent(), true);
+        $foundNames = array_column($data, 'value');
+
+        self::assertCount(4, $foundNames);
+
+        foreach ($foundNames as $key => $name) {
+            self::assertSame('User '.($key + 1), $name);
+        }
+    }
+
+    /**
+     * @throws MappingException
+     */
+    public function testContactListActionSuggestionsByNonAdminUser(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->em->getRepository(User::class);
+
+        $adminUser = $userRepository->findOneBy(['username' => 'admin']);
+        self::assertInstanceOf(User::class, $adminUser);
+
+        $leads = [];
+
+        // Create 2 leads with owned by admin user.
+        for ($i = 1; $i <= 2; ++$i) {
+            $lead = new Lead();
+            $lead->setFirstname("User $i");
+            $lead->setOwner($adminUser);
+            $leads[] = $lead;
+        }
+
+        /** @var LeadRepository $leadRepository */
+        $leadRepository = $this->em->getRepository(Lead::class);
+        $leadRepository->saveEntities($leads);
+        $this->em->clear();
+
+        $role = new Role();
+        $role->setName('Role');
+        $role->setIsAdmin(false);
+        $role->setRawPermissions(['lead:leads' => ['viewown']]);
+
+        /** @var RoleRepository $roleRepository */
+        $roleRepository = $this->em->getRepository(Role::class);
+        $roleRepository->saveEntity($role);
+
+        // Create a non admin user with view own contacts permission.
+        $user = new User();
+        $user->setFirstName('Non');
+        $user->setLastName('Admin');
+        $user->setEmail('non-admin-user@test.com');
+        $user->setUsername('non-admin-user');
+        $user->setRole($role);
+
+        /** @var PasswordEncoderInterface $encoder */
+        $encoder = $this->container->get('security.encoder_factory')->getEncoder($user);
+
+        $user->setPassword($encoder->encodePassword('mautic', null));
+        $userRepository->saveEntity($user);
+
+        /** @var User $nonAdminUser */
+        $nonAdminUser = $userRepository->findOneBy(['email' => 'non-admin-user@test.com']);
+
+        $nonAdminLeads = [];
+
+        // Create 2 leads with owned by non-admin user.
+        for ($i = 3; $i <= 4; ++$i) {
+            $lead = new Lead();
+            $lead->setFirstname("User $i");
+            $lead->setOwner($nonAdminUser);
+            $nonAdminLeads[] = $lead;
+        }
+
+        $leadRepository->saveEntities($nonAdminLeads);
+        $this->em->clear();
+
+        // Logout admin.
+        $this->client->request(Request::METHOD_GET, '/s/logout');
+
+        // Check suggestions for a non admin user.
+        $this->loginUser('non-admin-user');
+        $this->client->setServerParameter('PHP_AUTH_USER', 'non-admin-user');
+        $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:contactList&field=undefined&filter=user');
+        $response = $this->client->getResponse();
+        self::assertTrue($response->isOk());
+
+        $data       = json_decode($response->getContent(), true);
+        $foundNames = array_column($data, 'value');
+
+        self::assertCount(2, $foundNames);
+        self::assertSame('User 3', $foundNames[0]);
+        self::assertSame('User 4', $foundNames[1]);
     }
 
     private function getMembersForCampaign(int $campaignId): array


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | 
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
As a marketer, I'd like to be able to test my emails and ensure tokens are properly replaced and variants are sent to the right contacts without requiring a live send. Currently, the "Send example" only sends to an address, and does not recognize any profile data from a record.

Before:

![Screenshot 2024-07-18 at 17 27 54](https://github.com/user-attachments/assets/07675a4b-97cc-4739-a675-f8edf2edc649)

After:
![Screenshot 2024-07-18 at 17 26 17](https://github.com/user-attachments/assets/d4cdd233-db9c-486b-b4dd-54c9a30b94f5)

#### Steps to test this PR:
1. Go to email view page
2. Click send example
3. Choose contact
4. Click send
5. To selected e-mail address will be delivered email content based on selected contact
6. Test with a non-root admin user
7. Test dynamic content
8. Testy contact and company tokens
