### PR TITLE
fix: Fix broken layout of My Categories on preference page (make them match public segments list)

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Lead/preference_options.html.twig
@@ -102,11 +102,13 @@
                 {% set categoryCount = form.global_categories is defined ? form.global_categories.vars.choices|length : 0 %}
                 {% if showContactCategories and categoryCount > 0 %}
                     <hr />
-                    <div id="global-categories" class="text-left">
-                        <div>{{ form_label(form.global_categories) }}</div>
-                        {% for category in form.global_categories %}
-                            {{ form_widget(category) }}
-                            {{ form_label(category) }}
+                    <div id="global-categories">
+                        <div class="text-left">{{ form_label(form.global_categories) }}</div>
+                        {% for key, category in form.global_categories %}
+                            <div id="category-{{ key }}" class="text-left">
+                                {{ form_widget(category) }}
+                                {{ form_label(category) }}
+                            </div>
                         {% endfor %}
                     </div>
                 {% endif %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

Before:
<img width="252" alt="Screenshot 2025-01-07 at 09 35 22" src="https://github.com/user-attachments/assets/94b9a7d2-e61e-4f02-844f-cf124a710c93" />

After:
<img width="206" alt="Screenshot 2025-01-07 at 09 34 40" src="https://github.com/user-attachments/assets/9cf06fdd-bf37-41e0-a91b-3e0e20bdb56d" />

It now matches what the public segment list looks like.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create some Global Categories
3. Create some public segments
4. In Email Settings under Unsubscribe Settings, show the contact preference page, and show contact's categories and show contact segment preferences
5. Trigger any email with an unsubscribe link in it
6. Click the unsubscribe link
7. Note the layout of the checkboxes for the categories compared to the segments
