### PR TITLE
MailHelper::dispatchSendEvent() made reliable

### DIFF
--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BuilderSubscriberFunctionalTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        if (str_contains($this->getDataSetAsString(false), 'Invalid unsubscribe_text configured')) {
+            $this->configParams['unsubscribe_text']  = '<a href="|some|">Unsubscribe</a> with invalid token within the href attribute.';
+        }
+
+        if (str_contains($this->getDataSetAsString(false), 'No unsubscribe_text configured')) {
+            $this->configParams['unsubscribe_text']  = '';
+        }
+
+        $this->configParams['mailer_spool_type'] = 'file';
+        parent::setUp();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function dataOneTrackingLinkIsNotUsedForDifferentContacts(): iterable
+    {
+        yield 'Invalid unsubscribe_text configured' => ['<!DOCTYPE html><htm><body><a href="https://localhost">link</a></body></html>'];
+        yield 'No unsubscribe_text configured' => ['<!DOCTYPE html><htm><body><a href="https://localhost">link</a></body></html>'];
+        yield 'Invalid tag attribute for unsubscribe_url' => ['<!DOCTYPE html><htm><body><a href="https://localhost">link</a><a id="{unsubscribe_url}">unsubscribe</a></body></html>'];
+    }
+
+    /**
+     * @dataProvider dataOneTrackingLinkIsNotUsedForDifferentContacts
+     */
+    public function testOneTrackingLinkIsNotUsedForDifferentContacts(string $content): void
+    {
+        $numContacts = 3;
+        $segment     = $this->createSegment('Segment', 'segment');
+        $leads       = $this->createContacts($numContacts, $segment);
+        $email       = $this->createEmail('Email subject', $segment, $content);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->sendMessages($email, $numContacts);
+        $this->assertQueuedEmailCount(3);
+
+        foreach ($this->getMailerMessages() as $message) {
+            $clickThrough = $this->parseClickThrough($message->getHtmlBody());
+            $email        = $message->getTo()[0]->getAddress();
+            Assert::assertSame((string) $leads[$email]->getId(), $clickThrough['lead'], '"lead" parameter within the click through should match the contact\'s ID.');
+        }
+    }
+
+    private function createEmail(string $subject, LeadList $segment, string $emailContent): Email
+    {
+        $email = new Email();
+        $email->setDateAdded(new \DateTime());
+        $email->setName('Email name');
+        $email->setSubject($subject);
+        $email->setEmailType('list');
+        $email->setLists([$segment]);
+        $email->setTemplate('Blank');
+        $email->setCustomHtml($emailContent);
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    /**
+     * @return array<string, LEAD>
+     */
+    private function createContacts(int $count, LeadList $segment): array
+    {
+        $contacts = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $contact = new Lead();
+            $email   = "contact-flood-{$i}@doe.com";
+            $contact->setEmail($email);
+            $this->em->persist($contact);
+
+            $this->addContactToSegment($segment, $contact);
+            $contacts[$email] = $contact;
+        }
+
+        return $contacts;
+    }
+
+    private function createSegment(string $name, string $alias): LeadList
+    {
+        $segment = new LeadList();
+        $segment->setName($name);
+        $segment->setPublicName($name);
+        $segment->setAlias($alias);
+        $this->em->persist($segment);
+
+        return $segment;
+    }
+
+    private function addContactToSegment(LeadList $segment, Lead $lead): void
+    {
+        $listLead = new ListLead();
+        $listLead->setLead($lead);
+        $listLead->setList($segment);
+        $listLead->setDateAdded(new \DateTime());
+
+        $this->em->persist($listLead);
+    }
+
+    private function sendMessages(Email $email, int $pending): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/s/ajax?action=email:sendBatch',
+            ['id' => $email->getId(), 'pending' => $pending],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        Assert::assertSame(
+            '{"success":1,"percent":100,"progress":['.$pending.','.$pending.'],"stats":{"sent":'.$pending.',"failed":0,"failedRecipients":[]}}',
+            $response->getContent()
+        );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function parseClickThrough(string $string): array
+    {
+        preg_match('/<a href=\"([^\"]*)\">(.*)<\/a>/iU', $string, $match);
+        parse_str(parse_url($match[1], PHP_URL_QUERY), $queryParams);
+
+        return unserialize(base64_decode($queryParams['ct']));
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR makes the `MailHelper::dispatchSendEvent()` method reliable.
Within our extensions we use event listeners that manipulate email's content.
Such listeners are pretty straightforward. They look as follows.
```php
public static function getSubscribedEvents(): array
{
    return [
        EmailEvents::EMAIL_ON_SEND => ['onEmailSend', 9999],
    ];
}

public function onEmailSend(EmailSendEvent $event)
{
    $content   = $event->getContent();
    $plainText = $event->getPlainText();

    // modify the content/plainText

    $event->setContent($content);
    $event->setPlainText($plainText);
}
```
Under some circumstances we experienced is a critical issue. **Tokens and tracking hashes were shared among different contacts.** There were several places within the code that made this critical issue happen (see [this line](https://github.com/mautic/mautic/blob/5.x/app/bundles/EmailBundle/Helper/MailHelper.php#L1471) for example).


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. It is impossible to reproduce the issue without adding extra `EmailEvents::EMAIL_ON_SEND` listeners.
2. Just make sure the email sending to multiple contacts (at least to two contacts) works as expected.
   1. Check that tokens are replaced appropriately.
   2. Check that tracking of "email open" and "link click" actions works fine.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->
