### PR TITLE
Update decision/action panel colors in campaign's builder

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/Campaign/Builder/_index.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/Builder/_index.html.twig
@@ -8,7 +8,7 @@
     <div id="CampaignEventPanelGroups">
         <div class="row">
             <div class="mr-0 ml-0 pl-xs pr-xs campaign-group-container col-md-4" id="DecisionGroupSelector">
-                <div class="panel panel-success mb-0">
+                <div class="panel panel-info mb-0">
                     <div class="panel-heading">
                         <div class="col-xs-8 col-sm-10 np">
                             <h3 class="panel-title">{{ 'mautic.campaign.event.decision.header'|trans }}</h3>
@@ -95,7 +95,7 @@
                 </div>
             </div>
             <div class="mr-0 ml-0 pl-xs pr-xs campaign-group-container col-md-4" id="ConditionGroupSelector">
-                <div class="panel panel-danger mb-0">
+                <div class="panel panel-warning mb-0">
                     <div class="panel-heading">
                         <div class="col-xs-8 col-sm-10 np">
                             <h3 class="panel-title">{{ 'mautic.campaign.event.condition.header'|trans }}</h3>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴<!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

There is a logic issue in the campaign builder. We have different colors in the modal to select a decision or condition (green vs. red) compared to the builder itself (blue vs. yellow).
Green and red are more suited for "danger" or "validation" buttons, so it might make sense to use the same yellow and blue colors for consistency.
This PR fixes it, just by switching panel classes.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->
- Go to campaigns > New
- Open the Builder
- Try to add a node

**Before:**

<img width="1606" alt="Capture d’écran 2024-12-20 à 10 38 11" src="https://github.com/user-attachments/assets/d19e319d-87fd-45fa-bfa0-7507ae8d9943" />


**After:**

<img width="595" alt="Capture d’écran 2024-12-20 à 10 40 20" src="https://github.com/user-attachments/assets/e217f748-d469-4f1d-bbe5-a1df469c4a22" />

