### PR TITLE
[UI] disable tabs with attr data-disable-on

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -366,6 +366,20 @@ Mautic.switchFormFieldState = function (formName) {
         }
     }
 
+    /**
+     * Switch to first tab disabled/hidden field is a tab.
+     */
+    var clickFirstTab = function (field) {
+        if (field.parent().hasClass('nav-tabs')) {
+            // Get the first tab.
+            firstTab = field.siblings().first();
+            if (!firstTab.hasClass('active')) {
+                console.log('click')
+                firstTab.find('a').click()
+            }
+        }
+    }
+
     // find all fields to show
     processConditions('data-show-on', visibleFields, false);
 
@@ -397,6 +411,7 @@ Mautic.switchFormFieldState = function (formName) {
             fieldContainer.fadeIn();
         } else {
             toggleFieldOff(field);
+            clickFirstTab(field);
             fieldContainer.fadeOut();
         }
     });
@@ -411,6 +426,7 @@ Mautic.switchFormFieldState = function (formName) {
         var field = mQuery('#' + fieldId)
         if (disable) {
             toggleFieldOff(field);
+            clickFirstTab(field);
             field.addClass('disabled', disable);
             field.attr('disabled', 'disabled');
         } else {

--- a/app/bundles/DynamicContentBundle/Assets/js/dynamicContent.js
+++ b/app/bundles/DynamicContentBundle/Assets/js/dynamicContent.js
@@ -1,12 +1,3 @@
-Mautic.toggleDwcFilters = function () {
-    mQuery("#dwcFiltersTab, #slotNameDiv").toggleClass("hide");
-    if (mQuery("#dwcFiltersTab").hasClass('hide')) {
-        mQuery('.nav-tabs a[href="#details"]').click();
-    } else {
-        Mautic.dynamicContentOnLoad();
-    }
-};
-
 Mautic.dwcGenerator = (function() {
     // Selectors
     const copyBtnSelector = '#generator-copy-dynamic-content-slot';

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -172,7 +172,6 @@ class DynamicContentController extends FormController
 
             $passthrough = [
                 'activeLink'    => '#mautic_dynamicContent_index',
-                'mauticContent' => 'dynamicContent',
             ];
 
             // Check to see if this is a popup
@@ -203,7 +202,8 @@ class DynamicContentController extends FormController
             }
         }
 
-        $passthrough['route'] = $action;
+        $passthrough['mauticContent'] = 'dynamicContent';
+        $passthrough['route']         = $action;
 
         return $this->delegateView(
             [

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -129,8 +129,9 @@ class DynamicContentType extends AbstractType
                 'label'      => 'mautic.dynamicContent.send.slot_name',
                 'label_attr' => ['class' => 'control-label'],
                 'attr'       => [
-                    'class'   => 'form-control',
-                    'tooltip' => 'mautic.dynamicContent.send.slot_name.tooltip',
+                    'class'           => 'form-control',
+                    'tooltip'         => 'mautic.dynamicContent.send.slot_name.tooltip',
+                    'data-disable-on' => '{"dwc_isCampaignBased_1": "checked"}',
                 ],
             ]
         );
@@ -158,7 +159,6 @@ class DynamicContentType extends AbstractType
                 'data'  => (bool) $options['data']->isCampaignBased(),
                 'attr'  => [
                     'tooltip'  => 'mautic.dwc.form.is_campaign_based.tooltip',
-                    'onchange' => 'Mautic.toggleDwcFilters()',
                 ],
             ]
         );

--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/form.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/form.html.twig
@@ -35,7 +35,7 @@
                             {% endif %}
                         </a>
                     </li>
-                    <li class="{% if form.vars.value.isCampaignBased or form.updateSelect is defined %}hide{% endif %}" id="dwcFiltersTab">
+                    <li data-disable-on='{"dwc_isCampaignBased_1": "checked"}' id="dwcFiltersTab">
                         <a href="#filters" role="tab" data-toggle="tab" class="{% if hasFilterErrors %}text-danger{% endif %}">
                             {{ 'mautic.core.filters'|trans }}
                             {% if hasFilterErrors %}
@@ -130,7 +130,7 @@
             {% if form.updateSelect is not defined %}
                 {{ form_row(form.isCampaignBased) }}
             {% endif %}
-            <div id="slotNameDiv" class="{% if form.vars.value.isCampaignBased %}hide{% endif %}">
+            <div id="slotNameDiv">
                 {{ form_row(form.slotName) }}
             </div>
             <hr/>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the 6.x branch)      | 🟢
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This changes the behaviour of the Filters tab and Requested Slot Name field when creating a Dynamic Content. Instead of being hidden if "Is campaign based?" is Yes, the tab and field are disabled. This is done with the data-disable-on attribute introduced in  #14221.

This PR also allows the attribute to also works with tabs and will switch to the first tab if the tab you are currently on is hidden or disabled.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Components > Dynamic Content
3. Click on New to create a new Dynamic Content
4. See that the Filters tab and the Requested Slot Name field are disabled
5. Toggle off  "Is campaign based?"
6. See that the Filters tab and the Requested Slot Name field are enabled now
7. Click on the Filters tab and toggle on  "Is campaign based?"
8. See that you are back on the Details tab

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->