### PR TITLE
Point Triggers broken: Triggers vanish after first invocation #13817

### DIFF
--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -432,9 +432,6 @@ class TriggerModel extends CommonFormModel
             if (!empty($persist)) {
                 $this->getEventRepository()->saveEntities($persist);
                 $this->getEventRepository()->detachEntities($persist);
-                if (isset($triggerEvent)) {
-                    $this->getEventRepository()->deleteEntity($triggerEvent);
-                }
             }
         }
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

This PR fixed a critical error where trigger events were being deleted from the database after their first invocation.

![image](https://github.com/user-attachments/assets/04ca894b-6dc9-4a9c-bef1-1f7dbb2107ab)
![image](https://github.com/user-attachments/assets/2a1c6fb9-1cf3-4852-b06f-9b6b4800ec08)
![image](https://github.com/user-attachments/assets/c557dc0a-8fb7-4baf-ad78-537bb399ce3e)

---
### 📋 Steps to test this PR:

1. Create a new Point Trigger and add multiple events.
2. Execute the trigger and ensure all events are executed correctly without being deleted.
3. Check that all events remain intact in the UI and the database (point_trigger_events) after invocation.
4. Repeat the process for triggers with a single event to confirm that the issue is resolved.