### PR TITLE
fix: The VIEW_INJECT_CUSTOM_CONTENT event was not getting dispatched with a valid viewName during AJAX content updates

### DIFF
--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -330,6 +330,9 @@ class CommonController extends AbstractController implements MauticController
                     $newContent = $newContentResponse->getContent();
                 }
             } else {
+                $parameters['mauticTemplate']     = $contentTemplate;
+                $parameters['mauticTemplateVars'] = $parameters;
+
                 $GLOBALS['MAUTIC_AJAX_DIRECT_RENDER'] = 1; // for error handling
                 $newContent                           = $this->renderView($contentTemplate, $parameters);
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

This affects the https://github.com/acquia/mc-cs-plugin-custom-objects v5 branch (https://github.com/acquia/mc-cs-plugin-custom-objects/pull/338). Essentially the tabs on the Contacts page has a customContent event so that plugins can inject new tabs. However, when the contact page is loaded via AJAX the tabs added by plugins such as the custom objects plugin do not appear. This is because the viewName is empty when the event is dispatched so the plugin can't tell where the customContent is being called from. This is due to missing mauticTemplate and mauticTemplateVars in the Ajax content rendering. This fix puts it in place and I have been running this fix for some time now.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Install https://github.com/acquia/mc-cs-plugin-custom-objects/pull/338
3. Create a new Custom Object
4. Visit a Contact and note the tab for that Custom Object is only there if you refresh the page (non-AJAX rendering) - if you visit the contact naturally it AJAX loads and then never shows the tabs

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->