### PR TITLE
Campaign event: same day execution fix

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -256,11 +256,11 @@ class Interval implements ScheduleModeInterface
         $testGroupHour->setTime($groupHour->format('H'), $groupHour->format('i'));
 
         if ($groupExecutionDate <= $testGroupHour) {
+            // Schedule for the configured hour today if it's not passed yet.
             return $testGroupHour;
-        } else {
-            $groupExecutionDate->modify('+1 day')->setTime($groupHour->format('H'), $groupHour->format('i'));
         }
 
+        // Execute rigtaway if the hour has passed.
         return $groupExecutionDate;
     }
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -121,11 +121,12 @@ class Interval implements ScheduleModeInterface
                 $endTime,
                 $daysOfWeek
             );
-            if (!isset($groupedExecutionDates[$groupExecutionDate->getTimestamp()])) {
-                $groupedExecutionDates[$groupExecutionDate->getTimestamp()] = new GroupExecutionDateDAO($groupExecutionDate);
+            $key = $groupExecutionDate->format(DateTimeHelper::FORMAT_DB);
+            if (!isset($groupedExecutionDates[$key])) {
+                $groupedExecutionDates[$key] = new GroupExecutionDateDAO($groupExecutionDate);
             }
 
-            $groupedExecutionDates[$groupExecutionDate->getTimestamp()]->addContact($contact);
+            $groupedExecutionDates[$key]->addContact($contact);
         }
 
         return $groupedExecutionDates;
@@ -260,7 +261,7 @@ class Interval implements ScheduleModeInterface
             return $testGroupHour;
         }
 
-        // Execute rigtaway if the hour has passed.
+        // Execute rigt away if the hour has passed.
         return $groupExecutionDate;
     }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -200,7 +200,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
 
         $executionDate = $this->scheduler->validateExecutionDateTime($log, $simulatedNow);
         $this->assertTrue($this->scheduler->shouldSchedule($executionDate, $simulatedNow));
-        $this->assertEquals('2018-09-01 09:00:00', $executionDate->format('Y-m-d H:i:s'));
+        $this->assertEquals('2018-08-31 17:00:00', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
 
@@ -255,7 +255,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
 
         $executionDate = $this->scheduler->validateExecutionDateTime($log, $simulatedNow);
         $this->assertTrue($this->scheduler->shouldSchedule($executionDate, $simulatedNow));
-        $this->assertEquals('2018-09-01 11:00:00', $executionDate->format('Y-m-d H:i:s'));
+        // It is OK to set the execution date 15 seconds in the past. It means execute right now.
+        $this->assertEquals('2018-08-31 13:00:00', $executionDate->format('Y-m-d H:i:s'));
         $this->assertEquals('America/New_York', $executionDate->getTimezone()->getName());
     }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -283,12 +283,12 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
                 case 'America/North_Dakota/Center':
                     $this->assertCount(2, $groupExecutionDateDAO->getContacts());
                     $this->assertEquals([3, 4], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('2018-10-19 06:00', $executionDate->format('Y-m-d H:i'));
+                    $this->assertEquals('2018-10-18 08:00', $executionDate->format('Y-m-d H:i'));
                     break;
                 case 'America/New_York':
                     $this->assertCount(4, $groupExecutionDateDAO->getContacts());
                     $this->assertEquals([5, 6, 7, 8], $groupExecutionDateDAO->getContacts()->getKeys());
-                    $this->assertEquals('2018-10-19 06:00', $executionDate->format('Y-m-d H:i'));
+                    $this->assertEquals('2018-10-18 09:00', $executionDate->format('Y-m-d H:i'));
                     break;
             }
         }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -224,53 +224,37 @@ class IntervalTest extends \PHPUnit\Framework\TestCase
             ->willReturn(1);
 
         $interval = $this->getInterval();
-        $contact1 = $this->createMock(Lead::class);
-        $contact1->method('getId')
-            ->willReturn(1);
-        $contact1->method('getTimezone')
-            ->willReturn('America/Los_Angeles');
+        $contact1 = new Lead();
+        $contact1->setId(1);
+        $contact1->setTimezone('America/Los_Angeles');
 
-        $contact2 = $this->createMock(Lead::class);
-        $contact2->method('getId')
-            ->willReturn(2);
-        $contact2->method('getTimezone')
-            ->willReturn('America/Los_Angeles');
+        $contact2 = new Lead();
+        $contact2->setId(2);
+        $contact2->setTimezone('America/Los_Angeles');
 
