### PR TITLE
Fix flaky E2E tests in Contact Management and Email Management suites

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -52,4 +52,13 @@ class AcceptanceTester extends Codeception\Actor
         $this->waitForElementClickable(CategoriesPage::$SAVE_AND_CLOSE);
         $this->click(CategoriesPage::$SAVE_AND_CLOSE);
     }
+
+    /**
+     * Ensures that a notification appears after an action and contains the expected text.
+     */
+    public function ensureNotificationAppears(string $message): void
+    {
+        $this->waitForElementVisible('#flashes .alert', 10);
+        $this->see($message, '#flashes .alert');
+    }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -44,11 +44,15 @@ class AcceptanceTester extends Codeception\Actor
         $this->amOnPage(CategoriesPage::$URL);
         $this->waitForElementClickable(CategoriesPage::$NEW_BUTTON);
         $this->click(CategoriesPage::$NEW_BUTTON);
+        $this->wait(2);
         $this->waitForElementClickable(CategoriesPage::$BUNDLE_DROPDOWN);
         $this->click(CategoriesPage::$BUNDLE_DROPDOWN);
+        $this->wait(2);
         $this->waitForElementClickable(CategoriesPage::$BUNDLE_EMAIL_OPTION);
         $this->click(CategoriesPage::$BUNDLE_EMAIL_OPTION);
+        $this->wait(2);
         $this->fillField(CategoriesPage::$TITLE_FIELD, $name);
         $this->click(CategoriesPage::$SAVE_AND_CLOSE);
+        $this->wait(2);
     }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -44,15 +44,12 @@ class AcceptanceTester extends Codeception\Actor
         $this->amOnPage(CategoriesPage::$URL);
         $this->waitForElementClickable(CategoriesPage::$NEW_BUTTON);
         $this->click(CategoriesPage::$NEW_BUTTON);
-        $this->wait(2);
         $this->waitForElementClickable(CategoriesPage::$BUNDLE_DROPDOWN);
         $this->click(CategoriesPage::$BUNDLE_DROPDOWN);
-        $this->wait(2);
         $this->waitForElementClickable(CategoriesPage::$BUNDLE_EMAIL_OPTION);
         $this->click(CategoriesPage::$BUNDLE_EMAIL_OPTION);
-        $this->wait(2);
         $this->fillField(CategoriesPage::$TITLE_FIELD, $name);
+        $this->waitForElementClickable(CategoriesPage::$SAVE_AND_CLOSE);
         $this->click(CategoriesPage::$SAVE_AND_CLOSE);
-        $this->wait(2);
     }
 }

--- a/tests/_support/Page/Acceptance/ContactPage.php
+++ b/tests/_support/Page/Acceptance/ContactPage.php
@@ -75,7 +75,7 @@ class ContactPage
 
     // Do Not Contact
     public static $firstContactDoNotContact  = '#leadTable > tbody > tr:nth-child(1) > td:nth-child(2) > a > div.pull-right > span';
