### PR TITLE
Automatic code cleanup (Rector)

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
@@ -47,7 +47,7 @@ final class Oauth2Test extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(400, $response->getStatusCode(), $response->getContent());
+        self::assertResponseStatusCodeSame(400, $response->getContent());
         Assert::assertSame(
             '{"errors":[{"message":"The client credentials are invalid","code":400,"type":"invalid_client"}]}',
             $response->getContent()
@@ -73,7 +73,7 @@ final class Oauth2Test extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(401, $response->getStatusCode(), $response->getContent());
+        self::assertResponseStatusCodeSame(401, $response->getContent());
         Assert::assertSame('{"errors":[{"message":"The access token provided is invalid.","code":401,"type":"invalid_grant"}]}', $response->getContent());
     }
 
@@ -110,7 +110,7 @@ final class Oauth2Test extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
         $payload     = json_decode($response->getContent(), true);
         $accessToken = $payload['access_token'];
         Assert::assertNotEmpty($accessToken);
@@ -127,7 +127,7 @@ final class Oauth2Test extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('"users":[', $response->getContent());
     }
 }

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -15,7 +15,7 @@ class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
         $this->client->request('POST', 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(201, $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
         $this->assertEquals($payload['title'], $response['asset']['title']);
         $this->assertEquals($payload['storageLocation'], $response['asset']['storageLocation']);
@@ -33,7 +33,7 @@ class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
         $this->client->request('POST', 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(400, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(400, $clientResponse->getContent());
         $this->assertEquals('{"errors":[{"code":400,"message":"remotePath: The remote should be a valid URL.","details":{"remotePath":["The remote should be a valid URL."]}}]}', $clientResponse->getContent());
     }
 
@@ -49,7 +49,7 @@ class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
         $this->client->request('POST', 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(201, $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
         $this->assertEquals($payload['title'], $response['asset']['title']);
         $this->assertEquals($payload['storageLocation'], $response['asset']['storageLocation']);

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -4,7 +4,6 @@ namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\AssetBundle\Tests\Asset\AbstractAssetTest;
-use Symfony\Component\HttpFoundation\Response;
 
 class PublicControllerFunctionalTest extends AbstractAssetTest
 {

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -22,7 +22,7 @@ class PublicControllerFunctionalTest extends AbstractAssetTest
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->expectedMimeType, $response->headers->get('Content-Type'));
         $this->assertNotSame($this->expectedContentDisposition.$this->asset->getOriginalFileName(), $response->headers->get('Content-Disposition'));
         $this->assertEquals($this->expectedPngContent, $content);
@@ -42,7 +42,7 @@ class PublicControllerFunctionalTest extends AbstractAssetTest
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->expectedContentDisposition.$this->asset->getOriginalFileName(), $response->headers->get('Content-Disposition'));
         $this->assertEquals($this->expectedPngContent, $content);
     }
@@ -61,7 +61,7 @@ class PublicControllerFunctionalTest extends AbstractAssetTest
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->expectedMimeType, $response->headers->get('Content-Type'));
         $this->assertNotSame($this->expectedContentDisposition.$this->asset->getOriginalFileName(), $response->headers->get('Content-Disposition'));
         $this->assertEquals($this->expectedPngContent, $content);

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -149,7 +149,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             /**
              * @param array<int|string> $parameters
              */
-            public function trans($id, array $parameters = [], string $domain = null, string $locale = null): string
+            public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
             {
                 return '[trans]'.$id.'[/trans]';
             }

--- a/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
+++ b/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CampaignDeleteEventLogsCommand extends Command
 {
+    protected static $defaultDescription = 'Delete campaign event logs';
     /**
      * @var string
      */
@@ -28,7 +29,6 @@ class CampaignDeleteEventLogsCommand extends Command
     protected function configure(): void
     {
         $this->setName(self::COMMAND_NAME)
-            ->setDescription('Delete campaign event logs')
             ->addArgument(
                 'campaign_event_ids',
                 InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
@@ -57,6 +57,6 @@ class CampaignDeleteEventLogsCommand extends Command
             $this->eventModel->deleteEventsByEventIds($eventIds);
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 }

--- a/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
+++ b/app/bundles/CampaignBundle/Command/CampaignDeleteEventLogsCommand.php
@@ -57,6 +57,6 @@ class CampaignDeleteEventLogsCommand extends Command
             $this->eventModel->deleteEventsByEventIds($eventIds);
         }
 
-        return \Symfony\Component\Console\Command\Command::SUCCESS;
+        return Command::SUCCESS;
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
@@ -36,7 +36,7 @@ class AbstractCampaignCommand extends MauticMysqlTestCase
     protected $prefix;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $eventDate;
 

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -195,7 +195,7 @@ class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, 'api/campaigns/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(201, $clientResponse->getContent());
         $response   = json_decode($clientResponse->getContent(), true);
         $campaignId = $response['campaign']['id'];
         Assert::assertGreaterThan(0, $campaignId);
@@ -251,7 +251,7 @@ class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         // Search for this campaign:
         $this->client->request(Request::METHOD_GET, "/api/campaigns?search=ids:{$response['campaign']['id']}");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
         Assert::assertEquals($payload['name'], $response['campaigns'][$campaignId]['name'], $clientResponse->getContent());
         Assert::assertEquals($payload['description'], $response['campaigns'][$campaignId]['description'], $clientResponse->getContent());

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
@@ -3,7 +3,6 @@
 namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
 class CampaignControllerTest extends MauticMysqlTestCase

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
@@ -15,7 +15,7 @@ class CampaignControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', '/s/campaigns');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 
     /**
@@ -25,7 +25,7 @@ class CampaignControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', '/s/campaigns?search=has%3Aresults&tmpl=list');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 
     /**
@@ -48,11 +48,11 @@ class CampaignControllerTest extends MauticMysqlTestCase
     {
         $crawler                = $this->client->request('GET', '/s/campaigns/new/');
         $clientResponse         = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $form = $crawler->filter('form[name="campaign"]')->selectButton('campaign_buttons_cancel')->form();
         $this->client->submit($form);
         $clientResponse         = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
@@ -31,7 +31,7 @@ class SourceControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/s/campaigns/sources/new/random_object_id?sourceType=forms', [], [], $this->createAjaxHeaders());
         $clientResponse  = $this->client->getResponse();
         $responseContent = $clientResponse->getContent();
-        $this->assertSame(200, $clientResponse->getStatusCode(), $responseContent);
+        $this->assertResponseIsSuccessful($responseContent);
 
         $html = json_decode($responseContent, true)['newContent'];
         $this->assertStringContainsString("<option value=\"{$form1->getId()}\">test ({$form1->getId()})</option>", $html);

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -87,7 +87,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             /**
              * @param mixed[] $parameters
              */
-            public function trans($id, array $parameters = [], $domain = null, $locale = null)
+            public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null)
             {
                 Assert::assertSame('mautic.campaign.campaign.jump_to_event.target_not_exist', $id);
 

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -87,7 +87,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             /**
              * @param mixed[] $parameters
              */
-            public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null)
+            public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null)
             {
                 Assert::assertSame('mautic.campaign.campaign.jump_to_event.target_not_exist', $id);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -45,7 +45,7 @@ class DetailsTest extends MauticMysqlTestCase
         $this->client->request('GET', sprintf('/s/campaigns/view/%s', $campaign->getId()));
 
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString($campaign->getName(), $response->getContent());
         Assert::assertStringContainsString(sprintf('data-target-url="/s/campaigns/view/%s/contact/1"', $campaign->getId()), $response->getContent());
     }

--- a/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
@@ -203,7 +203,7 @@ final class InfiniteLoopValidatorFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request('POST', '/api/campaigns/new', $payload);
         $response = $this->client->getResponse();
-        Assert::assertSame($expectedStatusCode, $response->getStatusCode(), $response->getContent());
+        self::assertResponseStatusCodeSame($expectedStatusCode, $response->getContent());
 
         if ($expectedString) {
             Assert::assertStringContainsString($expectedString, $response->getContent());

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -31,7 +31,7 @@ JSON;
 
         $this->client->request('POST', '/api/messages/new', $payloadArray);
         $responseJson = $this->client->getResponse()->getContent();
-        Assert::assertSame(201, $this->client->getResponse()->getStatusCode(), $responseJson);
+        self::assertResponseStatusCodeSame(201, $responseJson);
         $this->assertMessagePayload($payloadArray, json_decode($responseJson, true)['message'], $responseJson);
     }
 
@@ -61,7 +61,7 @@ JSON;
         $patchPayload = ['id' => $message->getId()] + $payload;
         $this->client->request('PATCH', "/api/messages/{$message->getId()}/edit", $patchPayload);
         $responseJson = $this->client->getResponse()->getContent();
-        Assert::assertSame(200, $this->client->getResponse()->getStatusCode(), $responseJson);
+        self::assertResponseIsSuccessful($responseJson);
         $this->assertMessagePayload(
             ['id' => $message->getId()] + $expectedResponsePayload,
             json_decode($responseJson, true)['message'],
@@ -154,7 +154,7 @@ JSON;
         ];
         $this->client->request('PATCH', '/api/messages/batch/edit', $patchPayload);
         $responseJson = $this->client->getResponse()->getContent();
-        Assert::assertSame(200, $this->client->getResponse()->getStatusCode(), $responseJson);
+        self::assertResponseIsSuccessful($responseJson);
         $responseArray = json_decode($responseJson, true);
         $this->assertMessagePayload(
             [

--- a/app/bundles/CoreBundle/Command/AnonymizeIpCommand.php
+++ b/app/bundles/CoreBundle/Command/AnonymizeIpCommand.php
@@ -43,7 +43,7 @@ class AnonymizeIpCommand extends Command
             return $this->exitWithError(sprintf('Anonymization of IP addresses failed because of database error: %s', $e->getMessage()), $output);
         }
 
-        return \Symfony\Component\Console\Command\Command::SUCCESS;
+        return Command::SUCCESS;
     }
 
     private function exitWithError(string $message, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/AnonymizeIpCommand.php
+++ b/app/bundles/CoreBundle/Command/AnonymizeIpCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AnonymizeIpCommand extends Command
 {
+    protected static $defaultDescription = 'Delete all stored ip addresses.';
     /**
      * @var string
      */
@@ -26,8 +27,7 @@ class AnonymizeIpCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName(self::COMMAND_NAME)
-            ->setDescription('Delete all stored ip addresses.');
+        $this->setName(self::COMMAND_NAME);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -43,7 +43,7 @@ class AnonymizeIpCommand extends Command
             return $this->exitWithError(sprintf('Anonymization of IP addresses failed because of database error: %s', $e->getMessage()), $output);
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     private function exitWithError(string $message, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -38,7 +38,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         $this->client->request('GET', 's/ajax?action=core:updateRunChecks');
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
         Assert::assertStringContainsString('Great! You are running the current version of Mautic.', $response->getContent());
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
@@ -7,7 +7,6 @@ namespace Mautic\CoreBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\HttpFoundation\Response;
 
 class FileControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
@@ -18,7 +18,7 @@ class FileControllerTest extends MauticMysqlTestCase
         $image = $this->createUploadFile('png-test.png', 'tmp-png-test.png');
         $this->client->request('POST', 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
         Assert::assertEquals(true, $responseData['uploaded']);
         Assert::arrayHasKey('url');
@@ -34,7 +34,7 @@ class FileControllerTest extends MauticMysqlTestCase
 
         $this->client->request('POST', 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
         Assert::assertEquals(false, $responseData['uploaded']);
         Assert::assertEquals('The uploaded image does not have an allowed mime type', $responseData['error']['message']);

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -6,7 +6,6 @@ namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This test is breaking other tests, so running it in a separate process.

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -28,7 +28,7 @@ final class JsControllerTest extends MauticMysqlTestCase
     public function testIndexActionRendersSuccessfully(): void
     {
         $this->client->request('GET', '/mtc.js');
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', $this->client->getResponse()->getContent());
         Assert::assertStringContainsString('gtag(\'config\',\'G-F3825DS9CD\')', $this->client->getResponse()->getContent());
     }
@@ -36,7 +36,7 @@ final class JsControllerTest extends MauticMysqlTestCase
     public function testIndexActionRendersSuccessfullyWithAnonymizeIp(): void
     {
         $this->client->request('GET', '/mtc.js');
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', $this->client->getResponse()->getContent());
         Assert::assertStringContainsString('gtag(\'config\',\'G-F3825DS9CD\',{"anonymize_ip":!0})', $this->client->getResponse()->getContent());
     }

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/UpdateControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/UpdateControllerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Symfony\Component\HttpFoundation\Response;
 
 final class UpdateControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/UpdateControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/UpdateControllerTest.php
@@ -13,13 +13,13 @@ final class UpdateControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', 's/update');
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testSchemaActionRendersSuccessfully(): void
     {
         $this->client->request('GET', 's/update/schema');
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Command/src/FakeModeratedCommand.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/src/FakeModeratedCommand.php
@@ -15,11 +15,11 @@ class FakeModeratedCommand extends ModeratedCommand
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->checkRunStatus($input, $output);
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     public function forceCompleteRun(): void

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
@@ -44,7 +44,7 @@ class RequestSubscriberTest extends \PHPUnit\Framework\TestCase
             ->setConstructorArgs([
                 $this->createMock(HttpKernelInterface::class),
                 $this->request,
-                HttpKernelInterface::MASTER_REQUEST,
+                HttpKernelInterface::MAIN_REQUEST,
             ])
             ->getMock();
 

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -41,7 +41,7 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $content = $response->getContent();
         Assert::assertJson($content);
@@ -85,7 +85,7 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $content = $response->getContent();
         Assert::assertJson($content);

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
@@ -28,7 +28,7 @@ class DynamicContentApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, '/dwc/slot-a');
 
-        Assert::assertSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT, $this->client->getResponse()->getContent());
     }
 
     public function testDwcGetEndpointForASlotAndContact(): void
@@ -63,7 +63,7 @@ class DynamicContentApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/dwc/slot-a?ct={$ct}");
 
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
 
         $responseArray = json_decode($this->client->getResponse()->getContent(), true);
         Assert::assertSame('<some>content</some>', $responseArray['content']);
@@ -77,6 +77,6 @@ class DynamicContentApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(Request::METHOD_POST, '/api/dynamiccontents/new', $payload);
-        Assert::assertSame(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED, $this->client->getResponse()->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -984,12 +984,10 @@ class EmailController extends FormController
                         $returnUrl = $this->generateUrl('mautic_email_action', $viewParameters);
                         $template  = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
                     } else {
-                        return $this->redirect($this->generateUrl('mautic_email_action',
-                            [
-                                'objectAction' => 'edit',
-                                'objectId'     => $entity->getId(),
-                            ]
-                        ));
+                        return $this->redirectToRoute('mautic_email_action', [
+                            'objectAction' => 'edit',
+                            'objectId'     => $entity->getId(),
+                        ]);
                     }
                 }
             } else {

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -50,7 +50,7 @@ class Stat
     private $ipAddress;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     private $dateSent;
 
@@ -70,7 +70,7 @@ class Stat
     private $viewedInBrowser = false;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     private $dateRead;
 
@@ -110,7 +110,7 @@ class Stat
     private $openCount = 0;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     private $lastOpened;
 

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -261,7 +261,7 @@ class Stat
     }
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getDateRead()
     {
@@ -279,7 +279,7 @@ class Stat
     }
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getDateSent()
     {
@@ -580,7 +580,7 @@ class Stat
     }
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getLastOpened()
     {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -47,7 +47,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/s/emails');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200');
+        $this->assertResponseIsSuccessful('Return code must be 200');
         $this->assertStringContainsString('February 7, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('March 21, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('Test User', $clientResponse->getContent());
@@ -68,7 +68,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', '/s/emails?search=has%3Aresults&tmpl=list');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -83,7 +83,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $response = $this->client->getResponse()->getContent();
-        self::assertSame(201, $this->client->getResponse()->getStatusCode(), $response);
+        self::assertResponseStatusCodeSame(201, $response);
         self::assertJson($response);
 
         // Create email with dynamic content variant
@@ -154,7 +154,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $response = $this->client->getResponse()->getContent();
-        self::assertSame(201, $this->client->getResponse()->getStatusCode(), $response);
+        self::assertResponseStatusCodeSame(201, $response);
         self::assertJson($response);
 
         // Create email with dynamic content variant
@@ -209,11 +209,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
                 ],
             ]
         );