-        $contact3 = $this->createMock(Lead::class);
-        $contact3->method('getId')
-            ->willReturn(3);
-        $contact3->method('getTimezone')
-            ->willReturn('America/North_Dakota/Center');
+        $contact3 = new Lead();
+        $contact3->setId(3);
+        $contact3->setTimezone('America/North_Dakota/Center');
 
-        $contact4 = $this->createMock(Lead::class);
-        $contact4->method('getId')
-            ->willReturn(4);
-        $contact4->method('getTimezone')
-            ->willReturn('America/North_Dakota/Center');
+        $contact4 = new Lead();
+        $contact4->setId(4);
+        $contact4->setTimezone('America/North_Dakota/Center');
 
-        $contact5 = $this->createMock(Lead::class);
-        $contact5->method('getId')
-            ->willReturn(5);
-        $contact5->method('getTimezone')
-            ->willReturn(''); // use default of New_York
+        $contact5 = new Lead();
+        $contact5->setId(5);
+        $contact5->setTimezone(''); // use default of New_York
 
-        $contact6 = $this->createMock(Lead::class);
-        $contact6->method('getId')
-            ->willReturn(6);
-        $contact6->method('getTimezone')
-            ->willReturn(''); // use default of New_York
+        $contact6 = new Lead();
+        $contact6->setId(6);
+        $contact6->setTimezone(''); // use default of New_York
 
-        $contact7 = $this->createMock(Lead::class);
-        $contact7->method('getId')
-            ->willReturn(7);
-        $contact7->method('getTimezone')
-            ->willReturn('Bad/Timezone'); // use default of New_York
+        $contact7 = new Lead();
+        $contact7->setId(7);
+        $contact7->setTimezone('Bad/Timezone'); // use default of New_York
 
