### PR TITLE
Consider a campaign's Activate at / Deactivate at dates when triggering campaign events

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -429,7 +429,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
     /**
      * Set publishUp.
      *
-     * @param \DateTime $publishUp
+     * @param ?\DateTime $publishUp
      *
      * @return Campaign
      */
@@ -454,7 +454,7 @@ class Campaign extends FormEntity implements PublishStatusIconAttributesInterfac
     /**
      * Set publishDown.
      *
-     * @param \DateTimeInterface $publishDown
+     * @param ?\DateTime $publishDown
      *
      * @return Campaign
      */

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -81,6 +81,14 @@ class EventRepository extends CommonRepository
             ->where(
                 $q->expr()->andX(
                     $q->expr()->eq('c.isPublished', 1),
+                    $q->expr()->orX(
+                        $q->expr()->isNull('c.publishUp'),
+                        $q->expr()->lt('c.publishUp', 'CURRENT_TIMESTAMP()'),
+                    ),
+                    $q->expr()->orX(
+                        $q->expr()->isNull('c.publishDown'),
+                        $q->expr()->gt('c.publishDown', 'CURRENT_TIMESTAMP()'),
+                    ),
                     $q->expr()->isNull('c.deleted'),
                     $q->expr()->eq('e.type', ':type'),
                     $q->expr()->isNull('e.deleted'),

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Entity;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+class EventRepositoryFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * @return iterable<string, array{?\DateTime, ?\DateTime, int}>
+     */
+    public function dataGetContactPendingEventsConsidersCampaignPublishUpAndDown(): iterable
+    {
+        yield 'Publish Up and Down not set' => [null, null, 1];
+        yield 'Publish Up and Down set' => [new \DateTime('-1 day'), new \DateTime('+1 day'), 1];
+        yield 'Publish Up and Down set with Publish Up in the future' => [new \DateTime('+1 day'), new \DateTime('+2 day'), 0];
+        yield 'Publish Up and Down set with Publish Down in the past' => [new \DateTime('-2 day'), new \DateTime('-1 day'), 0];
+        yield 'Publish Up in the past' => [new \DateTime('-1 day'), null, 1];
+        yield 'Publish Up in the future' => [new \DateTime('+1 day'), null, 0];
+        yield 'Publish Down in the past' => [null, new \DateTime('-1 day'), 0];
+        yield 'Publish Down in the future' => [null, new \DateTime('+1 day'), 1];
+    }
+
+    /**
+     * @dataProvider dataGetContactPendingEventsConsidersCampaignPublishUpAndDown
+     */
+    public function testGetContactPendingEventsConsidersCampaignPublishUpAndDown(?\DateTime $publishUp, ?\DateTime $publishDown, int $expectedCount): void
+    {
+        $repository = static::getContainer()->get('mautic.campaign.repository.event');
+        \assert($repository instanceof EventRepository);
+
+        $campaign = $this->createCampaign();
+        $event    = $this->createEvent($campaign);
+        $lead     = $this->createLead();
+        $this->createCampaignMember($lead, $campaign);
+
+        $campaign->setPublishUp($publishUp);
+        $campaign->setPublishDown($publishDown);
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        Assert::assertCount($expectedCount, $repository->getContactPendingEvents($lead->getId(), $event->getType()));
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test');
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+
+    private function createEvent(Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setName('test');
+        $event->setCampaign($campaign);
+        $event->setType('test.type');
+        $event->setEventType('action');
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createCampaignMember(Lead $lead, Campaign $campaign): void
+    {
+        $member = new CampaignMember();
+        $member->setLead($lead);
+        $member->setCampaign($campaign);
+        $member->setDateAdded(new \DateTime());
+        $this->em->persist($member);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds a check for a campaign's publishUp/Down dates into the RealTimeExecutioner so it will not execute the events when a given campaign is considered unpublished via its publishUp/Down dates.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Create a campaign with a `Visit a page` decision with an `Adjust contact points` action on the positive branch as follows
    ![Screenshot 2024-11-20 at 16 00 21](https://github.com/user-attachments/assets/64d5a9a1-87e7-41d0-b245-c303cb582f38)
   
2. Set the campaign's PublishUp/Down dates, so the campaign is considered unpublished based on these dates.
3. Make sure the campaign's Publish toggle is set to `Yes`.
4. Open a page with one of the contacts who are members of the campaign.
5. No points should be adjusted for the contact at this moment as the campaign is considered unpublished.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->