### PR TITLE
API new contact - set PATCH method If the contact exists

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -330,7 +330,9 @@ class CommonApiController extends FetchCommonApiController
             return $this->accessDenied();
         }
 
-        return $this->processForm($request, $entity, $parameters, 'POST');
+        $method = $entity->getId() ? 'PATCH' : 'POST';
+
+        return $this->processForm($request, $entity, $parameters, $method);
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR updates the ```/api/contacts/new``` endpoint to improve how it handles existing contacts. Previously, if the API found an existing contact, it would update the contact using a "clear method," meaning it would overwrite all contact data, keeping only the fields passed in the request and removing any other existing data.

With this update, the API will no longer erase existing contact data when certain fields are not passed in the request.

The previous behavior could unintentionally result in the loss of important contact data. This change ensures that updating a contact through the API is safer and more predictable, reducing the risk of accidental data loss.

### 📋 Steps to test this PR:

- Use the /api/contacts/new endpoint with data for an existing contact.
- Pass only a subset of fields in the request.
- Verify that only the provided fields are updated and all other existing contact data is retained.

