### PR TITLE
feat: Add Docker Compose setup for Mautic development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build
+build:
+	docker-compose -f docker/docker-compose.yml build --no-cache
+
+.PHONY: start
+start:
+	docker-compose -f docker/docker-compose.yml up -d
+
+.PHONY: stop
+stop:
+	docker-compose -f docker/docker-compose.yml stop

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM php:8.1-apache
+
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    libpng-dev \
+    libjpeg-dev \
+    libfreetype6-dev \
+    libicu-dev \
+    libonig-dev \
+    libzip-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    libc-client-dev \
+    libkrb5-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install -j$(nproc) \
+    intl \
+    mbstring \
+    zip \
+    opcache \
+    gd \
+    pdo \
+    pdo_mysql \
+    mysqli \
+    bcmath \
+    imap \
+    sockets
+
+RUN pecl install redis && docker-php-ext-enable redis
+
+# install Node.js and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt-get install -y nodejs
+
+# install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+RUN a2enmod rewrite
+
+# put custom php.ini
+COPY php.ini /usr/local/etc/php/conf.d/99-custom.ini
+
+# need permission
+RUN chown -R www-data:www-data /var/www/html
+
+CMD ["apache2-foreground"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3'
+
+services:
+  mautic:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    networks:
+      - database
+      - mautic
+    depends_on:
+      - mauticMysql
+    ports:
+      - 8080:80
+    environment:
+      - MAUTIC_DB_HOST=mauticMysql
+      - MAUTIC_DB_USER=docker
+      - MAUTIC_DB_PASSWORD=docker
+      - MAUTIC_DB_NAME=mautic
+      - MAUTIC_RUN_CRON_JOBS=true
+      - DDEV_TLD=1
+    volumes:
+      - "../:/var/www/html:cached"
+    container_name: mautic
+
+  mauticMysql:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    networks:
+      - database
+    environment:
+      - MYSQL_DATABASE=mautic
+      - MYSQL_USER=docker
+      - MYSQL_PASSWORD=docker
+      - MYSQL_ROOT_PASSWORD=docker
+    volumes:
+      - ./.storage/mysql:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  mauticMailhog:
+    image: mailhog/mailhog
+    ports:
+      - 8025:8025
+    networks:
+      - mautic
+
+networks:
+  database:
+  mautic:

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,4 @@
+#date.timezone = "Asia/Tokyo"
+upload_max_filesize=100M
+memory_limit=1G
+post_max_size = 100M


### PR DESCRIPTION
- Added docker-compose.yml and Dockerfile for containerized development setup
- Included php.ini for custom PHP configurations
- Created Makefile for streamlined Docker commands:
  - `build`: Builds Docker images without cache
  - `start`: Starts the Docker containers in detached mode
  - `stop`: Stops the running Docker containers

<!-- ## Which branch should I use for my PR? Assuming that: a = current major release b = current minor release c = future major release * a.x for any features and enhancements (e.g. 5.x) * a.b for any bug fixes (e.g. 4.4, 5.1) * c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!-- Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request): - Always add tests and ensure they pass. - Bug fixes must be submitted against the lowest maintained branch where they apply (lowest branches are regularly merged to upper ones so they get the fixes too.) - Features and deprecations must be submitted against the "4.x" branch. -->

## Description

This PR introduces a Docker-based development setup for Mautic, including docker-compose.yml, Dockerfile, php.ini, and a Makefile for commonly used commands. This setup simplifies development by containerizing Mautic and ensuring custom PHP configurations are easily managed.

### Important Notes
#### 1. Third-party Library Installation
After applying this PR, install the necessary third-party libraries by executing the following command:
```
docker exec -it mautic composer install
```
#### 2. Database Connection Setup
During the Mautic install setup process, when configuring the database connection, make sure to set Host to mauticMysql instead of 127.0.0.1. Using 127.0.0.1 will result in a connection failure because it points to the container’s local network rather than the mauticMysql service.

<img width="1274" alt="setup" src="https://github.com/user-attachments/assets/5bfacb91-4e9d-4d99-b0a6-173a63be0bf1">


### 📋 Steps to test this PR:
1. Open this PR on Gitpod or pull it down for local testing (see the documentation on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester)).  
2. Run docker exec -it mautic composer install after the initial setup to install required libraries.  
3. During the install setup phase, set Host to mauticMysql to ensure successful database connection.
4. (Optional) For debugging, add APP_ENV=dev and APP_DEBUG=1 to your .env file to enable Symfony’s profiler.
<img width="1724" alt="スクリーンショット 2024-11-03 15 59 30" src="https://github.com/user-attachments/assets/05284218-5d80-4970-af07-648edf051123">

