### PR TITLE
feat: Show Building if a segment is new or updated but not yet rebuilt

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -277,7 +277,7 @@ Mautic.getLeadId = function() {
 }
 
 Mautic.leadlistOnLoad = function(container, response) {
-    const segmentCountElem = mQuery('a.col-count');
+    const segmentCountElem = mQuery('span.col-count');
 
     if (segmentCountElem.length) {
         segmentCountElem.each(function() {
@@ -288,7 +288,8 @@ Mautic.leadlistOnLoad = function(container, response) {
                 'lead:getLeadCount',
                 {id: id},
                 function (response) {
-                    elem.html(response.html);
+                    elem.className = response.className;
+                    elem.children('a').html(response.html);
                 },
                 false,
                 true,

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -876,16 +876,20 @@ class AjaxController extends CommonAjaxController
     {
         $id = (int) InputHelper::clean($request->get('id'));
 
-        $leadListExists = $model->leadListExists($id);
-
-        if (!$leadListExists) {
-            return new JsonResponse($this->prepareJsonResponse(0), Response::HTTP_NOT_FOUND);
+        $leadList = $model->getEntity($id);
+        if (!$leadList) {
+            return new JsonResponse($this->prepareJsonResponse(0, false), Response::HTTP_NOT_FOUND);
         }
 
         $leadCounts = $model->getSegmentContactCount([$id]);
         $leadCount  = $leadCounts[$id];
 
-        return new JsonResponse($this->prepareJsonResponse($leadCount));
+        return new JsonResponse(
+            $this->prepareJsonResponse(
+                $leadCount,
+                $leadList->needsRebuild(),
+            )
+        );
     }
 
     public function getSegmentDependencyTreeAction(Request $request, SegmentDependencyTreeFactory $segmentDependencyTreeFactory, ListModel $model): JsonResponse
@@ -906,13 +910,14 @@ class AjaxController extends CommonAjaxController
     /**
      * @return array<string, mixed>
      */
-    private function prepareJsonResponse(int $leadCount): array
+    private function prepareJsonResponse(int $leadCount, bool $needsRebuild): array
     {
         return [
-            'html' => $this->translator->trans(
-                'mautic.lead.list.viewleads_count',
+            'html'      => $this->translator->trans(
+                $needsRebuild ? 'mautic.lead.list.building' : 'mautic.lead.list.viewleads_count',
                 ['%count%' => $leadCount]
             ),
+            'className' => sprintf('label %s col-count', $needsRebuild ? 'label-info' : 'label-gray'),
             'leadCount' => $leadCount,
         ];
     }

--- a/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
@@ -71,10 +71,10 @@
         {% endif %}
     </td>
     <td class="visible-md visible-lg">
-        <a size="sm" class="label label-gray col-count"
-           data-id="{{ item.id }}"
-           href="{{ path('mautic_contact_index', {'search': 'mautic.lead.lead.searchcommand.list'|trans ~ ':' ~ item.alias}) }}"
-           data-toggle="ajax">{{ 'mautic.lead.list.viewleads_count'|trans({'%count%': leadCounts[item.id]}) }}</a>
+        <span size="sm" class="label {{ item.needsRebuild() ? 'label-info' : 'label-gray' }} col-count" data-id="{{ item.id }}">
+            <a href="{{ path('mautic_contact_index', {'search': 'mautic.lead.lead.searchcommand.list'|trans ~ ':' ~ item.alias}) }}"
+                data-toggle="ajax">{{ (item.needsRebuild() ? 'mautic.lead.list.building' : 'mautic.lead.list.viewleads_count')|trans({'%count%': leadCounts[item.id]}) }}</a>
+        </span>
     </td>
     <td class="visible-md visible-lg" title="{% if item.dateAdded %}{{ dateToFullConcat(item.dateAdded) }}{% endif %}">
         {% if item.getDateAdded %}{{ dateToDate(item.dateAdded) }}{% endif %}

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
@@ -135,7 +135,7 @@ class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
         // exclude the segment
         $segmentTest3Ref = $this->getReference('segment-test-3');
         $lastRebuiltDate = $segmentTest3Ref->getLastBuiltDate();
-        self::assertNotNull($lastRebuiltDate);
+        self::assertNull($lastRebuiltDate);
 
         $this->testSymfonyCommand(
             UpdateLeadListsCommand::NAME,

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -1016,6 +1016,7 @@ mautic.lead.field.notification.cannot_be_created_message="Custom field '%label%'
 mautic.lead.field.notification.cannot_be_created_header="Custom field cannot be created"
 mautic.lead.field.notification.custom_field_limit_hit_message="Custom field '%label%' cannot be created - you have reached the limit of custom fields allowed by your database."
 mautic.lead.field.notification.custom_field_limit_hit_header="Custom field cannot be created"
+mautic.lead.list.building="{0} Building|{1} Building (1 Contact)|]1,Inf[ Building (%count% Contacts)"
 mautic.lead.command.error="Command %name%, error: %error%"
 mautic.lead.command.delete_contact_secondary_company.allow_multiple_enabled="The 'Multiple companies for contact' setting is enabled, aborting process. (Set this configuration option to false to run this command)"
 mautic.lead.command.delete_contact_secondary_company.success="Secondary companies have been successfully deleted."


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🟢
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 

Docs PR: https://github.com/mautic/user-documentation/pull/349

## Description

When creating a new segment with filters, it displays immediately "No Contacts". This can be confusing to new users as it does not indicate there is an action waiting to build the new segment. Additionally, once build begins, you will see "123 Contacts" - however, the build may not be finished yet. The only way a user can know it is finished is to keep refreshing the page until the count does not change for a minute. It's not really easy to know if it's completed.

Similarly, when editing a segment, for example if you realised you captured too many due to a typo, after saving you just see the same contact count. There is no indication that a rebuild is waiting that might substantially change the count (even potentially reducing it to "No Contacts"). Neither is there indication of progress or when it completes. So again you are left refreshing the page waiting for it to stop changing. In cases where the change is 0 it is then even more difficult as you cannot know if it just didn't get around to rebuilding yet or if it did rebuild but it was 0 change because of an error in your filters.

This PR adds in additional statuses, bringing the list to:

* **Building** - Displayed for a new segment that has filters which is not yet built
* **No Contacts** - Displayed for a segment with filters that has been successfully built at least once since creation or last modification
* **Building (X Contacts)** - Displayed for a segment with filters that has been modified since it was last built
* **X Contacts** - Displayed for a segment with filters that has been successfully built at least once since creation or last modification

Screenshot for a new segment:

<img width="856" alt="Screenshot 2025-01-04 at 12 32 24" src="https://github.com/user-attachments/assets/f56f18d5-afc6-42ec-9ed3-f6919aa0f335" />

After `mautic:segments:update` passes over it:

<img width="862" alt="Screenshot 2025-01-04 at 12 45 52" src="https://github.com/user-attachments/assets/6e7ad182-3474-43d8-9817-b44e8d464d78" />

After it is modified by a user:

<img width="864" alt="Screenshot 2025-01-04 at 12 46 21" src="https://github.com/user-attachments/assets/00c86d8b-bc4f-4a1c-88dc-bfa976a31fb7" />

This then returns to the previous screen after `mautic:segments:update` passes over it.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new segment without filters. It will display No Contacts.
3. Create a new segment with filters. It will display Building.
4. Run `mautic:segments:update`. It will now display No Contacts or X Contacts depending on the filters.
5. Edit the segment's filters. It will display either Building or Building (X Contacts) depending on the previous filters.
6. Run `mautic:segments:update`. It will now display No Contacts or X Contacts depending on the filters.

I did deprecate the `Mautic\LeadBundle\Entity\LeadList::initializeLastBuiltDate` as we need to allow `null` last built date for new segments. Previously it would be set to a last built date of now for a new segment which was incorrect. The field was always nullable though so it's hard to say how bad a BC change this would be. I left the method in place as it was public, and marked it `@deprecated`.

My sponsoring organisation here is [Other Media](https://other.media/)