### PR TITLE
Add well-known paths for each project

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,236 +1,242 @@
 {
-    "version": "v1.0.0",
-    "entity": {
-      "type": "organisation",
-      "role": "steward",
+  "version": "v1.0.0",
+  "entity": {
+    "type": "organisation",
+    "role": "steward",
+    "name": "Mautic",
+    "email": "ruth.cheesley@mautic.org",
+    "phone": "447308164475",
+    "description": "Mautic is the world's first open source marketing automation platform. Based on the Symfony framework and used by over 40,000 businesses worldwide to power their digital experience, Mautic became a fully independent open source project in April 2023 after spinning off from ownership by Acquia.",
+    "webpageUrl": {
+      "url": "https://www.mautic.org",
+      "wellKnown": "https://www.mautic.org/.well-known/funding-manifest-urls"
+    }
+  },
+  "projects": [
+    {
+      "guid": "mautic",
       "name": "Mautic",
-      "email": "ruth.cheesley@mautic.org",
-      "phone": "447308164475",
       "description": "Mautic is the world's first open source marketing automation platform. Based on the Symfony framework and used by over 40,000 businesses worldwide to power their digital experience, Mautic became a fully independent open source project in April 2023 after spinning off from ownership by Acquia.",
       "webpageUrl": {
-        "url": "https://www.mautic.org"
-      }
+        "url": "https://www.mautic.org",
+        "wellKnown": "https://www.mautic.org/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mautic/mautic"
+      },
+      "licenses": [
+        "spdx:GPL-3.0"
+      ],
+      "tags": [
+        "marketing-automation",
+        "php",
+        "symfony",
+        "mautic",
+        "marketing-software"
+      ]
     },
-    "projects": [
+    {
+      "guid": "mautic-api-library",
+      "name": "Mautic's API library",
+      "description": "The Mautic API library provides developers with a comprehensive tool to interact programmatically with Mautic's marketing automation platform. Hosted on GitHub, this official PHP library supports REST API operations. \n\nIt facilitates a wide range of actions from managing contacts to controlling campaigns and accessing analytical data, enabling developers to seamlessly integrate and automate marketing workflows. The API library requires authentication via OAuth 2 or Basic Auth, depending on the Mautic installation settings.\n\nExtensive documentation accompanying the API library can be found directly within the GitHub repository or via Mautic's official developer docs at https://devdocs.mautic.org (legacy docs at https://developer.mautic.org), ensuring developers have guidance on setting up and utilizing the library effectively. \n\nThere is not currently 100% API coverage however it's a long term goal to work towards this, such that the front-end of Mautic could be entirely decoupled, enabling it to run headless if desired.",
+      "webpageUrl": {
+        "url": "https://github.com/mautic/api-library",
+        "wellKnown": "https://github.com/mautic/api-library/blob/main/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mautic/api-library"
+      },
+      "licenses": [
+        "spdx:MIT"
+      ],
+      "tags": [
+        "programming",
+        "core-development",
+        "core",
+        "api"
+      ]
+    },
+    {
+      "guid": "user-docs",
+      "name": "Mautic's User Documentation",
+      "description": "The Mautic user documentation at https://docs.mautic.org provides a thorough guide specifically designed to assist end users in navigating and maximizing the capabilities of Mautic. \n\nThe End User Documentation is rich with detailed explanations on how to set up and manage campaigns, create and utilize marketing channels like emails and SMS, and analyze results through reports and dashboards. \n\nIt is regularly updated to reflect the latest functionalities introduced in new releases of Mautic, ensuring users have up-to-date information to operate the software proficiently.",
+      "webpageUrl": {
+        "url": "https://docs.mautic.org",
+        "wellKnown": "https://github.com/mautic/user-documentation/blob/5.x/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mautic/user-documentation"
+      },
+      "licenses": [
+        "spdx:CC-BY-SA-4.0"
+      ],
+      "tags": [
+        "docs",
+        "documentation"
+      ]
+    },
+    {
+      "guid": "developer-documentation",
+      "name": "Developer Documentation",
+      "description": "The Mautic Developer Documentation, accessible at https://devdocs.mautic.org, is a comprehensive resource designed to aid developers in understanding and using the Mautic platform effectively. \n\nIt covers various aspects of Mautic’s open-source marketing automation system, offering detailed guides on APIs, plugin development, and core contributions. \n\nThis documentation is crucial for developers looking to integrate or extend Mautic’s functionalities. It includes a structured overview of Mautic's architecture, API endpoints, webhook implementations, and practical examples of how to create and customize plugins.\n\nAdditionally, the documentation provides insights into the development environment setup, covering system requirements and installation steps to ensure a smooth start for new developers. \n\nNote: The old dev docs are at https://developer.mautic.org as some sections are yet to be migrated.",
+      "webpageUrl": {
+        "url": "https://devdocs.mautic.org",
+        "wellKnown": "https://github.com/mautic/developer-documentation-new/blob/5.x/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mautic/developer-documentation-new"
+      },
+      "licenses": [
+        "spdx:CC-BY-SA-4.0"
+      ],
+      "tags": [
+        "docs",
+        "documentation",
+        "developer-relations",
+        "devrel",
+        "developer-documentation"
+      ]
+    },
+    {
+      "guid": "grapesjs-preset",
+      "name": "GrapesJS Builder Preset",
+      "description": "At the heart of Mautic is the email and landing page builder, used by every marketer to create stunning resources using a drag-and-drop builder powered by the open source framework, GrapesJS.\n\nMautic's implementation of GrapesJS is made through a preset, which allows us to add our own custom blocks.\n\nThis is an area of Mautic that needs a lot of attention because we have several shortcomings and people are asking for a lot more functionality.",
+      "webpageUrl": {
+        "url": "https://github.com/mautic/grapesjs-preset-mautic",
+        "wellKnown": "https://github.com/mautic/grapesjs-preset-mautic/blob/5.x/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/mautic/grapesjs-preset-mautic"
+      },
+      "licenses": [
+        "spdx:MIT"
+      ],
+      "tags": [
+        "grapesjs",
+        "email-builder",
+        "landing-page-builder",
+        "mautic",
+        "builder"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
       {
-        "guid": "mautic",
-        "name": "Mautic",
-        "description": "Mautic is the world's first open source marketing automation platform. Based on the Symfony framework and used by over 40,000 businesses worldwide to power their digital experience, Mautic became a fully independent open source project in April 2023 after spinning off from ownership by Acquia.",
-        "webpageUrl": {
-          "url": "https://www.mautic.org"
-        },
-        "repositoryUrl": {
-          "url": "https://github.com/mautic/mautic"
-        },
-        "licenses": [
-          "spdx:GPL-3.0"
-        ],
-        "tags": [
-          "marketing-automation",
-          "php",
-          "symfony",
-          "mautic",
-          "marketing-software"
+        "guid": "open-collective",
+        "type": "gateway",
+        "address": "440 N Barranca Ave #3939 Covina, CA 91723",
+        "description": "Open Source Collective - https://opencollective.com/mautic"
+      }
+    ],
+    "plans": [
+      {
+        "guid": "individual-member",
+        "status": "active",
+        "name": "Individual membership",
+        "description": "$100 or appropriate rate based on your location for tax purposes using https://mau.tc/big-mac.",
+        "amount": 100,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
         ]
       },
       {
-        "guid": "mautic-api-library",
-        "name": "Mautic's API library",
-        "description": "The Mautic API library provides developers with a comprehensive tool to interact programmatically with Mautic's marketing automation platform. Hosted on GitHub, this official PHP library supports REST API operations. \n\nIt facilitates a wide range of actions from managing contacts to controlling campaigns and accessing analytical data, enabling developers to seamlessly integrate and automate marketing workflows. The API library requires authentication via OAuth 2 or Basic Auth, depending on the Mautic installation settings.\n\nExtensive documentation accompanying the API library can be found directly within the GitHub repository or via Mautic's official developer docs at https://devdocs.mautic.org (legacy docs at https://developer.mautic.org), ensuring developers have guidance on setting up and utilizing the library effectively. \n\nThere is not currently 100% API coverage however it's a long term goal to work towards this, such that the front-end of Mautic could be entirely decoupled, enabling it to run headless if desired.",
-        "webpageUrl": {
-          "url": "https://github.com/mautic/api-library"
-        },
-        "repositoryUrl": {
-          "url": "https://github.com/mautic/api-library"
-        },
-        "licenses": [
-          "spdx:MIT"
-        ],
-        "tags": [
-          "programming",
-          "core-development",
-          "core",
-          "api"
+        "guid": "community-tier",
+        "status": "active",
+        "name": "Community Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nCommunity tier benefits\n\nAt the Community Tier, the following benefits are provided:\nLogo on members page\nNo-follow link on members page\nMember badge with tier\nSocial media thank you shout-out\n1 complimentary ticket to Mautic Conference Global\nOrganization logo on members slide\n1 vote in any election and voting process",
+        "amount": 1200,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
         ]
       },
       {
-        "guid": "user-docs",
-        "name": "Mautic's User Documentation",
-        "description": "The Mautic user documentation at https://docs.mautic.org provides a thorough guide specifically designed to assist end users in navigating and maximizing the capabilities of Mautic. \n\nThe End User Documentation is rich with detailed explanations on how to set up and manage campaigns, create and utilize marketing channels like emails and SMS, and analyze results through reports and dashboards. \n\nIt is regularly updated to reflect the latest functionalities introduced in new releases of Mautic, ensuring users have up-to-date information to operate the software proficiently.",
-        "webpageUrl": {
-          "url": "https://docs.mautic.org"
-        },
-        "repositoryUrl": {
-          "url": "https://github.com/mautic/user-documentation"
-        },
-        "licenses": [
-          "spdx:CC-BY-SA-4.0"
-        ],
-        "tags": [
-          "docs",
-          "documentation"
+        "guid": "bronze-tier",
+        "status": "active",
+        "name": "Bronze Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nBronze tier benefits\n\nAt the Bronze Tier, the following benefits are provided from the Community Tier:\nLogo on members page\nNo-follow link on members page\nMember badge with tier\nSocial media thank you shout-out\nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nAlso the following benefits which are specific to the Bronze tier:\nExclusive forum badge for all staff\n1 forum ad campaign per year\n2 complimentary tickets to Mautic Conference Global\nOrganization logo on physical printed project sponsor banners at in-person events",
+        "amount": 5000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
         ]
       },
       {
-        "guid": "developer-documentation",
-        "name": "Developer Documentation",
-        "description": "The Mautic Developer Documentation, accessible at https://devdocs.mautic.org, is a comprehensive resource designed to aid developers in understanding and using the Mautic platform effectively. \n\nIt covers various aspects of Mautic’s open-source marketing automation system, offering detailed guides on APIs, plugin development, and core contributions. \n\nThis documentation is crucial for developers looking to integrate or extend Mautic’s functionalities. It includes a structured overview of Mautic's architecture, API endpoints, webhook implementations, and practical examples of how to create and customize plugins.\n\nAdditionally, the documentation provides insights into the development environment setup, covering system requirements and installation steps to ensure a smooth start for new developers. \n\nNote: The old dev docs are at https://developer.mautic.org as some sections are yet to be migrated.",
-        "webpageUrl": {
-          "url": "https://devdocs.mautic.org"
-        },
-        "repositoryUrl": {
-          "url": "https://github.com/mautic/developer-documentation-new"
-        },
-        "licenses": [
-          "spdx:CC-BY-SA-4.0"
-        ],
-        "tags": [
-          "docs",
-          "documentation",
-          "developer-relations",
-          "devrel",
-          "developer-documentation"
+        "guid": "silver-tier",
+        "status": "active",
+        "name": "Silver Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nSilver tier benefits\n\nAt the Silver Tier, the following benefits are provided from the Community and Bronze Tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nAlso the following benefits which are specific to the Silver tier:\nA do-follow link on sponsors page\n2 forum ad campaigns per year\n1 website ad campaign per year\n1 sponsored blog post per year\n3 complimentary tickets to Mautic Conference Global\n1 complimentary ticket to the official in-person Mautic conference",
+        "amount": 10000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
         ]
       },
       {
-        "guid": "grapesjs-preset",
-        "name": "GrapesJS Builder Preset",
-        "description": "At the heart of Mautic is the email and landing page builder, used by every marketer to create stunning resources using a drag-and-drop builder powered by the open source framework, GrapesJS.\n\nMautic's implementation of GrapesJS is made through a preset, which allows us to add our own custom blocks.\n\nThis is an area of Mautic that needs a lot of attention because we have several shortcomings and people are asking for a lot more functionality.",
-        "webpageUrl": {
-          "url": "https://github.com/mautic/grapesjs-preset-mautic"
-        },
-        "repositoryUrl": {
-          "url": "https://github.com/mautic/grapesjs-preset-mautic"
-        },
-        "licenses": [
-          "spdx:MIT"
-        ],
-        "tags": [
-          "grapesjs",
-          "email-builder",
-          "landing-page-builder",
-          "mautic",
-          "builder"
+        "guid": "gold-tier",
+        "status": "active",
+        "name": "Gold Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nGold tier benefits\n\nAt the Gold Tier, the following benefits are provided from the Community, Bronze and Silver Tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n2 forum ad campaigns per year\nAlso the following benefits which are specific to the Gold tier:\nJoint press release with Mautic and your company\n2 website ad campaigns per year\n2 sponsored blog posts per year\n1 featured case study on the homepage of mautic.org per year\n1 official promotion of your case study, webinar or training course on Mautic channels per year\n4 complimentary tickets to Mautic Conference Global \n2 complimentary tickets to the official in-person Mautic conference\n5% discount code for additional tickets to all Mautic official conferences\n1 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n1 complimentary ticket to Mautic Awards Dinner\nSponsor a Mautic Awards category\n",
+        "amount": 15000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
+        ]
+      },
+      {
+        "guid": "platinum-tier",
+        "status": "active",
+        "name": "Platinum Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nPlatinum tier benefits\n\nAt the Platinum Tier, the following benefits are provided from all lower tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n1 sponsored blog post per year\nJoint press release with Mautic and your company\n2 sponsored blog posts per year\n1 featured case study on the homepage of mautic.org per year\nSponsor a Mautic Awards category\nAlso the following benefits which are specific to the Platinum tier:\n3 forum ad campaigns per year\n3 website ad campaigns per year\n1 newsletter feature per year\n1 featured webinar per year\n2 official promotions of your case study, webinar or training course on Mautic channels per year\n25% discount on sponsorship of one official Mautic conference per year\n5 complimentary tickets to Mautic Conference Global\n3 complimentary tickets to the official in-person Mautic conference\n10% discount code for additional tickets to all Mautic official conferences\n2 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n2 complimentary ticket to Mautic Awards Dinner",
+        "amount": 20000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
+        ]
+      },
+      {
+        "guid": "diamond-tier",
+        "status": "active",
+        "name": "Diamond Tier membership",
+        "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nDiamond tier benefits\n\nAt the Diamond Tier, the following benefits are provided from all lower tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n1 sponsored blog post per year\nJoint press release with Mautic and your company\nSponsor a Mautic Awards category\nAlso the following benefits which are specific to the Diamond tier:\n4 forum ad campaigns per year\n4 website ad campaigns per year\n3 sponsored blog posts per year\n2 featured case studies on the homepage of mautic.org per year\n2 newsletter feature per year\n2 featured webinar per year\n2 official promotions of your case study, webinar or training course on Mautic channels per year\n50% discount on sponsorship of one official Mautic conference per year\n6 complimentary tickets to Mautic Conference Global\n4 complimentary tickets to the official in-person Mautic conference\n15% discount code for additional tickets to all Mautic official conferences\n3 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n3 complimentary ticket to Mautic Awards Dinner\n",
+        "amount": 30000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": [
+          "open-collective"
         ]
       }
     ],
-    "funding": {
-      "channels": [
-        {
-          "guid": "open-collective",
-          "type": "gateway",
-          "address": "440 N Barranca Ave #3939 Covina, CA 91723",
-          "description": "Open Source Collective - https://opencollective.com/mautic"
-        }
-      ],
-      "plans": [
-        {
-          "guid": "individual-member",
-          "status": "active",
-          "name": "Individual membership",
-          "description": "$100 or appropriate rate based on your location for tax purposes using https://mau.tc/big-mac.",
-          "amount": 100,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "community-tier",
-          "status": "active",
-          "name": "Community Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nCommunity tier benefits\n\nAt the Community Tier, the following benefits are provided:\nLogo on members page\nNo-follow link on members page\nMember badge with tier\nSocial media thank you shout-out\n1 complimentary ticket to Mautic Conference Global\nOrganization logo on members slide\n1 vote in any election and voting process",
-          "amount": 1200,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "bronze-tier",
-          "status": "active",
-          "name": "Bronze Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nBronze tier benefits\n\nAt the Bronze Tier, the following benefits are provided from the Community Tier:\nLogo on members page\nNo-follow link on members page\nMember badge with tier\nSocial media thank you shout-out\nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nAlso the following benefits which are specific to the Bronze tier:\nExclusive forum badge for all staff\n1 forum ad campaign per year\n2 complimentary tickets to Mautic Conference Global\nOrganization logo on physical printed project sponsor banners at in-person events",
-          "amount": 5000,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "silver-tier",
-          "status": "active",
-          "name": "Silver Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nSilver tier benefits\n\nAt the Silver Tier, the following benefits are provided from the Community and Bronze Tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nAlso the following benefits which are specific to the Silver tier:\nA do-follow link on sponsors page\n2 forum ad campaigns per year\n1 website ad campaign per year\n1 sponsored blog post per year\n3 complimentary tickets to Mautic Conference Global\n1 complimentary ticket to the official in-person Mautic conference",
-          "amount": 10000,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "gold-tier",
-          "status": "active",
-          "name": "Gold Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nGold tier benefits\n\nAt the Gold Tier, the following benefits are provided from the Community, Bronze and Silver Tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n2 forum ad campaigns per year\nAlso the following benefits which are specific to the Gold tier:\nJoint press release with Mautic and your company\n2 website ad campaigns per year\n2 sponsored blog posts per year\n1 featured case study on the homepage of mautic.org per year\n1 official promotion of your case study, webinar or training course on Mautic channels per year\n4 complimentary tickets to Mautic Conference Global \n2 complimentary tickets to the official in-person Mautic conference\n5% discount code for additional tickets to all Mautic official conferences\n1 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n1 complimentary ticket to Mautic Awards Dinner\nSponsor a Mautic Awards category\n",
-          "amount": 15000,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "platinum-tier",
-          "status": "active",
-          "name": "Platinum Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nPlatinum tier benefits\n\nAt the Platinum Tier, the following benefits are provided from all lower tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n1 sponsored blog post per year\nJoint press release with Mautic and your company\n2 sponsored blog posts per year\n1 featured case study on the homepage of mautic.org per year\nSponsor a Mautic Awards category\nAlso the following benefits which are specific to the Platinum tier:\n3 forum ad campaigns per year\n3 website ad campaigns per year\n1 newsletter feature per year\n1 featured webinar per year\n2 official promotions of your case study, webinar or training course on Mautic channels per year\n25% discount on sponsorship of one official Mautic conference per year\n5 complimentary tickets to Mautic Conference Global\n3 complimentary tickets to the official in-person Mautic conference\n10% discount code for additional tickets to all Mautic official conferences\n2 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n2 complimentary ticket to Mautic Awards Dinner",
-          "amount": 20000,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        },
-        {
-          "guid": "diamond-tier",
-          "status": "active",
-          "name": "Diamond Tier membership",
-          "description": "A Unique Opportunity to Influence and Innovate\nEnhance your company's engagement in the open source community by joining the General Assembly of Mautic. Let your business be a beacon of influence and innovation.\n\nAs a member, you can lend your corporate vision to help shape our governance and future. Vote in the Community Council elections, make substantive contributions to strategic decisions and help us evolve in the right direction.\n\nTake advantage of this platform to form meaningful connections within our community, lend your expertise, and associate your brand with a driving force in the open source world. \n\nActively contributing to the General Assembly is more than altruism: it’s smart business, fostering goodwill, visibility and strong relationships within a passionate community.\n\nTake the lead in open source. Join us today.\n\nDiamond tier benefits\n\nAt the Diamond Tier, the following benefits are provided from all lower tiers:\nLogo on sponsors page\nMember badge with tier\nSocial media thank you shout-out\nOrganization name on General Assembly members page \nOrganization logo on project sponsors slide\n1 vote in any election and voting process\nExclusive forum badge for all staff\nOrganization logo on physical printed project sponsor banners at in-person events \nA do-follow link on sponsors page\n1 sponsored blog post per year\nJoint press release with Mautic and your company\nSponsor a Mautic Awards category\nAlso the following benefits which are specific to the Diamond tier:\n4 forum ad campaigns per year\n4 website ad campaigns per year\n3 sponsored blog posts per year\n2 featured case studies on the homepage of mautic.org per year\n2 newsletter feature per year\n2 featured webinar per year\n2 official promotions of your case study, webinar or training course on Mautic channels per year\n50% discount on sponsorship of one official Mautic conference per year\n6 complimentary tickets to Mautic Conference Global\n4 complimentary tickets to the official in-person Mautic conference\n15% discount code for additional tickets to all Mautic official conferences\n3 complimentary ticket to sponsors' dinner at one in-person Mautic conference per year\n3 complimentary ticket to Mautic Awards Dinner\n",
-          "amount": 30000,
-          "currency": "USD",
-          "frequency": "yearly",
-          "channels": [
-            "open-collective"
-          ]
-        }
-      ],
-      "history": [
-        {
-          "year": 2023,
-          "income": 148948.48,
-          "expenses": 122047.34,
-          "currency": "USD",
-          "description": "The financial report can be found here: https://community.mautic.org/assemblies/general-assembly/f/25/proposals/46 which was accepted in 2024's General Assembly.\n\nMore detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
-        },
-        {
-          "year": 2022,
-          "income": 45027.09,
-          "expenses": 47578.75,
-          "currency": "USD",
-          "description": "More detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
-        },
-        {
-          "year": 2021,
-          "income": 53282.63,
-          "expenses": 32537.79,
-          "currency": "USD",
-          "description": "More detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
-        }
-      ]
-    }
+    "history": [
+      {
+        "year": 2023,
+        "income": 148948.48,
+        "expenses": 122047.34,
+        "currency": "USD",
+        "description": "The financial report can be found here: https://community.mautic.org/assemblies/general-assembly/f/25/proposals/46 which was accepted in 2024's General Assembly.\n\nMore detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
+      },
+      {
+        "year": 2022,
+        "income": 45027.09,
+        "expenses": 47578.75,
+        "currency": "USD",
+        "description": "More detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
+      },
+      {
+        "year": 2021,
+        "income": 53282.63,
+        "expenses": 32537.79,
+        "currency": "USD",
+        "description": "More detailed metrics are available in our Open Startup Reporting: https://docs.google.com/spreadsheets/d/1UE1R762hsHIqYUd1kJRyuEp_6DQ5kriwIKaHB7kSh9Y/edit?usp=sharing"
+      }
+    ]
   }
+}


### PR DESCRIPTION
This PR is a 'chore' in that it simply adds a required URL which directs people to a file that links it back to the funding.json file in the mautic/mautic directory, in line with the documentation here: https://floss.fund/funding-manifest/.

This doesn't require testing.