### PR TITLE
13730: Fixing "Error when creating a user without password"

### DIFF
--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -236,7 +236,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(
             [
                 'message' => 'mautic.user.user.password.notblank',
-                'groups'  => ['CheckPassword'],
+                'groups'  => ['CheckPasswordNotBlank'],
             ]
         ));
 
@@ -262,10 +262,15 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     {
         $data   = $form->getData();
         $groups = ['User', 'SecondPass'];
+        if ($data instanceof User) {
+            $isNewUser        = !$data->getId();
+            $hasPlainPassword = !empty($data->getPlainPassword());
 
-        // check if creating a new user or editing an existing user and the password has been updated
-        if ($data instanceof User && (!$data->getId() || ($data->getId() && $data->getPlainPassword()))) {
-            $groups[] = 'CheckPassword';
+            if ($isNewUser) {
+                $groups[] = $hasPlainPassword ? 'CheckPassword' : 'CheckPasswordNotBlank';
+            } elseif ($hasPlainPassword) {
+                $groups[] = 'CheckPassword';
+            }
         }
 
         return $groups;

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -59,9 +59,9 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
     /**
      * @param array<string, string> $data
      *
-     * @dataProvider dataForUserCreation
+     * @dataProvider dataNewUserForPasswordField
      */
-    public function testNewUserCreation(array $data, string $message): void
+    public function testNewUserForPasswordField(array $data, string $message): void
     {
         $crawler = $this->client->request('GET', '/s/users/new');
 
@@ -82,7 +82,7 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
     /**
      * @return iterable<string, array<int, string|array<string, string>>>
      */
-    public function dataForUserCreation(): iterable
+    public function dataNewUserForPasswordField(): iterable
     {
         yield 'Blank' => [
             [
@@ -92,6 +92,52 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
             'Password cannot be blank.',
         ];
 
+        yield 'Do not match with confirm' => [
+            [
+                'user[plainPassword][password]' => 'same',
+            ],
+            'Passwords do not match.',
+        ];
+
+        yield 'Minimum length' => [
+            [
+                'user[plainPassword][password]' => 'same',
+                'user[plainPassword][confirm]'  => 'same',
+            ],
+            'Password must be at least 6 characters.',
+        ];
+
+        yield 'No stronger' => [
+            [
+                'user[plainPassword][password]' => 'same123',
+                'user[plainPassword][confirm]'  => 'same123',
+            ],
+            'Please enter a stronger password. Your password must use a combination of upper and lower case, special characters and numbers.',
+        ];
+    }
+
+    /**
+     * @param array<string, string> $data
+     *
+     * @dataProvider dataForEditUserForPasswordField
+     */
+    public function testEditUserForPasswordField(array $data, string $message): void
+    {
+        $crawler = $this->client->request('GET', '/s/users/edit/1');
+
+        $form = $crawler->selectButton('Save')->form($data);
+
+        $this->client->submit($form);
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString($message, $this->client->getResponse()->getContent());
+    }
+
+    /**
+     * @return iterable<string, array<int, string|array<string, string>>>
+     */
+    public function dataForEditUserForPasswordField(): iterable
+    {
         yield 'Do not match with confirm' => [
             [
                 'user[plainPassword][password]' => 'same',

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -57,6 +57,66 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
+     * @param array<string, string> $data
+     *
+     * @dataProvider dataForUserCreation
+     */
+    public function testNewUserCreation(array $data, string $message): void
+    {
+        $crawler = $this->client->request('GET', '/s/users/new');
+
+        $formData = [
+            'user[firstName]' => 'John',
+            'user[lastName]'  => 'Doe',
+            'user[email]'     => 'john.doe@example.com',
+        ];
+
+        $form = $crawler->selectButton('Save')->form($formData + $data);
+
+        $this->client->submit($form);
+
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString($message, $this->client->getResponse()->getContent());
+    }
+
+    /**
+     * @return iterable<string, array<int, string|array<string, string>>>
+     */
+    public function dataForUserCreation(): iterable
+    {
+        yield 'Blank' => [
+            [
+                'user[plainPassword][password]' => '',
+                'user[plainPassword][confirm]'  => '',
+            ],
+            'Password cannot be blank.',
+        ];
+
+        yield 'Do not match with confirm' => [
+            [
+                'user[plainPassword][password]' => 'same',
+            ],
+            'Passwords do not match.',
+        ];
+
+        yield 'Minimum length' => [
+            [
+                'user[plainPassword][password]' => 'same',
+                'user[plainPassword][confirm]'  => 'same',
+            ],
+            'Password must be at least 6 characters.',
+        ];
+
+        yield 'No stronger' => [
+            [
+                'user[plainPassword][password]' => 'same123',
+                'user[plainPassword][confirm]'  => 'same123',
+            ],
+            'Please enter a stronger password. Your password must use a combination of upper and lower case, special characters and numbers.',
+        ];
+    }
+
+    /**
      * @param array<mixed> $details
      */
     public function auditLogSetter(


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13730 


## Description



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Users
3. Create new
4. Fill in First name, Last name, Username, and Email, letting password fields blank
5. Click on Save or Save & Close
6. See the validations
