### PR TITLE
E2e test fixes

### DIFF
--- a/tests/_support/Page/Acceptance/CategoriesPage.php
+++ b/tests/_support/Page/Acceptance/CategoriesPage.php
@@ -11,5 +11,5 @@ class CategoriesPage
     public const BUNDLE_DROPDOWN     = '#category_form_bundle_chosen > a > span';
     public const BUNDLE_EMAIL_OPTION = "#category_form_bundle_chosen > div > ul > li[data-option-array-index='3']";
     public const TITLE_FIELD         = 'category_form[title]';
-    public const SAVE_AND_CLOSE      = '#MauticSharedModal > div > div > div.modal-footer > div > button.btn.btn-default.btn-save.btn-copy';
+    public const SAVE_AND_CLOSE      = 'div.modal-form-buttons button.btn.btn-primary.btn-save.btn-copy';
 }

--- a/tests/_support/Page/Acceptance/EmailsPage.php
+++ b/tests/_support/Page/Acceptance/EmailsPage.php
@@ -13,7 +13,7 @@ class EmailsPage
     public const NEW_CATEGORY_DROPDOWN     = '#email_batch_newCategory_chosen';
     public const CHANGE_CATEGORY_ACTION    = "a[href='/s/emails/batch/categories/view']";
     public const SELECTED_ACTIONS_DROPDOWN = '#page-list-wrapper > div.page-list > div.table-responsive > table > thead > tr > th.col-actions > div > div > button > i';