-        self::assertSame(
-            201,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(201, $this->client->getResponse()->getContent());
         $contacts = json_decode($this->client->getResponse()->getContent(), true);
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
@@ -249,7 +245,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $response = $this->client->getResponse()->getContent();
-        self::assertSame(201, $this->client->getResponse()->getStatusCode(), $response);
+        self::assertResponseStatusCodeSame(201, $response);
         self::assertJson($response);
 
         // Create email with dynamic content variant
@@ -304,11 +300,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
                 ],
             ]
         );
-        self::assertSame(
-            201,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(201, $this->client->getResponse()->getContent());
         $contacts = json_decode($this->client->getResponse()->getContent(), true);
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -12,7 +12,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 final class EmailSendFunctionalTest extends MauticMysqlTestCase
 {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -41,7 +41,7 @@ final class EmailSendFunctionalTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
         Assert::assertSame(
             '{"success":1,"percent":100,"progress":[2,2],"stats":{"sent":2,"failed":0,"failedRecipients":[]}}',
             $response->getContent()

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -43,7 +43,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
     private function assertPageContent(string $url, string ...$expectedContents): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
         foreach ($expectedContents as $expectedContent) {
             self::assertStringContainsString($expectedContent, $crawler->text());
         }
@@ -141,7 +141,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
                 ],
             ]
         );
