### PR TITLE
Fixing more places getting non-scalar values from request in Symfony 6

### DIFF
--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -213,7 +213,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
             $this->extraGetEntitiesArguments
         );
 
-        if ($select = InputHelper::cleanArray($request->get('select', []))) {
+        if ($select = InputHelper::cleanArray($request->query->all()['select'] ?? $request->request->all()['select'] ?? [])) {
             $args['select']              = $select;
             $this->customSelectRequested = true;
         }
@@ -253,7 +253,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      */
     protected function getWhereFromRequest(Request $request)
     {
-        $where = InputHelper::cleanArray($request->get('where', []));
+        $where = InputHelper::cleanArray($request->query->all()['where'] ?? []);
 
         $this->sanitizeWhereClauseArrayFromRequest($where);
 
@@ -267,7 +267,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      */
     protected function getOrderFromRequest(Request $request): array
     {
-        return InputHelper::cleanArray($request->get('order', []));
+        return InputHelper::cleanArray($request->query->all()['order'] ?? []);
     }
 
     /**

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -76,15 +76,8 @@ class CommonApiControllerTest extends CampaignTestAbstract
             ],
         ];
 
-        $request = $this->getMockBuilder(Request::class)
-            ->onlyMethods(['get'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $request->method('get')
-            ->willReturn($where);
-
-        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request]);
+        $request = new Request(['where' => $where]);
+        $result  = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request]);
 
         $this->assertEquals($where, $result);
     }

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -61,11 +61,7 @@ class CommonApiControllerTest extends CampaignTestAbstract
 
     public function testgetWhereFromRequestWithNoWhere(): void
     {
-        $request = $this->getMockBuilder(Request::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request]);
+        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [new Request()]);
 
         $this->assertEquals([], $result);
     }

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -16,7 +16,7 @@ class CircularDependencyValidator extends ConstraintValidator
 {
     public function __construct(
         private ListModel $model,
-        private RequestStack $requestStack
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -43,7 +43,7 @@ class CircularDependencyValidator extends ConstraintValidator
     private function getSegmentIdFromRequest(): int
     {
         $request     = $this->requestStack->getCurrentRequest();
-        $routeParams = $request->get('_route_params');
+        $routeParams = $request->request->all()['_route_params'] ?? [];
 
         if (empty($routeParams['objectId'])) {
             throw new \UnexpectedValueException('Segment ID is missing in the request');

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -1,36 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Form\Validator\Constraints;
 
 use Mautic\CoreBundle\Form\Validator\Constraints\CircularDependency;
 use Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Context\ExecutionContext;
 
 class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ListModel
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $mockListModel;
+    private MockObject&ListModel $mockListModel;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ExecutionContext
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $context;
+    private MockObject&ExecutionContext $context;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|RequestStack
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $requestStack;
+    private MockObject&RequestStack $requestStack;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|Request
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $request;
+    private Request $request;
 
     private CircularDependencyValidator $validator;
 
@@ -41,7 +32,7 @@ class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
         $this->mockListModel = $this->createMock(ListModel::class);
         $this->context       = $this->createMock(ExecutionContext::class);
         $this->requestStack  = $this->createMock(RequestStack::class);
-        $this->request       = $this->createMock(Request::class);
+        $this->request       = new Request();
 
         $this->requestStack->expects($this->once())
             ->method('getCurrentRequest')
@@ -154,12 +145,7 @@ class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
                 ->method('addViolation');
         }
 
-        $this->request->expects($this->once())
-            ->method('get')
-            ->with('_route_params')
-            ->willReturn([
-                'objectId' => $currentSegmentId,
-            ]);
+        $this->request->request->add(['_route_params' => ['objectId' => $currentSegmentId]]);
 
         return $this->validator;
     }

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -79,7 +79,7 @@ class WidgetApiController extends CommonApiController
         $to         = InputHelper::clean($request->get('dateTo', null));
         $dataFormat = InputHelper::clean($request->get('dataFormat', null));
         $unit       = InputHelper::clean($request->get('timeUnit', 'Y'));
-        $dataset    = InputHelper::clean($request->get('dataset', []));
+        $dataset    = InputHelper::clean($request->query->all()['dataset'] ?? $request->request->all()['dataset'] ?? []);
         $response   = ['success' => 0];
 
         try {
@@ -102,7 +102,7 @@ class WidgetApiController extends CommonApiController
             'dateFrom'   => $fromDate,
             'dateTo'     => $toDate,
             'limit'      => (int) $request->get('limit', null),
-            'filter'     => InputHelper::clean($request->get('filter', [])),
+            'filter'     => InputHelper::clean($request->query->all()['filter'] ?? $request->request->all()['filter'] ?? []),
             'dataset'    => $dataset,
         ];
 

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -41,7 +41,7 @@ class DashboardController extends AbstractFormController
         }
 
         $action          = $this->generateUrl('mautic_dashboard_index');
-        $dateRangeFilter = $request->get('daterange', []);
+        $dateRangeFilter = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
 
         // Set new date range to the session
         if ($request->isMethod(Request::METHOD_POST)) {

--- a/app/bundles/DashboardBundle/Dashboard/Widget.php
+++ b/app/bundles/DashboardBundle/Dashboard/Widget.php
@@ -18,7 +18,7 @@ class Widget
     public function __construct(
         private DashboardModel $dashboardModel,
         private UserHelper $userHelper,
-        private RequestStack $requestStack
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/DashboardBundle/Dashboard/Widget.php
+++ b/app/bundles/DashboardBundle/Dashboard/Widget.php
@@ -59,7 +59,7 @@ class Widget
             return;
         }
 
-        $dateRangeFilter = $request->get('daterange', []);
+        $dateRangeFilter = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
 
         if (!empty($dateRangeFilter['date_from'])) {
             $from = new \DateTime($dateRangeFilter['date_from']);

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -383,7 +383,7 @@ class DynamicContentController extends FormController
         $logs          = $auditLogModel->getLogForObject('dynamicContent', $entity->getId(), $entity->getDateAdded());
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $entityViews     = $model->getHitsLineChartData(

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -649,7 +649,7 @@ class EmailController extends FormController
         EmailModel $model,
         $objectId,
         $ignorePost = false,
-        $forceTypeSelection = false
+        $forceTypeSelection = false,
     ) {
         $method  = $request->getMethod();
         $entity  = $model->getEntity($objectId);
@@ -1669,7 +1669,7 @@ class EmailController extends FormController
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
-        $page = 1
+        $page = 1,
     ) {
         return $this->generateContactsGrid(
             $request,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -274,7 +274,7 @@ class EmailController extends FormController
         $page = $request->getSession()->get('mautic.email.page', 1);
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -85,7 +85,7 @@ class FormApiController extends CommonApiController
             return $this->notFound();
         }
 
-        $fieldsToDelete = $request->get('fields');
+        $fieldsToDelete = $request->query->all()['fields'] ?? $request->request->all()['fields'] ?? [];
 
         if (!is_array($fieldsToDelete)) {
             return $this->badRequest('The fields attribute must be array.');
@@ -115,7 +115,7 @@ class FormApiController extends CommonApiController
             return $this->notFound();
         }
 
-        $actionsToDelete = $request->get('actions');
+        $actionsToDelete = $request->query->all()['actions'] ?? $request->request->all()['actions'] ?? [];
 
         if (!is_array($actionsToDelete)) {
             return $this->badRequest('The actions attribute must be array.');

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -49,7 +49,7 @@ class FormApiController extends CommonApiController
         ModelFactory $modelFactory,
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
-        MauticFactory $factory
+        MauticFactory $factory,
     ) {
         $formModel = $modelFactory->getModel('form');
         \assert($formModel instanceof FormModel);

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -221,7 +221,7 @@ class FormController extends CommonFormController
         $logs = $auditLogModel->getLogForObject('form', $objectId, $activeForm->getDateAdded());
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_form_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -49,7 +49,7 @@ class FormController extends CommonFormController
         Translator $translator,
         FlashBag $flashBag,
         RequestStack $requestStack,
-        CorePermissions $security
+        CorePermissions $security,
     ) {
         parent::__construct($formFactory, $fieldHelper, $doctrine, $factory, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -398,7 +398,7 @@ class LeadApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $filters = $this->sanitizeEventFilter(InputHelper::clean($request->get('filters', [])));
+        $filters = $this->sanitizeEventFilter(InputHelper::clean($request->query->all()['filters'] ?? $request->request->all()['filters'] ?? []));
         $limit   = (int) $request->get('limit', 25);
         $page    = (int) $request->get('page', 1);
         $order   = InputHelper::clean($request->get('order', ['timestamp', 'DESC']));

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -68,7 +68,7 @@ class LeadApiController extends CommonApiController
         ModelFactory $modelFactory,
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
-        MauticFactory $factory
+        MauticFactory $factory,
     ) {
         $this->doNotContactModel = $doNotContactModel;
 

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -43,7 +43,7 @@ class BatchSegmentController extends AbstractFormController
      */
     public function setAction(Request $request): JsonResponse
     {
-        $params     = $request->get('lead_batch', []);
+        $params     = $request->query->all()['lead_batch'] ?? $request->request->all()['lead_batch'] ?? [];
         $contactIds = empty($params['ids']) ? [] : json_decode($params['ids']);
 
         if ($contactIds && is_array($contactIds)) {

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -33,7 +33,7 @@ class BatchSegmentController extends AbstractFormController
         Translator $translator,
         FlashBag $flashBag,
         RequestStack $requestStack,
-        CorePermissions $security
+        CorePermissions $security,
     ) {
         parent::__construct($doctrine, $factory, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -728,7 +728,7 @@ class ListController extends FormController
 
         if ('POST' === $request->getMethod() && $request->request->has('includeEvents')) {
             $filters = [
-                'includeEvents' => InputHelper::clean($request->get('includeEvents', [])),
+                'includeEvents' => InputHelper::clean($request->request->all()['includeEvents'] ?? []),
             ];
             $request->getSession()->set('mautic.segment.filters', $filters);
         } else {
@@ -767,7 +767,7 @@ class ListController extends FormController
         $translator = $this->translator;
         /** @var ListModel $listModel */
         $listModel                    = $this->getModel('lead.list');
-        $dateRangeValues              = $request->get('daterange', []);
+        $dateRangeValues              = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action                       = $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm                = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $segmentContactsLineChartData = $listModel->getSegmentContactsLineChartData(
@@ -945,7 +945,7 @@ class ListController extends FormController
         $listFilters     = ['manually_removed' => $manuallyRemoved];
         if ('POST' === $request->getMethod() && $request->request->has('includeEvents')) {
             $filters = [
-                'includeEvents' => InputHelper::clean($request->get('includeEvents', [])),
+                'includeEvents' => InputHelper::clean($request->query->all()['includeEvents'] ?? $request->request->all()['includeEvents'] ?? []),
             ];
             $request->getSession()->set('mautic.segment.filters', $filters);
         } else {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -32,11 +32,8 @@ class FieldApiControllerTest extends TestCase
 
     public function testgetWhereFromRequestWithNoWhere(): void
     {
-        $request = $this->getMockBuilder(Request::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request], $request);
+        $request = new Request();
+        $result  = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request], $request);
 
         $this->assertEquals($this->defaultWhere, $result);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -48,17 +48,8 @@ class FieldApiControllerTest extends TestCase
             ],
         ];
 
-        $request = $this->getMockBuilder(Request::class)
-            ->onlyMethods(['get'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $request->method('get')
-            ->willReturnMap([
-                ['where', [], $where],
-            ]);
-
-        $result = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request], $request);
+        $request = new Request(['where' => $where]);
+        $result  = $this->getResultFromProtectedMethod('getWhereFromRequest', [$request], $request);
 
         $this->assertEquals(array_merge($where, $this->defaultWhere), $result);
     }

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -192,7 +192,7 @@ class MobileNotificationController extends FormController
         $logs = $auditLogModel->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_mobile_notification_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $entityViews     = $model->getHitsLineChartData(

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -742,7 +742,7 @@ class MobileNotificationController extends FormController
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
-        $page = 1
+        $page = 1,
     ) {
         return $this->generateContactsGrid(
             $request,

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -195,7 +195,7 @@ class NotificationController extends AbstractFormController
         $logs = $auditLog->getLogForObject('notification', $notification->getId(), $notification->getDateAdded());
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_notification_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $entityViews     = $model->getHitsLineChartData(

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -740,7 +740,7 @@ class NotificationController extends AbstractFormController
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
-        $page = 1
+        $page = 1,
     ) {
         return $this->generateContactsGrid(
             $request,

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -495,7 +495,7 @@ class PageController extends FormController
         RouterInterface $routerHelper,
         CoreParametersHelper $coreParametersHelper,
         $objectId,
-        $ignorePost = false
+        $ignorePost = false,
     ) {
         /** @var PageModel $model */
         $model    = $this->getModel('page.page');

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -273,7 +273,7 @@ class PageController extends FormController
         }
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_page_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -156,7 +156,7 @@ class ReportController extends FormController
     /**
      * Deletes the entity.
      *
-     * @return array<string, string|array<string, string>>|bool|HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|HttpFoundation\Response
+     * @return array<string, string|array<string, string>>|bool|HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|Response
      */
     public function deleteAction(Request $request, $objectId)
     {
@@ -703,7 +703,7 @@ class ReportController extends FormController
      * @param array<mixed> $postActionVars
      * @param array<mixed> $permissions
      *
-     * @return array<string, string|array<string, string>>|bool|HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|HttpFoundation\Response
+     * @return array<string, string|array<string, string>>|bool|HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|Response
      */
     private function checkEntityAccess(array $postActionVars, ?Report $entity, int $objectId, array $permissions, ReportModel $model, string $modelName)
     {

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -578,7 +578,7 @@ class ReportController extends FormController
         $action = $this->generateUrl('mautic_report_action', ['objectAction' => 'view', 'objectId' => $objectId]);
 
         // Get the date range filter values from the request of from the session
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
 
         if (!empty($dateRangeValues['date_from'])) {
             $from = new \DateTime($dateRangeValues['date_from']);

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -182,7 +182,7 @@ class SmsController extends FormController
         $logs = $auditLogModel->getLogForObject('sms', $sms->getId(), $sms->getDateAdded());
 
         // Init the date range filter form
-        $dateRangeValues = $request->get('daterange', []);
+        $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_sms_action', ['objectAction' => 'view', 'objectId' => $objectId]);
         $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $entityViews     = $model->getHitsLineChartData(

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -726,7 +726,7 @@ class SmsController extends FormController
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
-        $page = 1
+        $page = 1,
     ) {
         return $this->generateContactsGrid(
             $request,

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -43,7 +43,7 @@ class FocusController extends AbstractStandardFormController
         Translator $translator,
         FlashBag $flashBag,
         RequestStack $requestStack,
-        CorePermissions $security
+        CorePermissions $security,
     ) {
         parent::__construct($formFactory, $fieldHelper, $doctrine, $factory, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -208,7 +208,7 @@ class FocusController extends AbstractStandardFormController
      */
     protected function getPostActionRedirectArguments(array $args, $action): array
     {
-        $focus        = $this->getCurrentRequest()->request->get('focus') ?? [];
+        $focus        = $this->getCurrentRequest()->request->all()['focus'] ?? [];
         $updateSelect = 'POST' === $this->getCurrentRequest()->getMethod()
             ? ($focus['updateSelect'] ?? false)
             : $this->getCurrentRequest()->get('updateSelect', false);
@@ -239,7 +239,7 @@ class FocusController extends AbstractStandardFormController
      */
     protected function getEntityFormOptions()
     {
-        $focus        = $this->getCurrentRequest()->request->get('focus') ?? [];
+        $focus        = $this->getCurrentRequest()->request->all()['focus'] ?? [];
         $updateSelect = 'POST' === $this->getCurrentRequest()->getMethod()
             ? ($focus['updateSelect'] ?? false)
             : $this->getCurrentRequest()->get('updateSelect', false);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴🟢
| Deprecations?                          | 🔴🟢
| BC breaks? (use the c.x branch)        | 🔴🟢
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

@laurielim reported on Slack this error:
```
Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\BadRequestHttpException: "Input value "focus" contains a non-scalar value." at /var/www/html/vendor/symfony/http-kernel/HttpKernel.php line 83
```

This PR fixes creating a new Focus items and I went through the rest of the code base and fixed it on other places where it was obvious from the code that the value is suppose to be an array (non-scalar value)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new Focus item
3. Test wherever we use date ranges like in dashboards, reports, carts on various detail pages that it works as expected.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->