### PR TITLE
Bump version to 5.2.2

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.1",
+  "version": "5.2.2",
   "stability": "stable",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "4.4.10",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.2.1"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.2.2"
 }


### PR DESCRIPTION
This PR bumps the version to 5.2.2 in readiness for the release today.

Things to check:

- Version
- Stability
- Tag in URL