### PR TITLE
Running e2e with debug info

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo -e "APP_ENV=test\nAPP_DEBUG=1" > .env.local
 
       - name: Run E2E tests
-        run: ddev exec bin/codecept run acceptance
+        run: ddev exec composer e2e-test
 
       - name: Upload test artifacts
         if: failure()

--- a/composer.json
+++ b/composer.json
@@ -147,7 +147,7 @@
       "@generate-assets"
     ],
     "test": "bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
-    "e2e-test": "bin/codecept run acceptance",
+    "e2e-test": "php -dAPP_ENV=test bin/codecept run acceptance -vvv --debug",
     "phpstan": "[ ! -f var/cache/test/AppKernelTestDebugContainer.xml ] && (echo 'Building test cache ...'; APP_ENV=test APP_DEBUG=1 bin/console > /dev/null 2>&1);  php -d memory_limit=5G bin/phpstan analyse --ansi",
     "cs": "bin/php-cs-fixer fix --config=.php-cs-fixer.php -v --dry-run --diff",
     "fixcs": "bin/php-cs-fixer fix -v",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴🟢
| Deprecations?                          | 🔴🟢
| BC breaks? (use the c.x branch)        | 🔴🟢
| Automated tests included?              | 🔴🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description


The E2E tests are failing in the CI on both 5.2 and 6.x branch:
```
Run ddev exec bin/codecept run acceptance
Codeception PHP Testing Framework v5.1.2 https://stand-with-ukraine.pp.ua
ERROR 10[4](https://github.com/mautic/mautic/actions/runs/12888075991/job/35932137733#step:5:5)5 (28000): Access denied for user 'db'@'172.19.0.7' (using password: YES)

In DbPopulator.php line 107:
                                                    
  The populator command did not end successfully:   
    Exit code: 1                                    
    Output:                                         
                                                    
run [-o|--override OVERRIDE] [-e|--ext EXT] [--report] [--html [HTML]] [--xml [XML]] [--phpunit-xml [PHPUNIT-XML]] [--colors] [--no-colors] [--silent] [--steps] [-d|--debug] [--shard SHARD] [--filter FILTER] [--grep GREP] [--bootstrap [BOOTSTRAP]] [--no-redirect] [--coverage [COVERAGE]] [--coverage-html [COVERAGE-HTML]] [--coverage-xml [COVERAGE-XML]] [--coverage-text [COVERAGE-TEXT]] [--coverage-crap4j [COVERAGE-CRAP4J]] [--coverage-cobertura [COVERAGE-COBERTURA]] [--coverage-phpunit [COVERAGE-PHPUNIT]] [--no-exit] [-g|--group GROUP] [-s|--skip SKIP] [-x|--skip-group SKIP-GROUP] [--env ENV] [-f|--fail-fast [FAIL-FAST]] [--no-rebuild] [--seed SEED] [--no-artifacts] [--] [<suite> [<test>]]

COMMAND DID NOT FINISH PROPERLY.
Failed to execute command bin/codecept run acceptance: exit status 12[5](https://github.com/mautic/mautic/actions/runs/12888075991/job/35932137733#step:5:6)
Error: Process completed with exit code 1.
```

See https://github.com/mautic/mautic/actions/runs/12888075991/job/35932137733

This PR is debugging it as I cannot replicate it locally


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->