### PR TITLE
Fixing preference center - the email unsubscribe checkbox

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
@@ -56,6 +56,7 @@
                                     </div>
                                 </td>
                             </tr>
+                            {%- do form.lead_channels.subscribed_channels.setRendered(true) %}
                             <tr>
                                 <td>
                                     <div id="frequency_<?php echo $channel->value; ?>" class="text-left row">

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -36,10 +36,24 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
     protected function setUp(): void
     {
+        $this->configParams['show_contact_segments']           = 0;
+        $this->configParams['show_contact_frequency']          = 0;
+        $this->configParams['show_contact_pause_dates']        = 0;
+        $this->configParams['show_contact_categories']         = 0;
+        $this->configParams['show_contact_preferred_channels'] = 0;
+
         if (in_array($this->getName(), self::UNSUBSCRIBE_TESTS)) {
             $this->configParams['show_contact_preferences'] = 0;
         } else {
             $this->configParams['show_contact_preferences'] = 1;
+        }
+
+        if (in_array($this->getName(), ['testContactPreferencesSaveMessage'])) {
+            $this->configParams['show_contact_segments']           = 1;
+            $this->configParams['show_contact_frequency']          = 1;
+            $this->configParams['show_contact_pause_dates']        = 1;
+            $this->configParams['show_contact_categories']         = 1;
+            $this->configParams['show_contact_preferred_channels'] = 1;
         }
 
         parent::setUp();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14162

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The preference center checkbox to unsubscribe did not actually unsubscribe and did not hold the value.

The problem was that there were actually 2 unsubscribe checkboxes rendered. The second one was hidden. The fix is that if it gets rendered once, it will be marked as rendered and won't be rendered for the second time.

An automated functional test got improved so this will be checked.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to the Mautic global configuration
3. Go to the email settings
4. Scroll down to the Preference center setting and set all the switches for it to Yes
5. Save the configuration
6. Send a segment email to a contact that contains the `{unsubscribe_text}` token
7. Click on the unsubscribe link in the email
8. Clean the checkbox so it would unsubscribe you

Before this PR, you save and the checkbox is checked again and no DNC record is created for this contact.

With this PR the checkbox keeps getting empty after the preference center save and the DNC record is being created for this contact.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->