### PR TITLE
[UX] Disable "isUniqueIdentifier" when creating a Custom Field if leadfield_object is company

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -355,7 +355,7 @@ Mautic.switchFormFieldState = function (formName) {
 
     var resetField = function (field) {
         // Set Yes/No toggle to No.
-        if ('Mautic.toggleYesNo(this);' === field.attr('onchange')
+        if (field.attr('onchange')?.includes('Mautic.toggleYesNo(this)')
             && field.val() === "1"
             && field.is(':checked')
         ) {

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -597,7 +597,7 @@ class FieldType extends AbstractType
                 'label' => 'mautic.lead.field.form.isuniqueidentifer',
                 'attr'  => [
                     'tooltip'         => 'mautic.lead.field.form.isuniqueidentifer.tooltip',
-                    'onchange'        => 'Mautic.displayUniqueIdentifierWarning(this)',
+                    'onchange'        => 'Mautic.displayUniqueIdentifierWarning(this);',
                     'data-disable-on' => '{"leadfield_object":"company"}',
                 ],
                 'data' => (!empty($data)),

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -596,8 +596,9 @@ class FieldType extends AbstractType
             [
                 'label' => 'mautic.lead.field.form.isuniqueidentifer',
                 'attr'  => [
-                    'tooltip'  => 'mautic.lead.field.form.isuniqueidentifer.tooltip',
-                    'onchange' => 'Mautic.displayUniqueIdentifierWarning(this)',
+                    'tooltip'         => 'mautic.lead.field.form.isuniqueidentifer.tooltip',
+                    'onchange'        => 'Mautic.displayUniqueIdentifierWarning(this)',
+                    'data-disable-on' => '{"leadfield_object":"company"}',
                 ],
                 'data' => (!empty($data)),
             ]


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14179 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
- Fixed issue with same data attribute created in #14221
- Updated resetField to account for elements with multiple event listeners
- Also added a semi colon to onchange attr value as it would create a js error and stop fn from actually being called

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Custom Fields
3. Create a new custom field
4. Set "Is Unique Identifier" to yes
5. See that the unique identifier warning appears
6. Change Object to company and see that "Is Unique Identifier" is disabled and set to "No" automatically
7. Fill the required fields and hit save
8. The page should refresh and the field should still be disabled.
9. Repeat step 3 & 4
10. Change Object back to contact and the field should be enabled again
11. Fill the required fields and hit save
12. The page should refresh and the field should still be enabled.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->