### PR TITLE
Twig library update

### DIFF
--- a/app/bundles/CoreBundle/Tests/Twig/Fixtures/tests/instanceof.test
+++ b/app/bundles/CoreBundle/Tests/Twig/Fixtures/tests/instanceof.test
@@ -1,13 +1,13 @@
 --TEST--
 instanceof test
 --TEMPLATE--
-{% if date is instanceof('\\DateTimeInterface') %}
+{% if date is instanceof('DateTimeInterface') %}
 Date is instance of DateTimeInterface
 {% endif %}
-{% if date is instanceof('\\DateTimeImmutable') %}
+{% if date is instanceof('DateTimeImmutable') %}
 Date is instance of DateTimeImmutable
 {% endif %}
-{% if date is not instanceof('\DateTimeImmutable') %}
+{% if date is not instanceof('DateTimeImmutable') %}
 Date is not instance of DateTimeImmutable
 {% endif %}
 --DATA--

--- a/composer.lock
+++ b/composer.lock
@@ -14417,30 +14417,37 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.8.0",
+            "version": "v3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
+                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
-                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
+                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php80": "^1.22"
+                "symfony/polyfill-php81": "^1.29"
             },
             "require-dev": {
                 "psr/container": "^1.0|^2.0",
-                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -14473,7 +14480,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.14.0"
             },
             "funding": [
                 {
@@ -14485,7 +14492,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-21T18:54:41+00:00"
+            "time": "2024-09-09T17:55:12+00:00"
         },
         {
             "name": "twilio/sdk",

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 use Twig\Environment;
+use Twig\Runtime\EscaperRuntime;
 
 /**
  * @extends FormModel<Focus>
@@ -180,7 +181,7 @@ class FocusModel extends FormModel
             $focusContent .= $cached['form'];
         }
 
-        $focusContent = twig_escape_filter($this->twig, $focusContent, 'js');
+        $focusContent = $this->twig->getRuntime(EscaperRuntime::class)->escape($focusContent, 'js');
 
         return str_replace('{focus_content}', $focusContent, $cached['js']);
     }


### PR DESCRIPTION

## Description

This is a clone of https://github.com/mautic/mautic/pull/14104 for Mautic 5.1

Running `composer update twig/twig:^3.14`


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. See the steps in https://github.com/mautic/mautic/pull/14104

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->