-    public static $secondContactDoNotContact = '#leadTable > tbody > tr:nth-child(1) > td:nth-child(2) > a > div.pull-right > span';
+    public static $secondContactDoNotContact = '#leadTable > tbody > tr:nth-child(2) > td:nth-child(2) > a > div.pull-right > span';
     public static $doNotContactSaveButton    = '//*[@id="MauticSharedModal"]/div/div/div[3]/div/button[1]';
 
     /**

--- a/tests/_support/Step/Acceptance/ContactStep.php
+++ b/tests/_support/Step/Acceptance/ContactStep.php
@@ -67,6 +67,7 @@ class ContactStep extends \AcceptanceTester
     {
         $I     = $this;
         $xpath = "//*[@id='leadTable']/tbody/tr[$place]/td[1]/div/span/input";
+        $I->waitForElementClickable($xpath, 10);
         $I->checkOption($xpath);
         $I->seeCheckboxIsChecked($xpath);
     }
@@ -78,9 +79,13 @@ class ContactStep extends \AcceptanceTester
     {
         $I = $this;
         // Click the dropdown button for bulk actions
-        $I->click('//*[@id="leadTable"]/thead/tr/th[1]/div/div/button/i');
+        $xpathDropdownButton = '//*[@id="leadTable"]/thead/tr/th[1]/div/div/button/i';
+        $I->waitForElementClickable($xpathDropdownButton, 10);
+        $I->click($xpathDropdownButton);
         // Select the desired option from the dropdown menu
-        $I->click("//*[@id='leadTable']/thead/tr/th[1]/div/div/ul/li[$option]/a/span");
+        $xpathOption = "//*[@id='leadTable']/thead/tr/th[1]/div/div/ul/li[$option]/a/span";
+        $I->waitForElementClickable($xpathOption, 10);
+        $I->click($xpathOption);
     }
 
     /**

--- a/tests/_support/Step/Acceptance/ContactStep.php
+++ b/tests/_support/Step/Acceptance/ContactStep.php
@@ -65,8 +65,10 @@ class ContactStep extends \AcceptanceTester
      */
     public function selectContactFromList($place): void
     {
-        $I = $this;
-        $I->checkOption("//*[@id='leadTable']/tbody/tr[$place]/td[1]/div/span/input");
+        $I     = $this;
+        $xpath = "//*[@id='leadTable']/tbody/tr[$place]/td[1]/div/span/input";
+        $I->checkOption($xpath);
+        $I->seeCheckboxIsChecked($xpath);
     }
 
     /**

--- a/tests/_support/Step/Acceptance/EmailStep.php
+++ b/tests/_support/Step/Acceptance/EmailStep.php
@@ -32,13 +32,22 @@ class EmailStep extends \AcceptanceTester
     public function changeEmailCategory(): string
     {
         $I = $this;
+
         $I->waitForElementClickable(EmailsPage::$NEW_CATEGORY_DROPDOWN);
         $I->click(EmailsPage::$NEW_CATEGORY_DROPDOWN);
+
+        $I->wait(2);
+
         $I->waitForElementVisible(EmailsPage::$NEW_CATEGORY_OPTION);
         $newCategoryName = $I->grabTextFrom(EmailsPage::$NEW_CATEGORY_OPTION);
         $I->click(EmailsPage::$NEW_CATEGORY_OPTION);
+
+        $I->wait(2);
+
         $I->waitForElementClickable(EmailsPage::$SAVE_BUTTON);
         $I->click(EmailsPage::$SAVE_BUTTON);
+
+        $I->wait(2);
 
         return $newCategoryName;
     }

--- a/tests/_support/Step/Acceptance/EmailStep.php
+++ b/tests/_support/Step/Acceptance/EmailStep.php
@@ -36,18 +36,14 @@ class EmailStep extends \AcceptanceTester
         $I->waitForElementClickable(EmailsPage::$NEW_CATEGORY_DROPDOWN);
         $I->click(EmailsPage::$NEW_CATEGORY_DROPDOWN);
 
-        $I->wait(2);
-
         $I->waitForElementVisible(EmailsPage::$NEW_CATEGORY_OPTION);
         $newCategoryName = $I->grabTextFrom(EmailsPage::$NEW_CATEGORY_OPTION);
-        $I->click(EmailsPage::$NEW_CATEGORY_OPTION);
 
-        $I->wait(2);
+        $I->waitForElementClickable(EmailsPage::$NEW_CATEGORY_OPTION);
+        $I->click(EmailsPage::$NEW_CATEGORY_OPTION);
 
         $I->waitForElementClickable(EmailsPage::$SAVE_BUTTON);
         $I->click(EmailsPage::$SAVE_BUTTON);
-
-        $I->wait(2);
 
         return $newCategoryName;
     }

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -435,7 +435,6 @@ class ContactManagementCest
         $I->click(ContactPage::$doNotContactSaveButton);
 
         $I->waitForElementVisible('#flashes .alert', 15);
-        $I->seeElement('#flashes .alert');
         $I->see('2 contacts affected', '#flashes .alert');
 
         $I->reloadPage();

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -434,8 +434,7 @@ class ContactManagementCest
         $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, 10);
         $I->click(ContactPage::$doNotContactSaveButton);
 
-        $I->waitForElementVisible('#flashes .alert', 15);
-        $I->see('2 contacts affected', '#flashes .alert');
+        $I->ensureNotificationAppears('2 contacts affected');
 
         $I->reloadPage();
 

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -428,24 +428,22 @@ class ContactManagementCest
         $contact->selectContactFromList(1);
         $contact->selectContactFromList(2);
 
-        $I->wait(1);
-
         // Select change segment option from dropdown for multiple selections
         $contact->selectOptionFromDropDownForMultipleSelections(10);
 
         $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, 10);
         $I->click(ContactPage::$doNotContactSaveButton);
 
-        $I->wait(1);
+        $I->waitForElementVisible('#flashes .alert', 15);
+        $I->seeElement('#flashes .alert');
+        $I->see('2 contacts affected', '#flashes .alert');
 
         $I->reloadPage();
 
-        $I->wait(5);
-
-        $I->waitForElementVisible(ContactPage::$firstContactDoNotContact, 10);
+        $I->waitForElementVisible(ContactPage::$firstContactDoNotContact, 15);
         $I->seeElement(ContactPage::$firstContactDoNotContact);
 
-        $I->waitForElementVisible(ContactPage::$secondContactDoNotContact, 10);
+        $I->waitForElementVisible(ContactPage::$secondContactDoNotContact, 15);
         $I->seeElement(ContactPage::$secondContactDoNotContact);
     }
 

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -428,15 +428,24 @@ class ContactManagementCest
         $contact->selectContactFromList(1);
         $contact->selectContactFromList(2);
 
+        $I->wait(1);
+
         // Select change segment option from dropdown for multiple selections
         $contact->selectOptionFromDropDownForMultipleSelections(10);
 
-        $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, 5);
+        $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, 10);
         $I->click(ContactPage::$doNotContactSaveButton);
+
+        $I->wait(1);
 
         $I->reloadPage();
 
+        $I->wait(5);
+
+        $I->waitForElementVisible(ContactPage::$firstContactDoNotContact, 10);
         $I->seeElement(ContactPage::$firstContactDoNotContact);
+
+        $I->waitForElementVisible(ContactPage::$secondContactDoNotContact, 10);
         $I->seeElement(ContactPage::$secondContactDoNotContact);
     }
 

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -35,21 +35,12 @@ class EmailManagementCest
         $this->selectChangeCategoryAction($I);
         $newCategoryName = $email->changeEmailCategory();
 
-        $this->ensureNotificationAppears($I, 'emails affected');
+        $I->ensureNotificationAppears('emails affected');
 
         $I->reloadPage();
 
         // Assert
         $this->verifyAllEmailsBelongTo($I, $newCategoryName);
-    }
-
-    /**
-     * Ensures that a notification appears after an action and contains the expected text.
-     */
-    protected function ensureNotificationAppears(AcceptanceTester $I, string $message): void
-    {
-        $I->waitForElementVisible('#flashes .alert', 10);
-        $I->see($message, '#flashes .alert');
     }
 
     public function selectAllEmails(AcceptanceTester $I): void

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -34,7 +34,10 @@ class EmailManagementCest
         $this->selectAllEmails($I);
         $this->selectChangeCategoryAction($I);
         $newCategoryName = $email->changeEmailCategory();
