### PR TITLE
fix: [DPMMA-2945] use hex colors in ckeditor

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/11.editor.js
+++ b/app/bundles/CoreBundle/Assets/js/11.editor.js
@@ -305,7 +305,23 @@ Mautic.ConvertFieldToCkeditor  = function(textarea, ckEditorToolbarOptions) {
 Mautic.GetCkEditorConfigOptions  = function(ckEditorToolbarOptions, tokenCallback) {
     const defaultOptions = ['undo', 'redo', '|', 'bold', 'italic', 'underline', 'heading', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', 'alignment', 'numberedList', 'bulletedList', 'blockQuote', 'removeFormat', 'link', 'ckfinder', 'mediaEmbed', 'insertTable', 'sourceEditing'];
     const ckEditorToolbar = typeof ckEditorToolbarOptions != "undefined" && ckEditorToolbarOptions.length > 0 ? ckEditorToolbarOptions : defaultOptions;
-
+    const ckEditorColors = [
+        { color: '#000000', label: 'Black' },
+        { color: '#4d4d4d', label: 'Dim grey' },
+        { color: '#999999', label: 'Grey' },
+        { color: '#e6e6e6', label: 'Light grey' },
+        { color: '#ffffff', label: 'White', hasBorder: true },
+        { color: '#e64c4c', label: 'Red' },
+        { color: '#e6994c', label: 'Orange' },
+        { color: '#e6e64c', label: 'Yellow' },
+        { color: '#99e64c', label: 'Light green' },
+        { color: '#4ce64c', label: 'Green' },
+        { color: '#4ce699', label: 'Aquamarine' },
+        { color: '#4ce6e6', label: 'Turquoise' },
+        { color: '#4c99e6', label: 'Light blue' },
+        { color: '#4c4ce6', label: 'Blue' },
+        { color: '#994ce6', label: 'Purple' }
+    ];
     const ckEditorOption = {
         toolbar: {
             items: ckEditorToolbar,
@@ -318,6 +334,20 @@ Mautic.GetCkEditorConfigOptions  = function(ckEditorToolbarOptions, tokenCallbac
         fontSize: {
             options: [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 72],
             supportAllValues : true
+        },
+        fontColor: {
+            // Use 'hex' format for output instead of 'hsl' as it causes problems in emails
+            colorPicker: {
+                format: 'hex'
+            },
+            colors: ckEditorColors
+        },
+        fontBackgroundColor: {
+            // Use 'hex' format for output instead of 'hsl' as it causes problems in emails
+            colorPicker: {
+                format: 'hex'
+            },
+            colors: ckEditorColors
         },
         link: {
             allowCreatingEmptyLinks: true, // allow creation of empty links, as it was before the 14.x update of cke5


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13718

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR replaces the HSL color values in CKEditor with HEX, as it causes problem in some email clients like outlook.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an email
3. Edit the email by double-clicking on some text.
4. Change the color of the selected text.
5. Send a test email and check it in Outlook, or verify the text style in an HTML code editor. The color should be in the format #000000, not hsl(0, 0, 0).

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->