-        $contact8 = $this->createMock(Lead::class);
-        $contact8->method('getId')
-            ->willReturn(8);
-        $contact8->method('getTimezone')
-            ->willReturn('Bad/Timezone'); // use default of New_York
+        $contact8 = new Lead();
+        $contact8->setId(8);
+        $contact8->setTimezone('Bad/Timezone'); // use default of New_York
 
         $contacts = new ArrayCollection([
             1 => $contact1,

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -108,6 +108,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
      */
     public function dataForCampaignWithJumpToEventWithIntervalTriggerMode(): iterable
     {
+        $now = new \DateTimeImmutable();
+
         $event = new Event();
         $event->setName('Adjust points');
         $event->setEventType(Event::TYPE_ACTION);
@@ -129,7 +131,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerHour((new \DateTime())->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerHour($now->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Scheduled at - before one hour' => [
             $adjustPointEvent,
@@ -138,10 +140,10 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerDate(new \DateTime());
+        $adjustPointEvent->setTriggerDate();
         $adjustPointEvent->setTriggerInterval(1);
         $adjustPointEvent->setTriggerIntervalUnit('H');
-        $adjustPointEvent->setTriggerHour((new \DateTime())->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerHour($now->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Scheduled at - before one hour with delay of 1 hour' => [
             $adjustPointEvent,
@@ -150,19 +152,19 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerDate(new \DateTime('tomorrow'));
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+2 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+3 hour'));
+        $adjustPointEvent->setTriggerDate();
+        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('+2 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('+3 hour')->format('H:i'));
 
         yield 'Points at a relative time: Between future start and stop time on same day' => [
             $adjustPointEvent,
             '%h',
-            (int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'),
+            2,
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour'));
+        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('-2 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Between passed time' => [
             $adjustPointEvent,
@@ -171,13 +173,13 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+3 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+4 hour'));
+        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('+3 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('+4 hour')->format('H:i'));
 
         yield 'Points at a relative time: Between future time' => [
             $adjustPointEvent,
             '%h',
-            (int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'),
+            3,
         ];
 
         $adjustPointEvent = clone $event;
@@ -193,7 +195,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         $adjustPointEvent = clone $event;
         $adjustPointEvent->setTriggerMode(Event::TRIGGER_MODE_DATE);
-        $adjustPointEvent->setTriggerDate((new \DateTime())->modify('+5 hour'));
+        $adjustPointEvent->setTriggerDate($now->modify('+5 hour'));
 
         yield 'Points at specific date/time' => [
             $adjustPointEvent,

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -132,7 +132,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
                 Assert::assertEqualsWithDelta(10, $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%i'), 1);
-            }
+            },
         ];
 
         $adjustPointEvent = clone $event;
@@ -146,7 +146,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
                     (new \DateTime())->format('Y-m-d H:00:00'),
                     $eventLog->getTriggerDate()->format('Y-m-d H:00:00')
                 );
-            }
+            },
         ];
 
         $adjustPointEvent = clone $event;
@@ -160,44 +160,57 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
                 Assert::assertEqualsWithDelta(0, $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+            },
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerDate(new \DateTime('tomorrow'));
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+2 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+3 hour'));
+        $adjustPointEvent->setTriggerInterval(1);
+        $adjustPointEvent->setTriggerIntervalUnit('d');
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+2 hours')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+3 hours')->format('H:i'));
 
-        yield 'Points at a relative time: Between future start and stop time on same day' => [
+        yield 'Points at a relative time: Between future start and stop time with 1 day delay will trigger tomorrow when the time slot starts' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog) use ($adjustPointEvent): void {
+            function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                Assert::assertEqualsWithDelta((int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'), $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+                $this->assertPlusMinusOneMinuteOf((new \DateTime())->modify('+1 day')->modify('+2 hours')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
+            },
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Between passed time' => [
             $adjustPointEvent,
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
                 Assert::assertEqualsWithDelta(22, $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+            },
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+3 hour'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+4 hour'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+3 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+4 hour')->format('H:i'));
 
-        yield 'Points at a relative time: Between future time' => [
+        yield 'Points at a relative time: Between future time today will schedule for today when the window starts' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog) use ($adjustPointEvent): void {
+            function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                Assert::assertEqualsWithDelta((int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'), $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+                $this->assertPlusMinusOneMinuteOf((new \DateTime())->modify('+3 hour')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
+            },
+        ];
+
+        $adjustPointEvent = clone $event;
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+1 hour')->format('H:i'));
+
+        yield 'Points at a relative time: Between future time today will execute immediatelly as the window is open right now' => [
+            $adjustPointEvent,
+            function (LeadEventLog $eventLog): void {
+                Assert::assertTrue($eventLog->getIsScheduled());
+                $this->assertPlusMinusOneMinuteOf((new \DateTime())->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
+            },
         ];
 
         $adjustPointEvent = clone $event;
@@ -210,7 +223,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
                 Assert::assertEqualsWithDelta(1, $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+            },
         ];
 
         $adjustPointEvent = clone $event;
@@ -222,7 +235,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
                 Assert::assertEqualsWithDelta(5, $eventLog->getDateTriggered()->diff($eventLog->getTriggerDate())->format('%h'), 1);
-            }
+            },
         ];
 
         $triggerHourDate  = (new \DateTime())->modify('+3 hours');
@@ -236,8 +249,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             $adjustPointEvent,
             function (LeadEventLog $eventLog) use ($triggerHourDate): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                Assert::assertSame($triggerHourDate->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
-            }
+                $this->assertPlusMinusOneMinuteOf($triggerHourDate->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
+            },
         ];
 
         $adjustPointEvent = clone $event;
@@ -250,11 +263,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             $adjustPointEvent,
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                Assert::assertSame(
-                    (new \DateTime('tomorrow'))->setTime(15, 0, 0)->format('Y-m-d 15:00:00'),
-                    $eventLog->getTriggerDate()->format('Y-m-d H:i:s')
-                );
-            }
+                $this->assertPlusMinusOneMinuteOf((new \DateTime('tomorrow'))->format('Y-m-d 15:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:i:s'));
+            },
         ];
 
         $triggerHourDate  = (new \DateTime())->modify('-3 hours');
@@ -268,8 +278,19 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
             $adjustPointEvent,
             function (LeadEventLog $eventLog): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                Assert::assertSame((new \DateTime())->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
-            }
+                $this->assertPlusMinusOneMinuteOf((new \DateTime())->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
+            },
         ];
+    }
+
+    /**
+     * Avoid flaky test when executing the test right whe the minute is increasing.
+     */
+    private function assertPlusMinusOneMinuteOf(string $expectedDateString, string $actualDateString): void
+    {
+        $expectedDate = new \DateTime($expectedDateString);
+        $actualDate   = new \DateTime($actualDateString);
+        Assert::assertLessThanOrEqual($expectedDate->modify('+1 minute'), $actualDate);
+        Assert::assertGreaterThanOrEqual($expectedDate->modify('-1 minute'), $actualDate);
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -146,7 +146,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         yield 'Points at a relative time: Scheduled at - before one hour. Should trigger now.' => [
             $adjustPointEvent,
             function (LeadEventLog $eventLog) use ($testNow): void {
-                Assert::assertTrue($eventLog->getIsScheduled());
+                Assert::assertFalse($eventLog->getIsScheduled());
                 $this->assertPlusMinusOneMinuteOf($testNow->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
             },
         ];
@@ -212,7 +212,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         yield 'Points at a relative time: Between future time today will execute immediatelly as the window is open right now' => [
             $adjustPointEvent,
             function (LeadEventLog $eventLog): void {
-                Assert::assertTrue($eventLog->getIsScheduled());
+                Assert::assertFalse($eventLog->getIsScheduled());
                 $this->assertPlusMinusOneMinuteOf((new \DateTime())->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
             },
         ];
@@ -284,7 +284,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         yield 'Execute the event when Send From is in the past on the selected day when the day is today' => [
             $adjustPointEvent,
             function (LeadEventLog $eventLog) use ($testNow): void {
-                Assert::assertTrue($eventLog->getIsScheduled());
+                Assert::assertFalse($eventLog->getIsScheduled());
                 $this->assertPlusMinusOneMinuteOf($testNow->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
             },
         ];

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -13,6 +13,15 @@ use Mautic\LeadBundle\Entity\Lead;
 
 class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends MauticMysqlTestCase
 {
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->configParams += [
+            'default_timezone' => 'UTC',
+        ];
+    }
+
     /**
      * @dataProvider dataForCampaignWithJumpToEventWithIntervalTriggerMode
      */

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -113,6 +113,10 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
      */
     public function dataForCampaignWithJumpToEventWithIntervalTriggerMode(): iterable
     {
+        // Event times starts when the PHPUNIT suite starts. The closures can run minutes later
+        // which breaks the test in the CI. Use this time in the closures to avoid flaky tests.
+        $testNow = new \DateTime();
+
         $event = new Event();
         $event->setName('Adjust points');
         $event->setEventType(Event::TYPE_ACTION);
@@ -141,9 +145,9 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         yield 'Points at a relative time: Scheduled at - before one hour. Should trigger now.' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog): void {
+            function (LeadEventLog $eventLog) use ($testNow): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                $this->assertPlusMinusOneMinuteOf((new \DateTime())->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
+                $this->assertPlusMinusOneMinuteOf($testNow->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
             },
         ];
 
@@ -169,9 +173,10 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         yield 'Points at a relative time: Between future start and stop time with 1 day delay will trigger tomorrow when the time slot starts' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog): void {
+            function (LeadEventLog $eventLog) use ($testNow): void {
+                $testNow = clone $testNow;
                 Assert::assertTrue($eventLog->getIsScheduled());
-                $this->assertPlusMinusOneMinuteOf((new \DateTime())->modify('+1 day')->modify('+2 hours')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
+                $this->assertPlusMinusOneMinuteOf($testNow->modify('+1 day')->modify('+2 hours')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
             },
         ];
 
@@ -193,9 +198,10 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         yield 'Points at a relative time: Between future time today will schedule for today when the window starts' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog): void {
+            function (LeadEventLog $eventLog) use ($testNow): void {
+                $testNow = clone $testNow;
                 Assert::assertTrue($eventLog->getIsScheduled());
-                $this->assertPlusMinusOneMinuteOf((new \DateTime())->modify('+3 hour')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
+                $this->assertPlusMinusOneMinuteOf($testNow->modify('+3 hour')->format('Y-m-d H:i'), $eventLog->getTriggerDate()->format('Y-m-d H:i'));
             },
         ];
 
@@ -277,9 +283,9 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         yield 'Execute the event when Send From is in the past on the selected day when the day is today' => [
             $adjustPointEvent,
-            function (LeadEventLog $eventLog): void {
+            function (LeadEventLog $eventLog) use ($testNow): void {
                 Assert::assertTrue($eventLog->getIsScheduled());
-                $this->assertPlusMinusOneMinuteOf((new \DateTime())->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
+                $this->assertPlusMinusOneMinuteOf($testNow->format('Y-m-d H:00:00'), $eventLog->getTriggerDate()->format('Y-m-d H:00:00'));
             },
         ];
     }

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -108,8 +108,6 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
      */
     public function dataForCampaignWithJumpToEventWithIntervalTriggerMode(): iterable
     {
-        $now = new \DateTimeImmutable();
-
         $event = new Event();
         $event->setName('Adjust points');
         $event->setEventType(Event::TYPE_ACTION);
@@ -131,7 +129,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerHour($now->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerHour((new \DateTime())->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Scheduled at - before one hour' => [
             $adjustPointEvent,
@@ -140,10 +138,10 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerDate();
+        $adjustPointEvent->setTriggerDate(new \DateTime());
         $adjustPointEvent->setTriggerInterval(1);
         $adjustPointEvent->setTriggerIntervalUnit('H');
-        $adjustPointEvent->setTriggerHour($now->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerHour((new \DateTime())->modify('-1 hour')->format('H:i'));
 
         yield 'Points at a relative time: Scheduled at - before one hour with delay of 1 hour' => [
             $adjustPointEvent,
@@ -152,19 +150,19 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerDate();
-        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('+2 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('+3 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerDate(new \DateTime('tomorrow'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+2 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+3 hour'));
 
         yield 'Points at a relative time: Between future start and stop time on same day' => [
             $adjustPointEvent,
             '%h',
-            2,
+            (int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'),
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('-2 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour'));
 
         yield 'Points at a relative time: Between passed time' => [
             $adjustPointEvent,
@@ -173,13 +171,13 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour($now->modify('+3 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour($now->modify('+4 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime('tomorrow'))->modify('+3 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime('tomorrow'))->modify('+4 hour'));
 
         yield 'Points at a relative time: Between future time' => [
             $adjustPointEvent,
             '%h',
-            3,
+            (int) $adjustPointEvent->getTriggerRestrictedStartHour()->diff(new \DateTime())->format('%h'),
         ];
 
         $adjustPointEvent = clone $event;
@@ -195,7 +193,7 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
 
         $adjustPointEvent = clone $event;
         $adjustPointEvent->setTriggerMode(Event::TRIGGER_MODE_DATE);
-        $adjustPointEvent->setTriggerDate($now->modify('+5 hour'));
+        $adjustPointEvent->setTriggerDate((new \DateTime())->modify('+5 hour'));
 
         yield 'Points at specific date/time' => [
             $adjustPointEvent,

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -168,8 +168,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         $adjustPointEvent = clone $event;
         $adjustPointEvent->setTriggerInterval(1);
         $adjustPointEvent->setTriggerIntervalUnit('d');
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+2 hours')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+3 hours')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+2 hours'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+3 hours'));
 
         yield 'Points at a relative time: Between future start and stop time with 1 day delay will trigger tomorrow when the time slot starts' => [
             $adjustPointEvent,
@@ -181,8 +181,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-2 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('-1 hour'));
 
         yield 'Points at a relative time: Between passed time' => [
             $adjustPointEvent,
@@ -193,8 +193,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+3 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+4 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('+3 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+4 hour'));
 
         yield 'Points at a relative time: Between future time today will schedule for today when the window starts' => [
             $adjustPointEvent,
@@ -206,8 +206,8 @@ class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends Mau
         ];
 
         $adjustPointEvent = clone $event;
-        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-1 hour')->format('H:i'));
-        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+1 hour')->format('H:i'));
+        $adjustPointEvent->setTriggerRestrictedStartHour((new \DateTime())->modify('-1 hour'));
+        $adjustPointEvent->setTriggerRestrictedStopHour((new \DateTime())->modify('+1 hour'));
 
         yield 'Points at a relative time: Between future time today will execute immediatelly as the window is open right now' => [
             $adjustPointEvent,


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/13920, https://github.com/mautic/mautic/pull/14089

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

I create a simple campaign that I want to start every Wednesday at noon:
![164b9c66-92ec-40d3-bfcf-c1dd0b540309](https://github.com/user-attachments/assets/6903a938-e250-4e4b-926a-23ba05d46d13)

If we add a new contact to the campaign on Wednesday at 13:00 we expect the event to be executed right away. It is Wednesday after 12:00. But instead it gets scheduled to the next week:

![f8057bda-4a4f-48f1-9efa-ce6bc0b98026](https://github.com/user-attachments/assets/899fbd50-450f-49b3-9b68-3ab66c5aaa18)


#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an empty segment
3. Create a simple campaign that have the empty segment as the source
4. Add a new event adding 5 points. Schedule it to execute only this day of the week and 1 hour before you have now. For example, if it is Friday 14:57, set it to execute only on Fridays at 14:00 so you can see the problem right away and don’t have to wait a few days.
5. Create a new contact ideally with some email address.
6. Go to the contact list view, check the contact and select in the batch actions to add this contact to your campaign that you have created previously.
7. Execute the campaign or wait for the background job to execute it for you. (depends on your situation)
8. Notice that the contact didn’t get the 5 points and instead the point event is scheduled for next week

#### Other areas of Mautic that may be affected by the change:
1. Just Mautic event scheduling


[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The tests cover the steps to test above. There are many other tests testing the between time frame or absolute date scheduling. Some I had to update as the execution will be now faster. Those test values were mostly changed when the bug was introduced so I was changing them back.
