### PR TITLE
DPMMA-3033 Correct focus item script response codes and fix undefined Focus.iframe

### DIFF
--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -27,14 +27,14 @@ class PublicController extends CommonController
 
         if ($focus) {
             if (!$focus->isPublished()) {
-                return new Response('', 200, ['Content-Type' => 'application/javascript']);
+                return new Response('', Response::HTTP_NOT_FOUND);
             }
 
             $content  = $model->generateJavascript($focus, false, MAUTIC_ENV == 'dev');
 
             return new Response($content, 200, ['Content-Type' => 'application/javascript']);
         } else {
-            return new Response('', 200, ['Content-Type' => 'application/javascript']);
+            return new Response('', Response::HTTP_NOT_FOUND);
         }
     }
 

--- a/plugins/MauticFocusBundle/Resources/views/Builder/generate.js.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Builder/generate.js.twig
@@ -517,6 +517,9 @@
                 if (typeof Focus.iframeResizerEnabled !== 'undefined') {
                     return true;
                 }
+                if (typeof Focus.iframe === 'undefined') {
+                    return false;
+                }
 
                 {% if style in ['modal', 'notification', 'bar'] %}
                 Focus.iframeHeight = 0;

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticFocusBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use MauticPlugin\MauticFocusBundle\Entity\Focus;
+use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use Symfony\Component\HttpFoundation\Request;
+
+class FocusPublicControllerFunctionalTest extends MauticMysqlTestCase
+{
+    public function testGenerateFocusItemScript(): void
+    {
+        /** @var FocusModel $focusModel */
+        $focusModel = static::getContainer()->get('mautic.focus.model.focus');
+        $focus      = $this->createFocus('popup');
+        $focusModel->saveEntity($focus);
+
+        $this->client->request(Request::METHOD_GET, "/focus/{$focus->getId()}.js");
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isOk());
+        $this->assertNotEmpty($response->getContent());
+    }
+
+    public function testInactiveFocusItemScript(): void
+    {
+        /** @var FocusModel $focusModel */
+        $focusModel = static::getContainer()->get('mautic.focus.model.focus');
+        $focus      = $this->createFocus('popup');
+        $focus->setIsPublished(false);
+        $focusModel->saveEntity($focus);
+
+        $this->client->request(Request::METHOD_GET, "/focus/{$focus->getId()}.js");
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isNotFound());
+        $this->assertEmpty($response->getContent());
+    }
+
+    private function createFocus(string $name): Focus
+    {
+        $focus = new Focus();
+        $focus->setName($name);
+        $focus->setType('link');
+        $focus->setStyle('modal');
+        $focus->setProperties([
+            'bar' => [
+                'allow_hide' => 1,
+                'push_page'  => 1,
+                'sticky'     => 1,
+                'size'       => 'large',
+                'placement'  => 'top',
+            ],
+            'modal' => [
+                'placement' => 'top',
+            ],
+            'notification' => [
+                'placement' => 'top_left',
+            ],
+            'page'            => [],
+            'animate'         => 0,
+            'link_activation' => 1,
+            'colors'          => [
+                'primary'     => '4e5d9d',
+                'text'        => '000000',
+                'button'      => 'fdb933',
+                'button_text' => 'ffffff',
+            ],
+            'content' => [
+                'headline'        => null,
+                'tagline'         => null,
+                'link_text'       => null,
+                'link_url'        => null,
+                'link_new_window' => 1,
+                'font'            => 'Arial, Helvetica, sans-serif',
+                'css'             => null,
+            ],
+            'when'                  => 'immediately',
+            'timeout'               => null,
+            'frequency'             => 'everypage',
+            'stop_after_conversion' => 1,
+        ]);
+
+        return $focus;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR fixes some JS errors in browser when Focus.iframe is not defined and corrects the response codes when Focus Item doesn't exist.
![image](https://github.com/user-attachments/assets/97a4eb9b-7645-4059-8b1c-b49738e7a0bc)


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check the response code of focus item that doesn't exist, for example: `https://mautic.ddev.site/focus/111111.js` should have code 404
![image](https://github.com/user-attachments/assets/340c67d6-cbae-4aff-9237-39ebb983e33b)
3. Add the focus item that will be displayed after scrolling to middle of the page
![Screenshot from 2025-01-28 13-54-27](https://github.com/user-attachments/assets/5c0c787d-8adb-4654-905c-171b8f0310b2)
4. Add the focus item to landing page scripts
![image](https://github.com/user-attachments/assets/862a1577-d645-409e-bf2b-196a727dc2aa)
5. Check if the console log has any errors
![image](https://github.com/user-attachments/assets/b9201680-a507-4c1d-8176-e106be8e040c)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->