### PR TITLE
Do not fail scheduled events when publish date range is off

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -226,9 +226,13 @@ class EventExecutioner
     /**
      * @param ArrayCollection|LeadEventLog[] $logs
      * @param string                         $error
+     *
+     * @deprecated as not used
      */
     public function recordLogsWithError(ArrayCollection $logs, $error): void
     {
+        @trigger_error('EventExecutioner::recordLogsWithError() is deprecated in Mautic:4 and is removed from Mautic:5 as unused', E_USER_DEPRECATED);
+
         foreach ($logs as $log) {
             $log->appendToMetadata(
                 [

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -142,11 +142,6 @@ class ScheduledExecutioner implements ExecutionerInterface, ResetInterface
                 } catch (NoContactsFoundException) {
                     // All of the events were rescheduled
                 }
-            } else {
-                $this->executioner->recordLogsWithError(
-                    $organizedLogs,
-                    $this->translator->trans('mautic.campaign.event.campaign_unpublished')
-                );
             }
 
             $this->progressBar->advance($organizedLogs->count());

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CampaignBundle\Tests\Command;
 
-use DateTime;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CampaignBundle\Tests\Command;
 
+use DateTime;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -26,7 +28,6 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Form\Type\EmailSendType;
 use Mautic\LeadBundle\Entity\Lead;
-use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -35,57 +36,57 @@ class EventExecutionerTest extends \PHPUnit\Framework\TestCase
     /**
      * @var EventCollector&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $eventCollector;
+    private MockObject $eventCollector;
 
     /**
      * @var EventLogger&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $eventLogger;
+    private MockObject $eventLogger;
 
     /**
      * @var ActionExecutioner&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $actionExecutioner;
+    private MockObject $actionExecutioner;
 
     /**
      * @var ConditionExecutioner&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $conditionExecutioner;
+    private MockObject $conditionExecutioner;
 
     /**
      * @var DecisionExecutioner&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $decisionExecutioner;
+    private MockObject $decisionExecutioner;
 
     /**
      * @var LoggerInterface&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private MockObject $logger;
 
     /**
      * @var EventScheduler&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $eventScheduler;
+    private MockObject $eventScheduler;
 
     /**
      * @var RemovedContactTracker&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $removedContactTracker;
+    private MockObject $removedContactTracker;
 
     /**
      * @var LeadRepository&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $leadRepository;
+    private MockObject $leadRepository;
 
     /**
-     * @var EventRepository|MockBuilder
+     * @var EventRepository&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $eventRepository;
+    private MockObject $eventRepository;
 
     /**
-     * @var Translator|MockBuilder
+     * @var Translator&MockObject
      */
-    private \PHPUnit\Framework\MockObject\MockObject $translator;
+    private MockObject $translator;
 
     protected function setUp(): void
     {
@@ -122,7 +123,7 @@ class EventExecutionerTest extends \PHPUnit\Framework\TestCase
         $this->eventLogger->expects($this->once())->method('persistCollection')->willReturn($this->eventLogger);
 
         set_error_handler($errorHandler);
-        $this->getEventExecutioner()->recordLogsWithError(new ArrayCollection([]), 'some message');
+        $this->getEventExecutioner()->recordLogsWithError(new ArrayCollection([]), 'some message'); // @phpstan-ignore-line as recordLogsWithError() is deprecated
         restore_error_handler();
 
         $this->assertTrue($deprecationTriggered, 'Deprecation should be triggered');

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -452,9 +452,6 @@ class ScheduledExecutionerTest extends \PHPUnit\Framework\TestCase
         $this->executioner->expects($this->never())
             ->method('executeLogs');
 
-        $this->executioner->expects($this->once())
-            ->method('recordLogsWithError');
-
         $this->contactFinder->expects($this->never())
             ->method('hydrateContacts');
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [Y]
| New feature/enhancement? (use the a.x branch)      | [N]
| Deprecations?                          | [Y]
| BC breaks? (use the c.x branch)        | [N]
| Automated tests included?              | [Y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

### Description
We discovered that the scheduled events are being canceled if the event is scheduled out of the publish down and publish up date range. Those events are then not rescheduled when the campaign is re-published.

This is different behavior than when the event is scheduled when the campaign is unpublished. Those events are ignored and when the campaign is unpublished, those events are executed or rescheduled.

The reason why those scenarios behave differently is because the events for the campaigns that are unpublished are not even loaded from the database here:

https://github.com/mautic/mautic/blob/5.x/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php#L101

But events that are out of the publish date range are. Those are then failed in the removed else statement.

### Steps to Reproduce

1. Create a campaign with 1 event scheduled in 5 minutes.
2. Add a contact to this campaign.
3. Edit the campaign. Set the publish up and down dates to the past
4. Check the `campaign_lead_event_log` table for the log IDs for this campaign and then execute this command: `bin/console mautic:campaigns:execute --scheduled-log-ids=1,2,3` (replace 1,2,3 with the actual log IDs)
5. Go to the contact detail page and see that the campaign event failed with the "The campaign was unpublished" message.
6. Remove the publish up and down dates
7. The scheduled event will never be executed as it has already failed.

You can compare it to this scenario:

1. Create a campaign with 1 event scheduled in 5 minutes.
2. Add a contact to this campaign.
3. Unpublish the campaign.
4. Check the `campaign_lead_event_log` table for the log IDs for this campaign and then execute this command: `bin/console mautic:campaigns:execute --scheduled-log-ids=1,2,3` (replace 1,2,3 with the actual log IDs)
5. Go to the contact detail page and see that the event is still scheduled. It hasn't failed nor executed.
6. Republish the campaign
7. The scheduled event is either rescheduled or executed

### Expected Result

Both scenarios should behave the same. Based on the report from EAB they expect that those events should be rescheduled or executed so we should update the first scenario with publish up and down dates to behave the same as when the campaign is unpublished.

#### Other areas of Mautic that may be affected by the change:
1. Just republishing of campaigns and how it deals with scheduled events

#### List deprecations along with the new alternative:
1. EventExecutioner::recordLogsWithError() method is deprecated as unused.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The events scheduled to be executed when a campaign is either unpublished or the publish date range is off scenarios are tested to be ignoring the scheduled events so they could be executed when the campaign is republished.
