### PR TITLE
fix: Creating or updating a contact via the Rest API discards seconds for date time fields

### DIFF
--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -137,7 +137,7 @@ trait RequestTrait
 
                     switch ($type::class) {
                         case DateTimeType::class:
-                            $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i');
+                            $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i:s');
                             break;
                         case DateType::class:
                             $params[$name] = (new \DateTime(date('Y-m-d', $timestamp)))->format('Y-m-d');

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -210,16 +210,16 @@ class RequestTraitTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedValues, $fieldData);
     }
 
-    public function testDatTimePrepareParametersFromRequest(): void
+    public function testDateTimePrepareParametersFromRequest(): void
     {
         $params = [
             'datetime'  => '',
-            'datetime2' => '2023-01-01 21:00:00',
+            'datetime2' => '2023-01-01 21:00:10',
         ];
 
         $expectedValues =
             [
-                'datetime2' => '2023-01-01 21:00',
+                'datetime2' => '2023-01-01 21:00:10',
             ];
 
         foreach ($params as $alias => $value) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 

## Description

When using the Contacts create or edit Rest API requests, and updating a `datetime` field, the seconds are always set to `00` regardless of what you send, even though in the actual UI you can specify the seconds successfully.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new `datetime` custom field
3. Populate in UI the date time with seconds, it works
4. Use the Rest API to update the contact with seconds, and note it does not work and seconds get set to `00`