### PR TITLE
Fix Not allowing template rewrites on ajax page load

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -114,6 +114,26 @@ class CommonController extends AbstractController implements MauticController
     }
 
     /**
+     * eventAwareRenderView.
+     *
+     * @param array<string, string> $parameters
+     */
+    public function eventAwareRenderView(string &$contentTemplate, array &$parameters, Request $request = null): string
+    {
+        if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
+            $event = $this->dispatcher->dispatch(
+                new CustomTemplateEvent($request, $contentTemplate, $parameters),
+                CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
+            );
+
+            $contentTemplate   = $event->getTemplate();
+            $parameters        = $event->getVars();
+        }
+
+        return $this->renderView($contentTemplate, $parameters);
+    }
+
+    /**
      * Determines if ajax content should be returned or direct content (page refresh).
      *
      * @param array $args
@@ -331,7 +351,7 @@ class CommonController extends AbstractController implements MauticController
                 }
             } else {
                 $GLOBALS['MAUTIC_AJAX_DIRECT_RENDER'] = 1; // for error handling
-                $newContent                           = $this->renderView($contentTemplate, $parameters);
+                $newContent                           = $this->eventAwareRenderView($contentTemplate, $parameters, $request);
 
                 unset($GLOBALS['MAUTIC_AJAX_DIRECT_RENDER']);
             }


### PR DESCRIPTION
eventAwareRenderView: We added this method, because ajax call needs to dispatch event to give plugins chance to replace templates.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          |  Y
| New feature/enhancement? (use the a.x branch)      | N
| Deprecations?                          | N
| BC breaks? (use the c.x branch)        | N
| Automated tests included?              | N
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

In Mautic 5, when you override core template, changes only take an effect if page is not loaded via ajax, that is because when loading page via ajax does not dispatch CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE. This PR, fixes that

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
[most likely you will have to test this locally]

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Load a plugin that overrides some core template
3. Visit a dashboard page.
4. Then click on a menu/link that uses custom template
5. Mautic should load the custom template.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->