### PR TITLE
Fix "This form should not contain extra fields" error in campaign event form

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -310,6 +310,10 @@ class EventType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $resolver->setDefaults([
+            'allow_extra_fields' => true, // Allow extra fields in the form
+        ]);
+
         $resolver->setRequired(['settings']);
     }
 

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -236,6 +236,17 @@ class EventType extends AbstractType
                     'placeholder'       => false,
                 ]
             );
+
+            $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+                $data        = $event->getData();
+                $triggerMode = $data['triggerMode'] ?? 'immediate';
+
+                // Do not set any trigger window when optimized mode is not used
+                if ('optimized' !== $triggerMode) {
+                    $data['triggerWindow'] = null;
+                    $event->setData($data);
+                }
+            });
         }
 
         if (!empty($options['settings']['formType'])) {
@@ -290,17 +301,6 @@ class EventType extends AbstractType
             ]
         );
 
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
-            $data        = $event->getData();
-            $triggerMode = $data['triggerMode'] ?? 'immediate';
-
-            // Do not set any trigger window when optimized mode is not used
-            if ('optimized' !== $triggerMode) {
-                $data['triggerWindow'] = null;
-                $event->setData($data);
-            }
-        });
-
         $builder->addEventSubscriber(new CleanFormSubscriber($masks));
 
         if (!empty($options['action'])) {
@@ -310,10 +310,6 @@ class EventType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults([
-            'allow_extra_fields' => true, // Allow extra fields in the form
-        ]);
-
         $resolver->setRequired(['settings']);
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14319 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR resolves the issue where adding a new decision in campaigns results in the error:
`This form should not contain extra fields.`

**Changes**
- Enabled the `allow_extra_fields` option in the `EventType` form configuration to allow additional fields during form submission.

This change aligns with Symfony's recommendation for handling dynamic form data.
From Symfony documentation: https://symfony.com/doc/5.x/reference/forms/types/form.html#allow-extra-fields

PR #13569 introduced new enhancement and modified the `EventType.php` file. While it's not certain, these changes might be related to the validation error observed in Mautic 5.2.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new segment/form
3. Create a new campaign
4. Open the campaign builder
5. Attempt to add any decision type (e.g., Device visit, Downloads asset, Visits a page, etc.).

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->

https://github.com/user-attachments/assets/7d8c04af-e315-4b27-86dc-6c980b286377