### PR TITLE
UI: update segment filter icons theme

### DIFF
--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -64,14 +64,6 @@
     margin-left:20px;
 }
 
-.selected-filters .btn-group {
-    margin-top:4px;
-}
-
-.selected-filters .btn-group .btn {
-    margin-right:4px;
-}
-
 .selected-filters .panel {
     margin-bottom:0;
     margin-top:20px;

--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -299,3 +299,8 @@ ul.tag-cloud li {
     border-bottom: 1px solid #eee;
     font-size: 14px;
 }
+
+.segment-button {
+    display: flex;
+    justify-content: flex-end;
+}

--- a/app/bundles/LeadBundle/Assets/css/lead.css
+++ b/app/bundles/LeadBundle/Assets/css/lead.css
@@ -299,8 +299,3 @@ ul.tag-cloud li {
     border-bottom: 1px solid #eee;
     font-size: 14px;
 }
-
-.segment-button {
-    display: flex;
-    justify-content: flex-end;
-}

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -731,6 +731,8 @@ Mautic.segmentFilter = function() {
                     {'opacity': 0},
                     'fast',
                     function () {
+                        // Remove existing tooltip
+                        mQuery('*[role="tooltip"]').tooltip('destroy');
                         mQuery(this).remove();
                         Mautic.reorderSegmentFilters();
                     }

--- a/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
@@ -24,13 +24,34 @@
                 {{ form_widget(form.glue) }}
             </div>
             <div class="col-sm-2 pr-0 pull-right">
-                <div class="btn-group btn-group-xs pull-right" role="group">
-                    <a href="javascript: void(0);" type="button" class="pull-right remove-selected btn btn-xs btn-secondary">
-                        <i class="ri-delete-bin-line"></i>
-                    </a>
-                    <a href="javascript: void(0);" type="button" class="pull-right copy-filter-group btn btn-xs btn-secondary  btn-nospin{% if inGroup %} hide{% endif %}" data-toggle="tooltip" title="{{ 'mautic.lead.list.copy.filter.group'|trans }}">
-                        <i class="ri-file-copy-line"></i>
-                    </a>
+                <div class="segment-button btn-group btn-group-xs pull-right" role="group">
+                    {% include '@MauticCore/Helper/button.html.twig' with {
+                        buttons: [
+                            {
+                                label: 'mautic.lead_list.filter.label.clonefilter',
+                                variant: 'ghost',
+                                icon_only: true,
+                                size: 'sm',
+                                icon: 'ri-file-copy-line',
+                                href: 'javascript: void(0);',
+                                attributes: {
+                                'class': 'copy-filter-group',
+                            },
+                            },
+                            {
+                                label: 'mautic.lead_list.filter.label.removefilter',
+                                variant: 'ghost',
+                                icon_only: true,
+                                size: 'sm',
+                                danger: 'true',
+                                icon: 'ri-delete-bin-line',
+                                href: 'javascript: void(0);',
+                                attributes: {
+                                'class': 'remove-selected',
+                            },
+                            }
+                        ]
+                    } %}
                 </div>
             </div>
         </div>

--- a/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/FormTheme/Filter/_leadlist_filters_entry_widget.html.twig
@@ -24,7 +24,7 @@
                 {{ form_widget(form.glue) }}
             </div>
             <div class="col-sm-2 pr-0 pull-right">
-                <div class="segment-button btn-group btn-group-xs pull-right" role="group">
+                <div class="segment-button d-flex jc-end btn-group btn-group-xs pull-right" role="group">
                     {% include '@MauticCore/Helper/button.html.twig' with {
                         buttons: [
                             {

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -1033,3 +1033,5 @@ mautic.lead_list.filter.alert.endwith = 'This Ends With filter will slow down in
 mautic.lead_list.filter.alert.contain = 'This Contains filter will slow down instance performance. We recommend using "Starts with" if possible.'
 mautic.lead_list.filter.alert.like = 'This Like filter will slow down instance performance. We recommend using "Starts with" if possible.'
 mautic.lead_list.filter.alert.email = 'Consider using the "Email Domain" filter instead of "Email" to be able to match the email domain.'
+mautic.lead_list.filter.label.removefilter="Remove filter"
+mautic.lead_list.filter.label.clonefilter="Clone filter"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

**Initial issue:**
Buttons in segment filter are a bit broken like below:

<img width="801" alt="Capture d’écran 2024-12-20 à 11 51 44" src="https://github.com/user-attachments/assets/a5a1794e-5991-473a-bb6a-28e4707f1624" />


We suggest using the same component as in forms:
<img width="865" alt="Capture d’écran 2024-12-20 à 11 51 01" src="https://github.com/user-attachments/assets/10107460-a7e5-40c4-b664-b052c91c7b64" />

---
### 📋 Steps to test this PR:

- Go to Segments > New
- Go to filters > Add some filters:

<img width="845" alt="Capture d’écran 2024-12-20 à 11 40 56" src="https://github.com/user-attachments/assets/a687135f-fa60-40e6-969d-225fff27e5a7" />
