### PR TITLE
Updated the field entity to set readOnly to false when passed null

### DIFF
--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -1026,8 +1026,8 @@ class Field
         return $this->isAutoFill && $this->isReadOnly;
     }
 
-    public function setIsReadOnly(bool $isReadOnly): void
+    public function setIsReadOnly(?bool $isReadOnly): void
     {
-        $this->isReadOnly = $isReadOnly;
+        $this->isReadOnly = $isReadOnly ?? false;
     }
 }

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -14,8 +14,8 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
     protected $useCleanupRollback = false;
 
     /**
-     * @param array<string, bool|null>  $data
-     * @param array<string, string>     $expected
+     * @param array<string, bool|null> $data
+     * @param array<string, string>    $expected
      *
      * @dataProvider dataForReadOnlyConfigurationSetting
      */

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -14,8 +14,8 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
     protected $useCleanupRollback = false;
 
     /**
-     * @param array<string, bool|null>   $data
-     * @param array<string, string> $expected
+     * @param array<string, bool|null>  $data
+     * @param array<string, string>     $expected
      *
      * @dataProvider dataForReadOnlyConfigurationSetting
      */

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -14,7 +14,7 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
     protected $useCleanupRollback = false;
 
     /**
-     * @param array<string, bool>   $data
+     * @param array<string, bool|null>   $data
      * @param array<string, string> $expected
      *
      * @dataProvider dataForReadOnlyConfigurationSetting
@@ -51,7 +51,7 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return iterable<string, array<int, array<string, bool|string>>>
+     * @return iterable<string, array<int, array<string, bool|string|null>>>
      */
     public function dataForReadOnlyConfigurationSetting(): iterable
     {

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -55,6 +55,19 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
      */
     public function dataForReadOnlyConfigurationSetting(): iterable
     {
+        yield 'When no behaviour configured' => [
+            // given
+            [
+                'isAutoFill' => null,
+                'isReadOnly' => null,
+            ],
+            // expected
+            [
+                'isAutoFill' => '0',
+                'isReadOnly' => '0',
+            ],
+        ];
+
         yield 'When field set to read only' => [
             // given
             [
@@ -172,8 +185,8 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
         Form $form,
         string $label,
         string $type,
-        bool $isAutoFill = false,
-        bool $isReadOnly = false,
+        ?bool $isAutoFill = false,
+        ?bool $isReadOnly = false,
         ?string $mappedField = null,
         ?string $mappedObject = null,
     ): Field {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

Yields the following error when creating a simple standalone form with an email field. 

![image](https://github.com/user-attachments/assets/47b47506-cf16-4f7d-8718-5459ef7a19b5)

Please see more here: https://github.com/mautic/mautic/pull/14422#issuecomment-2614579684


### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a form by adding the email field with label only
3. Save the form
4. The form with the email field will be created successfully
