### PR TITLE
[UI] Header alignment

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
@@ -1,11 +1,12 @@
 <div class="page-header">
 	<div class="box-layout">
 		<div class="col-xs-5 col-sm-6 col-md-5 va-m">
-			<h1 class="pull-left page-header-title">{{ headerTitle|purify }}</h1>
-			<div class="ml-sm pull-left">
-					{{ publishStatus|purify }}
-			</div>
+			<div class="d-flex ai-center">
+				<h1 class="pull-left page-header-title">{{ headerTitle|purify }}</h1>
+			<div class="ml-sm pull-left">{{ publishStatus|purify }}</div>
 			{{ customContent('page.header.left', _context) }}
+			</div>
+			
 		</div>
 		<div class="col-xs-7 col-sm-6 col-md-7 va-m">
 			<div class="toolbar text-right" id="toolbar">

--- a/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
@@ -1,15 +1,15 @@
 <div class="page-header">
-	<div class="box-layout">
-		<div class="col-xs-5 col-sm-6 col-md-5 va-m">
-			<div class="d-flex ai-center">
+	<div class="row-no-gutters ai-center gap-md fw-nowrap-md fd-row-md fd-column-reverse">
+		<div class="col-xs-12 col-sm-6 col-md-5 va-m">
+			<div class="d-flex ai-center fw-wrap fw-nowrap-md">
 				<h1 class="pull-left page-header-title">{{ headerTitle|purify }}</h1>
 			<div class="ml-sm pull-left">{{ publishStatus|purify }}</div>
 			{{ customContent('page.header.left', _context) }}
 			</div>
 			
 		</div>
-		<div class="col-xs-7 col-sm-6 col-md-7 va-m">
-			<div class="toolbar text-right" id="toolbar">
+		<div class="col-xs-12 col-sm-6 col-md-7 va-m">
+			<div class="d-flex toolbar jc-end-md jc-start" id="toolbar">
 				{# only print if it's a string beause that contains HTML,
 						eg. in PointsBundle and FormBundle's 'new' pages it's outputting an Array #}
 				{{ actions is not iterable ? actions|raw }}

--- a/app/bundles/CoreBundle/Resources/views/Helper/publishstatus_badge.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/publishstatus_badge.html.twig
@@ -17,4 +17,4 @@
     {%- endif -%}
 {% endset %}
 {% set labelText = ('mautic.core.form.' ~ (entity.getPublishStatus() == 'published' ? 'active' : 'inactive'))|trans %}
-<span title="{{ labelText }}" aria-label="{{ labelText }}" class="bg-{{ labelColor }} mt-sm publishstatus_pulse"> </span>
+<span title="{{ labelText }}" aria-label="{{ labelText }}" class="bg-{{ labelColor }} publishstatus_pulse"> </span>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR:
- Makes a [UI] Header alignment using flex utilities
- Also features a [UI] Header improvement for mobile, similar to the GitHub's layout for PRs (you can check it right now)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->

| Before                                 | After
| -------------------------------------- | ---
|  ![image](https://github.com/user-attachments/assets/ea8aa2cf-92c2-4ab0-b117-e26e680e5908)                                      | ![image](https://github.com/user-attachments/assets/4792c9b3-d064-4c8c-a5c6-ae19dc456f81)

| Before                                 | After
| -------------------------------------- | ---
|  ![image](https://github.com/user-attachments/assets/08dc15d9-3d50-41c8-b025-57322f148577)                                      | ![image](https://github.com/user-attachments/assets/9103ec55-26b7-42c3-a759-8cde39178f6a)




---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the Forms page and inspect the header. Ensure that it is perfectly aligned to the center vertically.
3. Create a form with a very long name, save it, and then close it. Open your developer tools, activate mobile mode, and check how the header behaves.

 
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->