-        self::assertSame(201, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(201);
         self::assertJson($this->client->getResponse()->getContent());
 
         // Create some contacts
@@ -169,11 +169,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
                 ],
             ]
         );
-        self::assertSame(
-            201,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(201, $this->client->getResponse()->getContent());
         $contacts = json_decode($this->client->getResponse()->getContent(), true);
 
         // Create email with dynamic content variant
@@ -244,7 +240,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
     public function testPreviewEmailWithInvalidIdThrows404Error(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/email/preview/5009');
-        self::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         self::assertStringContainsString('404 Not Found - Requested URL not found: /email/preview/5009', $crawler->text());
     }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class BuilderSubscriberFunctionalTest extends MauticMysqlTestCase
 {

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
@@ -127,7 +127,7 @@ class BuilderSubscriberFunctionalTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
         Assert::assertSame(
             '{"success":1,"percent":100,"progress":['.$pending.','.$pending.'],"stats":{"sent":'.$pending.',"failed":0,"failedRecipients":[]}}',
             $response->getContent()

--- a/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
@@ -43,6 +43,7 @@ final class EmailStatModelTest extends TestCase
 
             public function __construct()
             {
+                parent::__construct();
             }
 
             public function dispatch(object $event, string $eventName = null): object

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -57,7 +57,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             /**
              * @param mixed[] $parameters
              */
-            public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null): string
+            public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null): string
             {
                 return $id;
             }

--- a/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -22,7 +22,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $payload        = json_decode($clientResponse->getContent(), true);
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         // Assert some random fields exist.
         Assert::assertSame(

--- a/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -7,7 +7,6 @@ namespace Mautic\FormBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -101,7 +101,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         if (!empty($response['errors'][0])) {
             $this->fail($response['errors'][0]['code'].': '.$response['errors'][0]['message']);
         }
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, 'Return code must be 201.');
 
         $formId = $response['form']['id'];
         $this->assertGreaterThan(0, $formId);
@@ -124,7 +124,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/forms/{$formId}/edit", ['name' => $expectedResponse['newName']]);
         $clientResponse = $this->client->getResponse();
         $responsePatch  = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($formId, $responsePatch['form']['id'], 'ID of the created form does not match with the edited one.');
         $this->assertEquals($expectedResponse['newName'], $responsePatch['form']['name']);
         $this->assertEquals($payload['formType'], $responsePatch['form']['formType']);
@@ -275,7 +275,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $formId = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
         $this->assertGreaterThan(0, $formId);
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
@@ -347,7 +347,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $fieldCount     = $fieldCount + 1;
 
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $this->assertSame($formId, $response['form']['id']);
         $this->assertEquals('API form renamed', $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
@@ -362,7 +362,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_PUT, "/api/forms/{$formId}/edit", $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $this->assertSame($formId, $response['form']['id']);
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals('Form created via API test renamed', $response['form']['description']);
@@ -375,7 +375,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $this->assertSame($formId, $response['form']['id']);
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
@@ -443,7 +443,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $this->assertNull($response['form']['id']);
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
@@ -456,7 +456,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(Response::HTTP_NOT_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND, $clientResponse->getContent());
         $this->assertSame(Response::HTTP_NOT_FOUND, $response['errors'][0]['code']);
     }
 
@@ -512,7 +512,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         if (!empty($response['errors'][0])) {
             $this->fail($response['errors'][0]['code'].': '.$response['errors'][0]['message']);
         }
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, 'Return code must be 201.');
 
         $formId = $response['form']['id'];
         $this->assertGreaterThan(0, $formId);
