### PR TITLE
Do not track attachment downloads when there is no request

### DIFF
--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -124,6 +124,12 @@ class AssetModel extends FormModel
             $request = $this->requestStack->getCurrentRequest();
         }
 
+        if (!($request instanceof Request)) {
+            // likely this download came via a cron (no request), do not bother logging the download.
+            // https://github.com/mautic/mautic/issues/13577
+            return;
+        }
+
         $download = new Download();
         $download->setDateDownload(new \DateTime());
         $download->setUtmCampaign($request->get('utm_campaign'));

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -262,10 +262,7 @@ class AssetModel extends FormModel
 
         $download->setCode($code);
         $download->setIpAddress($ipAddress);
-
-        if (null !== $request) {
-            $download->setReferer($request->server->get('HTTP_REFERER'));
-        }
+        $download->setReferer($request->server->get('HTTP_REFERER'));
 
         // Dispatch event
         if ($this->dispatcher->hasListeners(AssetEvents::ASSET_ON_LOAD)) {

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -26,8 +26,6 @@ use Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorService;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
-use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,7 +35,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AssetModelTest extends \PHPUnit\Framework\TestCase
 {
-
     private AssetModel $assetModel;
 
     private CoreParametersHelper&MockObject $coreParametersHelper;
@@ -87,25 +84,25 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('max_size'))
             ->willReturn('2MB');
 
-        $this->container = $this->createMock(ContainerInterface::class);
-        $this->cacheProvider = new CacheProvider($this->coreParametersHelper, $this->container);
-        $this->leadModel = $this->createMock(LeadModel::class);
-        $this->categoryModel = $this->createMock(CategoryModel::class);
-        $this->requestStack = $this->createMock(RequestStack::class);
-        $this->ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $this->container             = $this->createMock(ContainerInterface::class);
+        $this->cacheProvider         = new CacheProvider($this->coreParametersHelper, $this->container);
+        $this->leadModel             = $this->createMock(LeadModel::class);
+        $this->categoryModel         = $this->createMock(CategoryModel::class);
+        $this->requestStack          = $this->createMock(RequestStack::class);
+        $this->ipLookupHelper        = $this->createMock(IpLookupHelper::class);
         $this->deviceDetectorFactory = new DeviceDetectorFactory($this->cacheProvider);
-        $this->deviceCreatorService = new DeviceCreatorService();
+        $this->deviceCreatorService  = new DeviceCreatorService();
         $this->deviceTrackingService = $this->getMockBuilder(DeviceTrackingServiceInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->contactTracker = $this->createMock(ContactTracker::class);
-        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->contactTracker  = $this->createMock(ContactTracker::class);
+        $this->entityManager   = $this->createMock(EntityManager::class);
         $this->corePermissions = $this->createMock(CorePermissions::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $this->translator = $this->createMock(Translator::class);
-        $this->userHelper = $this->createMock(UserHelper::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->urlGenerator    = $this->createMock(UrlGeneratorInterface::class);
+        $this->translator      = $this->createMock(Translator::class);
+        $this->userHelper      = $this->createMock(UserHelper::class);
+        $this->logger          = $this->createMock(LoggerInterface::class);
 
         $this->assetModel = new AssetModel(
             $this->leadModel,
@@ -128,7 +125,7 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test that TrackDownload works only with a request
+     * Test that TrackDownload works only with a request.
      */
     public function testTrackDownloadRequest(): void
     {
@@ -155,12 +152,12 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test that TrackDownload works successfully
+     * Test that TrackDownload works successfully.
      */
     public function testTrackDownload(): void
     {
         $asset = new Asset();
-        $lead = new Lead();
+        $lead  = new Lead();
 
         $this->corePermissions->expects($this->once())
             ->method('isAnonymous')
@@ -221,7 +218,11 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
 
         $assetRepository->expects($this->once())
             ->method('upDownloadCount')
-            ->with($this->equalTo($asset->getId(), 1, true));
+            ->with(
+                $this->equalTo($asset->getId()),
+                $this->equalTo(1),
+                $this->equalTo(true),
+            );
 
         $ipAddress = new IpAddress('127.0.0.1');
 
@@ -241,6 +242,7 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
             ->method('persist')
             ->with($this->callback(function ($downloadPersist) use (&$download) {
                 $download = $downloadPersist;
+
                 return $download instanceof Download;
             }));
 
@@ -251,6 +253,7 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
             ->method('detach')
             ->with($this->callback(function ($downloadDetach) use (&$download) {
                 $this->assertSame($downloadDetach, $download);
+
                 return true;
             }));
 
@@ -267,5 +270,4 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($asset, $download->getAsset());
         $this->assertEquals('http://localhost', $download->getReferer());
     }
-
 }

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\AssetBundle\Tests\Model;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\AssetBundle\AssetEvents;
+use Mautic\AssetBundle\Entity\Asset;
+use Mautic\AssetBundle\Entity\AssetRepository;
+use Mautic\AssetBundle\Entity\Download;
+use Mautic\AssetBundle\Model\AssetModel;
+use Mautic\CacheBundle\Cache\CacheProvider;
+use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Mautic\LeadBundle\Tracker\Factory\DeviceDetectorFactory\DeviceDetectorFactory;
+use Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorService;
+use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\ServerBag;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class AssetModelTest extends \PHPUnit\Framework\TestCase
+{
+
+    private AssetModel $assetModel;
+
+    private CoreParametersHelper&MockObject $coreParametersHelper;
+
+    private ContainerInterface&MockObject $container;
+
+    private CacheProvider $cacheProvider;
+
+    private LeadModel&MockObject $leadModel;
+
+    private CategoryModel&MockObject $categoryModel;
+
+    private RequestStack&MockObject $requestStack;
+
+    private IpLookupHelper&MockObject $ipLookupHelper;
+
+    private DeviceDetectorFactory $deviceDetectorFactory;
+
+    private DeviceCreatorService $deviceCreatorService;
+
+    private DeviceTrackingServiceInterface&MockObject $deviceTrackingService;
+
+    private ContactTracker&MockObject $contactTracker;
+
+    private EntityManager&MockObject $entityManager;
+
+    private CorePermissions&MockObject $corePermissions;
+
+    private EventDispatcherInterface&MockObject $eventDispatcher;
+
+    private MockObject&UrlGeneratorInterface $urlGenerator;
+
+    private Translator&MockObject $translator;
+
+    private UserHelper&MockObject $userHelper;
+
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+
+        $this->coreParametersHelper->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('max_size'))
+            ->willReturn('2MB');
+
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->cacheProvider = new CacheProvider($this->coreParametersHelper, $this->container);
+        $this->leadModel = $this->createMock(LeadModel::class);
+        $this->categoryModel = $this->createMock(CategoryModel::class);
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $this->deviceDetectorFactory = new DeviceDetectorFactory($this->cacheProvider);
+        $this->deviceCreatorService = new DeviceCreatorService();
+        $this->deviceTrackingService = $this->getMockBuilder(DeviceTrackingServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->contactTracker = $this->createMock(ContactTracker::class);
+        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->corePermissions = $this->createMock(CorePermissions::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->translator = $this->createMock(Translator::class);
+        $this->userHelper = $this->createMock(UserHelper::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->assetModel = new AssetModel(
+            $this->leadModel,
+            $this->categoryModel,
+            $this->requestStack,
+            $this->ipLookupHelper,
+            $this->deviceCreatorService,
+            $this->deviceDetectorFactory,
+            $this->deviceTrackingService,
+            $this->contactTracker,
+            $this->entityManager,
+            $this->corePermissions,
+            $this->eventDispatcher,
+            $this->urlGenerator,
+            $this->translator,
+            $this->userHelper,
+            $this->logger,
+            $this->coreParametersHelper,
+        );
+    }
+
+    /**
+     * Test that TrackDownload works only with a request
+     */
+    public function testTrackDownloadRequest(): void
+    {
+        $asset = new Asset();
+
+        $this->corePermissions->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
+        $this->requestStack->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn(null);
+
+        $this->entityManager->expects($this->never())
+            ->method('persist');
+
+        $this->entityManager->expects($this->never())
+            ->method('flush');
+
+        $this->entityManager->expects($this->never())
+            ->method('detach');
+
+        $this->assetModel->trackDownload($asset);
+    }
+
+    /**
+     * Test that TrackDownload works successfully
+     */
+    public function testTrackDownload(): void
+    {
+        $asset = new Asset();
+        $lead = new Lead();
+
+        $this->corePermissions->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
+        $request = $this->createMock(Request::class);
+
+        $serverBag = $this->createMock(ServerBag::class);
+
+        $serverBag->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('HTTP_REFERER'))
+            ->willReturn('http://localhost');
+
+        $request->server = $serverBag;
+
+        $request->expects($this->exactly(6))
+            ->method('get')
+            ->withConsecutive(
+                [$this->equalTo('utm_campaign')],
+                [$this->equalTo('utm_content')],
+                [$this->equalTo('utm_medium')],
+                [$this->equalTo('utm_source')],
+                [$this->equalTo('utm_term')],
+                [$this->equalTo('ct')]
+            )
+            ->willReturnOnConsecutiveCalls(
+                'test_utm_campaign',
+                'test_utm_content',
+                'test_utm_medium',
+                'test_utm_source',
+                'test_utm_term',
+                false
+            );
+
+        $this->requestStack->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $this->deviceTrackingService->expects($this->once())
+            ->method('isTracked')
+            ->willReturn(false);
+
+        $this->contactTracker->expects($this->once())
+            ->method('getContact')
+            ->willReturn($lead);
+
+        $this->deviceTrackingService->expects($this->once())
+            ->method('getTrackedDevice')
+            ->willReturn(null);
+
+        $assetRepository = $this->createMock(AssetRepository::class);
+
+        $this->entityManager->expects($this->once())
+            ->method('getRepository')
+            ->with($this->equalTo(Asset::class))
+            ->willReturn($assetRepository);
+
+        $assetRepository->expects($this->once())
+            ->method('upDownloadCount')
+            ->with($this->equalTo($asset->getId(), 1, true));
+
+        $ipAddress = new IpAddress('127.0.0.1');
+
+        $this->ipLookupHelper->expects($this->once())
+            ->method('getIpAddress')
+            ->willReturn($ipAddress);
+
+        $this->eventDispatcher->expects($this->once())
+            ->method('hasListeners')
+            ->with($this->equalTo(AssetEvents::ASSET_ON_LOAD))
+            ->willReturn(false);
+
+        /** @var Download $download */
+        $download = null;
+
+        $this->entityManager->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(function ($downloadPersist) use (&$download) {
+                $download = $downloadPersist;
+                return $download instanceof Download;
+            }));
+
+        $this->entityManager->expects($this->once())
+            ->method('flush');
+
+        $this->entityManager->expects($this->once())
+            ->method('detach')
+            ->with($this->callback(function ($downloadDetach) use (&$download) {
+                $this->assertSame($downloadDetach, $download);
+                return true;
+            }));
+
+        $this->assetModel->trackDownload($asset);
+
+        $this->assertEquals('test_utm_campaign', $download->getUtmCampaign());
+        $this->assertEquals('test_utm_content', $download->getUtmContent());
+        $this->assertEquals('test_utm_medium', $download->getUtmMedium());
+        $this->assertEquals('test_utm_source', $download->getUtmSource());
+        $this->assertEquals('test_utm_term', $download->getUtmTerm());
+        $this->assertEquals('200', $download->getCode());
+        $this->assertEquals($ipAddress, $download->getIpAddress());
+        $this->assertEquals($lead, $download->getLead());
+        $this->assertEquals($asset, $download->getAsset());
+        $this->assertEquals('http://localhost', $download->getReferer());
+    }
+
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢
| Issue(s) addressed                     | Fixes [#13577](https://github.com/mautic/mautic/issues/13577)

## Description

This pull request addresses an issue where a download event triggered by a CLI command (e.g., via cron) causes an error due to the absence of a request object. As discussed in [#13577](https://github.com/mautic/mautic/pull/13974) and [#14305](https://github.com/mautic/mautic/issues/14305), this occurs because the request object is null in non-request contexts. The proposed fix ensures that download tracking is ignored when initiated from a non-request source, such as a CLI command.

A solution was originally proposed in [#13974](https://github.com/mautic/mautic/pull/13974), but the author became unresponsive and did not address the requested changes. To ensure the issue is resolved, I have retained the original approach while adding comprehensive tests to verify the functionality and prevent regressions.

---
### 📋 Steps to test this PR:

See [#13577](https://github.com/mautic/mautic/pull/13974) and [#14305](https://github.com/mautic/mautic/issues/14305):

1. Create a new asset.
2. Create a email that includes the attachment.
3. Try to send using mautic:broadcasts:send
