### PR TITLE
Fixing problem with single search operators in search fields

### DIFF
--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -159,7 +159,7 @@ class SearchStringHelper
                 // arrived at the end of a single word that is not within a quote or parenthesis so add it as standalone
                 if (' ' != $string) {
                     $string = trim($string);
-                    $type   = ('or' == strtolower($string) || 'and' == strtolower($string)) ? $string : '';
+                    $type   = ('OR' === $string || 'AND' === $string) ? $string : '';
                     $this->setFilter($filters, $baseName, $keyCount, $string, $command, $overrideCommand, true, $type, !empty($chars));
                 }
                 continue;
@@ -232,12 +232,12 @@ class SearchStringHelper
         $setUpNext = true): void
     {
         if (!empty($type)) {
-            $filters->{$baseName}[$keyCount]->type = strtolower($type);
+            $filters->{$baseName}[$keyCount]->type = ('OR' === $type || 'AND' === $type) ? strtolower($type) : 'and';
         } elseif ($setFilter) {
-            $string = trim(strtolower($string));
+            $string = trim($string);
 
             // remove operators and empty values
-            if (in_array($string, ['', 'or', 'and']) && count($filters->{$baseName}) > 1) {
+            if (in_array($string, ['', 'OR', 'AND'])) {
                 unset($filters->{$baseName}[$keyCount]);
 
                 return;

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -243,6 +243,11 @@ class SearchStringHelper
                 return;
             }
 
+            // Convert search terms to lowercase, but only after checking for operators
+            if (!empty($filters->{$baseName}[$keyCount]->command)) {
+                $string = strtolower($string);
+            }
+
             if (!isset($filters->{$baseName}[$keyCount]->strict)) {
                 $filters->{$baseName}[$keyCount]->strict = 0;
             }

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -237,7 +237,7 @@ class SearchStringHelper
             $string = trim(strtolower($string));
 
             // remove operators and empty values
-            if (in_array($string, ['', 'or', 'and'])) {
+            if (in_array($string, ['', 'or', 'and']) && count($filters->{$baseName}) > 1) {
                 unset($filters->{$baseName}[$keyCount]);
 
                 return;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR is fixing the issue https://github.com/mautic/mautic/issues/14350 so that when only search operators are added into a search field but nothing else they are considered as string


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add contacts
3. Both in the global search and the contact search enter 'and' or 'or'. Check that now you'll only see contacts, etc. which contain the string 'and'/'or' will be displayed

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->