### PR TITLE
Best hour widget fix

### DIFF
--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -36,14 +36,10 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->detach($widget);
 
-        $this->client->request('GET', sprintf('/s/dashboard/widget/%s', $widget->getId()), [], [], [
-            'HTTP_X-Requested-With' => 'XMLHttpRequest',
-        ]);
+        $this->client->xmlHttpRequest('GET', sprintf('/s/dashboard/widget/%s', $widget->getId()));
+        $this->assertResponseIsSuccessful();
 
-        $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
-
-        $content = $response->getContent();
+        $content = $this->client->getResponse()->getContent();
         Assert::assertJson($content);
 
         $data = json_decode($content, true);
@@ -58,6 +54,42 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($widget->getHeight(), $data['widgetHeight']);
         Assert::assertArrayHasKey('widgetHtml', $data);
         Assert::assertStringContainsString('View Full Report', $data['widgetHtml']);
+    }
+
+    public function testWidgetWithBestHours(): void
+    {
+        $user    = $this->em->getRepository(User::class)->findOneBy([]);
+        $segment = $this->createSegment('A', 'a');
+        $widget  = new Widget();
+        $widget->setName('Best email read hours');
+        $widget->setType('emails.best.hours');
+        $widget->setParams(['timeFormat' => 24, 'segmentId' => $segment->getId()]);
+        $widget->setWidth(100);
+        $widget->setHeight(200);
+        $widget->setCreatedBy($user);
+        $this->em->persist($widget);
+
+        $this->em->flush();
+        $this->em->detach($widget);
+
+        $this->client->xmlHttpRequest('GET', "/s/dashboard/widget/{$widget->getId()}");
+        $this->assertResponseIsSuccessful();
+
+        $content = $this->client->getResponse()->getContent();
+        Assert::assertJson($content);
+
+        $data = json_decode($content, true);
+        Assert::assertIsArray($data);
+        Assert::assertArrayHasKey('success', $data);
+        Assert::assertSame(1, $data['success']);
+        Assert::assertArrayHasKey('widgetId', $data);
+        Assert::assertSame((string) $widget->getId(), $data['widgetId']);
+        Assert::assertArrayHasKey('widgetWidth', $data);
+        Assert::assertSame($widget->getWidth(), $data['widgetWidth']);
+        Assert::assertArrayHasKey('widgetHeight', $data);
+        Assert::assertSame($widget->getHeight(), $data['widgetHeight']);
+        Assert::assertArrayHasKey('widgetHtml', $data);
+        Assert::assertStringContainsString('Best email read hours', $data['widgetHtml']);
     }
 
     public function testWidgetWithSegmentBuildTime(): void
@@ -80,14 +112,10 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->detach($widget);
 
-        $this->client->request('GET', sprintf('/s/dashboard/widget/%s', $widget->getId()), [], [], [
-            'HTTP_X-Requested-With' => 'XMLHttpRequest',
-        ]);
+        $this->client->xmlHttpRequest('GET', sprintf('/s/dashboard/widget/%s', $widget->getId()));
+        $this->assertResponseIsSuccessful();
 
-        $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
-
-        $content = $response->getContent();
+        $content = $this->client->getResponse()->getContent();
         Assert::assertJson($content);
 
         $data = json_decode($content, true);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -117,6 +117,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface
         CoreParametersHelper $coreParametersHelper,
         private EmailStatModel $emailStatModel
     ) {
+        $this->connection = $em->getConnection(); // Necessary for FilterTrait
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14346

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

I removed the `Connection` dependency in the `EmailModel` in https://github.com/mautic/mautic/pull/13341/files#diff-09b3ad8df265e6fc5d43a0ead1c0d5394e085e56093f39af644b641d52827d82L117 as it seemed unused. Unfortunately, the `FilterTrait` is badly designed and silently requires this dependency.

This meant the Best email hour widget stopped working when a segment is selected.

### 📋 Steps to test this PR:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
1. Create this dashboard widget:
![Screenshot 2024-12-09 at 15 04 27](https://github.com/user-attachments/assets/2cfc7017-d89b-4b80-a999-2ddd604796c2)
It will fail with this error when you save it:
![Screenshot 2024-12-09 at 15 04 42](https://github.com/user-attachments/assets/59eef70a-b5c3-4665-b831-0753b593bf6b)

When you apply the changes in this PR, it will load the widget.


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->