### PR TITLE
Fix new themes ready for packagist

### DIFF
--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -169,6 +169,72 @@
             "name": "theme-vibrant",
             "directory": "themes/vibrant",
             "target": "git@github.com:mautic/theme-vibrant.git"
+        },
+        {
+            "name": "theme-1-2-1-2-column",
+            "directory": "themes/1-2-1-2-column",
+            "target": "git@github.com:mautic/theme-1-2-1-2-column.git"
+        },
+        {
+            "name": "theme-1-2-1-column",
+            "directory": "themes/1-2-1-column",
+            "target": "git@github.com:mautic/theme-1-2-1-column.git"
+        },
+        {
+            "name": "theme-1-2-column",
+            "directory": "themes/1-2-column",
+            "target": "git@github.com:mautic/theme-1-2-column.git"
+        },
+        {
+            "name": "theme-1-3-1-3-column",
+            "directory": "themes/1-3-1-3-column",
+            "target": "git@github.com:mautic/theme-1-3-1-3-column.git"
+        },
+        {
+            "name": "theme-1-3-column",
+            "directory": "themes/1-3-column",
+            "target": "git@github.com:mautic/theme-1-3-column.git"
+        },
+        {
+            "name": "theme-connect-through-content",
+            "directory": "themes/connect-through-content",
+            "target": "git@github.com:mautic/theme-connect-through-content.git"
+        },
+        {
+            "name": "theme-education",
+            "directory": "themes/education",
+            "target": "git@github.com:mautic/theme-education.git"
+        },
+        {
+            "name": "theme-gallery",
+            "directory": "themes/gallery",
+            "target": "git@github.com:mautic/theme-gallery.git"
+        },
+        {
+            "name": "theme-make-announcement",
+            "directory": "themes/make-announcement",
+            "target": "git@github.com:mautic/theme-make-announcement.git"
+        },
+        {
+            "name": "theme-showcase",
+            "directory": "themes/showcase",
+            "target": "git@github.com:mautic/theme-showcase.git"
+        },
+        {
+            "name": "theme-simple-text",
+            "directory": "themes/simple-text",
+            "target": "git@github.com:mautic/theme-simple-text.git"
+        },
+        {
+            "name": "theme-survey",
+            "directory": "themes/survey",
+            "target": "git@github.com:mautic/theme-survey.git"
+        },
+        {
+            "name": "theme-welcome",
+            "directory": "themes/welcome",
+            "target": "git@github.com:mautic/theme-welcome.git"
         }
+
     ]
 }

--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -201,9 +201,9 @@
             "target": "git@github.com:mautic/theme-connect-through-content.git"
         },
         {
-            "name": "theme-education",
-            "directory": "themes/education",
-            "target": "git@github.com:mautic/theme-education.git"
+            "name": "theme-educate",
+            "directory": "themes/educate",
+            "target": "git@github.com:mautic/theme-educate.git"
         },
         {
             "name": "theme-gallery",

--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -69,6 +69,19 @@ jobs:
                     - theme-sunday
                     - theme-trulypersonal
                     - theme-vibrant
+                    - theme-1-2-1-2-column
+                    - theme-1-2-1-column
+                    - theme-1-2-column
+                    - theme-1-3-1-3-column
+                    - theme-1-3-column
+                    - theme-connect-through-content
+                    - theme-educate
+                    - theme-gallery
+                    - theme-make-announcement
+                    - theme-showcase
+                    - theme-simple-text
+                    - theme-survey
+                    - theme-welcome
         name: Sync commits into mautic/${{ matrix.config }}
         steps:
             -   uses: actions/checkout@v4

--- a/themes/_1-2-1-2-column/.github/workflows/close_pull_requests.yml
+++ b/themes/_1-2-1-2-column/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_1-2-1-2-column` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_1-2-1-column/.github/workflows/close_pull_requests.yml
+++ b/themes/_1-2-1-column/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_1-2-1-column` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_1-2-column/.github/workflows/close_pull_requests.yml
+++ b/themes/_1-2-column/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_1-2-column` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_1-3-1-3-column/.github/workflows/close_pull_requests.yml
+++ b/themes/_1-3-1-3-column/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_1-3-1-3-column` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_1-3-column/.github/workflows/close_pull_requests.yml
+++ b/themes/_1-3-column/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_1-3-column` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_connect-through-content/.github/workflows/close_pull_requests.yml
+++ b/themes/_connect-through-content/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_connect-through-content` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_educate/.github/workflows/close_pull_requests.yml
+++ b/themes/_educate/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_educate` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_gallery/.github/workflows/close_pull_requests.yml
+++ b/themes/_gallery/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_gallery` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_make-announcement/.github/workflows/close_pull_requests.yml
+++ b/themes/_make-announcement/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_make-announcement` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_showcase/.github/workflows/close_pull_requests.yml
+++ b/themes/_showcase/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_showcase` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_simple-text/.github/workflows/close_pull_requests.yml
+++ b/themes/_simple-text/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_simple-text` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_survey/.github/workflows/close_pull_requests.yml
+++ b/themes/_survey/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_survey` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/_welcome/.github/workflows/close_pull_requests.yml
+++ b/themes/_welcome/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/_welcome` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 
| Deprecations?                          | 
| BC breaks? (use the c.x branch)        | 
| Automated tests included?              | <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

In https://github.com/mautic/mautic/pull/14155 we haven't been correctly set up each theme with a separate repo and Packagist package or configured the git split settings, so they are not going to be picked up by Composer installations. 

Each one should have a Packagist package, connected to the repository, and that should be pulled in [here](https://github.com/mautic/mautic/blob/5.x/.github/subtree-splitter-config.json) (which controls the git split, pushing changes / tags etc to the themes in core into the relevant repositories) and marked in the Composer file here: https://github.com/mautic/mautic/blob/5.x/composer.json#L53 this way they can be selectively added or removed from the build and in the future managed via the marketplace. 

This PR:

* Adds the git split configuration to connect the theme folder in mautic/mautic with the individual theme repos on GitHub
* Adds a GitHub Workflow for each sub-repo which we use to auto-close any PRs accidentally made in the sub-repos

Once this is merged, the sub-repos should be populated by the git split GitHub Action and then we can add the packages to composer.json (because we can't add an empty repo on Packagist - it requires the composer.json file).

### 📋 Steps to test this PR:

Please do code review as it won't be fully working until we get the Composer part sorted out.

The theme repos can be found using this query: https://github.com/orgs/mautic/repositories?type=all&q=theme.