### PR TITLE
Upload artifacts for failed E2E-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -143,6 +143,14 @@ jobs:
 
     - name: Run E2E tests
       run: ddev exec bin/codecept run acceptance
+
+    - name: Upload test artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-test-screenshots
+        path: tests/_output
+        if-no-files-found: ignore
 
   misc:
     # We don't want the scheduled jobs to run on forks of Mautic


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Codeception (the tool used for automated end-to-end tests) takes a screenshot as well as an html-snapshot when a test fails. This PR makes it so that these files are uploaded as an artifact during the CI workflow.
I have also bumped the version of the checkout-action to v4 during the e2e-step, to be in line with the other steps.


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
This is tricky, since the changes are only to the CI workflow. However, there a 2 criteria:
1. If the Job "e2e-tests" succeeds, there should be **no** artifact called "e2e-test-screenshots"
2. If the Job "e2e-tests" fails, there should be an artifact called "e2e-test-screenshots" which contains a png- and an html-file (as well as a third file, which lists the failed tests)

I have successfully tested this on my fork, but I do not know how to properly test it in this repo.
