### PR TITLE
Stop double increasing failure in campaign

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -370,6 +370,23 @@ class EventRepository extends CommonRepository
     }
 
     /**
+     * Update the failed count using DBAL to avoid
+     * race conditions and deadlocks.
+     */
+    public function decreaseFailedCount(Event $event): void
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+
+        $q->update(MAUTIC_TABLE_PREFIX.'campaign_events')
+            ->set('failed_count', 'failed_count - 1')
+            ->where($q->expr()->eq('id', ':id'))
+            ->andWhere($q->expr()->gt('failed_count', 0))
+            ->setParameter('id', $event->getId());
+
+        $q->executeStatement();
+    }
+
+    /**
      * Get the up to date failed count
      * for the given Event.
      */
@@ -400,5 +417,21 @@ class EventRepository extends CommonRepository
             ->setParameter('campaignId', $campaign->getId());
 
         $q->executeStatement();
+    }
+
+    /**
+     * Get the count of failed event for Lead/Event.
+     */
+    public function getFailedCountLeadEvent(int $leadId, int $eventId): int
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q->select('count(le.id)')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'le')
+            ->innerJoin('le', MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log', 'fle', 'le.id = fle.log_id')
+            ->where('le.lead_id = :leadId')
+            ->andWhere('le.event_id = :eventId')
+            ->setParameters(['leadId' => $leadId, 'eventId' => $eventId]);
+
+        return (int) $q->executeQuery()->fetchOne();
     }
 }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -642,4 +642,21 @@ SQL;
             $deleteEntries = $conn->executeQuery($sql, [$eventIds], [ArrayParameterType::INTEGER])->rowCount();
         }
     }
+
+    /**
+     * Check if last lead/event failed.
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function isLastFailed(int $leadId, int $eventId): bool
+    {
+        /** @var LeadEventLog $log */
+        $log = $this->findOneBy(['lead' => $leadId, 'event' => $eventId], ['dateTriggered' => 'DESC']);
+
+        if (null !== $log && null !== $log->getFailedLog()) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -102,7 +102,7 @@ class CampaignEventSubscriber implements EventSubscriberInterface
         $log                  = $event->getLog();
         $executedEvent        = $log->getEvent();
         $lead                 = $log->getLead();
-        $leadId               = $lead->getId() ?? $lead->deletedId;
+        $leadId               = ($lead->getId() > 0) ? $lead->getId() : $lead->deletedId;
 
         $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($leadId, $executedEvent->getId());
         // Decrease if success event and last failed

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -5,16 +5,20 @@ namespace Mautic\CampaignBundle\EventListener;
 use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\EventRepository;
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Event\CampaignEvent;
+use Mautic\CampaignBundle\Event\ExecutedEvent;
 use Mautic\CampaignBundle\Event\FailedEvent;
 use Mautic\CampaignBundle\Executioner\Helper\NotificationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CampaignEventSubscriber implements EventSubscriberInterface
 {
-    private float $disableCampaignThreshold = 0.1;
+    public const LOOPS_TO_FAIL = 100;
 
-    public function __construct(private EventRepository $eventRepository, private NotificationHelper $notificationHelper, private CampaignRepository $campaignRepository)
+    private float $disableCampaignThreshold = 0.35;
+
+    public function __construct(private EventRepository $eventRepository, private NotificationHelper $notificationHelper, private CampaignRepository $campaignRepository, private LeadEventLogRepository $leadEventLogRepository)
     {
     }
 
@@ -28,6 +32,7 @@ class CampaignEventSubscriber implements EventSubscriberInterface
         return [
             CampaignEvents::CAMPAIGN_PRE_SAVE => ['onCampaignPreSave', 0],
             CampaignEvents::ON_EVENT_FAILED   => ['onEventFailed', 0],
+            CampaignEvents::ON_EVENT_EXECUTED => ['onEventExecuted', 0],
         ];
     }
 
