### PR TITLE
fix: Fix category selection on admin preference panel and segment filter only showing first 10

### DIFF
--- a/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
@@ -368,7 +368,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
      */
     private function getCategoryChoices(): array
     {
-        return $this->makeChoices($this->categoryModel->getLookupResults('global'), 'title', 'id');
+        return $this->makeChoices($this->categoryModel->getLookupResults('global', '', 300), 'title', 'id');
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/Type/LeadCategoryType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadCategoryType.php
@@ -22,7 +22,7 @@ class LeadCategoryType extends AbstractType
     {
         $resolver->setDefaults([
             'choices'           => function (Options $options): array {
-                $categories = $this->categoryModel->getLookupResults('global');
+                $categories = $this->categoryModel->getLookupResults('global', '', 300);
                 $choices    = [];
 
                 foreach ($categories as $cat) {

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -154,7 +154,7 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->categoryModel->expects($this->once())
             ->method('getLookupResults')
-            ->with('global')
+            ->with('global', '', 300)
             ->willReturn([['title' => 'Category E', 'id' => 66]]);
 
         $this->emailModel->expects($this->once())


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 

## Description

When viewing a contact and heading to "Manage Preferences" in the backend, and then the categories area, it will only ever display the first 10 global categories.

Similarly when creating a segment the Subscribed Categories filter only displays the first 10 categories.

This fixes it to display them all much like it does for the segment dropdown.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create 15 Global Categories
3. Create a contact and head to its Manage Preferences and Categories. You'll see without the PR it will only display 10. With PR it displays all.
4. Create a segment and add a filter for Subscribed Categories and the same applies.