@@ -565,7 +565,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $lastValidFormId = $response['form']['id'];
         $this->assertGreaterThan(0, $lastValidFormId);
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, 'Return code must be 201.');
 
         // Get the last correctly saved form
         $this->client->request(Request::METHOD_GET, '/api/forms/'.$lastValidFormId);
@@ -606,7 +606,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertNotEmpty($response['errors'], 'No errors were returned when trying to save an invalid form');
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response['errors'][0]['code'], 'Return code must be 400.');
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode(), 'Return code must be 400.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST, 'Return code must be 400.');
         $this->assertSame($expectedMessage, $response['errors'][0]['message'], 'Returned message is different than expected');
     }
 
@@ -638,6 +638,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertNotEmpty($responseContent->errors, 'No errors were returned when trying to save an invalid form');
         $this->assertSame('Form Field ID 123 not found', $responseContent->errors[0]->message);
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode(), 'Return code must be 404.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND, 'Return code must be 404.');
     }
 }

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -26,7 +26,7 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $payload        = json_decode($clientResponse->getContent(), true);
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('<option value="email" selected="selected">', $payload['newContent']);
     }
 
@@ -57,7 +57,7 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/forms/field/new?type=captcha&tmpl=field&formId={$formId}&inBuilder=1", [], [], $this->createAjaxHeaders());
         $content     = $this->client->getResponse()->getContent();

