### PR TITLE
Date Modified populated on create

### DIFF
--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -2,8 +2,6 @@
 
 namespace Mautic\CoreBundle\Model;
 
-use DateInterval;
-use DateTime;
 use Doctrine\ORM\UnitOfWork;
 use Mautic\CoreBundle\Entity\SkipModifiedInterface;
 use Mautic\CoreBundle\Helper\InputHelper;
@@ -30,7 +28,7 @@ class FormModel extends AbstractCommonModel
         // lock the row if applicable
         if (method_exists($entity, 'setCheckedOut') && method_exists($entity, 'getId') && $entity->getId()) {
             if ($this->userHelper->getUser()->getId()) {
-                $entity->setCheckedOut(new DateTime());
+                $entity->setCheckedOut(new \DateTime());
                 $entity->setCheckedOutBy($this->userHelper->getUser());
                 $this->em->persist($entity);
                 $this->em->flush();
@@ -47,14 +45,14 @@ class FormModel extends AbstractCommonModel
     {
         if (method_exists($entity, 'getCheckedOut')) {
             $checkedOut = $entity->getCheckedOut();
-            if (!empty($checkedOut) && $checkedOut instanceof DateTime) {
+            if (!empty($checkedOut) && $checkedOut instanceof \DateTime) {
                 $checkedOutBy     = $entity->getCheckedOutBy();
                 $maxLockTime      = $this->coreParametersHelper->get('max_entity_lock_time', 0);
                 $lockValidityDate = false;
 
                 if (0 != $maxLockTime && is_numeric($maxLockTime)) {
                     $lockValidityDate = clone $checkedOut;
-                    $lockValidityDate->add(new DateInterval('PT'.$maxLockTime.'S'));
+                    $lockValidityDate->add(new \DateInterval('PT'.$maxLockTime.'S'));
                 }
 
                 // is lock expired ?
@@ -232,7 +230,7 @@ class FormModel extends AbstractCommonModel
 
         if ($isNew) {
             if (method_exists($entity, 'setDateAdded') && !$entity->getDateAdded()) {
-                $entity->setDateAdded(new DateTime());
+                $entity->setDateAdded(new \DateTime());
             }
 
             if (($user = $this->userHelper->getUser()) instanceof User) {
@@ -261,7 +259,7 @@ class FormModel extends AbstractCommonModel
     {
         if (method_exists($entity, 'setDateModified')) {
             $entity->setDateModified(
-                defined('MAUTIC_DATE_MODIFIED_OVERRIDE') ? DateTime::createFromFormat('U', MAUTIC_DATE_MODIFIED_OVERRIDE) : new DateTime()
+                defined('MAUTIC_DATE_MODIFIED_OVERRIDE') ? \DateTime::createFromFormat('U', MAUTIC_DATE_MODIFIED_OVERRIDE) : new \DateTime()
             );
         }
 

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -257,7 +257,7 @@ class FormModel extends AbstractCommonModel
 
     private function setModifiedData(object $entity): void
     {
-        if (method_exists($entity, 'setDateModified')) {
+        if (method_exists($entity, 'setDateModified') && method_exists($entity, 'getDateModified') && !$entity->getDateModified()) {
             $entity->setDateModified(
                 defined('MAUTIC_DATE_MODIFIED_OVERRIDE') ? \DateTime::createFromFormat('U', MAUTIC_DATE_MODIFIED_OVERRIDE) : new \DateTime()
             );

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -2,6 +2,9 @@
 
 namespace Mautic\CoreBundle\Model;
 
+use DateInterval;
+use DateTime;
+use Doctrine\ORM\UnitOfWork;
 use Mautic\CoreBundle\Entity\SkipModifiedInterface;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\UserBundle\Entity\User;
@@ -27,7 +30,7 @@ class FormModel extends AbstractCommonModel
         // lock the row if applicable
         if (method_exists($entity, 'setCheckedOut') && method_exists($entity, 'getId') && $entity->getId()) {
             if ($this->userHelper->getUser()->getId()) {
-                $entity->setCheckedOut(new \DateTime());
+                $entity->setCheckedOut(new DateTime());
                 $entity->setCheckedOutBy($this->userHelper->getUser());
                 $this->em->persist($entity);
                 $this->em->flush();
@@ -44,15 +47,14 @@ class FormModel extends AbstractCommonModel
     {
         if (method_exists($entity, 'getCheckedOut')) {
             $checkedOut = $entity->getCheckedOut();
-            if (!empty($checkedOut) && $checkedOut instanceof \DateTime) {
-                $checkedOutBy = $entity->getCheckedOutBy();
-                $maxLockTime  = $this->coreParametersHelper->get('max_entity_lock_time', 0);
+            if (!empty($checkedOut) && $checkedOut instanceof DateTime) {
+                $checkedOutBy     = $entity->getCheckedOutBy();
+                $maxLockTime      = $this->coreParametersHelper->get('max_entity_lock_time', 0);
+                $lockValidityDate = false;
 
                 if (0 != $maxLockTime && is_numeric($maxLockTime)) {
                     $lockValidityDate = clone $checkedOut;
-                    $lockValidityDate->add(new \DateInterval('PT'.$maxLockTime.'S'));
-                } else {
-                    $lockValidityDate = false;
+                    $lockValidityDate->add(new DateInterval('PT'.$maxLockTime.'S'));
                 }
 
                 // is lock expired ?
@@ -169,12 +171,10 @@ class FormModel extends AbstractCommonModel
         }
 
         if (method_exists($entity, 'getId')) {
-            $isNew = ($entity->getId()) ? false : true;
-        } else {
-            $isNew = \Doctrine\ORM\UnitOfWork::STATE_NEW === $this->em->getUnitOfWork()->getEntityState($entity);
+            return !$entity->getId();
         }
 
-        return $isNew;
+        return UnitOfWork::STATE_NEW === $this->em->getUnitOfWork()->getEntityState($entity);
     }
 
     /**
@@ -193,9 +193,9 @@ class FormModel extends AbstractCommonModel
                 case 'unpublished':
                     $entity->setIsPublished(true);
                     break;
-                case 'published':
                 case 'expired':
                 case 'pending':
+                case 'published':
                     $this->dispatchEvent('pre_unpublish', $entity);
                     $entity->setIsPublished(false);
                     break;
@@ -204,9 +204,7 @@ class FormModel extends AbstractCommonModel
             // set timestamp changes
             $this->setTimestamps($entity, false, false);
         } elseif (method_exists($entity, 'setIsEnabled')) {
-            $enabled    = $entity->getIsEnabled();
-            $newSetting = ($enabled) ? false : true;
-            $entity->setIsEnabled($newSetting);
+            $entity->setIsEnabled(!$entity->getIsEnabled());
         }
 
         // hit up event listeners
@@ -234,16 +232,18 @@ class FormModel extends AbstractCommonModel
 
         if ($isNew) {
             if (method_exists($entity, 'setDateAdded') && !$entity->getDateAdded()) {
-                $entity->setDateAdded(new \DateTime());
+                $entity->setDateAdded(new DateTime());
             }
 
-            if ($this->userHelper->getUser() instanceof User) {
+            if (($user = $this->userHelper->getUser()) instanceof User) {
                 if (method_exists($entity, 'setCreatedBy') && !$entity->getCreatedBy()) {
-                    $entity->setCreatedBy($this->userHelper->getUser());
+                    $entity->setCreatedBy($user);
                 } elseif (method_exists($entity, 'setCreatedByUser') && !$entity->getCreatedByUser()) {
-                    $entity->setCreatedByUser($this->userHelper->getUser()->getName());
+                    $entity->setCreatedByUser($user->getName());
                 }
             }
+
+            $this->setModifiedData($entity);
 
             return;
         }
@@ -252,29 +252,24 @@ class FormModel extends AbstractCommonModel
             return;
         }
 
+        if (method_exists($entity, 'getChanges') ? !empty($entity->getChanges()) : true) {
+            $this->setModifiedData($entity);
+        }
+    }
+
+    private function setModifiedData(object $entity): void
+    {
         if (method_exists($entity, 'setDateModified')) {
-            $setDateModified = true;
-            if (method_exists($entity, 'getChanges')) {
-                $changes = $entity->getChanges();
-                if (empty($changes)) {
-                    $setDateModified = false;
-                }
-                if (is_array($changes) && 1 === count($changes) && isset($changes['dateLastActive'])) {
-                    $setDateModified = false;
-                }
-            }
-            if ($setDateModified) {
-                $dateModified = (defined('MAUTIC_DATE_MODIFIED_OVERRIDE')) ? \DateTime::createFromFormat('U', MAUTIC_DATE_MODIFIED_OVERRIDE)
-                    : new \DateTime();
-                $entity->setDateModified($dateModified);
-            }
+            $entity->setDateModified(
+                defined('MAUTIC_DATE_MODIFIED_OVERRIDE') ? DateTime::createFromFormat('U', MAUTIC_DATE_MODIFIED_OVERRIDE) : new DateTime()
+            );
         }
 
-        if ($this->userHelper->getUser() instanceof User) {
+        if (($user = $this->userHelper->getUser()) instanceof User) {
             if (method_exists($entity, 'setModifiedBy')) {
-                $entity->setModifiedBy($this->userHelper->getUser());
+                $entity->setModifiedBy($user);
             } elseif (method_exists($entity, 'setModifiedByUser')) {
-                $entity->setModifiedByUser($this->userHelper->getUser()->getName());
+                $entity->setModifiedByUser($user->getName());
             }
         }
     }

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -254,6 +254,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
             ->addLifecycleEvent('checkAttributionDate', 'prePersist')
             ->addLifecycleEvent('checkDateAdded', 'prePersist')
             ->addIndex(['date_added'], 'lead_date_added')
+            ->addIndex(['date_modified'], 'lead_date_modified')
             ->addIndex(['date_identified'], 'date_identified');
 
         $builder->addBigIntIdField();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -174,6 +174,16 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(null, $response['contacts'][1]['fields']['all']['company']);
         $this->assertEquals(null, $response['contacts'][2]['fields']['all']['company']);
 
+        // Assert date modified
+        $this->assertNotEmpty($response['contacts'][0]['dateModified']);
+        $this->assertNotEmpty($response['contacts'][1]['dateModified']);
+        $this->assertNotEmpty($response['contacts'][2]['dateModified']);
+
+        // Assert date added
+        $this->assertNotEmpty($response['contacts'][0]['dateAdded']);
+        $this->assertNotEmpty($response['contacts'][1]['dateAdded']);
+        $this->assertNotEmpty($response['contacts'][2]['dateAdded']);
+
         // Emulate an unsanitized email to ensure that doesn't cause duplicates
         $payload[0]['email'] = 'batchemail1@email.com,';
 

--- a/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
@@ -40,8 +40,8 @@ class ImportCommandTest extends MauticMysqlTestCase
     public function testImportNotification(): void
     {
         // Create contact import for ghosting.
-        $this->createCsvContactImport(2);
-        $this->createCsvContactImport(2);
+        $this->createCsvContactImport(Import::IN_PROGRESS);
+        $this->createCsvContactImport(Import::IN_PROGRESS);
 
         // Create another import to be run
         $import = $this->createCsvContactImport();
@@ -71,7 +71,7 @@ class ImportCommandTest extends MauticMysqlTestCase
         return $tmpFile;
     }
 
-    private function createCsvContactImport(int $status = 1): Import
+    private function createCsvContactImport(int $status = Import::QUEUED): Import
     {
         $csvFile = $this->generateSmallCSV();
 

--- a/app/migrations/Version20211020092759.php
+++ b/app/migrations/Version20211020092759.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+use Mautic\LeadBundle\Field\Helper\IndexHelper;
+
+final class Version20211020092759 extends PreUpAssertionMigration
+{
+    private const TABLE = 'leads';
+
+    protected function preUpAssertions(): void
+    {
+        $this->skipAssertion(
+            function (Schema $schema) {
+                $table = $schema->getTable($this->getPrefixedTableName(self::TABLE));
+
+                return count($table->getIndexes()) >= IndexHelper::MAX_COUNT_ALLOWED || $table->hasIndex($this->getIndexName());
+            },
+            "Index {$this->getIndexName()} cannot be created because the {$this->getPrefixedTableName(self::TABLE)} has hit the table index limit or the index already exists"
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE INDEX {$this->getIndexName()} ON {$this->getPrefixedTableName(self::TABLE)} (date_modified)");
+    }
+
+    private function getIndexName(): string
+    {
+        return $this->prefix.'lead_date_modified';
+    }
+}

--- a/app/migrations/Version20211020142629.php
+++ b/app/migrations/Version20211020142629.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20211020142629 extends AbstractMauticMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE {$this->getPrefixedTableName('leads')} SET date_modified = date_added WHERE date_modified IS NULL;");
+    }
+}


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Enhancement
| Automated tests included? | Y
| Related user documentation PR URL | /
| Related developer documentation PR URL | /
| Issues addressed (#s or URLs) | /
| BC breaks? | N
| Deprecations? | N

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:

This PR will populate the `date_modified` on entity creation. Up till now we set it as NULL and populated the value only on update.

The reason for this is that if someone wants to get a list of all contacts that were crated or updated in a certain time frame via API then they have to make 2 distinct requests because they have to fetch the created and modified contacts separately. With this change they can get all contacts that needs sync in one request.

This PR also adds index on the date_modified column and it populates all empty date_modified values with values from date_added column.

There is also a migration that will set the `date_added` the same value as `date_modified` if it is empty to get the best guess of the `date_added` date on the `leads` table where it is the most important.

#### Steps to test this PR:
1. Create a contact
2. Notice the date modified is not empty.

#### Other areas of Mautic that may be affected by the change:
1. This will affect all entities that are saved through the FormModel which are most if not all of them.
2. It will also affect not only the date modified field but also the modified by and modified by user fields. There are no migrations for those fields though as I'm not aware of a use case where these fields would be used.


[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. Saving the contact entity and checking that the date modified value is not empty