-    public const SAVE_BUTTON               = '#MauticSharedModal > div > div > div.modal-footer > div > button.btn.btn-default.btn-save.btn-copy';
+    public const SAVE_BUTTON               = 'div.modal-form-buttons > button.btn.btn-primary.btn-save.btn-copy';
     public const SELECT_ALL_CHECKBOX       = '#customcheckbox-one0';
     public const SELECT_SEGMENT_EMAIL      = '#app-content > div > div.modal.fade.in.email-type-modal > div > div > div.modal-body.form-select-modal > div > div:nth-child(2) > div > div.hidden-xs.panel-footer.text-center > button';
     public const CONTACT_SEGMENT_DROPDOWN  = '#emailform_lists_chosen';

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -6,10 +6,9 @@ use Page\Acceptance\EmailsPage;
 
 class EmailManagementCest
 {
-    private AcceptanceTester $I;
-    public const ADMIN_PASSWORD                   = 'Maut1cR0cks!';
-    public const ADMIN_USER                       = 'admin';
-    public const DATE_FORMAT                      = 'Y:m:d H:i:s';
+    public const ADMIN_PASSWORD = 'Maut1cR0cks!';
+    public const ADMIN_USER     = 'admin';
+    public const DATE_FORMAT    = 'Y:m:d H:i:s';
 
     public function _before(AcceptanceTester $I): void
     {
@@ -18,8 +17,6 @@ class EmailManagementCest
 
     public function tryToBatchChangeEmailCategory(AcceptanceTester $I): void
     {
-        $this->I = $I;
-
         $now = date(self::DATE_FORMAT);
 
         // Arrange
@@ -29,46 +26,39 @@ class EmailManagementCest
 
         // Act
         $I->amOnPage(EmailsPage::URL);
-        $I->wait(1);
-        $this->selectAllEmails();
-        $this->selectChangeCategoryAction();
-        $newCategoryName = $this->doChangeCategory();
+        $this->selectAllEmails($I);
+        $this->selectChangeCategoryAction($I);
+        $newCategoryName = $this->doChangeCategory($I);
         $I->reloadPage();
 
         // Assert
-        $this->verifyAllEmailsBelongTo($newCategoryName);
+        $this->verifyAllEmailsBelongTo($I, $newCategoryName);
     }
 
-    public function selectAllEmails(): void
+    public function selectAllEmails(AcceptanceTester $I): void
     {
-        $I = $this->I;
         $I->waitForElementClickable(EmailsPage::SELECT_ALL_CHECKBOX);
         $I->click(EmailsPage::SELECT_ALL_CHECKBOX);
     }
 
-    private function selectChangeCategoryAction(): void
+    private function selectChangeCategoryAction(AcceptanceTester $I): void
     {
-        $I = $this->I;
         $I->waitForElementClickable(EmailsPage::SELECTED_ACTIONS_DROPDOWN);
         $I->click(EmailsPage::SELECTED_ACTIONS_DROPDOWN);
         $I->waitForElementClickable(EmailsPage::CHANGE_CATEGORY_ACTION);
         $I->click(EmailsPage::CHANGE_CATEGORY_ACTION);
     }
 
-    protected function verifyAllEmailsBelongTo(string $firstCategoryName): void
+    protected function verifyAllEmailsBelongTo(AcceptanceTester $I, string $firstCategoryName): void
     {
-        $I = $this->I;
-
         $categories = $I->grabMultiple('span.label-category');
         for ($i = 1; $i <= count($categories); ++$i) {
             $I->see($firstCategoryName, '//*[@id="app-content"]/div/div[2]/div[2]/div[1]/table/tbody/tr['.$i.']/td[3]/div');
         }
     }
 
-    private function doChangeCategory(): string
+    private function doChangeCategory(AcceptanceTester $I): string
     {
-        $I = $this->I;
-
         $I->waitForElementClickable(EmailsPage::NEW_CATEGORY_DROPDOWN);
         $I->click(EmailsPage::NEW_CATEGORY_DROPDOWN);
         $I->waitForElementVisible(EmailsPage::NEW_CATEGORY_OPTION);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴🟢
| Deprecations?                          | 🔴🟢
| BC breaks? (use the c.x branch)        | 🔴🟢
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description


The end to end tests are [failing on the 5.x](https://github.com/mautic/mautic/actions/runs/11120569925) branch with
```
There was 1 error:
1) EmailManagementCest: Select all emails
 Test  tests/acceptance/EmailManagementCest.php:selectAllEmails

  [Facebook\WebDriver\Exception\ElementClickInterceptedException] element click intercepted: Element <input type="checkbox" id="customcheckbox-one0" value="1" data-toggle="checkall" data-target="#categoryTable"> is not clickable at point (274, 218). Other element would receive the click: <div class="modal fade in" id="MauticSharedModal" data-backdrop="static" role="dialog" aria-labelledby="MauticSharedModal-label" aria-hidden="true" style="display: block;">...</div>
  (Session info: chrome=101.0.4951.[41](https://github.com/mautic/mautic/actions/runs/11120569925/job/30915277051#step:5:42))  


Scenario Steps:

 1. $I->loadSessionSnapshot("login") at tests/_support/AcceptanceTester.php:31

#1  /var/www/html/vendor/php-webdriver/webdriver/lib/Exception/WebDriverException.php:96
#2  /var/www/html/vendor/php-webdriver/webdriver/lib/Remote/HttpCommandExecutor.php:359
#3  /var/www/html/vendor/php-webdriver/webdriver/lib/Remote/RemoteWebDriver.php:601
#4  /var/www/html/vendor/php-webdriver/webdriver/lib/Remote/RemoteExecuteMethod.php:23
#5  /var/www/html/vendor/php-webdriver/webdriver/lib/Remote/RemoteWebElement.php:78
#6  Codeception\Module\WebDriver->click
#7  /var/www/html/tests/_support/_generated/AcceptanceTesterActions.php:585
#8  /var/www/html/tests/acceptance/EmailManagementCest.php:46
#9  EmailManagementCest->selectAllEmails
#10 /var/www/html/bin/codecept:119
Artifacts:

Png: /var/www/html/tests/_output/EmailManagementCest.selectAllEmails.fail.png
Html: /var/www/html/tests/_output/EmailManagementCest.selectAllEmails.fail.html

---------

There was 1 failure:
1) EmailManagementCest: Try to batch change email category
 Test  tests/acceptance/EmailManagementCest.php:tryToBatchChangeEmailCategory
 Step  Click "#customcheckbox-one0"
 Fail  Link or Button or CSS or XPath element with '#MauticSharedModal > div > div > div.modal-footer > div > button.btn.btn-default.btn-save.btn-copy' was not found.

Scenario Steps:

 18. $I->click("#customcheckbox-one0") at tests/acceptance/EmailManagementCest.php:46
 17. $I->waitForElementClickable("#customcheckbox-one0") at tests/acceptance/EmailManagementCest.php:[45](https://github.com/mautic/mautic/actions/runs/11120569925/job/30915277051#step:5:46)
 16. $I->click("#MauticSharedModal > div > div > div.modal-footer > div > b...") at tests/_support/AcceptanceTester.php:64
 15. $I->fillField("category_form[title]","Category 2024:10:01 13:20:[46](https://github.com/mautic/mautic/actions/runs/11120569925/job/30915277051#step:5:47)") at tests/_support/AcceptanceTester.php:63
 14. $I->click("#category_form_bundle_chosen > div > ul > li[data-option-ar...") at tests/_support/AcceptanceTester.php:62
 13. $I->waitForElementClickable("#category_form_bundle_chosen > div > ul >...") at tests/_support/AcceptanceTester.php:61

Artifacts:

Png: /var/www/html/tests/_output/EmailManagementCest.tryToBatchChangeEmailCategory.fail.png
Html: /var/www/html/tests/_output/EmailManagementCest.tryToBatchChangeEmailCategory.fail.html

ERRORS!
Tests: 15, Assertions: [51](https://github.com/mautic/mautic/actions/runs/11120569925/job/30915277051#step:5:52), Errors: 1, Failures: 1.
Failed to execute command bin/codecept run acceptance: exit status 1
Error: Process completed with exit code 1.
```

This PR is fixing the problem where some button classes were changed from `default` to `primary` in some other PR. It also simplifies the XPATH and the code of the test itself. And saving 2 seconds as the wait seems to be unnecessary as the code is waiting for the checkbox to be clickable anyway.
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Just check that the CI is green. No production code was changed. Just the tests.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->