### PR TITLE
[Campaign] In the builder when adding an event in 5.2, it always shows the paste option even if nothing to paste

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/Campaign/Builder/_index.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/Builder/_index.html.twig
@@ -139,7 +139,7 @@
         </div>
         <div class="row">
             <div class="mr-0 ml-0 pl-xs pr-xs mt-xs campaign-group-container col-md-12">
-                <div id="CampaignPasteContainer mt-10" class="panel mb-0">
+                <div id="CampaignPasteContainer" class="panel mb-0">
                     <div id="CampaignPasteDescription" class="panel-body">
                         <div><b>{{ 'mautic.campaign.event.clone.header'|trans }}</b></div>
                         <div><span class="text-muted">{{ 'mautic.campaign.event.clone.name'|trans }}: </span><span data-campaign-event-clone="sourceEventName"></span></div>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

When in the Campaign builder and adding events it always shows "Insert cloned event here" even if nothing was copied. This seems to be as the `id` is corrupted.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Campaign Builder - clicking "+" will not show "Insert cloned event here" if your local storage is empty 