### PR TITLE
Respect doesColumnSupportEmptyValue when building empty/notEmpty filtered queries

### DIFF
--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -58,17 +58,31 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
 
         switch ($filterOperator) {
             case 'empty':
+                $isNullExpr = $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField());
+
+                if (!$filter->doesColumnSupportEmptyValue()) {
+                    $expression = $isNullExpr;
+                    break;
+                }
+
                 $expression = new CompositeExpression(CompositeExpression::TYPE_OR,
                     [
-                        $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField()),
+                        $isNullExpr,
                         $queryBuilder->expr()->eq($tableAlias.'.'.$filter->getField(), $queryBuilder->expr()->literal('')),
                     ]
                 );
                 break;
             case 'notEmpty':
+                $isNotNullExpr = $queryBuilder->expr()->isNotNull($tableAlias.'.'.$filter->getField());
+
+                if (!$filter->doesColumnSupportEmptyValue()) {
+                    $expression = $isNotNullExpr;
+                    break;
+                }
+
                 $expression = new CompositeExpression(CompositeExpression::TYPE_AND,
                     [
-                        $queryBuilder->expr()->isNotNull($tableAlias.'.'.$filter->getField()),
+                        $isNotNullExpr,
                         $queryBuilder->expr()->neq($tableAlias.'.'.$filter->getField(), $queryBuilder->expr()->literal('')),
                     ]
                 );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | None <!-- required for new features -->
| Related developer documentation PR URL | None <!-- required for developer-facing changes -->
| Issue(s) addressed                     | None <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Having segments being built with a filter that asserts "date is not empty" or "date is empty" throws a SQL Exception when performing a comparison between a date and an empty string. 

This only applies to this ComplexRelationValueFilterQueryBuilder.php not the newer BaseFilterQueryBuilder.php that invokes SegmentOperatorQuerySubscriber.php leading to inconsistent results between the two. 

This has only been identified and tested on 5.1, might apply to versions as low as 5.0. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->

1. Create a custom field using the "date" type on a contact
2. Create a segment that is built based on that field being empty
3. Run the "mautic:segments:update" command

Without this it errors out.