### PR TITLE
FEAT: Adds `contactfield` token to landing pages

### DIFF
--- a/app/bundles/LeadBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/PageSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\EventListener;
 
 use Mautic\LeadBundle\Helper\TokenHelper;
-use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -11,7 +10,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class PageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private ContactTracker $contactTracker,
         private TokenHelper $leadTokenHelper,
     ) {
     }
@@ -26,7 +24,7 @@ class PageSubscriber implements EventSubscriberInterface
     public function replaceContactFieldTokenOnPageDisplay(PageDisplayEvent $event): void
     {
         $content = $event->getContent();
-        $lead    = $this->contactTracker->getContact();
+        $lead    = $event->getLead();
         $event->setContent($this->leadTokenHelper->findLeadTokens($content, $lead?->convertToArray() ?? [], replace: true));
     }
 }

--- a/app/bundles/LeadBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/PageSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Mautic\LeadBundle\EventListener;
+
+use Mautic\LeadBundle\Helper\TokenHelper;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Mautic\PageBundle\Event\PageDisplayEvent;
+use Mautic\PageBundle\PageEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PageSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private ContactTracker $contactTracker,
+        private TokenHelper $leadTokenHelper,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PageEvents::PAGE_ON_DISPLAY => ['replaceContactFieldTokenOnPageDisplay', 0],
+        ];
+    }
+
+    public function replaceContactFieldTokenOnPageDisplay(PageDisplayEvent $event): void
+    {
+        $content = $event->getContent();
+        $lead    = $this->contactTracker->getContact();
+        $event->setContent($this->leadTokenHelper->findLeadTokens($content, $lead?->convertToArray() ?? [], replace: true));
+    }
+}

--- a/app/bundles/LeadBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/PageSubscriber.php
@@ -2,18 +2,13 @@
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Mautic\LeadBundle\Helper\TokenHelper;
+use Mautic\LeadBundle\Helper\TokenHelper as LeadTokenHelper;
 use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PageSubscriber implements EventSubscriberInterface
 {
-    public function __construct(
-        private TokenHelper $leadTokenHelper,
-    ) {
-    }
-
     public static function getSubscribedEvents(): array
     {
         return [
@@ -25,6 +20,6 @@ class PageSubscriber implements EventSubscriberInterface
     {
         $content = $event->getContent();
         $lead    = $event->getLead();
-        $event->setContent($this->leadTokenHelper->findLeadTokens($content, $lead?->convertToArray() ?? [], replace: true));
+        $event->setContent(LeadTokenHelper::findLeadTokens($content, $lead?->convertToArray() ?? [], replace: true));
     }
 }

--- a/app/bundles/LeadBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/PageSubscriberTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Tests\CommonMocks;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\EventListener\PageSubscriber;
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Event\PageDisplayEvent;
+use Mautic\PageBundle\PageEvents;
+
+class PageSubscriberTest extends CommonMocks
+{
+    public function testSubscribedEvents(): void
+    {
+        $this->assertSame(
+            [
+                PageEvents::PAGE_ON_DISPLAY => ['replaceContactFieldTokenOnPageDisplay', 0],
+            ],
+            PageSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function replaceContactFieldTokenOnPageDisplay(): void
+    {
+        $page = new Page();
+        $page->setCustomHtml('<html><body>{contactfield=email}{contactfield=name}</body></html>');
+
+        $lead = (new Lead())
+            ->setEmail('john@doe.com');
+
+        $event = new PageDisplayEvent($page->getCustomHtml(), $page, []);
+        $event->setLead($lead);
+
+        $pageSubscriber = new PageSubscriber();
+        $pageSubscriber->replaceContactFieldTokenOnPageDisplay($event);
+
+        $this->assertSame('<html><body>john@doe.com</body></html>', $event->getContent(), 'Token should get replaced by lead data or by an empty string for missing data.');
+    }
+
+    public function replaceContactFieldTokenWithEmptyStringForMissingLeadOnPageDisplay(): void
+    {
+        $page = new Page();
+        $page->setCustomHtml('<html><body>{contactfield=email}</body></html>');
+
+        $event = new PageDisplayEvent($page->getCustomHtml(), $page, []);
+
+        $pageSubscriber = new PageSubscriber();
+        $pageSubscriber->replaceContactFieldTokenOnPageDisplay($event);
+
+        $this->assertSame('<html><body>john@doe.com</body></html>', $event->getContent(), 'Token should get replaced by an empty string.');
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds `{contactfield=FIELD_ALIAS}` token to landing pages.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->

| Before                                                          | After                                                       |
|-----------------------------------------------------------------|-------------------------------------------------------------|
| `{contactfield=ALIAS}` tokens are not replaced on landing pages | `{contactfield=ALIAS}` tokens are replaced on landing pages |



---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Create a landing page
2. Add a contact field token, e.g., `{contactfield=email}` (or even simpler: `{contactfield=id}`).
3. Load the landing page in a browser session where you're **not logged in to the dashboard**
4. Make sure you're being an identified lead. E.g. by filling out a form. (If you're using `{contactfield=id}` having the tracking script on this landing page installed should be sufficient)
5. See the plain `{contactfield=email}` or `{contactfield=id}` text.
6. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
7. Make sure, you're still not logged in into the dashboard and you're an identified lead.
8. Load the landing page again.
9. See that the `{contactfield=email}` or `{contactfield=id}` tokens got replaced by their actual values.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->