### PR TITLE
fix: Fix font selection in CKEditor not including fallback fonts in output

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/11.editor.js
+++ b/app/bundles/CoreBundle/Assets/js/11.editor.js
@@ -284,8 +284,8 @@ Mautic.getCKEditorFonts = function(fonts) {
     const CKEditorFonts = [];
 
     for (let i = 0; i < fonts.length; i++) {
-        if ('undefined' != typeof fonts[i].name) {
-            CKEditorFonts.push(fonts[i].name);
+        if ('undefined' != typeof fonts[i].font) {
+            CKEditorFonts.push(fonts[i].font);
         }
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴

## Description

When adding a Text block to an email, if you add text to it and style it in a certain custom font that Mautic provides (or a plugin provides), such as Roboto, then it only adds "Roboto" as the `font-family`. When sending this email to a client that does not have Roboto available it will then render as Arial or Times New Roman as no fallbacks are in the `font-family`.

You can see this mainly by saving the CKEditor box and then while still in the Builder, open the code editor and look at what it inserted - it will be `font-family: Roboto` instead of `font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif`

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create email and enter builder
3. Add text block and open editor (CKEditor)
4. Add some text, select it, choose the Roboto font
5. Save the block
6. Open the code editor in the builder and inspect the code that was inserted, it should now be `font-family: Roboto, Tahoma, Verdana, Segoe, sans-serif`

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->