### PR TITLE
Plugins are not logging the security token

### DIFF
--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -3,6 +3,7 @@
 namespace Mautic\PluginBundle\EventListener;
 
 use Mautic\PluginBundle\Event\PluginIntegrationRequestEvent;
+use Mautic\PluginBundle\Helper\oAuthHelper;
 use Mautic\PluginBundle\PluginEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -50,6 +51,8 @@ class IntegrationSubscriber implements EventSubscriberInterface
         } else {
             $this->logger->debug("$name REQUEST URL: ".$event->getMethod().' '.$event->getUrl());
             if ('' !== $headers) {
+                $hashedHeaders  = oAuthHelper::hashSensitiveHeaderData($event->getHeaders());
+                $headers        = var_export($hashedHeaders, true);
                 $this->logger->debug("$name REQUEST HEADERS: \n".$headers.PHP_EOL);
             }
             if ('' !== $params) {

--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -51,7 +51,7 @@ class IntegrationSubscriber implements EventSubscriberInterface
         } else {
             $this->logger->debug("$name REQUEST URL: ".$event->getMethod().' '.$event->getUrl());
             if ('' !== $headers) {
-                $hashedHeaders  = oAuthHelper::hashSensitiveHeaderData($event->getHeaders());
+                $hashedHeaders  = oAuthHelper::sanitizeHeaderData($event->getHeaders());
                 $headers        = var_export($hashedHeaders, true);
                 $this->logger->debug("$name REQUEST HEADERS: \n".$headers.PHP_EOL);
             }

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -211,11 +211,11 @@ class oAuthHelper
      *
      * @return string[]
      */
-    public static function hashSensitiveHeaderData(array $data): array
+    public static function sanitizeHeaderData(array $data): array
     {
         foreach ($data as &$value) {
             if (preg_match('/Authorization:\s+(Bearer|Basic)\s+(\S+)/', $value, $match)) {
-                $value = sprintf('Authorization: %s %s', $match[1], hash('sha256', $match[2]));
+                $value = sprintf('Authorization: %s %s', $match[1], '[REDACTED]');
             }
         }
 

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -205,4 +205,20 @@ class oAuthHelper
 
         return $result;
     }
+
+    /**
+     * @param string[] $data
+     *
+     * @return string[]
+     */
+    public static function hashSensitiveHeaderData(array $data): array
+    {
+        foreach ($data as &$value) {
+            if (preg_match('/Authorization:\s+Bearer\s+(\S+)/', $value, $match)) {
+                $value = 'Authorization: Bearer '.hash('sha256', $match[1]);
+            }
+        }
+
+        return $data;
+    }
 }

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -214,8 +214,8 @@ class oAuthHelper
     public static function hashSensitiveHeaderData(array $data): array
     {
         foreach ($data as &$value) {
-            if (preg_match('/Authorization:\s+Bearer\s+(\S+)/', $value, $match)) {
-                $value = 'Authorization: Bearer '.hash('sha256', $match[1]);
+            if (preg_match('/Authorization:\s+(Bearer|Basic)\s+(\S+)/', $value, $match)) {
+                $value = sprintf('Authorization: %s %s', $match[1], hash('sha256', $match[2]));
             }
         }
 

--- a/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
+++ b/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PluginBundle\Tests\EventListener;
+
+use Mautic\PluginBundle\Event\PluginIntegrationRequestEvent;
+use Mautic\PluginBundle\EventListener\IntegrationSubscriber;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class IntegrationSubscriberTest extends TestCase
+{
+    public function testOnRequestLogging(): void
+    {
+        $event = $this->createMock(PluginIntegrationRequestEvent::class);
+        $event->method('getIntegrationName')->willReturn('Integration');
+        $event->method('getHeaders')->willReturn(['Authorization: Bearer some_token']);
+        $event->method('getMethod')->willReturn('POST');
+        $event->method('getUrl')->willReturn('https://mautic.org');
+        $event->method('getParameters')->willReturn(['key' => 'value']);
+        $event->method('getSettings')->willReturn(['setting' => 'value']);
+
+        $authorization = ['Authorization: Bearer 9a45520a1213f15016d2d768b5fb3d904492a44ee274b44d4de8803e00fb536a'];
+        $authorization = var_export($authorization, true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(4))
+            ->method('debug')
+            ->withConsecutive(
+                ['INTEGRATION REQUEST URL: POST https://mautic.org'],
+                ["INTEGRATION REQUEST HEADERS: \n".$authorization.PHP_EOL],
+            );
+
+        $subscriber = new IntegrationSubscriber($logger);
+        $subscriber->onRequest($event);
+    }
+}

--- a/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
+++ b/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
@@ -21,7 +21,7 @@ final class IntegrationSubscriberTest extends TestCase
         $event->method('getParameters')->willReturn(['key' => 'value']);
         $event->method('getSettings')->willReturn(['setting' => 'value']);
 
-        $authorization = ['Authorization: Bearer 9a45520a1213f15016d2d768b5fb3d904492a44ee274b44d4de8803e00fb536a'];
+        $authorization = ['Authorization: Bearer [REDACTED]'];
         $authorization = var_export($authorization, true);
 
         $logger = $this->createMock(LoggerInterface::class);

--- a/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 final class oAuthHelperTest extends TestCase
 {
     /**
+     * @param array<int, string> $headers
+     *
      * @dataProvider dataForHashSensitiveHeaderData
      */
     public function testHashSensitiveHeaderData(string $authorization, array $headers): void

--- a/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PluginBundle\Tests\Helper;
+
+use Mautic\PluginBundle\Helper\oAuthHelper;
+use PHPUnit\Framework\TestCase;
+
+final class oAuthHelperTest extends TestCase
+{
+    public function testHashSensitiveHeaderData()
+    {
+        $headers = [
+            'Authorization: Bearer SME-ASA',
+        ];
+
+        $hashedHeaders = oAuthHelper::hashSensitiveHeaderData($headers);
+
+        $this->assertStringContainsString('Authorization: Bearer ', $hashedHeaders[0]);
+        $this->assertMatchesRegularExpression('/Authorization: Bearer [a-f0-9]{64}/', $hashedHeaders[0]);
+    }
+}

--- a/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class oAuthHelperTest extends TestCase
 {
-    public function testHashSensitiveHeaderData()
+    public function testHashSensitiveHeaderData(): void
     {
         $headers = [
             'Authorization: Bearer SME-ASA',

--- a/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
@@ -16,10 +16,9 @@ final class oAuthHelperTest extends TestCase
      */
     public function testHashSensitiveHeaderData(string $authorization, array $headers): void
     {
-        $hashedHeaders = oAuthHelper::hashSensitiveHeaderData($headers);
+        $hashedHeaders = oAuthHelper::sanitizeHeaderData($headers);
 
-        $this->assertStringContainsString(sprintf('Authorization: %s ', $authorization), $hashedHeaders[0]);
-        $this->assertMatchesRegularExpression(sprintf('/Authorization: %s [a-f0-9]{64}/', $authorization), $hashedHeaders[0]);
+        $this->assertStringContainsString(sprintf('Authorization: %s [REDACTED]', $authorization), $hashedHeaders[0]);
     }
 
     /**

--- a/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/oAuthHelperTest.php
@@ -9,15 +9,34 @@ use PHPUnit\Framework\TestCase;
 
 final class oAuthHelperTest extends TestCase
 {
-    public function testHashSensitiveHeaderData(): void
+    /**
+     * @dataProvider dataForHashSensitiveHeaderData
+     */
+    public function testHashSensitiveHeaderData(string $authorization, array $headers): void
     {
-        $headers = [
-            'Authorization: Bearer SME-ASA',
-        ];
-
         $hashedHeaders = oAuthHelper::hashSensitiveHeaderData($headers);
 
-        $this->assertStringContainsString('Authorization: Bearer ', $hashedHeaders[0]);
-        $this->assertMatchesRegularExpression('/Authorization: Bearer [a-f0-9]{64}/', $hashedHeaders[0]);
+        $this->assertStringContainsString(sprintf('Authorization: %s ', $authorization), $hashedHeaders[0]);
+        $this->assertMatchesRegularExpression(sprintf('/Authorization: %s [a-f0-9]{64}/', $authorization), $hashedHeaders[0]);
+    }
+
+    /**
+     * @return \Generator<string, array<int, string|array<int, string>>>
+     */
+    public function dataForHashSensitiveHeaderData(): \Generator
+    {
+        yield 'For Bearer' => [
+            'Bearer',
+            [
+                'Authorization: Bearer SME-ASA',
+            ],
+        ];
+
+        yield 'For Basic' => [
+            'Basic',
+            [
+                'Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Integrated plugins are logging the security. This PR hashes the token before logging.

| Before                                 | After
| -------------------------------------- | ---
| <img width="643" alt="Before" src="https://github.com/user-attachments/assets/ae498698-22a5-4276-88f8-25025d2d96c4"> | <img width="643" alt="Before" src="https://github.com/user-attachments/assets/28f10b56-c0f4-4ab0-8026-32277941d035"> 

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Activate the hubspot plugin and add the Access token.
3. Close and open the fubspot integration modal window.
4. Find the logged data. The token is now hashed. This was not the case before

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->