### PR TITLE
fix: Fix upsert sometimes storing incorrect ID in entity from a previous upsert operation

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -837,6 +837,13 @@ class CommonRepository extends ServiceEntityRepository
             if ($metadata->isIdentifier($fieldName)) {
                 if ($value) {
                     $hasId = true;
+                } elseif ($fieldName === $identifier) {
+                    // https://bugs.php.net/bug.php?id=76896
+                    // mysql_last_insert_id might return 0 if our insert updates a row
+                    // Call LAST_INSERT_ID() for the column to ensure the correct value
+                    $column   = $metadata->getColumnName($fieldName);
+                    $update[] = "{$column} = LAST_INSERT_ID({$column})";
+                    continue;
                 } else {
                     continue;
                 }

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -85,6 +85,8 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
             $this->connection->rollback();
         }
 
+        $this->afterRollback();
+
         if (!$this->useCleanupRollback || !$isTransactionActive || $customFieldsReset || !$this->wasRollbackSuccessful()) {
             $this->resetDatabase();
         }
@@ -106,6 +108,13 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      * Override this method to execute some logic right before the tearDown() is invoked.
      */
     protected function beforeTearDown(): void
+    {
+    }
+
+    /**
+     * Override this method to execute some logic right after the transaction ends.
+     */
+    protected function afterRollback(): void
     {
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mautic\CoreBundle\Tests\Functional\Entity;
+
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Entity\IpAddressRepository;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+
+class CommonRepositoryUpsertTest extends MauticMysqlTestCase
+{
+    protected function beforeBeginTransaction(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE '.MAUTIC_TABLE_PREFIX.'ip_addresses ADD UNIQUE INDEX idx_ip_address (ip_address)');
+    }
+
+    protected function afterRollback(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE '.MAUTIC_TABLE_PREFIX.'ip_addresses DROP INDEX idx_ip_address');
+    }
+
+    public function testUpsert(): void
+    {
+        // Insert twice, to get two insert IDs, and then insert the first one again to trigger update, and check insert ID
+        /** @var IpAddressRepository $ipAddressRepository */
+        $ipAddressRepository = $this->getContainer()->get(IpAddressRepository::class);
+        $ipAddress1          = new IpAddress('10.10.10.10');
+        $ipAddressRepository->upsert($ipAddress1);
+        $this->assertNotEmpty($ipAddress1->getId());
+        $ipAddress2 = new IpAddress('10.10.10.11');
+        $ipAddressRepository->upsert($ipAddress2);
+        $this->assertNotEmpty($ipAddress2->getId());
+        $ipAddress3 = new IpAddress('10.10.10.10');
+        $ipAddressRepository->upsert($ipAddress3);
+        $this->assertEquals($ipAddress1->getId(), $ipAddress3->getId());
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

When performing an upsert operation, if on the same connection a previous insert took place, and the upsert operation performs an update, the object has it's ID set to the insert ID of the previous insert, instead of being set to the ID of the row that was updated.

This is due to a missing `LAST_INSERT_ID` function call on the `ON DUPLICATE KEY UPDATE`.

There is no test for upsert and I'm happy to add one but I need some guidance as I couldn't find an entity in the CoreBundle that has a secondary unique key we can use to trigger an update. I assume there is a way to drop in an entity for test only but not entirely sure how to do that - if it's possible then happy to try add one, or happy for someone else to attempt.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Write a custom plugin with an entity that has a primary key and a separate unique index on a separate column
3. Perform an upsert of a new object, note it returns with an ID now set
4. Perform another upsert with different values, note it returns with a different ID now set
5. Perform an upsert of a new object with the same values as the original one in step 3, note that it returns with the ID of the object from step 4 instead of the ID from step 3 due to the connection's `LAST_INSERT_ID` being for the `INSERT` operation in step 4 rather than it actually gaining the ID of the row that was updated in this step