### PR TITLE
Use the global search modal for search help

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -317,6 +317,7 @@ Mautic.processPageContent = function (response) {
  */
 Mautic.onPageLoad = function (container, response, inModal) {
     Mautic.initDateRangePicker(container + ' #daterange_date_from', container + ' #daterange_date_to');
+    Mautic.initSearchHelpButton();
 
     //initiate links
     Mautic.makeLinksAlive(mQuery(container + " a[data-toggle='ajax']"));

--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -450,4 +450,30 @@ Mautic.showModal = function(target) {
     mQuery(target).modal('show');
 };
 
+Mautic.initSearchHelpButton = function (accordionId) {
+    const $searchHelpButton = mQuery('[data-toggle="searchhelp"]');
+    const $searchHelpModal = mQuery('#searchCommandsModal');
+    const searchId = $searchHelpButton.data('target');
+
+    // Scroll to the accordion item
+    $searchHelpModal.on('shown.bs.modal', function () {
+        const $modalBody = mQuery(this).find('.modal-content');
+        const $accordion = $modalBody.find('#specificCommandsAccordion');
+        $accordion.find('.collapse').collapse('hide');
+
+        if (searchId.length <= 1) {
+            return;
+        }
+        
+        const $accordionItem = $accordion.find(searchId);
+        $accordionItem.collapse('show');
+        const elementTop = $accordionItem.offset().top;
+        $modalBody.scrollTop($modalBody.scrollTop() + elementTop - $modalBody.offset().top);
+    });
+
+    $searchHelpButton.on('click', function (e) {
+        $searchHelpModal.modal('toggle');
+    });
+}
+
 

--- a/app/bundles/CoreBundle/Resources/views/Helper/search.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/search.html.twig
@@ -2,19 +2,18 @@
 {% set target = target|default('.page-list') %}
 {% set overlayTarget = overlayTarget|default(target) %}
 {% set overlayEnabled = overlayDisabled is defined and overlayDisabled is not empty ? 'false' : 'true' %}
-{% set id = searchId|default('list-search') %}
 {% set tmpl = tmpl|default('list') %}
 
 <div class="input-group">
     {% if searchHelp is defined and searchHelp is not empty %}
     <div class="input-group-btn">
-        <button class="input-group-addon btn-nospin" data-toggle="modal" data-target="#{{ searchId }}-search-help">
+        <button class="input-group-addon btn-nospin" data-toggle="searchhelp" data-target="#{{ searchId }}">
             <i class="ri-question-line"></i>
         </button>
     </div>
     {% endif %}
 
-    <input type="search" class="form-control search" id="{{ id }}" name="search" placeholder="{% trans %}mautic.core.search.placeholder{% endtrans %}" value="{{ searchValue|escape }}" autocomplete="false" data-toggle="livesearch" data-target="{{ target }}" data-tmpl="{{ tmpl }}" data-action="{{ action }}" data-overlay="{{ overlayEnabled }}" data-overlay-text="{% trans %}mautic.core.search.livesearch{% endtrans %}" data-overlay-target="{{ overlayTarget }}" />
+    <input type="search" class="form-control search" id="list-search" name="search" placeholder="{% trans %}mautic.core.search.placeholder{% endtrans %}" value="{{ searchValue|escape }}" autocomplete="false" data-toggle="livesearch" data-target="{{ target }}" data-tmpl="{{ tmpl }}" data-action="{{ action }}" data-overlay="{{ overlayEnabled }}" data-overlay-text="{% trans %}mautic.core.search.livesearch{% endtrans %}" data-overlay-target="{{ overlayTarget }}" />
     <div class="input-group-btn">
         <button type="button" class="input-group-addon btn-search btn-nospin" id="btn-filter" data-livesearch-parent="{{ id }}">
             <i class="ri-search-line ri-fw"></i>

--- a/app/bundles/CoreBundle/Resources/views/Helper/search.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/search.html.twig
@@ -15,7 +15,7 @@
 
     <input type="search" class="form-control search" id="list-search" name="search" placeholder="{% trans %}mautic.core.search.placeholder{% endtrans %}" value="{{ searchValue|escape }}" autocomplete="false" data-toggle="livesearch" data-target="{{ target }}" data-tmpl="{{ tmpl }}" data-action="{{ action }}" data-overlay="{{ overlayEnabled }}" data-overlay-text="{% trans %}mautic.core.search.livesearch{% endtrans %}" data-overlay-target="{{ overlayTarget }}" />
     <div class="input-group-btn">
-        <button type="button" class="input-group-addon btn-search btn-nospin" id="btn-filter" data-livesearch-parent="{{ id }}">
+        <button type="button" class="input-group-addon btn-search btn-nospin" id="btn-filter" data-livesearch-parent="list-search">
             <i class="ri-search-line ri-fw"></i>
         </button>
     </div>

--- a/app/bundles/LeadBundle/Resources/views/Lead/_filter.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_filter.html.twig
@@ -28,6 +28,7 @@
     {% endif %}
     <div id="page-list-wrapper">
         {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
+            'searchId': 'collapseMautic_lead_leads',
             'searchValue': searchValue|default(''),
             'searchHelp': 'mautic.lead.lead.help.searchcommands',
             'action': currentRoute,

--- a/app/bundles/NotificationBundle/Resources/views/MobileNotification/list.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/MobileNotification/list.html.twig
@@ -33,7 +33,6 @@
         {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
                 'searchValue': searchValue,
                 'searchHelp': 'mautic.notification.help.searchcommands',
-                'searchId': 'mobile-notification-search',
                 'action': currentRoute,
         }) }}
         <div class="page-list">

--- a/app/bundles/NotificationBundle/Resources/views/Notification/list.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/Notification/list.html.twig
@@ -33,7 +33,6 @@
         {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
                 'searchValue': searchValue,
                 'searchHelp': 'mautic.notification.help.searchcommands',
-                'searchId': 'notification-search',
                 'action': currentRoute,
         }) }}
         <div class="page-list">

--- a/app/bundles/ReportBundle/Resources/views/Report/list.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/list.html.twig
@@ -21,6 +21,7 @@
   {% if isIndex %}
   <div id="page-list-wrapper">
       {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
+              'searchId': 'collapseMautic_report_reports',
               'searchValue': searchValue,
               'searchHelp': 'mautic.report.report.help.searchcommands',
               'action': currentRoute,

--- a/app/bundles/SmsBundle/Resources/views/Sms/list.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/Sms/list.html.twig
@@ -19,7 +19,6 @@
         {{- include('@MauticCore/Helper/list_toolbar.html.twig', {
             'searchValue' : searchValue,
             'searchHelp'  : 'mautic.sms.help.searchcommands',
-            'searchId'    : 'sms-search',
             'action'      : currentRoute,
         }) -}}
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 (mostly JS/UI changes) <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This is a showcase of how to use the global search help button when the local search help button is clicked. It is reaction to https://github.com/mautic/mautic/pull/13950 that is deleting the local search help buttons.

### ToDo

- [ ] Scroll to the accordion item that is open (I tried to do it in the JS, doesn't work at the moment. I run out of time to debug)
- [ ] Search for all the usages of `list_toolbar.html.twig` and set the right accordion ID as it is done in this PR for contacts and reports.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to the contact list view
3. Click on the help icon in front of the search input
4. It will input the global search help instead of the old one. It will also open the accordion to show the search commands related to the contact.