### PR TITLE
DPMMA-3048 Fix campaign execution stuck due to incorrect lead detachment in membership change action

### DIFF
--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -132,7 +132,7 @@ class MembershipManager
         }
 
         // Clear entities from RAM
-        $this->leadRepository->detachEntities($contacts->toArray());
+        $this->leadRepository->detachEntities($campaignMembers);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
@@ -128,12 +128,11 @@ class AbstractCampaignCommand extends MauticMysqlTestCase
         return $lead;
     }
 
-    protected function createCampaign(string $campaignName, bool $allowRestart = false): Campaign
+    protected function createCampaign(string $campaignName): Campaign
     {
         $campaign = new Campaign();
         $campaign->setName($campaignName);
         $campaign->setIsPublished(true);
-        $campaign->setAllowRestart($allowRestart);
         $this->em->persist($campaign);
 
         return $campaign;

--- a/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
@@ -128,11 +128,12 @@ class AbstractCampaignCommand extends MauticMysqlTestCase
         return $lead;
     }
 
-    protected function createCampaign(string $campaignName): Campaign
+    protected function createCampaign(string $campaignName, bool $allowRestart = false): Campaign
     {
         $campaign = new Campaign();
         $campaign->setName($campaignName);
         $campaign->setIsPublished(true);
+        $campaign->setAllowRestart($allowRestart);
         $this->em->persist($campaign);
 
         return $campaign;

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -557,6 +557,9 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $campaign1 = $this->createCampaign('Campaign 1');
         // create campaign with restart allowed
         $campaign2 = $this->createCampaign('Campaign 2', true);
+        $campaign2->setAllowRestart(true);
+        $this->em->persist($campaign2);
+
         $lead      = $this->createLead('Lead');
 
         // add lead to both campaigns

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -556,7 +556,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
     {
         $campaign1 = $this->createCampaign('Campaign 1');
         // create campaign with restart allowed
-        $campaign2 = $this->createCampaign('Campaign 2', true);
+        $campaign2 = $this->createCampaign('Campaign 2');
         $campaign2->setAllowRestart(true);
         $this->em->persist($campaign2);
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -535,7 +535,6 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $campaign2 = $this->createCampaign('Campaign 2');
         $lead      = $this->createLead('Lead');
         $this->createCampaignLead($campaign1, $lead);
-        $this->createCampaignLead($campaign2, $lead);
         $this->em->flush();
         $property = ['addTo' => [$campaign2->getId()], 'removeFrom' => ['this']];
         $this->createEvent('Event', $campaign1, 'campaign.addremovelead', 'action', $property);
@@ -551,6 +550,36 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         Assert::assertTrue($campaignLeads[0]->getManuallyRemoved());
         Assert::assertSame($campaign2->getId(), $campaignLeads[1]->getCampaign()->getId());
         Assert::assertFalse($campaignLeads[1]->getManuallyRemoved());
+    }
+
+    public function testCampaignActionChangeMembershipRestartRotation(): void
+    {
+        $campaign1 = $this->createCampaign('Campaign 1');
+        // create campaign with restart allowed
+        $campaign2 = $this->createCampaign('Campaign 2', true);
+        $lead      = $this->createLead('Lead');
+
+        // add lead to both campaigns
+        $this->createCampaignLead($campaign1, $lead);
+        $this->createCampaignLead($campaign2, $lead);
+        $this->em->flush();
+
+        // add action changeCampaigns to add the lead again to campaign2
+        $property = ['addTo' => [$campaign2->getId()], 'removeFrom' => ['this']];
+        $this->createEvent('Event', $campaign1, 'campaign.addremovelead', 'action', $property);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign1->getId(), '--contact-id' => $lead->getId(), '--kickoff-only' => true]);
+
+        $campaignLeads = $this->em->getRepository(Lead::class)->findBy(['lead' => $lead], ['campaign' => 'ASC']);
+
+        Assert::assertCount(2, $campaignLeads);
+        Assert::assertSame($campaign1->getId(), $campaignLeads[0]->getCampaign()->getId());
+        Assert::assertTrue($campaignLeads[0]->getManuallyRemoved());
+        Assert::assertSame($campaign2->getId(), $campaignLeads[1]->getCampaign()->getId());
+        Assert::assertFalse($campaignLeads[1]->getManuallyRemoved());
+        Assert::assertSame(2, $campaignLeads[1]->getRotation()); // assert it's the second rotation
     }
 
     public function testCampaignActionAfterChangeMembership(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14034

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
The campaign execution was getting stuck due to an issue with lead detachment in the change membership action. The previous implementation was detaching all contacts, including those newly added to the campaign, which caused problems while trying to save the campaign log after detach.

This PR also addresses an issue in the `testCampaignActionChangeMembership` test. Previously, the test was incorrectly set up: it was adding the contact to both campaigns before executing the campaign action. 


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create two empty segments in Mautic.

3. Create Campaign 1:
   - Start with Segment 1
   - Add an action (e.g., add tag to contact)

4. Create Campaign 2:
   - Start with Segment 2
   - Add "Change Campaigns" action
   - Select "Add to Campaign 1" in the action settings

5. Add a contact to Segment 2 and run the campaigns:
   ```
   php bin/console m:ca:u
   php bin/console m:ca:t
   ```

6. Verify that the campaign execution was successful.

7. Check if the created contact is now a member of Campaign 1.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->