### PR TITLE
Fix release name - needs to include stability level

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0",
+  "version": "6.0.0-alpha",
   "stability": "alpha",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",


### PR DESCRIPTION
Release workflow failed as the release name, 6.0.0, didn't match the milestone name, 6.0.0-alpha. I'll delete and re-tag but meanwhile this PR needs to be merged.