+
         $I->reloadPage();
+
+        $I->wait(5);
 
         // Assert
         $this->verifyAllEmailsBelongTo($I, $newCategoryName);
@@ -44,14 +47,18 @@ class EmailManagementCest
     {
         $I->waitForElementClickable(EmailsPage::$SELECT_ALL_CHECKBOX);
         $I->click(EmailsPage::$SELECT_ALL_CHECKBOX);
+        $I->wait(2);
+        $I->seeCheckboxIsChecked(EmailsPage::$SELECT_ALL_CHECKBOX);
     }
 
     private function selectChangeCategoryAction(AcceptanceTester $I): void
     {
         $I->waitForElementClickable(EmailsPage::$SELECTED_ACTIONS_DROPDOWN);
         $I->click(EmailsPage::$SELECTED_ACTIONS_DROPDOWN);
+        $I->wait(2);
         $I->waitForElementClickable(EmailsPage::$CHANGE_CATEGORY_ACTION);
         $I->click(EmailsPage::$CHANGE_CATEGORY_ACTION);
+        $I->wait(2);
     }
 
     protected function verifyAllEmailsBelongTo(AcceptanceTester $I, string $firstCategoryName): void

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -39,8 +39,6 @@ class EmailManagementCest
 
         $I->reloadPage();
 
