### PR TITLE
[UI] Update Mautic color saturation

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -1222,11 +1222,11 @@ a.text-white.dark-lg:hover {
   color: #595959;
 }
 .text-primary {
-  color: #4E5D9D;
+  color: #3B53B1;
 }
 a.text-primary:hover,
 a.text-primary:focus {
-  color: #3d497b;
+  color: #2e418b;
 }
 .text-success {
   color: #00B49C;
@@ -1405,7 +1405,7 @@ code {
   border-width: 1px;
 }
 .btn.btn-outline.btn-primary {
-  color: #4E5D9D;
+  color: #3B53B1;
 }
 .btn.btn-outline.btn-success {
   color: #00B49C;
@@ -1748,14 +1748,14 @@ a.media {
   left: -18px;
   right: auto;
   border-width: 10px 0 10px 10px;
-  border-color: transparent transparent transparent #4E5D9D;
+  border-color: transparent transparent transparent #3B53B1;
 }
 .media-list.media-list-bubble > .media.media-right .media-body {
   text-align: right;
 }
 .media-list.media-list-bubble > .media.media-right .media-body .media-text {
   color: #f2f2f2;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 .extra-menu {
   height: 60px;
@@ -2882,7 +2882,7 @@ ul.dropdown-menu-form {
   background-color: #a0acb8;
 }
 .bullet.bullet-primary {
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 .bullet.bullet-success {
   background-color: #00B49C;
@@ -3310,13 +3310,13 @@ input[type=file].form-control {
 .radio.custom-primary label input + span:after,
 .checkbox-inline.custom-primary label input + span:after,
 .radio-inline.custom-primary label input + span:after {
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 .checkbox.custom-primary label input:checked + span,
 .radio.custom-primary label input:checked + span,
 .checkbox-inline.custom-primary label input:checked + span,
 .radio-inline.custom-primary label input:checked + span {
-  border: 1px solid #4E5D9D;
+  border: 1px solid #3B53B1;
 }
 .checkbox.custom-primary label:hover input + span,
 .radio.custom-primary label:hover input + span,
@@ -3328,7 +3328,7 @@ input[type=file].form-control {
 .radio.custom-primary label:hover input:checked + span,
 .checkbox-inline.custom-primary label:hover input:checked + span,
 .radio-inline.custom-primary label:hover input:checked + span {
-  border: 1px solid #4E5D9D;
+  border: 1px solid #3B53B1;
 }
 .checkbox.custom-info label input + span:after,
 .radio.custom-info label input + span:after,
@@ -3901,11 +3901,11 @@ table i:not(.fa-lg) {
   transition: border 0.25s, left 0.15s 0.25s, right 0.25s 0.175s;
 }
 .switch.switch-primary input:checked + .switch {
-  border-color: #4E5D9D;
-  box-shadow: inset 0 0 0 0.6em #4E5D9D;
+  border-color: #3B53B1;
+  box-shadow: inset 0 0 0 0.6em #3B53B1;
 }
 .switch.switch-primary input:checked + .switch:after {
-  border-color: #4E5D9D;
+  border-color: #3B53B1;
 }
 .switch.switch-info input:checked + .switch {
   border-color: #35B4B9;
@@ -4210,49 +4210,49 @@ table i:not(.fa-lg) {
   color: #3c4650;
 }
 .bg-primary {
-  background-color: #4E5D9D !important;
-  border-color: #495793 !important;
+  background-color: #3B53B1 !important;
+  border-color: #374ea6 !important;
   color: #fff !important;
 }
 .bg-primary.bg-light-xs,
 .bg-primary .bg-light-xs {
-  background-color: #505fa0 !important;
-  border-color: #495793 !important;
+  background-color: #3c55b5 !important;
+  border-color: #374ea6 !important;
 }
 .bg-primary.bg-light-sm,
 .bg-primary .bg-light-sm {
-  background-color: #5363a7 !important;
-  border-color: #495793 !important;
+  background-color: #3f58bc !important;
+  border-color: #374ea6 !important;
 }
 .bg-primary.bg-light-md,
 .bg-primary .bg-light-md {
-  background-color: #5868ac !important;
-  border-color: #495793 !important;
+  background-color: #455ec1 !important;
+  border-color: #374ea6 !important;
 }
 .bg-primary.bg-light-lg,
 .bg-primary .bg-light-lg {
-  background-color: #5f6eb0 !important;
-  border-color: #495793 !important;
+  background-color: #4c65c3 !important;
+  border-color: #374ea6 !important;
 }
 .bg-primary.bg-dark-xs,
 .bg-primary .bg-dark-xs {
-  background-color: #4c5b9a !important;
-  border-color: #495793 !important;
+  background-color: #3a51ad !important;
+  border-color: #374ea6 !important;
 }
 .bg-primary.bg-dark-sm,
 .bg-primary .bg-dark-sm {
-  background-color: #495793 !important;
-  border-color: #445189 !important;
+  background-color: #374ea6 !important;
+  border-color: #33489a !important;
 }
 .bg-primary.bg-dark-md,
 .bg-primary .bg-dark-md {
-  background-color: #46538c !important;
-  border-color: #3f4b7e !important;
+  background-color: #354a9e !important;
+  border-color: #30438f !important;
 }
 .bg-primary.bg-dark-lg,
 .bg-primary .bg-dark-lg {
-  background-color: #424f85 !important;
-  border-color: #3a4574 !important;
+  background-color: #324696 !important;
+  border-color: #2c3d83 !important;
 }
 .bg-success {
   background-color: #00B49C !important;
@@ -4464,7 +4464,7 @@ lesshat-selector { -lh-property: 0 ;
   left: 0;
   right: 0;
   height: 2px;
-  background-color: #adb5d7;
+  background-color: #a4b1e1;
   overflow: hidden;
   -webkit-transition: opacity 0.3s ease;
   -moz-transition: opacity 0.3s ease;
@@ -4480,7 +4480,7 @@ lesshat-selector { -lh-property: 0 ;
   content: '';
   position: absolute;
   height: 2px;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 .loading-bar.active,
 .canvas-loading-bar.active,
@@ -4621,7 +4621,7 @@ lesshat-selector { -lh-property: 0 ;
   padding-top: 2px;
   padding-bottom: 2px;
   text-align: center;
-  color: #4E5D9D;
+  color: #3B53B1;
 }
 .timeline .events {
   padding-left: 0px;
@@ -7187,14 +7187,14 @@ ul.media-list.media-list-feed div.media-body {
   --label-border-green: #24a148;
 }
 :root {
-  --primary-20: #d0d5e8;
-  --primary-30: #aeb6d7;
-  --primary-40: #8c98c6;
-  --primary-50: #6a79b5;
-  --primary-60: #4e5e9e;
-  --primary-70: #3d4a7c;
-  --primary-80: #2c355a;
-  --primary-90: #1b2138;
+  --primary-20: #cbd2ee;
+  --primary-30: #a4b1e1;
+  --primary-40: #7e8fd4;
+  --primary-50: #586ec7;
+  --primary-60: #3B53B1;
+  --primary-70: #2e418b;
+  --primary-80: #212f65;
+  --primary-90: #151d3e;
   --secondary-20: #fffefd;
   --secondary-30: #feedcb;
   --secondary-40: #fedc98;

--- a/app/bundles/CoreBundle/Assets/css/app/less/brand.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/brand.less
@@ -1,0 +1,6 @@
+//
+// Brand center
+// --------------------------------------------------
+@primary-color: #3B53B1;
+@secondary-color: #fdb933;
+@border-radius: 0px;

--- a/app/bundles/CoreBundle/Assets/css/app/less/tokens.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/tokens.less
@@ -1,11 +1,4 @@
-//
-// Brand center
-// --------------------------------------------------
-@primary-color: #4e5e9e;
-@secondary-color: #fdb933;
-@border-radius: 0px;
-
- 
+@import "brand";
 
 // Themes
 /// Light theme
@@ -88,7 +81,7 @@
     --icon-primary: #161616;
     --icon-secondary: #525252;
     --icon-on-color: contrast(@primary-60);
-    --icon-on-color-disabled: contrast(@primary-60, #16161640, #8d8d8d); 
+    --icon-on-color-disabled: contrast(@primary-60, #16161640, #8d8d8d);
     --icon-interactive: var(--primary-60);
     --icon-inverse: #ffffff;
     --icon-disabled: #16161640;

--- a/app/bundles/CoreBundle/Assets/css/libraries/bootstrap/bootstrap-mautic-custom-variables.less
+++ b/app/bundles/CoreBundle/Assets/css/libraries/bootstrap/bootstrap-mautic-custom-variables.less
@@ -3,7 +3,7 @@
 //
 // Variables
 // --------------------------------------------------
-
+@import "../../app/less/brand";
 
 //== Colors
 //
@@ -16,7 +16,7 @@
 @gray-light:             lighten(#0c0e10, 61.8%); // #777
 @gray-lighter:           lighten(#0c0e10, 87.5%); // #eee
 
-@brand-primary:         #4E5D9D;
+@brand-primary:         @primary-color;
 @brand-success:         #00B49C;
 @brand-info:            #35B4B9;
 @brand-warning:         #FDB933;

--- a/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
+++ b/app/bundles/CoreBundle/Assets/css/libraries/libraries.css
@@ -1083,12 +1083,12 @@ textarea {
   line-height: inherit;
 }
 a {
-  color: #4E5D9D;
+  color: #3B53B1;
   text-decoration: none;
 }
 a:hover,
 a:focus {
-  color: #353f6a;
+  color: #283878;
   text-decoration: underline;
 }
 a:focus {
@@ -1323,11 +1323,11 @@ mark,
   color: #a0acb8;
 }
 .text-primary {
-  color: #4E5D9D;
+  color: #3B53B1;
 }
 a.text-primary:hover,
 a.text-primary:focus {
-  color: #3d497b;
+  color: #2e418b;
 }
 .text-success {
   color: #3c763d;
@@ -1359,11 +1359,11 @@ a.text-danger:focus {
 }
 .bg-primary {
   color: #fff;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 a.bg-primary:hover,
 a.bg-primary:focus {
-  background-color: #3d497b;
+  background-color: #2e418b;
 }
 .bg-success {
   background-color: #dff0d8;
@@ -2425,27 +2425,27 @@ fieldset[disabled] .btn-default.focus {
 }
 .btn-primary {
   color: #fff;
-  background-color: #4E5D9D;
-  border-color: #4E5D9D;
+  background-color: #3B53B1;
+  border-color: #3B53B1;
 }
 .btn-primary:focus,
 .btn-primary.focus {
   color: #fff;
-  background-color: #3d497b;
-  border-color: #242b48;
+  background-color: #2e418b;
+  border-color: #1b2651;
 }
 .btn-primary:hover {
   color: #fff;
-  background-color: #3d497b;
-  border-color: #3a4574;
+  background-color: #2e418b;
+  border-color: #2c3d83;
 }
 .btn-primary:active,
 .btn-primary.active,
 .open > .dropdown-toggle.btn-primary {
   color: #fff;
-  background-color: #3d497b;
+  background-color: #2e418b;
   background-image: none;
-  border-color: #3a4574;
+  border-color: #2c3d83;
 }
 .btn-primary:active:hover,
 .btn-primary.active:hover,
@@ -2457,8 +2457,8 @@ fieldset[disabled] .btn-default.focus {
 .btn-primary.active.focus,
 .open > .dropdown-toggle.btn-primary.focus {
   color: #fff;
-  background-color: #313b63;
-  border-color: #242b48;
+  background-color: #253570;
+  border-color: #1b2651;
 }
 .btn-primary.disabled:hover,
 .btn-primary[disabled]:hover,
@@ -2469,11 +2469,11 @@ fieldset[disabled] .btn-primary:focus,
 .btn-primary.disabled.focus,
 .btn-primary[disabled].focus,
 fieldset[disabled] .btn-primary.focus {
-  background-color: #4E5D9D;
-  border-color: #4E5D9D;
+  background-color: #3B53B1;
+  border-color: #3B53B1;
 }
 .btn-primary .badge {
-  color: #4E5D9D;
+  color: #3B53B1;
   background-color: #fff;
 }
 .btn-success {
@@ -2690,7 +2690,7 @@ fieldset[disabled] .btn-danger.focus {
 }
 .btn-link {
   font-weight: 400;
-  color: #4E5D9D;
+  color: #3B53B1;
   border-radius: 0;
 }
 .btn-link,
@@ -2710,7 +2710,7 @@ fieldset[disabled] .btn-link {
 }
 .btn-link:hover,
 .btn-link:focus {
-  color: #353f6a;
+  color: #283878;
   text-decoration: underline;
   background-color: transparent;
 }
@@ -2855,7 +2855,7 @@ tbody.collapse.in {
 .dropdown-menu > .active > a:focus {
   color: #fff;
   text-decoration: none;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
   outline: 0;
 }
 .dropdown-menu > .disabled > a,
@@ -3290,7 +3290,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav .open > a:hover,
 .nav .open > a:focus {
   background-color: #f7f7f7;
-  border-color: #4E5D9D;
+  border-color: #3B53B1;
 }
 .nav .nav-divider {
   height: 1px;
@@ -4014,7 +4014,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   padding: 6px 12px;
   margin-left: -1px;
   line-height: 1.3856;
-  color: #4E5D9D;
+  color: #3B53B1;
   text-decoration: none;
   background-color: #fff;
   border: 1px solid #ddd;
@@ -4024,7 +4024,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > li > a:focus,
 .pagination > li > span:focus {
   z-index: 2;
-  color: #353f6a;
+  color: #283878;
   background-color: #ebedf0;
   border-color: #ddd;
 }
@@ -4046,7 +4046,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > .active > a:focus,
 .pagination > .active > span:focus {
   z-index: 3;
-  color: #353f6a;
+  color: #283878;
   cursor: default;
   background-color: #ebedf0;
   border-color: #ddd;
@@ -4165,11 +4165,11 @@ a.label:focus {
   background-color: #8392a2;
 }
 .label-primary {
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
 }
 .label-primary[href]:hover,
 .label-primary[href]:focus {
-  background-color: #3d497b;
+  background-color: #2e418b;
 }
 .label-success {
   background-color: #00B49C;
@@ -4233,7 +4233,7 @@ a.badge:focus {
 }
 .list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
-  color: #4E5D9D;
+  color: #3B53B1;
   background-color: #fff;
 }
 .list-group-item > .badge {
@@ -4308,7 +4308,7 @@ a.badge:focus {
 a.thumbnail:hover,
 a.thumbnail:focus,
 a.thumbnail.active {
-  border-color: #4E5D9D;
+  border-color: #3B53B1;
 }
 .thumbnail .caption {
   padding: 9px;
@@ -4422,7 +4422,7 @@ a.thumbnail.active {
   line-height: 18px;
   color: #fff;
   text-align: center;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   -webkit-transition: width 0.6s ease;
@@ -4986,14 +4986,14 @@ button.list-group-item-danger.active:focus {
 }
 .panel-primary > .panel-heading {
   color: #fff;
-  background-color: #4E5D9D;
+  background-color: #3B53B1;
   border-color: rgba(0, 0, 0, 0.03);
 }
 .panel-primary > .panel-heading + .panel-collapse > .panel-body {
   border-top-color: rgba(0, 0, 0, 0.03);
 }
 .panel-primary > .panel-heading .badge {
-  color: #4E5D9D;
+  color: #3B53B1;
   background-color: #fff;
 }
 .panel-primary > .panel-footer + .panel-collapse > .panel-body {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

I created a separate file for all brand-related configs. This way, we can import in different files to have these variables available without generating all :root styles 3x in app.css, libraries.css and builder.css.
The result?
We keep all CSS variables only in app.css, avoiding users having to load the same thing again/Mautic keeps faster.

---
This PR improves the Mautic's main color saturation, to be closer to what the marketing team already uses.
This is also a great improvement for things like links, they become more visible against normal text.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!-
| Before                                 | After
| -------------------------------------- | ---
|  ![image](https://github.com/user-attachments/assets/166f6716-93aa-4636-8f40-9dede5486d04)                                      |![image](https://github.com/user-attachments/assets/9c9e6a20-4fda-4060-9d1c-f4d381077f48)



---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Contacts > Create one > Go back to the Contacts list and check the link (name)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->