### PR TITLE
Update Mailbox.php - correct mb_convert_encoding() error

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -1054,7 +1054,10 @@ class Mailbox
         if ($string && $fromEncoding != $toEncoding) {
             $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
             if (!$convertedString && extension_loaded('mbstring')) {
-                $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
+                $listEncodings = mb_list_encodings();
+                if (in_array($fromEncoding, $listEncodings)) {
+                    $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
+                }
             }
         }
 


### PR DESCRIPTION
The handle unsupported encoding we need add one more check with mb_list_encodings(), that will return as an array the supported encodings in the PHP instance. And the $fromEncoding is not on the list, it will be untouched.

See: https://github.com/mautic/mautic/issues/14468

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the 5.x, 6.x branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The error occurred while running console command `mautic:email:fetch` when the monitored email box contained unsupported text encoding in the email text.

**The issue prevents the console command `mautic:email:fetch` from running, so it is considered a critical error.**

According the manual page of mb_convert_encoding() this is an old issue with the function, and the @ operator is not enough the handle.

The original function in MailBox.php about line 1051, that fails:

```
protected function convertStringEncoding($string, $fromEncoding, $toEncoding)
    {
        $convertedString = null;
        if ($string && $fromEncoding != $toEncoding) {
            $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
            if (!$convertedString && extension_loaded('mbstring')) {
                $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
            }
        }

        return $convertedString ?: $string;
    }
```

The handle unsupported encoding we need add one more check with mb_list_encodings(), that will return as an array the supported encodings in the PHP instance. And the $fromEncoding is not on the list, it will be untouched.

```
protected function convertStringEncoding($string, $fromEncoding, $toEncoding)
    {
        $convertedString = null;
        if ($string && $fromEncoding != $toEncoding) {
            $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
            if (!$convertedString && extension_loaded('mbstring')) {
                $listOfEncodings = mb_list_encodings();
                if (in_array($fromEncoding, $listOfEncodings)) {
                    $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
                }
            }
        }

        return $convertedString ?: $string;
    }
```

The suggested solution will handle the bug fully.

### How can we reproduce this issue?

Step 1: Create a bounced email with unicode-1-1-utf-7 encoding and put to the monitored email box.
Step 2: Run `php bin/console mautic:email:fetch`
Step 3: View error logs

### Relevant log output

```shell
[2025-01-15T22:42:17.886492+01:00] mautic.ERROR: ValueError: mb_convert_encoding(): Argument #3 ($from_encoding) contains invalid encoding "unicode-1-1-utf-7" (uncaught exception) at /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php line 1058 while running console command `mautic:email:fetch` 
[stack trace] 
#0 /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php(1058): mb_convert_encoding('This is an auto...', 'UTF-8', 'unicode-1-1-utf...') 
#1 /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php(917): Mautic\EmailBundle\MonitoredEmail\Mailbox->convertStringEncoding('This is an auto...', 'unicode-1-1-utf...', 'UTF-8') 
#2 /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php(827): Mautic\EmailBundle\MonitoredEmail\Mailbox->initMailPart(Object(Mautic\EmailBundle\MonitoredEmail\Message), Object(stdClass), 1, true) 
#3 /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php(112): Mautic\EmailBundle\MonitoredEmail\Mailbox->getMail(314788, true) 
#4 /mautic-path/docroot/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php(68): Mautic\EmailBundle\MonitoredEmail\Fetcher->getMessages(Array, NULL, true) 
#5 /mautic-path/docroot/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php(51): Mautic\EmailBundle\MonitoredEmail\Fetcher->fetch(NULL) 
#6 /mautic-path/vendor/symfony/console/Command/Command.php(298): Mautic\EmailBundle\Command\ProcessFetchEmailCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#7 /mautic-path/vendor/symfony/console/Application.php(1058): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#8 /mautic-path/vendor/symfony/framework-bundle/Console/Application.php(96): Symfony\Component\Console\Application->doRunCommand(Object(Mautic\EmailBundle\Command\ProcessFetchEmailCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#9 /mautic-path/vendor/symfony/console/Application.php(301): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Mautic\EmailBundle\Command\ProcessFetchEmailCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#10 /mautic-path/vendor/symfony/framework-bundle/Console/Application.php(82): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#11 /mautic-path/vendor/symfony/console/Application.php(171): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#12 /mautic-path/bin/console(16): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#13 {main} [] {"hostname":"vps.example.com","pid":34533}
[2025-01-15T22:42:17.892883+01:00] mautic.WARNING: Command `mautic:email:fetch` exited with status code 1 [] {"hostname":"vps.example.com","pid":34533}


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->