### PR TITLE
Fix invalid paths in theme directory (needs an underscore)

### DIFF
--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -172,67 +172,67 @@
         },
         {
             "name": "theme-1-2-1-2-column",
-            "directory": "themes/1-2-1-2-column",
+            "directory": "themes/_1-2-1-2-column",
             "target": "git@github.com:mautic/theme-1-2-1-2-column.git"
         },
         {
             "name": "theme-1-2-1-column",
-            "directory": "themes/1-2-1-column",
+            "directory": "themes/_1-2-1-column",
             "target": "git@github.com:mautic/theme-1-2-1-column.git"
         },
         {
             "name": "theme-1-2-column",
-            "directory": "themes/1-2-column",
+            "directory": "themes/_1-2-column",
             "target": "git@github.com:mautic/theme-1-2-column.git"
         },
         {
             "name": "theme-1-3-1-3-column",
-            "directory": "themes/1-3-1-3-column",
+            "directory": "themes/_1-3-1-3-column",
             "target": "git@github.com:mautic/theme-1-3-1-3-column.git"
         },
         {
             "name": "theme-1-3-column",
-            "directory": "themes/1-3-column",
+            "directory": "themes/_1-3-column",
             "target": "git@github.com:mautic/theme-1-3-column.git"
         },
         {
             "name": "theme-connect-through-content",
-            "directory": "themes/connect-through-content",
+            "directory": "themes/_connect-through-content",
             "target": "git@github.com:mautic/theme-connect-through-content.git"
         },
         {
             "name": "theme-educate",
-            "directory": "themes/educate",
+            "directory": "themes/_educate",
             "target": "git@github.com:mautic/theme-educate.git"
         },
         {
             "name": "theme-gallery",
-            "directory": "themes/gallery",
+            "directory": "themes/_gallery",
             "target": "git@github.com:mautic/theme-gallery.git"
         },
         {
             "name": "theme-make-announcement",
-            "directory": "themes/make-announcement",
+            "directory": "themes/_make-announcement",
             "target": "git@github.com:mautic/theme-make-announcement.git"
         },
         {
             "name": "theme-showcase",
-            "directory": "themes/showcase",
+            "directory": "themes/_showcase",
             "target": "git@github.com:mautic/theme-showcase.git"
         },
         {
             "name": "theme-simple-text",
-            "directory": "themes/simple-text",
+            "directory": "themes/_simple-text",
             "target": "git@github.com:mautic/theme-simple-text.git"
         },
         {
             "name": "theme-survey",
-            "directory": "themes/survey",
+            "directory": "themes/_survey",
             "target": "git@github.com:mautic/theme-survey.git"
         },
         {
             "name": "theme-welcome",
-            "directory": "themes/welcome",
+            "directory": "themes/_welcome",
             "target": "git@github.com:mautic/theme-welcome.git"
         },
         {

--- a/.github/workflows/gitsplit/theme-1-2-1-2-column.json
+++ b/.github/workflows/gitsplit/theme-1-2-1-2-column.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-1-2-1-2-column",
-            "directory": "themes/1-2-1-2-column",
+            "directory": "themes/_1-2-1-2-column",
             "target": "git@github.com:mautic/theme-1-2-1-2-column.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-1-2-1-column.json
+++ b/.github/workflows/gitsplit/theme-1-2-1-column.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-1-2-1-column",
-            "directory": "themes/1-2-1-column",
+            "directory": "themes/_1-2-1-column",
             "target": "git@github.com:mautic/theme-1-2-1-column.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-1-2-column.json
+++ b/.github/workflows/gitsplit/theme-1-2-column.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-1-2-column",
-            "directory": "themes/1-2-column",
+            "directory": "themes/_1-2-column",
             "target": "git@github.com:mautic/theme-1-2-column.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-1-3-1-3-column.json
+++ b/.github/workflows/gitsplit/theme-1-3-1-3-column.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-1-3-1-3-column",
-            "directory": "themes/1-3-1-3-column",
+            "directory": "themes/_1-3-1-3-column",
             "target": "git@github.com:mautic/theme-1-3-1-3-column.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-1-3-column.json
+++ b/.github/workflows/gitsplit/theme-1-3-column.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-1-3-column",
-            "directory": "themes/1-3-column",
+            "directory": "themes/_1-3-column",
             "target": "git@github.com:mautic/theme-1-3-column.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-connect-through-content.json
+++ b/.github/workflows/gitsplit/theme-connect-through-content.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-connect-through-content",
-            "directory": "themes/connect-through-content",
+            "directory": "themes/_connect-through-content",
             "target": "git@github.com:mautic/theme-connect-through-content.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-educate.json
+++ b/.github/workflows/gitsplit/theme-educate.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-educate",
-            "directory": "themes/educate",
+            "directory": "themes/_educate",
             "target": "git@github.com:mautic/theme-educate.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-gallery.json
+++ b/.github/workflows/gitsplit/theme-gallery.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-gallery",
-            "directory": "themes/gallery",
+            "directory": "themes/_gallery",
             "target": "git@github.com:mautic/theme-gallery.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-make-announcement.json
+++ b/.github/workflows/gitsplit/theme-make-announcement.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-make-announcement",
-            "directory": "themes/make-announcement",
+            "directory": "themes/_make-announcement",
             "target": "git@github.com:mautic/theme-make-announcement.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-showcase.json
+++ b/.github/workflows/gitsplit/theme-showcase.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-showcase",
-            "directory": "themes/showcase",
+            "directory": "themes/_showcase",
             "target": "git@github.com:mautic/theme-showcase.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-simple-text.json
+++ b/.github/workflows/gitsplit/theme-simple-text.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-simple-text",
-            "directory": "themes/simple-text",
+            "directory": "themes/_simple-text",
             "target": "git@github.com:mautic/theme-simple-text.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-survey.json
+++ b/.github/workflows/gitsplit/theme-survey.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-survey",
-            "directory": "themes/survey",
+            "directory": "themes/_survey",
             "target": "git@github.com:mautic/theme-survey.git"
         }
     ]

--- a/.github/workflows/gitsplit/theme-welcome.json
+++ b/.github/workflows/gitsplit/theme-welcome.json
@@ -2,7 +2,7 @@
     "subtree-splits": [
         {
             "name": "theme-welcome",
-            "directory": "themes/welcome",
+            "directory": "themes/_welcome",
             "target": "git@github.com:mautic/theme-welcome.git"
         }
     ]


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 
| Deprecations?                          | 
| BC breaks? (use the c.x branch)        | 
| Automated tests included?              |  <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

While the Creative and Attract themes are synchronising fine, the others are not. When I looked into it, it seems like perhaps the problem is the preceding underscore in the folder for these themes, which was missing in the directory statement in both the main gitsplit json and the individual theme json files.

Hopefully .... this might be the last fix! 

### 📋 Steps to test this PR:

Please do code review. Check all of the new themes are included except for the two without an underscore which are synchronizing fine. Thanks!