### PR TITLE
Remove MauticFactory::get and MauticFactory::serviceExists.

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -28,6 +28,8 @@
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getEnvironment` use dependency injection instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getIpAddress` use IpLookupHelper instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getSecurity` use dependency injection instead.
+- Removed `Mautic\CoreBundle\Factory\MauticFactory::get` use dependency injection instead.
+- Removed `Mautic\CoreBundle\Factory\MauticFactory::serviceExists` use dependency injection instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getSecurityContext` use dependency injection instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getDispatcher` use dependency injection instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getMailer` use dependency injection instead with \Mautic\EmailBundle\Helper\MailHelper.

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -107,23 +107,4 @@ class MauticFactory
     {
         return $this->container->get('mautic.helper.ip_lookup')->getIpAddressFromRequest();
     }
-
-    public function serviceExists($service): bool
-    {
-        return $this->container->has($service);
-    }
-
-    /**
-     * @param string $service
-     *
-     * @return object|bool
-     */
-    public function get($service)
-    {
-        if ($this->serviceExists($service)) {
-            return $this->container->get($service);
-        }
-
-        return false;
-    }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -918,11 +918,8 @@ class MailHelperTest extends TestCase
             $parameterMap
         );
 
-        $fromEmailHelper = new FromEmailHelper($this->createMock(CoreParametersHelper::class), $mockLeadRepository);
-
         $mockFactory->method('getParameter')->willReturnMap($parameterMap);
         $mockFactory->method('getModel')->willReturnMap([['lead', $mockLeadModel]]);
-        $mockFactory->method('get')->willReturnMap([['mautic.helper.from_email_helper', $fromEmailHelper]]);
 
         $mockMailboxHelper = $this->getMockBuilder(Mailbox::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🟢
| BC breaks? (use the c.x branch)        | 🟢
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Remove deprecated MauticFactory::get and MauticFactory::serviceExists.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Check the tests are okay. The only usage was in the `MailHelperTest`.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->