### PR TITLE
fix: Use safe Symfony client IP in IPLookupHelper

### DIFF
--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -57,37 +57,13 @@ class IpLookupHelper
      */
     public function getIpAddressFromRequest()
     {
+        // Use Symfony's request stack to get the client IP
+        // This will ensure that trusted proxies are correctly handled
+        // And it will ensure that only trusted headers are handled
+        // @see https://symfony.com/doc/5.x/create_framework/http_foundation.html
         $request = $this->requestStack->getCurrentRequest();
 
-        if (null !== $request) {
-            $ipHolders = [
-                'HTTP_CLIENT_IP',
-                'HTTP_X_FORWARDED_FOR',
-                'HTTP_X_FORWARDED',
-                'HTTP_X_CLUSTER_CLIENT_IP',
-                'HTTP_FORWARDED_FOR',
-                'HTTP_FORWARDED',
-                'REMOTE_ADDR',
-            ];
-
-            foreach ($ipHolders as $key) {
-                if ($request->server->get($key)) {
-                    $ip = trim($request->server->get($key));
-
-                    if (str_contains($ip, ',')) {
-                        $ip = $this->getClientIpFromProxyList($ip);
-                    }
-
-                    // Validate IP
-                    if (null !== $ip && $this->ipIsValid($ip)) {
-                        return $ip;
-                    }
-                }
-            }
-        }
-
-        // if everything else fails
-        return '127.0.0.1';
+        return $request ? $request->getClientIp() : '127.0.0.1';
     }
 
     /**
@@ -211,32 +187,6 @@ class IpLookupHelper
             FILTER_VALIDATE_IP,
             FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | $filterFlagNoPrivRange | FILTER_FLAG_NO_RES_RANGE
         );
-    }
-
-    protected function getClientIpFromProxyList($ip)
-    {
-        // Proxies are included
-        $ips = explode(',', $ip);
-        array_walk(
-            $ips,
-            function (&$val): void {
-                $val = trim($val);
-            }
-        );
-
-        if ($this->doNotTrackInternalIps) {
-            $ips = array_diff($ips, $this->doNotTrackInternalIps);
-        }
-
-        // https://en.wikipedia.org/wiki/X-Forwarded-For
-        // X-Forwarded-For: client, proxy1, proxy2
-        foreach ($ips as $ip) {
-            if ($this->ipIsValid($ip)) {
-                return $ip;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
@@ -19,6 +19,15 @@ class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         defined('MAUTIC_ENV') or define('MAUTIC_ENV', 'test');
+
+        // Set trusted proxies - this is set by Mautic normally in app/middlewards/TrustMiddleware
+        Request::setTrustedProxies(['10.8.0.2', '192.168.0.1'], Request::HEADER_X_FORWARDED_FOR);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset trusted proxies
+        Request::setTrustedProxies([], 0);
     }
 
     /**
@@ -40,7 +49,7 @@ class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
      */
     public function testClientIpIsReturnedFromProxy(): void
     {
-        $request = new Request([], [], [], [], [], ['HTTP_X_FORWARDED_FOR' => '73.77.245.52,10.8.0.2,192.168.0.1']);
+        $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '192.168.0.1', 'HTTP_X_FORWARDED_FOR' => '1.2.3.4,73.77.245.52,10.8.0.2,192.168.0.1']);
         $ip      = $this->getIpHelper($request)->getIpAddress();
 
         $this->assertEquals('73.77.245.52', $ip->getIpAddress());


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴 **Needs checking**
| Automated tests included?              | 🟢

## Description

When looking up IP for tracking it's using an unsafe IP source that ignores any configuration made to Mautic with regards to trusted proxies etc. so you can end up with weird tracking IP source which are remote proxies within businesses etc. - it could also be spoofed - it should use Symfony and obey all the proxy settings properly.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a landing page
3. Visit the page with CURL or otherwise and set X-Cluster-Client-IP header to any IP address
4. The created tracked contact is using this IP even though it wasn't the actual source IP

Backwards compatibility I don't think is impacted, as Mautic is already using Symfony proxy settings and has a middleware setup to configure it on requests from the config.php. So this just brings the IPLookupHelper inline with that.