### PR TITLE
Bump version to 6.0.0-alpha in preparation for release

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,11 +1,11 @@
 {
-  "version": "5.2.1",
-  "stability": "stable",
+  "version": "6.0.0",
+  "stability": "alpha",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "4.4.10",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.2.1"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0-alpha"
 }


### PR DESCRIPTION
This PR bumps the version to 6.0.0-alpha in preparation for the release.

Things to check:

- Correct stability level
- Correctly formatted version
- Correct tag for release