### PR TITLE
DPMMA-2957 Prevent ORM error when sending multiple messages to one Lead

### DIFF
--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -185,12 +185,10 @@ class MessageQueueModel extends FormModel
         foreach ($this->getRepository()->getQueuedMessages($limit, $processStarted, $channel, $channelId) as $queue) {
             $counter += $this->processMessageQueue($queue);
             $event   = $queue->getEvent();
-            $lead    = $queue->getLead();
 
             if ($event) {
                 $this->em->detach($event);
             }
-            $this->em->detach($lead);
             $this->em->detach($queue);
         }
 

--- a/app/bundles/ChannelBundle/Tests/Command/ProcessMarketingMessagesQueueCommandFunctionalTest.php
+++ b/app/bundles/ChannelBundle/Tests/Command/ProcessMarketingMessagesQueueCommandFunctionalTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ChannelBundle\Tests\Command;
+
+use Mautic\ChannelBundle\Entity\MessageQueue;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+final class ProcessMarketingMessagesQueueCommandFunctionalTest extends MauticMysqlTestCase
+{
+    use CreateTestEntitiesTrait;
+
+    public function testIdleCommand(): void
+    {
+        $commandTester = $this->testSymfonyCommand('mautic:messages:send');
+        Assert::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testCommandWithEmailQueue(): void
+    {
+        $lead   = $this->createLead('John', 'Doe', 'jd@example.com');
+        $email1 = $this->createEmail('Test Email 1');
+        $email2 = $this->createEmail('Test Email 2');
+        $this->em->flush();
+
+        $scheduledDate = new \DateTime('-10 minutes');
+        $datePublished = new \DateTime('-1 day');
+
+        $messages = [
+            $this->createMessageQueue($email1, $lead, $scheduledDate, $datePublished),
+            $this->createMessageQueue($email2, $lead, $scheduledDate, $datePublished),
+        ];
+
+        foreach ($messages as $message) {
+            $this->em->persist($message);
+        }
+        $this->em->flush();
+
+        $commandTester = $this->testSymfonyCommand('mautic:messages:send');
+        Assert::assertSame(0, $commandTester->getStatusCode());
+
+        // Check if email stats are created for each email sent
+        $this->assertEmailStatCreated($email1, $lead);
+        $this->assertEmailStatCreated($email2, $lead);
+    }
+
+    private function createMessageQueue(Email $email, Lead $lead, \DateTime $scheduledDate, \DateTime $datePublished): MessageQueue
+    {
+        $message = new MessageQueue();
+        $message->setScheduledDate($scheduledDate);
+        $message->setDatePublished($datePublished);
+        $message->setChannel('email');
+        $message->setChannelId($email->getId());
+        $message->setLead($lead);
+        $message->setPriority(MessageQueue::PRIORITY_NORMAL);
+        $message->setMaxAttempts(3);
+        $message->setAttempts(0);
+        $message->setStatus(MessageQueue::STATUS_PENDING);
+
+        return $message;
+    }
+
+    private function assertEmailStatCreated(Email $email, Lead $lead): void
+    {
+        /** @var StatRepository $emailStatRepository */
+        $emailStatRepository = $this->em->getRepository(Stat::class);
+
+        /** @var Stat|null $emailStat */
+        $emailStat = $emailStatRepository->findOneBy([
+            'email' => $email->getId(),
+            'lead'  => $lead->getId(),
+        ]);
+
+        Assert::assertNotNull($emailStat, "Email stat not created for email ID {$email->getId()} and lead ID {$lead->getId()}");
+    }
+}

--- a/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
@@ -132,7 +132,7 @@ class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
         $this->leadModel->method('getRepository')->willReturn($leadRepository);
         $leadRepository->method('getContacts')->willReturn($contactData);
 
-        $this->entityManager->expects($this->exactly(2))
+        $this->entityManager->expects($this->exactly(1))
             ->method('detach');
 
         $this->messageQueueRepository->method('getQueuedMessages')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
When executing the `bin/console mautic:messages:send` command, an error occurred while attempting to send the second message to the same lead when two messages were pending. This resulted in the following error:
```
[2024-10-29T06:36:02.687730+01:00] mautic.ERROR: Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'Mautic\ChannelBundle\Entity\MessageQueue#lead' that was not configured to cascade persist operations for entity: Proxies_CG_\Mautic\LeadBundle\Entity\Lead with ID #550901.
```

This error was caused by the lead entity being detached after sending the first message. As a consequence:
- The system attempted to persist a new Lead entity that was already in the database.
- There was a **risk of sending the same message to a lead multiple times** because database persistence occurred after sending the email, followed by the error.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure Message Limit
   - Navigate to the Mautic configuration settings.
   - Set a low message limit (e.g., 1 per day) to ensure messages are queued.

3. Create a Segment
   - Go to Segments in the Mautic dashboard.
   - Create a new segment (e.g., "Test Segment").
   - Add at least one lead to this segment.

4. Create and Send Segment Emails
   - Create 3 different segment emails:
     a. Email 1: "Test Email 1"
     b. Email 2: "Test Email 2"
     c. Email 3: "Test Email 3"
   - Send all three emails to the "Test Segment":
     - The first email should be sent immediately.
     - The second and third emails should be queued due to the message limit.
```
ddev exec bin/console mautic:broadcasts:send
```

5. Verify Initial Send and Queue
   - Check that the first email was sent to the lead(s) in the segment.
   - Confirm that the other two emails are in the message queue.

6. Wait for 24 Hours
   - Allow 24 hours to pass so that the message limit resets.

7. Trigger the Queue
   - After 24 hours, run the following command:
     ```
     ddev exec bin/console mautic:messages:send
     ```

8. Verify Results
   - Check that the second email was sent successfully to the lead(s).
   - Confirm that no errors occurred during the sending process.
   - Verify that the third email remains in the queue (as the daily limit was reached again).

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->