@@ -53,22 +58,59 @@ class CampaignEventSubscriber implements EventSubscriberInterface
     /**
      * Process the FailedEvent event. Notifies users and checks
      * failed thresholds to notify CS and/or disable the campaign.
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
      */
     public function onEventFailed(FailedEvent $event): void
     {
-        $log           = $event->getLog();
-        $failedEvent   = $log->getEvent();
-        $campaign      = $failedEvent->getCampaign();
+        $log                  = $event->getLog();
+        $failedEvent          = $log->getEvent();
+        $campaign             = $failedEvent->getCampaign();
+        $lead                 = $log->getLead();
+        $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($lead->getId(), $failedEvent->getId());
+        if ($countFailedLeadEvent < self::LOOPS_TO_FAIL) {
+            // Do not increase if under LOOPS_TO_FAIL
+            return;
+        } elseif ($countFailedLeadEvent > self::LOOPS_TO_FAIL
+            && $this->leadEventLogRepository->isLastFailed($lead->getId(), $failedEvent->getId())
+        ) {
+            // Do not increase twice
+            return;
+        }
+        // Increase if LOOPS_TO_FAIL or last success
         $failedCount   = $this->eventRepository->incrementFailedCount($failedEvent);
         $contactCount  = $campaign->getLeads()->count();
         $failedPercent = $contactCount ? ($failedCount / $contactCount) : 1;
 
-        $this->notificationHelper->notifyOfFailure($log->getLead(), $failedEvent);
+        $this->notificationHelper->notifyOfFailure($lead, $failedEvent);
 
         if ($failedPercent >= $this->disableCampaignThreshold && $campaign->isPublished()) {
             $this->notificationHelper->notifyOfUnpublish($failedEvent);
             $campaign->setIsPublished(false);
             $this->campaignRepository->saveEntity($campaign);
         }
+    }
+
+    /**
+     * Check the fail log if the lead is recorded there. If yes it decrease the failed count. It prevents counting
+     * the same failure twice.
+     *
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function onEventExecuted(ExecutedEvent $event): void
+    {
+        $log                  = $event->getLog();
+        $executedEvent        = $log->getEvent();
+        $lead                 = $log->getLead();
+        $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($lead->getId(), $executedEvent->getId());
+        // Decrease if success event and last failed
+        if (!$this->leadEventLogRepository->isLastFailed($lead->getId(), $executedEvent->getId())
+            || $countFailedLeadEvent < self::LOOPS_TO_FAIL
+        ) {
+            // Do not decrease if under LOOPS_TO_FAIL or last succes
+            return;
+        }
+        // Decrease if last failed and over the LOOPS_TO_FAIL
+        $this->eventRepository->decreaseFailedCount($executedEvent);
     }
 }

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -102,12 +102,14 @@ class CampaignEventSubscriber implements EventSubscriberInterface
         $log                  = $event->getLog();
         $executedEvent        = $log->getEvent();
         $lead                 = $log->getLead();
-        $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($lead->getId(), $executedEvent->getId());
+        $leadId               = $lead->getId() ?? $lead->deletedId;
+
+        $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($leadId, $executedEvent->getId());
         // Decrease if success event and last failed
-        if (!$this->leadEventLogRepository->isLastFailed($lead->getId(), $executedEvent->getId())
+        if (!$this->leadEventLogRepository->isLastFailed($leadId, $executedEvent->getId())
             || $countFailedLeadEvent < self::LOOPS_TO_FAIL
         ) {
-            // Do not decrease if under LOOPS_TO_FAIL or last succes
+            // Do not decrease if under LOOPS_TO_FAIL or last success
             return;
         }
         // Decrease if last failed and over the LOOPS_TO_FAIL

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Entity;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query\Expr;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
+use PHPUnit\Framework\TestCase;
+
+final class EventRepositoryTest extends TestCase
+{
+    use RepositoryConfiguratorTrait;
+
+    public function testDecreaseFailedCount(): void
+    {
+        $emMock           = $this->createMock(EntityManager::class);
+        $connMock         = $this->createMock(Connection::class);
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $expressionMock   = $this->createMock(Expr::class);
+
+        $queryBuilderMock->expects($this->any())
+            ->method('expr')
+            ->willReturn($expressionMock);
+
+        $expressionMock->expects($this->once())
+            ->method('eq')
+            ->with('id', ':id')
+            ->willReturn('id = :id');
+
+        $queryBuilderMock->expects($this->any())
+            ->method('expr')
+            ->willReturn($expressionMock);
+
+        $expressionMock->expects($this->once())
+            ->method('gt')
+            ->with('failed_count', 0)
+            ->willReturn('failed_count > 0');
+
+        $queryBuilderMock->expects($this->once())
+            ->method('update')
+            ->with(MAUTIC_TABLE_PREFIX.'campaign_events')
+            ->willReturn($queryBuilderMock);
+
+        $queryBuilderMock->expects($this->once())
+            ->method('set')
+            ->with('failed_count', 'failed_count - 1')
+            ->willReturn($queryBuilderMock);
+
+        $queryBuilderMock->expects($this->once())
+            ->method('where')
+            ->with('id = :id')
+            ->willReturn($queryBuilderMock);
+
+        $queryBuilderMock->expects($this->once())
+            ->method('andWhere')
+            ->with('failed_count > 0')
+            ->willReturn($queryBuilderMock);
+
+        $queryBuilderMock->expects($this->once())
+            ->method('setParameter')
+            ->with('id', $this->equalTo(42))
+            ->willReturn($queryBuilderMock);
+
+        $connMock->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilderMock);
+
+        $emMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($connMock);
+
+        $eventRepository = $this->configureRepository(Event::class, $emMock);
+        $this->connection->method('createQueryBuilder')
+            ->willReturnCallback(fn () => $queryBuilderMock);
+
+        $eventMock       = $this->createMock(Event::class);
+        $eventMock->method('getId')
+            ->willReturn(42);
+
+        $eventRepository->decreaseFailedCount($eventMock);
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/LeadEventLogRepositoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Entity;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\UnitOfWork;
+use Mautic\CampaignBundle\Entity\FailedLeadEventLog;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
+use PHPUnit\Framework\TestCase;
+
+final class LeadEventLogRepositoryTest extends TestCase
+{
+    use RepositoryConfiguratorTrait;
+
+    /**
+     * @dataProvider isLastFailedDataProvider
+     */
+    public function testIsLastFailed(?LeadEventLog $leadEventLog, bool $expectedResult): void
+    {
+        $emMock                 = $this->createMock(EntityManager::class);
+        $unitOfWorkMock         = $this->createMock(UnitOfWork::class);
+        $emMock->method('getUnitOfWork')
+            ->willReturn($unitOfWorkMock);
+
+        $entityPersisterMock = $this->createMock(EntityPersister::class);
+        $unitOfWorkMock->method('getEntityPersister')
+            ->willReturn($entityPersisterMock);
+
+        $entityPersisterMock->method('load')
+            ->with(['lead' => 42, 'event' => 4242], null, null, [], null, 1, ['dateTriggered' => 'DESC'])
+            ->willReturn($leadEventLog);
+
+        $leadEventLogRepository = $this->configureRepository(LeadEventLog::class, $emMock);
+        $this->connection->method('createQueryBuilder')->willReturnCallback(fn () => new QueryBuilder($this->connection));
+
+        $isLastFailed = $leadEventLogRepository->isLastFailed(42, 4242);
+        $this->assertSame($expectedResult, $isLastFailed);
+    }
+
+    /**
+     * @return array<string,array<mixed>>
+     */
+    public function isLastFailedDataProvider(): array
+    {
+        $leadEventLogNoFail = new LeadEventLog();
+        $failedLeadEvent    = new FailedLeadEventLog();
+        $leadEventLogFail   = new LeadEventLog();
+        $leadEventLogFail->setFailedLog($failedLeadEvent);
+
+        return [
+            'no_last_log'      => [null, false],
+            'last_log_no_fail' => [$leadEventLogNoFail, false],
+            'last_log_fail'    => [$leadEventLogFail, true],
+        ];
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -261,8 +261,7 @@ class CampaignEventSubscriberTest extends TestCase
     {
         $mockEventLog = $this->createMock(LeadEventLog::class);
 
-        $lead = new Lead();
-        $lead->setId(null);
+        $lead            = new Lead();
         $lead->deletedId = 10;
 
         $eventMock = $this->createMock(Event::class);
@@ -270,24 +269,24 @@ class CampaignEventSubscriberTest extends TestCase
             ->method('getId')
             ->willReturn(1);
 
-        $mockEventLog->expects($this->at(0))
+        $mockEventLog->expects($this->once())
             ->method('getEvent')
             ->willReturn($eventMock);
 
-        $mockEventLog->expects($this->at(1))
+        $mockEventLog->expects($this->once())
             ->method('getLead')
             ->willReturn($lead);
 
         $this->leadEventLogRepositoryMock->expects($this->once())
             ->method('isLastFailed')
-            ->with($lead->deletedId, $eventMock->getId())
+            ->with($lead->deletedId, 1)
             ->willReturn(true);
 
         $executedEvent = new ExecutedEvent($this->createMock(AbstractEventAccessor::class), $mockEventLog);
 
         $this->eventRepo->expects($this->once())
             ->method('getFailedCountLeadEvent')
-            ->with($lead->deletedId, $eventMock->getId())
+            ->with($lead->deletedId, 1)
             ->willReturn(101);
 
         $this->eventRepo->expects($this->once())

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -8,7 +8,9 @@ use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Event\CampaignEvent;
+use Mautic\CampaignBundle\Event\ExecutedEvent;
 use Mautic\CampaignBundle\Event\FailedEvent;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 use Mautic\CampaignBundle\EventListener\CampaignEventSubscriber;
@@ -36,12 +38,23 @@ class CampaignEventSubscriberTest extends TestCase
      */
     private $campaignRepository;
 
+    /**
+     * @var MockObject|LeadEventLogRepository
+     */
+    private $leadEventLogRepositoryMock;
+
     public function setUp(): void
     {
-        $this->eventRepo          = $this->createMock(EventRepository::class);
-        $this->notificationHelper = $this->createMock(NotificationHelper::class);
-        $this->campaignRepository = $this->createMock(CampaignRepository::class);
-        $this->fixture            = new CampaignEventSubscriber($this->eventRepo, $this->notificationHelper, $this->campaignRepository);
+        $this->eventRepo                  = $this->createMock(EventRepository::class);
+        $this->notificationHelper         = $this->createMock(NotificationHelper::class);
+        $this->campaignRepository         = $this->createMock(CampaignRepository::class);
+        $this->leadEventLogRepositoryMock = $this->createMock(LeadEventLogRepository::class);
+        $this->fixture                    = new CampaignEventSubscriber(
+            $this->eventRepo,
+            $this->notificationHelper,
+            $this->campaignRepository,
+            $this->leadEventLogRepositoryMock
+        );
     }
 
     public function testEventFailedCountsGetResetOnCampaignPublish(): void
@@ -85,7 +98,15 @@ class CampaignEventSubscriberTest extends TestCase
 
     public function testFailedEventGeneratesANotification(): void
     {
+        $this->leadEventLogRepositoryMock->expects($this->once())
+            ->method('isLastFailed')
+            ->with(42, 42)
+            ->willReturn(false);
+
         $mockLead     = $this->createMock(Lead::class);
+        $mockLead->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
         $mockCampaign = $this->createMock(Campaign::class);
         $mockCampaign->expects($this->once())
             ->method('getLeads')
@@ -95,15 +116,23 @@ class CampaignEventSubscriberTest extends TestCase
         $mockEvent->expects($this->once())
             ->method('getCampaign')
             ->willReturn($mockCampaign);
+        $mockEvent->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
 
         $mockEventLog = $this->createMock(LeadEventLog::class);
         $mockEventLog->expects($this->once())
             ->method('getEvent')
             ->willReturn($mockEvent);
 
-        $mockEventLog->expects($this->once())
+        $mockEventLog->expects($this->any())
             ->method('getLead')
             ->willReturn($mockLead);
+
+        $this->eventRepo->expects($this->once())
+            ->method('getFailedCountLeadEvent')
+            ->withAnyParameters()
+            ->willReturn(105);
 
         // Set failed count to 5% of getLeads()->count()
         $this->eventRepo->expects($this->once())
@@ -122,7 +151,15 @@ class CampaignEventSubscriberTest extends TestCase
 
     public function testFailedCountOverDisableCampaignThresholdDisablesTheCampaign(): void
     {
+        $this->leadEventLogRepositoryMock->expects($this->once())
+            ->method('isLastFailed')
+            ->with(42, 42)
+            ->willReturn(false);
+
         $mockLead     = $this->createMock(Lead::class);
+        $mockLead->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
         $mockCampaign = $this->createMock(Campaign::class);
         $mockCampaign->expects($this->once())
             ->method('isPublished')
@@ -136,21 +173,29 @@ class CampaignEventSubscriberTest extends TestCase
         $mockEvent->expects($this->once())
             ->method('getCampaign')
             ->willReturn($mockCampaign);
+        $mockEvent->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
 
         $mockEventLog = $this->createMock(LeadEventLog::class);
         $mockEventLog->expects($this->once())
             ->method('getEvent')
             ->willReturn($mockEvent);
 
-        $mockEventLog->expects($this->once())
+        $mockEventLog->expects($this->any())
             ->method('getLead')
             ->willReturn($mockLead);
 
-        // Set failed count to 10% of getLeads()->count()
+        $this->eventRepo->expects($this->once())
+            ->method('getFailedCountLeadEvent')
+            ->withAnyParameters()
+            ->willReturn(200);
+
+        // Set failed count to 35% of getLeads()->count()
         $this->eventRepo->expects($this->once())
             ->method('incrementFailedCount')
             ->with($mockEvent)
-            ->willReturn(10);
+            ->willReturn(35);
 
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')
@@ -171,5 +216,44 @@ class CampaignEventSubscriberTest extends TestCase
             ->with(false);
 
         $this->fixture->onEventFailed($failedEvent);
+    }
+
+    public function testOnEventExecutedDecreaseTheCounter(): void
+    {
+        $mockEventLog = $this->createMock(LeadEventLog::class);
+
+        $lead = new Lead();
+        $lead->setId(42);
+
+        $eventMock = $this->createMock(Event::class);
+        $eventMock->expects($this->any())
+            ->method('getId')
+            ->willReturn(42);
+
+        $mockEventLog->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($eventMock);
+
+        $mockEventLog->expects($this->any())
+            ->method('getLead')
+            ->willReturn($lead);
+
+        $this->leadEventLogRepositoryMock->expects($this->once())
+            ->method('isLastFailed')
+            ->with(42, 42)
+            ->willReturn(true);
+
+        $executedEvent = new ExecutedEvent($this->createMock(AbstractEventAccessor::class), $mockEventLog);
+
+        $this->eventRepo->expects($this->once())
+            ->method('getFailedCountLeadEvent')
+            ->withAnyParameters()
+            ->willReturn(101);
+
+        $this->eventRepo->expects($this->once())
+            ->method('decreaseFailedCount')
+            ->with($eventMock);
+
+        $this->fixture->onEventExecuted($executedEvent);
     }
 }

--- a/app/bundles/CoreBundle/Test/Doctrine/RepositoryConfiguratorTrait.php
+++ b/app/bundles/CoreBundle/Test/Doctrine/RepositoryConfiguratorTrait.php
@@ -48,10 +48,10 @@ trait RepositoryConfiguratorTrait
     /**
      * @return object the repository for the entity
      */
-    private function configureRepository(string $entityClass)
+    private function configureRepository(string $entityClass, MockObject|EntityManagerInterface $entityManager = null)
     {
         $this->classMetadata   = $this->createMock(ClassMetadata::class);
-        $this->entityManager   = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager   = $entityManager ?? $this->createMock(EntityManagerInterface::class);
         $this->managerRegistry = $this->createMock(ManagerRegistry::class);
         $this->connection      = $this->getMockedConnection();
         $this->result          = $this->createMock(Result::class);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

There are three issues here.
1. There is no significant threshold taken into account before un-publishing. So if 1 contact goes through the campaign and 1 event happens to fail, the campaign is unpublished due to 100% fail rate. Expectation is that unpublishing a campaign does not kick in till it reaches a threshold that is more significant than a single or handful of contacts.
2. Repeat failures for the same contact are counted against the number of contacts. So a single contact that fails over and over because of a unique situation as was the case here will eventually cause the campaign to auto-unpublish. The expectation here is that repeat failures do not increase the failure counter to prevent this scenario.
3. This didn't happen in this situation but I noticed in the code that if there is a temporary failure that is corrected when re-attempted, the failure counter is not decreased. Thus events that are expected to self-correct (API rate limits, etc) will eventually cause the campaign to also unpublish. The expectation here is that an event that originally failed but now passed should decrease the failed event counter.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
#### Steps to reproduce the bug:
1. If 15% of actions fails, the campaign is unpublished.
2. Repeated failures of the same lead-event make higher the fail rate.
3. Success for lead-event do not decrease the fail rate.

Additionally test below scenario:
1. Create a segment with filter that accumulates few contacts
2. Create a campaign with the above segment and with the action 'Delete contact'
3. After the campaign is triggered, verify that the contacts in the segment are deleted.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
4. Make campaign where more than 10% and less than 35% of actions fail. It should not unpublish the campaign even you run it again and again.
5. Verify campaign working fine.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->