### PR TITLE
fix: Email preview now works again even if unpublished or expired

### DIFF
--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -472,7 +472,7 @@ class PublicController extends CommonFormController
         }
 
         if (
-            ($this->security->isAnonymous() && (!$emailEntity->isPublished() || !$publicPreview))
+            ($this->security->isAnonymous() && !$publicPreview)
             || (!$this->security->isAnonymous()
                 && !$this->security->hasEntityAccess(
                     'email:emails:viewown',

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -338,7 +338,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $this->client->request('GET', '/email/preview/'.$email->getId());
-        $this->assertFalse($this->client->getResponse()->isOk());
+        $this->assertTrue($this->client->getResponse()->isOk());
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 

## Description

Since v5 you cannot preview an expired email anymore. Also, you have never been able to preview an email that was not yet published - yet published means it will start sending if it doesn't have a start and end time - so can open up mistakes when trying to get preview to work. Though I think it is likely confusing that you can enable public preview at any time but yet it doesn't seem to work unless published but not clear this is case

Some history is that it worked in v4 for at least expired emails: https://github.com/mautic/mautic/pull/10971/files
But then in v5 there was work on drafts, and somehow it got reverted and the test changed incorrectly: https://github.com/mautic/mautic/pull/14028/files#diff-19429c7a4f887b40880788b54e72b2e4e996b6917b86c24ca098b1cd6d3a0ea8L469

This PR both restores the behaviour from v4 and #10971 where expired emails can be public previewed and also allows unpublished emails in general to be public previewed.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new email but leave it unpublished
3. Try to open preview URL in another browser or private browser tab - it should be forbidden
4. Enable public preview
5. Try to open preview URL in another browser or private browser tab - it should work, even though unpublished
6. Publish the email
7. Public preview should still work
8. Schedule email to expire, wait for expire
9. Public preview should still work

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->