### PR TITLE
Fixing 404 content

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -474,7 +474,7 @@ class CommonController extends AbstractController implements MauticController
             if (!empty($page) && $page->getIsPublished() && !empty($page->getCustomHtml())) {
                 $slug     = $pageModel->generateSlug($page);
                 $response = $this->forward(
-                    'MauticPageBundle:Public:index',
+                    'Mautic\PageBundle\Controller\PublicController::indexAction',
                     [
                         'slug'            => $slug,
                         'ignore_mismatch' => true,

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -466,16 +466,22 @@ class CommonController extends AbstractController implements MauticController
     public function notFound($msg = 'mautic.core.url.error.404')
     {
         $request = $this->getCurrentRequest();
-
-        $page_404 = $this->coreParametersHelper->get('404_page');
-        if (!empty($page_404)) {
+        $page404 = $this->coreParametersHelper->get('404_page');
+        if (!empty($page404)) {
             $pageModel = $this->getModel('page');
             \assert($pageModel instanceof PageModel);
-            $page = $pageModel->getEntity($page_404);
+            $page = $pageModel->getEntity($page404);
             if (!empty($page) && $page->getIsPublished() && !empty($page->getCustomHtml())) {
-                $slug = $pageModel->generateSlug($page);
+                $slug     = $pageModel->generateSlug($page);
+                $response = $this->forward(
+                    'MauticPageBundle:Public:index',
+                    [
+                        'slug'            => $slug,
+                        'ignore_mismatch' => true,
+                    ]
+                );
 
-                return $this->redirectToRoute('mautic_page_public', ['slug' => $slug]);
+                return new Response($response->getContent(), Response::HTTP_NOT_FOUND, $response->headers->all());
             }
         }
 

--- a/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
@@ -30,10 +30,10 @@ final class NotFoundFunctionalTest extends MauticMysqlTestCase
         parent::setUpSymfony($this->configParams);
 
         // Test the custom 404 page:
-        $crawler = $this->client->request(Request::METHOD_GET, '/s/page-that-does-not-exist');
+        $crawler = $this->client->request(Request::METHOD_GET, '/page-that-does-not-exist');
         Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
         Assert::assertStringContainsString('Custom 404 Not Found Page', $crawler->text());
         Assert::assertFalse($this->client->getResponse()->isRedirection(), 'The response should not be a redirect.');
-        Assert::assertSame('/s/page-that-does-not-exist', $this->client->getRequest()->getRequestUri(), 'The request URI should be the same as the original URI.');
+        Assert::assertSame('/page-that-does-not-exist', $this->client->getRequest()->getRequestUri(), 'The request URI should be the same as the original URI.');
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class NotFoundFunctionalTest extends MauticMysqlTestCase
+{
+    protected $useCleanupRollback = false;
+
+    public function testCustom404Page(): void
+    {
+        // Create a custom 404 page:
+        $notFoundPage = new Page();
+        $notFoundPage->setTitle('404 Not Found');
+        $notFoundPage->setAlias('404-not-found');
+        $notFoundPage->setCustomHtml('<html><body>Custom 404 Not Found Page</body></html>');
+
+        $this->em->persist($notFoundPage);
+        $this->em->flush();
+
+        // Configure the 404 page:
+        $this->configParams['404_page'] = $notFoundPage->getId();
+        parent::setUpSymfony($this->configParams);
+
+        // Test the custom 404 page:
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/page-that-does-not-exist');
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        Assert::assertStringContainsString('Custom 404 Not Found Page', $crawler->text());
+        Assert::assertFalse($this->client->getResponse()->isRedirection(), 'The response should not be a redirect.');
+        Assert::assertSame('/s/page-that-does-not-exist', $this->client->getRequest()->getRequestUri(), 'The request URI should be the same as the original URI.');
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When a custom 404 page is configured and a contact tries to access a URI that does not exist then the user is redirected to the custom 404 page. Instead the contact should stay on that bad URI and the 404 page content should show up under this bad URI.

This is important for example when tracking the 404 page with Google Analytics.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom landing page. Call it for example 404 - Not Found and add this text to the landing page content as well to identify what you are seeing later.
3. Go to the global configuration and select this page as custom 404 page.
4. Access any public route that doesn’t exist. For example https://your-mautic.com/abcdefg. 

#### Expected Result
The contact should still stay on the bad URI as the example above shows https://your-mautic.com/abcdefg. The contact should not be redirected to the custom 404 URI.

#### Other areas of Mautic that may be affected by the change:
1. Just accessing the custom 404 page

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The functional test covers accessing a route that does not exist when a custom 404 page is configured. It checks that there was no redirect and that the HTTP response code is 404 (not 200 as it was before) and the content of the custom HTML page is displayed.