--- a/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -19,7 +19,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->makeRequest(['string' => 'Company']);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST, $clientResponse->getContent());
         Assert::assertSame('{"error":"Invalid request param"}', $clientResponse->getContent(), $clientResponse->getContent());
     }
 
@@ -28,7 +28,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->makeRequest(['string' => 'Company', 'formId' => 3]);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST, $clientResponse->getContent());
         Assert::assertSame('{"error":"Invalid request param"}', $clientResponse->getContent(), $clientResponse->getContent());
     }
 
@@ -39,7 +39,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->makeRequest(['string' => 'Co', 'formId' => $form->getId()]);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST, $clientResponse->getContent());
         Assert::assertSame('{"error":"Invalid request param"}', $clientResponse->getContent(), $clientResponse->getContent());
     }
 

--- a/app/bundles/IntegrationsBundle/Command/CleanupCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/CleanupCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CleanupCommand extends Command
 {
+    protected static $defaultDescription = 'Delete records from field changes which are invalid';
     public const NAME = 'mautic:integrations:cleanup';
 
     public function __construct(private FieldChangeRepository $fieldChangeRepository)
@@ -21,13 +22,12 @@ class CleanupCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName(self::NAME)
-            ->setDescription('Delete records from field changes which are invalid');
+        $this->setName(self::NAME);
 
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/app/bundles/IntegrationsBundle/Command/CleanupCommand.php
+++ b/app/bundles/IntegrationsBundle/Command/CleanupCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class CleanupCommand extends Command
 {
     protected static $defaultDescription = 'Delete records from field changes which are invalid';
-    public const NAME = 'mautic:integrations:cleanup';
+    public const NAME                    = 'mautic:integrations:cleanup';
 
     public function __construct(private FieldChangeRepository $fieldChangeRepository)
     {

--- a/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
@@ -17,6 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class AnalyseCustomFieldCommand extends Command
 {
     protected static $defaultDescription = 'Analyse actual usage of custom columns in leads table.';
+
     public function __construct(private FieldModel $fieldModel, private LeadModel $leadModel, private TranslatorInterface $translator)
     {
         parent::__construct();
@@ -48,7 +49,7 @@ class AnalyseCustomFieldCommand extends Command
         if (empty($fieldDetails)) {
             $output->writeln('No custom field(s) to analyse!!!');
 
-            return \Symfony\Component\Console\Command\Command::SUCCESS;
+            return Command::SUCCESS;
         }
 
         $results = $this->leadModel->getCustomLeadFieldLength(array_keys($fieldDetails));
@@ -98,7 +99,7 @@ class AnalyseCustomFieldCommand extends Command
             }
         }
 
-        return \Symfony\Component\Console\Command\Command::SUCCESS;
+        return Command::SUCCESS;
     }
 
     /**

--- a/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
@@ -16,6 +16,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AnalyseCustomFieldCommand extends Command
 {
+    protected static $defaultDescription = 'Analyse actual usage of custom columns in leads table.';
     public function __construct(private FieldModel $fieldModel, private LeadModel $leadModel, private TranslatorInterface $translator)
     {
         parent::__construct();
@@ -28,7 +29,6 @@ class AnalyseCustomFieldCommand extends Command
     {
         $this
             ->setName('mautic:fields:analyse')
-            ->setDescription('Analyse actual usage of custom columns in leads table.')
             ->addOption(
                 'display-table',
                 't',
@@ -48,7 +48,7 @@ class AnalyseCustomFieldCommand extends Command
         if (empty($fieldDetails)) {
             $output->writeln('No custom field(s) to analyse!!!');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $results = $this->leadModel->getCustomLeadFieldLength(array_keys($fieldDetails));
@@ -98,7 +98,7 @@ class AnalyseCustomFieldCommand extends Command
             }
         }
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**

--- a/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
@@ -19,6 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class UpdateCustomFieldCommand extends Command
 {
     protected static $defaultDescription = 'Create custom field column in the background';
+
     public function __construct(private BackgroundService $backgroundService, private TranslatorInterface $translator)
     {
         parent::__construct();

--- a/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
@@ -18,6 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UpdateCustomFieldCommand extends Command
 {
+    protected static $defaultDescription = 'Create custom field column in the background';
     public function __construct(private BackgroundService $backgroundService, private TranslatorInterface $translator)
     {
         parent::__construct();
@@ -28,7 +29,6 @@ class UpdateCustomFieldCommand extends Command
         parent::configure();
 
         $this->setName('mautic:custom-field:update-column')
-            ->setDescription('Create custom field column in the background')
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
             ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
             ->setHelp(

--- a/app/bundles/LeadBundle/Form/Type/HtmlType.php
+++ b/app/bundles/LeadBundle/Form/Type/HtmlType.php
@@ -11,9 +11,4 @@ class HtmlType extends AbstractType
     {
         return TextareaType::class;
     }
-
-    public function getName(): string
-    {
-        return 'html';
-    }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
@@ -28,6 +28,6 @@ class DeviceApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -45,7 +45,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $fieldResponse  = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
         Assert::assertTrue($fieldResponse['field']['isPublished']);
         Assert::assertGreaterThan(0, $fieldResponse['field']['id']);
         Assert::assertSame($payload['label'], $fieldResponse['field']['label']);
@@ -58,7 +58,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         // Cleanup
         $this->client->request(Request::METHOD_DELETE, '/api/fields/contact/'.$fieldResponse['field']['id'].'/delete', $payload);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful($clientResponse->getContent());
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -105,7 +105,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -204,7 +204,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -303,7 +303,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful($clientResponse->getContent());
 
         $response= json_decode($clientResponse->getContent(), true);
 
@@ -321,7 +321,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful($clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -349,7 +349,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, $clientResponse->getContent());
 
         $response  = json_decode($clientResponse->getContent(), true);
         $contactId = $response['contact']['id'];
@@ -555,7 +555,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Remove contact
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testBatchNewEndpointCreateAndUpdate(): void
@@ -839,7 +839,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Remove contact
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testAddAndRemoveDncToExistingContact(): void
@@ -861,7 +861,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, "/api/contacts/$contactId/dnc/$dncChannel/add", $dncPayload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         // Leave the DNC payload empty to ensure it takes default values for channel and reason.
         $dncPayload = [];
@@ -878,7 +878,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Check DNC is recorded in the contact activity.
         $this->client->request('GET', "/api/contacts/{$contactId}/activity");
         $clientResponse = $this->client->getResponse();
-        self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful($clientResponse->getContent());
         $activityResponse = json_decode($clientResponse->getContent(), true);
         Assert::assertCount(2, $activityResponse['events']); // identified and dnc added events
         $dncEvents = array_values(array_filter($activityResponse['events'], fn ($event) => 'lead.donotcontact' === $event['event']));
@@ -889,7 +889,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Remove DNC from the contact.
         $this->client->request(Request::METHOD_POST, "/api/contacts/$contactId/dnc/$dncChannel/remove");
         $clientResponse    = $this->client->getResponse();
-        self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         $dncRemoveResponse = json_decode($clientResponse->getContent(), true);
 
         $this->assertArrayHasKey('contact', $dncRemoveResponse, $clientResponse->getContent());
@@ -898,7 +898,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Remove the contact.
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testGetAllActivityDownload(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -17,7 +17,7 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $tagId          = $response['tag']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), 'Return code must be 201.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, 'Return code must be 201.');
         $this->assertGreaterThan(0, $tagId);
         $this->assertEquals($tag1Payload['tag'], $response['tag']['tag']);
 
@@ -25,7 +25,7 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
         // The same tag id should be returned
         $this->assertEquals($tagId, $response['tag']['id'], 'ID of created tag with the same name does not match. Possible duplicates.');
         $this->assertEquals($tag1Payload['tag'], $response['tag']['tag']);
@@ -35,7 +35,7 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/tags/{$tagId}/edit", $tag1RenamePayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
         $this->assertSame($tagId, $response['tag']['id'], 'ID of the created tag does not match with the edited one.');
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
@@ -43,21 +43,21 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('GET', "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($tagId, $response['tag']['id'], 'ID of the created tag does not match with the fetched one.');
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
         // Delete:
         $this->client->request('DELETE', "/api/tags/{$tagId}/delete");
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
 
         // Get (ensure it's deleted):
         $this->client->request('GET', "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(404, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(404);
         $this->assertSame(404, $response['errors'][0]['code']);
     }
 
@@ -112,6 +112,6 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/tags/new', []);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(500, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(500);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -9,7 +9,6 @@ use Mautic\CoreBundle\Tests\Traits\ControllerTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
-use Symfony\Component\HttpFoundation\Response;
 
 class ListControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -51,7 +51,7 @@ class ListControllerTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/s/segments');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
         $this->assertStringContainsString('February 7, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('March 21, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('Test User', $clientResponse->getContent());
@@ -64,7 +64,7 @@ class ListControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', '/s/segments?search=has%3Aresults&tmpl=list');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 
     public function testSegmentView(): void
@@ -73,7 +73,7 @@ class ListControllerTest extends MauticMysqlTestCase
         $segment  = $this->addContactsToSegment($contacts, 'MySeg');
         $this->client->request('GET', sprintf('/s/segments/view/%d', $segment->getId()));
         $response = $this->client->getResponse();
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         self::assertStringContainsString('MySeg', $response->getContent());
         // Make sure that contact grid is not loaded synchronously
         self::assertStringNotContainsString('Kane', $response->getContent());
@@ -89,7 +89,7 @@ class ListControllerTest extends MauticMysqlTestCase
         $segment  = $this->addContactsToSegment($contacts, 'MySeg');
         $this->client->request('GET', sprintf('/s/segment/view/%d/contact/%d', $segment->getId(), $pageId));
         $response = $this->client->getResponse();
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         self::assertStringContainsString('Kane', $response->getContent());
         self::assertStringContainsString('Jacques', $response->getContent());
     }
@@ -189,7 +189,7 @@ class ListControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', sprintf('/s/segments/clone/%d', $list->getId()));
 
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful('Return code must be 200.');
         self::assertStringContainsString('Segment clone', $clientResponse->getContent());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Form/Type/FilterTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/FilterTypeTest.php
@@ -206,7 +206,7 @@ final class FilterTypeTest extends \PHPUnit\Framework\TestCase
                                  * @param FormInterface<FormInterface<mixed>>|string $child
                                  * @param mixed[]                                    $options
                                  */
-                                public function add($child, $type = null, array $options = [])
+                                public function add($child, string $type = null, array $options = [])
                                 {
                                     ++$this->addMethodCallCounter;
 

--- a/app/bundles/LeadBundle/Tests/Form/Type/HtmlTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/HtmlTypeTest.php
@@ -24,6 +24,6 @@ final class HtmlTypeTest extends TestCase
 
     public function testGetName(): void
     {
-        $this->assertSame('html', $this->htmlType->getName());
+        $this->assertSame('html', $this->htmlType->getBlockPrefix());
     }
 }

--- a/rector-older-symfony.php
+++ b/rector-older-symfony.php
@@ -19,7 +19,7 @@ return static function (Rector\Config\RectorConfig $rectorConfig): void {
         ],
     ]);
 
