### PR TITLE
Minify does not notify the minified file is missing.

### DIFF
--- a/app/assets/scaffold/files/package-lock.json
+++ b/app/assets/scaffold/files/package-lock.json
@@ -49,7 +49,7 @@
         "jquery": "^3.7.0",
         "jquery-datetimepicker": "^2.5.21",
         "jquery-form": "^4.3.0",
-        "jquery-ui": "^1.13.2",
+        "jquery-ui": "~1.13.2",
         "jquery-ui-touch-punch": "^0.2.3",
         "jquery.caret": "^0.3.1",
         "jquery.cookie": "^1.4.1",
@@ -4941,11 +4941,11 @@
       "integrity": "sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg=="
     },
     "node_modules/jquery-ui": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.14.0.tgz",
-      "integrity": "sha512-mPfYKBoRCf0MzaT2cyW5i3IuZ7PfTITaasO5OFLAQxrHuI+ZxruPa+4/K1OMNT8oElLWGtIxc9aRbyw20BKr8g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.3.tgz",
+      "integrity": "sha512-D2YJfswSJRh/B8M/zCowDpNFfwsDmtfnMPwjJTyvl+CBqzpYwQ+gFYIbUUlzijy/Qvoy30H1YhoSui4MNYpRwA==",
       "dependencies": {
-        "jquery": ">=1.12.0 <5.0.0"
+        "jquery": ">=1.8.0 <4.0.0"
       }
     },
     "node_modules/jquery-ui-touch-punch": {

--- a/app/assets/scaffold/files/package.json
+++ b/app/assets/scaffold/files/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.7.0",
     "jquery-datetimepicker": "^2.5.21",
     "jquery-form": "^4.3.0",
-    "jquery-ui": "^1.13.2",
+    "jquery-ui": "~1.13.2",
     "jquery-ui-touch-punch": "^0.2.3",
     "jquery.caret": "^0.3.1",
     "jquery.cookie": "^1.4.1",

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -195,6 +195,19 @@ class AssetGenerationHelper
                                     unlink($assetFile);
                                 }
 
+                                $missing = [];
+                                foreach ($files as $file) {
+                                    if (file_exists($file['fullPath'])) {
+                                        continue;
+                                    }
+
+                                    $missing[] = $file['fullPath'];
+                                }
+
+                                if ([] !== $missing) {
+                                    throw new \ErrorException('These files are missing: '.implode(', ', $missing).'. Have you forgot to install/update modules?');
+                                }
+
                                 if ('css' == $type) {
                                     $minifier = new Minify\CSS(...array_column($files, 'fullPath'));
                                     $minifier->minify($assetFile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "jquery": "^3.7.0",
         "jquery-datetimepicker": "^2.5.21",
         "jquery-form": "^4.3.0",
-        "jquery-ui": "^1.13.2",
+        "jquery-ui": "~1.13.2",
         "jquery-ui-touch-punch": "^0.2.3",
         "jquery.caret": "^0.3.1",
         "jquery.cookie": "^1.4.1",
@@ -4941,11 +4941,11 @@
       "integrity": "sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg=="
     },
     "node_modules/jquery-ui": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.14.0.tgz",
-      "integrity": "sha512-mPfYKBoRCf0MzaT2cyW5i3IuZ7PfTITaasO5OFLAQxrHuI+ZxruPa+4/K1OMNT8oElLWGtIxc9aRbyw20BKr8g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.13.3.tgz",
+      "integrity": "sha512-D2YJfswSJRh/B8M/zCowDpNFfwsDmtfnMPwjJTyvl+CBqzpYwQ+gFYIbUUlzijy/Qvoy30H1YhoSui4MNYpRwA==",
       "dependencies": {
-        "jquery": ">=1.12.0 <5.0.0"
+        "jquery": ">=1.8.0 <4.0.0"
       }
     },
     "node_modules/jquery-ui-touch-punch": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.7.0",
     "jquery-datetimepicker": "^2.5.21",
     "jquery-form": "^4.3.0",
-    "jquery-ui": "^1.13.2",
+    "jquery-ui": "~1.13.2",
     "jquery-ui-touch-punch": "^0.2.3",
     "jquery.caret": "^0.3.1",
     "jquery.cookie": "^1.4.1",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
The Minify does not check if the minified files are present. The constraint of `"jquery-ui": "^1.13.2",` was installing the _1.14.0_ version, which removed a couple of files, so generated files by Mautic were invalid.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run the `bin/console mautic:assets:generate` command. See there are no errors.
3. You can install a 5.x version and check if the command actually does not provide a proper JS file (libraries.js): open any page and see that a browser console has loads of errors.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->