-        $I->wait(5); // Wait for the page to load
-
         // Assert
         $this->verifyAllEmailsBelongTo($I, $newCategoryName);
     }
@@ -71,9 +69,12 @@ class EmailManagementCest
 
     protected function verifyAllEmailsBelongTo(AcceptanceTester $I, string $firstCategoryName): void
     {
+        $I->waitForElementVisible('span.label-category');
         $categories = $I->grabMultiple('span.label-category');
         for ($i = 1; $i <= count($categories); ++$i) {
-            $I->see($firstCategoryName, '//*[@id="app-content"]/div/div[2]/div[2]/div[1]/table/tbody/tr['.$i.']/td[3]/div');
+            $xpath = '//*[@id="app-content"]/div/div[2]/div[2]/div[1]/table/tbody/tr['.$i.']/td[3]/div';
+            $I->waitForElementVisible($xpath);
+            $I->see($firstCategoryName, $xpath);
         }
     }
 }

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -35,19 +35,29 @@ class EmailManagementCest
         $this->selectChangeCategoryAction($I);
         $newCategoryName = $email->changeEmailCategory();
 
+        $this->ensureNotificationAppears($I, 'emails affected');
+
         $I->reloadPage();
 
-        $I->wait(5);
+        $I->wait(5); // Wait for the page to load
 
         // Assert
         $this->verifyAllEmailsBelongTo($I, $newCategoryName);
+    }
+
+    /**
+     * Ensures that a notification appears after an action and contains the expected text.
+     */
+    protected function ensureNotificationAppears(AcceptanceTester $I, string $message): void
+    {
+        $I->waitForElementVisible('#flashes .alert', 10);
+        $I->see($message, '#flashes .alert');
     }
 
     public function selectAllEmails(AcceptanceTester $I): void
     {
         $I->waitForElementClickable(EmailsPage::$SELECT_ALL_CHECKBOX);
         $I->click(EmailsPage::$SELECT_ALL_CHECKBOX);
-        $I->wait(2);
         $I->seeCheckboxIsChecked(EmailsPage::$SELECT_ALL_CHECKBOX);
     }
 
@@ -55,10 +65,8 @@ class EmailManagementCest
     {
         $I->waitForElementClickable(EmailsPage::$SELECTED_ACTIONS_DROPDOWN);
         $I->click(EmailsPage::$SELECTED_ACTIONS_DROPDOWN);
-        $I->wait(2);
         $I->waitForElementClickable(EmailsPage::$CHANGE_CATEGORY_ACTION);
         $I->click(EmailsPage::$CHANGE_CATEGORY_ACTION);
-        $I->wait(2);
     }
 
     protected function verifyAllEmailsBelongTo(AcceptanceTester $I, string $firstCategoryName): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14174 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes two flaky E2E tests:

1. **ContactManagementCest: Batch set 'Do Not Contact'**
2. **EmailManagementCest: Try to batch change email category**

![image](https://github.com/user-attachments/assets/7f75a08b-7409-4302-ab30-35979d10676a)

**Changes Made**
1. **Contact Management: Batch Set 'Do Not Contact'**
   - **Issue:** The test intermittently failed to verify that both contacts were marked as "Do Not Contact."
   - **Fixes:**
     - Added waitForElementVisible to verify elements are visible.
     - The selector for the second contact's "Do Not Contact" indicator was incorrectly pointing to the first contact's element.
     - Verified contact selection by asserting checkboxes are checked before proceeding.
     - Added wait times for any UI transitions or backend processing between steps.

2. **Email Management: Batch Change Email Category**
   - **Issue:** The test intermittently failed to verify that all emails were assigned the new category.
   - **Fixes:**
     - Verified all contacts selection by asserting checkbox is checked before proceeding.
     - Added wait times for any UI transitions or backend processing between steps.

**Testing**
Both tests were run multiple times in the CI environment, confirming consistent results.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Run the tests in this PR repeatedly to check if either of the two tests fails.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->