-    $rectorConfig->symfonyContainerXml(__DIR__.'/var/cache/test/appAppKernelDevDebugContainer.xml');
+    $rectorConfig->symfonyContainerXml(__DIR__.'/var/cache/dev/appAppKernelDevDebugContainer.xml');
 
     $rectorConfig->sets([
         // helps with rebase of PRs for Symfony 3 and 4, @see https://github.com/mautic/mautic/pull/12676#issuecomment-1695531274


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 PHPSTAN
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

While working on https://github.com/mautic/mautic/pull/13962 I wanted to run Rector with rules for Symfony 6. We still have a [config for that](https://github.com/mautic/mautic/blob/5.x/rector-older-symfony.php) where I could just increase the Symfony version. However, the command

`bin/rector --config=rector-older-symfony.php`

returned a lot of changes also for Symfony 5.4. This PR is adding those changes now so the Symfony 6 PR would get smaller ~~and the current Mautic 5 code neater~~ (too late, M5 is in the bug fix release only).

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
Most of the changes were done in the test files. I've added all the changes to the production files into [this commit](https://github.com/mautic/mautic/commit/20083f6963706862001380780bd12f1102897437). From those changes we can for example test:
1. Clone an email and click on Save&Close button.
2. The command changes are really straight forward. Run `bin/console mautic:fields:analyse` just to test one.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->