### PR TITLE
Add Attract and Creative themes for Packagist / subtreesplit

### DIFF
--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -234,6 +234,16 @@
             "name": "theme-welcome",
             "directory": "themes/welcome",
             "target": "git@github.com:mautic/theme-welcome.git"
+        },
+        {
+            "name": "theme-attract",
+            "directory": "themes/attract",
+            "target": "git@github.com:mautic/theme-attract.git"
+        },
+        {
+            "name": "theme-creative",
+            "directory": "themes/creative",
+            "target": "git@github.com:mautic/theme-creative.git"
         }
 
     ]

--- a/.github/workflows/gitsplit/theme-attract.json
+++ b/.github/workflows/gitsplit/theme-attract.json
@@ -1,0 +1,9 @@
+{
+    "subtree-splits": [
+        {
+            "name": "theme-attract",
+            "directory": "themes/attract",
+            "target": "git@github.com:mautic/theme-attract.git"
+        }
+    ]
+}

--- a/.github/workflows/gitsplit/theme-creative.json
+++ b/.github/workflows/gitsplit/theme-creative.json
@@ -1,0 +1,9 @@
+{
+    "subtree-splits": [
+        {
+            "name": "theme-creative",
+            "directory": "themes/creative",
+            "target": "git@github.com:mautic/theme-creative.git"
+        }
+    ]
+}

--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -82,6 +82,8 @@ jobs:
                     - theme-simple-text
                     - theme-survey
                     - theme-welcome
+                    - theme-attract
+                    - theme-creative
         name: Sync commits into mautic/${{ matrix.config }}
         steps:
             -   uses: actions/checkout@v4

--- a/themes/attract/.github/workflows/close_pull_requests.yml
+++ b/themes/attract/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/attract` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 

--- a/themes/creative/.github/workflows/close_pull_requests.yml
+++ b/themes/creative/.github/workflows/close_pull_requests.yml
@@ -1,0 +1,26 @@
+# Workflow name:
+name: Close Pull Requests
+
+# Workflow triggers:
+on:
+  pull_request_target:
+    types: [opened]
+
+# Workflow jobs:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@v3
+      with:
+        comment: |
+          Thank you for submitting a pull request. :raised_hands:
+          
+          We greatly appreciate your willingness to submit a contribution. However, we are not accepting pull requests against this repository, as all development happens on the [main project repository](https://github.com/mautic/mautic).
+          
+          We kindly request that you submit this pull request against the respective directory `/themes/creative` of the [main repository](https://github.com/mautic/mautic) where we'll review and provide feedback. If this is your first Mautic contribution, be sure to read the [contributing guide](https://mau.tc/create-pr) which provides guidelines and instructions for submitting contributions.
+          
+          Thank you again, and we look forward to receiving your contribution! :smiley:
+          
+          Best,
+          The Mautic team 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |  ✅ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 
| Deprecations?                          | 
| BC breaks? (use the c.x branch)        | 
| Automated tests included?              |  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

In https://github.com/mautic/mautic/pull/14200 and https://github.com/mautic/mautic/pull/14201 we added two new themes but we didn't set them up for Packagist / subtreesplit which means they won't work properly as intended with the Mautic Marketplace and our deployment of code and tags/releases from mautic/mautic to the packages.

This PR:

* Adds the configuration to the subtree-splitter-config.json to include these two themes
* Adds the configuration to the split-monorepo-in-multi-repo.yml file to include these two themes
* Adds json files for each theme in the workflows folder
* Adds the GitHub Action workflow to auto-close PRs made on the theme repos (as they should be made in core)

Documentation for this process incoming so we don't have this issue again :D 

---
### 📋 Steps to test this PR:

Please do code review, check for any typos or issues with filenames and theme references.  The theme repos are at https://github.com/mautic/theme-attract and https://github.com/mautic/theme-creative.