### PR TITLE
[UX] Disable "Visible on quick add" when creating a Custom Field for Company object with data-disable-on

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -9950,7 +9950,7 @@ code:hover > .copy-icon {
   box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.5);
 }
 .toggle__label:focus .toggle__switch,
-.toggle:not(.toggle--disabled):active .toggle__switch {
+.toggle:not(.toggle--disabled):not(:has(.disabled)):active .toggle__switch {
   box-shadow: 0 0 0 1px var(--focus-inset, #ffffff), 0 0 0 3px var(--focus, #0f62fe);
 }
 .toggle__switch--checked {
@@ -9985,24 +9985,31 @@ code:hover > .copy-icon {
 .toggle__appearance[size="sm"] .toggle__switch--checked .toggle__check {
   visibility: visible;
 }
-.toggle--disabled {
+.toggle--disabled,
+.toggle:has(.disabled) {
   cursor: not-allowed;
 }
-.toggle--disabled .toggle__label {
+.toggle--disabled .toggle__label,
+.toggle:has(.disabled) .toggle__label {
   pointer-events: none;
 }
 .toggle--disabled .toggle__label-text,
-.toggle--disabled .toggle__text {
+.toggle:has(.disabled) .toggle__label-text,
+.toggle--disabled .toggle__text,
+.toggle:has(.disabled) .toggle__text {
   color: var(--text-disabled, rgba(22, 22, 22, 0.25));
 }
-.toggle--disabled .toggle__switch {
+.toggle--disabled .toggle__switch,
+.toggle:has(.disabled) .toggle__switch {
   background-color: var(--button-disabled, #c6c6c6);
 }
-.toggle--disabled .toggle__switch::before {
+.toggle--disabled .toggle__switch::before,
+.toggle:has(.disabled) .toggle__switch::before {
   background-color: var(--icon-on-color-disabled, #8d8d8d);
   box-shadow: none;
 }
-.toggle--disabled .toggle__check {
+.toggle--disabled .toggle__check,
+.toggle:has(.disabled) .toggle__check {
   fill: var(--button-disabled, #c6c6c6);
 }
 .toggle--readonly .toggle__appearance {
@@ -10036,7 +10043,7 @@ code:hover > .copy-icon {
 }
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
   .toggle__label:focus .toggle__switch,
-  .toggle:not(.toggle--disabled):active .toggle__switch {
+  .toggle:not(.toggle--disabled):not(:has(.disabled)):active .toggle__switch {
     color: Highlight;
     outline: 1px solid Highlight;
   }

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/toggle.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/toggle.less
@@ -42,7 +42,7 @@
 }
 
 .toggle__label:focus .toggle__switch,
-.toggle:not(.toggle--disabled):active .toggle__switch {
+.toggle:not(.toggle--disabled):not(:has(.disabled)):active .toggle__switch {
     box-shadow: 0 0 0 1px var(--focus-inset, #ffffff), 0 0 0 3px var(--focus, #0f62fe)
 }
 
@@ -82,28 +82,31 @@
     visibility: visible
 }
 
-.toggle--disabled {cursor: not-allowed;}
+.toggle--disabled, .toggle:has(.disabled)
+{
+    cursor: not-allowed;
 
-.toggle--disabled .toggle__label {
-    pointer-events: none;
-}
+    .toggle__label {
+        pointer-events: none;
+    }
 
-.toggle--disabled .toggle__label-text,
-.toggle--disabled .toggle__text {
-    color: var(--text-disabled, rgba(22, 22, 22, 0.25))
-}
+    .toggle__label-text,
+    .toggle__text {
+        color: var(--text-disabled, rgba(22, 22, 22, 0.25));
+    }
 
-.toggle--disabled .toggle__switch {
-    background-color: var(--button-disabled, #c6c6c6)
-}
+    .toggle__switch {
+        background-color: var(--button-disabled, #c6c6c6);
+    }
 
-.toggle--disabled .toggle__switch::before {
-    background-color: var(--icon-on-color-disabled, #8d8d8d);
-    box-shadow: none;
-}
+    .toggle__switch::before {
+        background-color: var(--icon-on-color-disabled, #8d8d8d);
+        box-shadow: none;
+    }
 
-.toggle--disabled .toggle__check {
-    fill: var(--button-disabled, #c6c6c6)
+    .toggle__check {
+        fill: var(--button-disabled, #c6c6c6);
+    }
 }
 
 .toggle--readonly .toggle__appearance {
@@ -147,7 +150,7 @@
 (forced-colors:active) {
 
     .toggle__label:focus .toggle__switch,
-    .toggle:not(.toggle--disabled):active .toggle__switch {
+    .toggle:not(.toggle--disabled):not(:has(.disabled)):active .toggle__switch {
         color: Highlight;
         outline: 1px solid Highlight
     }

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -44,7 +44,7 @@ Mautic.renameFormElements = function(container, oldIdPrefix, oldNamePrefix, newI
  * @param form
  */
 Mautic.ajaxifyForm = function (formName) {
-    Mautic.initializeFormFieldVisibilitySwitcher(formName);
+    Mautic.initializeFormFieldStateSwitcher(formName);
 
     // Prevent enter from submitting form and instead jump to next line
     var form = 'form[name="' + formName + '"]';
@@ -257,25 +257,28 @@ Mautic.postForm = function (form, callback) {
 
 
 /**
- * Initialize form field visibility switcher
+ * Initialize form field state switcher
  *
  * @param formName
  */
-Mautic.initializeFormFieldVisibilitySwitcher = function (formName)
+Mautic.initializeFormFieldStateSwitcher = function (formName)
 {
-    Mautic.switchFormFieldVisibilty(formName);
+    Mautic.switchFormFieldState(formName);
 
     mQuery('form[name="'+formName+'"]').on('change', function() {
-        Mautic.switchFormFieldVisibilty(formName);
+        Mautic.switchFormFieldState(formName);
     });
 };
 
 /**
- * Switch form field visibility based on selected values
+ * Switch form field state based on selected values
+ *
+ * Possible state: visible, disabled
  */
-Mautic.switchFormFieldVisibilty = function (formName) {
+Mautic.switchFormFieldState = function (formName) {
     var form   = mQuery('form[name="'+formName+'"]');
-    var fields = {};
+    var visibleFields = {};
+    var disabledFields = {};
     var fieldsPriority = {};
 
     var getFieldParts = function(fieldName) {
@@ -290,21 +293,21 @@ Mautic.switchFormFieldVisibilty = function (formName) {
     };
 
     var checkValueCondition = function (sourceFieldVal, condition) {
-        var visible = true;
+        var state = true;
         if (typeof condition == 'object') {
-            visible = mQuery.inArray(sourceFieldVal, condition) !== -1;
+            state = mQuery.inArray(sourceFieldVal, condition) !== -1;
         } else if (condition == 'empty' || (condition == 'notEmpty')) {
             var isEmpty = (sourceFieldVal == '' || sourceFieldVal == null || sourceFieldVal == 'undefined');
-            visible = (condition == 'empty') ? isEmpty : !isEmpty;
+            state = (condition == 'empty') ? isEmpty : !isEmpty;
         } else if (condition !== sourceFieldVal) {
-            visible = false;
+            state = false;
         }
 
-        return visible;
+        return state;
     };
 
     var checkFieldCondition = function (fieldId, attribute, condition) {
-        var visible = true;
+        var state = true;
 
         if (attribute) {
             // Compare the attribute value
@@ -314,7 +317,7 @@ Mautic.switchFormFieldVisibilty = function (formName) {
                 // Check the value option
                 var field = mQuery('#' + fieldId +' option[value="' + mQuery('#' + fieldId).val() + '"]');
             } else {
-                return visible;
+                return state;
             }
 
             var attributeValue = (typeof mQuery(field).attr(attribute) !== 'undefined') ? mQuery(field).attr(attribute) : null;
@@ -327,20 +330,31 @@ Mautic.switchFormFieldVisibilty = function (formName) {
         return checkValueCondition(mQuery('#' + fieldId).val(), condition);
     }
 
-    // find all fields to show
-    form.find('[data-show-on]').each(function(index, el) {
-        var field = mQuery(el);
-        var showOn = JSON.parse(field.attr('data-show-on'));
+    var processConditions = function (attribute, checkState, shouldInvert) {
+        form.find('[' + attribute + ']').each(function(_, el) {
+            var field = mQuery(el);
+            var conditions = JSON.parse(field.attr(attribute));
 
-        mQuery.each(showOn, function(fieldId, condition) {
-            var fieldParts = getFieldParts(fieldId);
+            mQuery.each(conditions, function(fieldId, condition) {
+                var fieldParts = getFieldParts(fieldId);
+                var stateId = field.attr('id');
 
-            // Treat multiple fields as OR statements
-            if (typeof fields[field.attr('id')] === 'undefined' || !fields[field.attr('id')]) {
-                fields[field.attr('id')] = checkFieldCondition(fieldParts.name, fieldParts.attribute, condition);
-            }
+                // Evaluate the condition and apply inversion if needed
+                var conditionResult = checkFieldCondition(fieldParts.name, fieldParts.attribute, condition);
+                if (shouldInvert) {
+                    conditionResult = !conditionResult;
+                }
+
+                // Set the state only if it's undefined or follows OR logic
+                if (typeof checkState[stateId] === 'undefined' || !checkState[stateId]) {
+                    checkState[stateId] = conditionResult;
+                }
+            });
         });
-    });
+    };
+
+    // find all fields to show
+    processConditions('data-show-on', visibleFields, false);
 
     // find all fields to hide
     form.find('[data-hide-on]').each(function(index, el) {
@@ -356,20 +370,36 @@ Mautic.switchFormFieldVisibilty = function (formName) {
             var fieldParts = getFieldParts(fieldId);
 
             // Treat multiple fields as OR statements
-            if (typeof fields[field.attr('id')] === 'undefined' || fields[field.attr('id')]) {
-                fields[field.attr('id')] = !checkFieldCondition(fieldParts.name, fieldParts.attribute, condition);
+            if (typeof visibleFields[field.attr('id')] === 'undefined' || visibleFields[field.attr('id')]) {
+                visibleFields[field.attr('id')] = !checkFieldCondition(fieldParts.name, fieldParts.attribute, condition);
             }
         });
     });
 
     // show/hide according to conditions
-    mQuery.each(fields, function(fieldId, show) {
+    mQuery.each(visibleFields, function(fieldId, show) {
         var fieldContainer = mQuery('#' + fieldId).closest('[class*="col-"]');;
         if (show) {
             fieldContainer.fadeIn();
         } else {
             fieldContainer.fadeOut();
         }
+    });
+
+    // find all fields to enable
+    processConditions('data-enable-on', disabledFields, true);
+    // find all fields to disable
+    processConditions('data-disable-on', disabledFields, false);
+
+    // disable according to conditions
+    mQuery.each(disabledFields, function(fieldId, disable) {
+        var field = mQuery('#' + fieldId)
+        if (disable) {
+            field.addClass('disabled', disable);
+        } else {
+            field.removeClass('disabled', disable);
+        }
+
     });
 };
 

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -353,6 +353,19 @@ Mautic.switchFormFieldState = function (formName) {
         });
     };
 
+    var resetField = function (field) {
+        // Set Yes/No toggle to No.
+        if ('Mautic.toggleYesNo(this);' === field.attr('onchange')
+            && field.val() === "1"
+            && field.is(':checked')
+        ) {
+            label = field.siblings('.toggle__label')
+            if (label.attr('aria-checked') === "true") {
+                label.trigger('click');
+            }
+        }
+    }
+
     // find all fields to show
     processConditions('data-show-on', visibleFields, false);
 
@@ -378,10 +391,12 @@ Mautic.switchFormFieldState = function (formName) {
 
     // show/hide according to conditions
     mQuery.each(visibleFields, function(fieldId, show) {
-        var fieldContainer = mQuery('#' + fieldId).closest('[class*="col-"]');;
+        var field = mQuery('#' + fieldId);
+        var fieldContainer = field.closest('[class*="col-"]');
         if (show) {
             fieldContainer.fadeIn();
         } else {
+            resetField(field);
             fieldContainer.fadeOut();
         }
     });
@@ -395,6 +410,7 @@ Mautic.switchFormFieldState = function (formName) {
     mQuery.each(disabledFields, function(fieldId, disable) {
         var field = mQuery('#' + fieldId)
         if (disable) {
+            resetField(field);
             field.addClass('disabled', disable);
         } else {
             field.removeClass('disabled', disable);

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -66,7 +66,7 @@ class LeadField extends FormEntity implements CacheInvalidateInterface
     /**
      * @var bool
      */
-    private $isShortVisible = true;
+    private $isShortVisible = false;
 
     /**
      * @var bool

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -551,7 +551,8 @@ class FieldType extends AbstractType
             [
                 'label' => 'mautic.lead.field.form.isshortvisible',
                 'attr'  => [
-                    'tooltip' => 'mautic.lead.field.form.isshortvisible.tooltip',
+                    'tooltip'         => 'mautic.lead.field.form.isshortvisible.tooltip',
+                    'data-disable-on' => '{"leadfield_object":"company"}',
                 ],
             ]
         );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes [#14178](https://github.com/mautic/mautic/issues/14178)<!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
In this PR, i've modified switchFormFieldVisibilty to switchFormFieldState so that you can add the following attributes:
- data-disable-on (new)
- data-enable-on (new)
- data-show-on
- data-hide-on

Based on the state, the element will be either visible or disabled. Disabled means that a disable class witll be added to the input.

Additionally, I updated the styling for toggle elements so that the element will look/be disabled if it has child element with class `disabled`.

This implementation is based on discussion on #14211

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Custom Fields
3. Create a new custom field
4. Set "Visible on quick add" to yes
5. Change Object to company and see that "Visible on quick add" is disabled and set to "No" automatically
6. Fill the required fields and hit save
7. The page should refresh and the field should still be disabled.
8. Repeat step 3 & 4
9. Change Object back to contact and the field should be enabled again
10. Fill the required fields and hit save
11. The page should refresh and the field should still be enabled.

Also see that `data-show-on` still works
  - Create a new custom field
  - See that `Maximum character length` is only visible when the following are selected as Data Type:
    - text - Text: Short answer
    - select -Select: Single choice
    - email - Email
    - url - URL
    - phone - ??? (Phone has value tel, may be a bug)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->