### PR TITLE
Remove unnecessary indexes on email_stat_replies

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
@@ -119,8 +119,8 @@ class IndexSchemaHelper
     {
         $textColumns = $this->getTextColumns($columns);
 
-        $index = new Index($this->prefix.$name, $textColumns, false, false, $options);
-        if ($this->table->hasIndex($this->prefix.$name)) {
+        $index = new Index($name, $textColumns, false, false, $options);
+        if ($this->table->hasIndex($name)) {
             $this->dropIndexes[] = $index;
         }
 

--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -46,6 +46,14 @@ return [
                 'tag'       => Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
                 'arguments' => [],
             ],
+            'mautic.install.fixture.remove_duplicate_index_on_stat_id_column_from_email_stat_replies_table' => [
+                'class'     => Mautic\InstallBundle\InstallFixtures\ORM\RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable::class,
+                'tag'       => Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
+                'arguments' => [
+                    'mautic.schema.helper.index',
+                    'event_dispatcher',
+                ],
+            ],
             'mautic.install.fixture.grape_js' => [
                 'class'     => Mautic\InstallBundle\InstallFixtures\ORM\GrapesJsData::class,
                 'tag'       => Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable.php
@@ -23,7 +23,7 @@ class RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable extends Abst
 
     public function __construct(IndexSchemaHelper $indexSchemaHelper, EventDispatcherInterface $eventDispatcher)
     {
-        $eventDispatcher->addListener(PreExecuteEvent::class, function (PreExecuteEvent $event) use ($indexSchemaHelper) {
+        $eventDispatcher->addListener(PreExecuteEvent::class, function (PreExecuteEvent $event) use ($indexSchemaHelper): void {
             $table   = $this->container->getParameter('mautic.db_table_prefix').self::TABLE_NAME;
             $indexes = $event->getEntityManager()->getConnection()->createSchemaManager()->listTableIndexes($table);
             $indexSchemaHelper->setName(self::TABLE_NAME);

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\InstallBundle\InstallFixtures\ORM;
+
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Mautic\CoreBundle\Doctrine\Common\DataFixtures\Event\PreExecuteEvent;
+use Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class RemoveDuplicatedIndexOnStatIdColumnsFromEmailStatRepliesTable extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface, FixtureGroupInterface
+{
+    use ContainerAwareTrait;
+
+    private const TABLE_NAME = 'email_stat_replies';
+    private const COLUMN     = ['stat_id'];
+
+    public function __construct(IndexSchemaHelper $indexSchemaHelper, EventDispatcherInterface $eventDispatcher)
+    {
+        $eventDispatcher->addListener(PreExecuteEvent::class, function (PreExecuteEvent $event) use ($indexSchemaHelper) {
+            $table   = $this->container->getParameter('mautic.db_table_prefix').self::TABLE_NAME;
+            $indexes = $event->getEntityManager()->getConnection()->createSchemaManager()->listTableIndexes($table);
+            $indexSchemaHelper->setName(self::TABLE_NAME);
+            foreach ($indexes as $index) {
+                if (!$index->spansColumns(self::COLUMN)) {
+                    continue;
+                }
+
+                $indexSchemaHelper->dropIndex(self::COLUMN, $index->getName())->executeChanges();
+                break;
+            }
+        });
+    }
+
+    public static function getGroups(): array
+    {
+        return ['group_install', 'group_mautic_install_data'];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        // https://www.doctrine-project.org/projects/doctrine-migrations/en/stable/explanation/implicit-commits
+    }
+
+    public function getOrder(): int
+    {
+        return 7;
+    }
+}

--- a/app/migrations/Version20201104215140.php
+++ b/app/migrations/Version20201104215140.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20201104215140 extends AbstractMauticMigration
+{
+    protected const TABLE_NAME = 'email_stat_replies';
+    private const COLUMN       = 'stat_id';
+
+    public function up(Schema $schema): void
+    {
+        $indexName = $this->getDefaultIndexName();
+        $tableName = $this->getTableName();
+        $this->skipIf(!$this->hasIndex(), sprintf('%s table doesn\'t contain the duplicated index (%s).', $tableName, $indexName));
+        $this->addSql(sprintf('ALTER TABLE `%s` DROP INDEX `%s`;', $tableName, $indexName));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $indexName = $this->getDefaultIndexName();
+        $tableName = $this->getTableName();
+        $this->skipIf($this->hasIndex(), sprintf('%s table already contains %s index.', $tableName, $indexName));
+        $this->addSql(sprintf('ALTER TABLE `%s` ADD INDEX `%s` (`%s` ASC);', $tableName, $indexName, static::COLUMN));
+    }
+
+    private function getTableName(): string
+    {
+        return $this->prefix.static::TABLE_NAME;
+    }
+
+    private function getDefaultIndexName(): string
+    {
+        return $this->getIndex() ?? $this->generatePropertyName($this->getTableName(), 'idx', [static::COLUMN]);
+    }
+
+    private function hasIndex(): bool
+    {
+        return (bool) $this->getIndex();
+    }
+
+    private function getIndex(): ?string
+    {
+        $indexes = $this->connection->createSchemaManager()->listTableIndexes($this->getTableName());
+
+        foreach ($indexes as $index) {
+            if (!$index->spansColumns([static::COLUMN])) {
+                continue;
+            }
+
+            return $index->getName();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
MAUT-4487: remove duplicate index (mautic_email_stat_replies table)

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴<!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
email_stat_replies table contains an unnecessary index on stat_id column.
It's name starts form IDX_ and it includes only stat_id column.


---
### 📋 Steps to test this PR:
<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Connect to its database.
3. Check that the unnecessary index no longer present.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->