### PR TITLE
Virtual permissions

### DIFF
--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -233,6 +233,8 @@ class CorePermissions
                 } elseif ('anon.' == $userEntity) {
                     // anon user or session timeout
                     $permissions[$permission] = false;
+                } elseif ($permissionObject instanceof VirtualPermissions) {
+                    $permissions[$permission] = $permissionObject->isVirtuallyGranted($parts[1], $parts[2]);
                 } elseif (!isset($activePermissions[$parts[0]])) {
                     // user does not have implicit access to bundle so deny
                     $permissions[$permission] = false;

--- a/app/bundles/CoreBundle/Security/Permissions/VirtualPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/VirtualPermissions.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Security\Permissions;
+
+/**
+ * If a permission implements this interface, a user does not need to have
+ * any permissions explicitly assigned to them. The `isVirtuallyGranted()` method is invoked right away.
+ */
+interface VirtualPermissions
+{
+    public function isVirtuallyGranted(string $name, string $level): bool;
+}

--- a/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional\Security\Permissions;
+
+use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
+use Mautic\CoreBundle\Security\Permissions\VirtualPermissions;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+
+class CorePermissionsTest extends MauticMysqlTestCase
+{
+    /**
+     * @return iterable<array{bool}>
+     */
+    public function dataVirtualPermission(): iterable
+    {
+        yield 'Permission granted' => [true];
+        yield 'Permission declined' => [false];
+    }
+
+    /**
+     * @dataProvider dataVirtualPermission
+     */
+    public function testVirtualPermission(bool $grant): void
+    {
+        $user        = $this->loginUser('sales');
+        $permissions = self::getContainer()->get('mautic.security');
+        $permissions->setPermissionObject($this->createVirtualPermission($grant));
+
+        Assert::assertSame($grant, $permissions->isGranted('test:group:action', 'MATCH_ALL', $user));
+    }
+
+    private function createVirtualPermission(bool $grant): AbstractPermissions
+    {
+        $permission = new class([]) extends AbstractPermissions implements VirtualPermissions {
+            public bool $grant;
+
+            public function getName(): string
+            {
+                return 'test';
+            }
+
+            public function isSupported($name, $level = ''): bool
+            {
+                Assert::assertSame('group', $name);
+                Assert::assertSame('action', $level);
+
+                return true;
+            }
+
+            /**
+             * @param mixed[] $userPermissions
+             */
+            public function isGranted($userPermissions, $name, $level): bool
+            {
+                Assert::fail('This method should not be invoked.');
+            }
+
+            public function isEnabled(): bool
+            {
+                return false;
+            }
+
+            public function isVirtuallyGranted(string $name, string $level): bool
+            {
+                Assert::assertSame('group', $name);
+                Assert::assertSame('action', $level);
+
+                return $this->grant;
+            }
+        };
+
+        $permission->grant = $grant;
+
+        return $permission;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR adds a new optional `VirtualPermissions` interface that can be used in situations where there is no need to explicitly define specific permissions in the UI. The newly added `isVirtuallyGranted` method let you decide whether you want to grant or decline a given permission. 

### Our use case for implementing virtual permissions 
We implemented a new entity within our plugin that allows user to create a new category connected with the new entity. We didn't want to see any permission checkbox regarding this entity in the UI. We just wanted to allow creating a new category to everyone. Without implementing any permission class we got an exception that read `"Permission class not found for <our-entity> in permissions classes"`.

### Example of virtual permissions implementation
```php
<?php

declare(strict_types=1);

namespace Mautic\SomeBundle\Security\Permissions;

use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
use Mautic\CoreBundle\Security\Permissions\VirtualPermissions;

class SomePermissions extends AbstractPermissions implements VirtualPermissions
{
    public function getName(): string
    {
        return 'some';
    }

    public function isSupported($name, $level = ''): bool
    {
        return true;
    }

    public function isGranted($userPermissions, $name, $level): bool
    {
        // this method is not supposed to be called
        return false;
    }

    public function isEnabled(): bool
    {
        // do not render any permission options in the UI
        return false;
    }

    public function isVirtuallyGranted(string $name, string $level): bool
    {
        // decline everything for 'some-section'
        if ('some-section' === $name) {
            return false;
        }

        // grant everything else
        return true;
    }
}
```


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. The PR only adds a new optional interface. There is no new feature to test.
2. Just verify that the existing functionality of granting and declining permissions is not broken.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->