### PR TITLE
Email click tracking fix, PHP warning fix

### DIFF
--- a/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
@@ -27,7 +27,7 @@ class TrackingSubscriber implements EventSubscriberInterface
         $clickthrough = $event->getClickthrough();
 
         // Nothing left to identify by so stick to the tracked lead
-        if (empty($clickthrough['channel']['email']) && empty($clickthrough['stat'])) {
+        if (empty($clickthrough['stat'])) {
             return;
         }
 
@@ -39,7 +39,7 @@ class TrackingSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($stat->getEmail() && (int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
+        if (isset($clickthrough['channel']['email']) && $stat->getEmail() && (int) $stat->getEmail()->getId() !== (int) $clickthrough['channel']['email']) {
             // ID mismatch - fishy so use tracked lead
             return;
         }

--- a/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Functional;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Entity\HitRepository;
+use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+final class EmailClickTrackingTest extends MauticMysqlTestCase
+{
+    public function testEmailClick(): void
+    {
+        $contact = new Lead();
+        $contact->setEmail('john@doe.cz');
+
+        $email = new Email();
+        $email->setName('Test email');
+        $email->setSubject('Test email');
+        $email->setCustomHtml('<html><head></head><body>Test email</body></html>');
+
+        $stat = new Stat();
+        $stat->setLead($contact);
+        $stat->setEmail($email);
+        $stat->setEmailAddress('john@doe.cz');
+        $stat->setTrackingHash('67167f57a4c05265936091');
+        $stat->setDateSent(new \DateTime());
+
+        $page = new Page();
+        $page->setTitle('Test page');
+        $page->setAlias('test-page');
+        $page->setCustomHtml('<html><head></head><body>Test page</body></html>');
+
+        $this->em->persist($contact);
+        $this->em->persist($email);
+        $this->em->persist($stat);
+        $this->em->persist($page);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, '/test-page?&ct=YToxOntzOjQ6InN0YXQiO3M6MjI6IjY3MTY3ZjU3YTRjMDUyNjU5MzYwOTEiO30%3D');
+        Assert::assertTrue($this->client->getResponse()->isSuccessful());
+
+        $pageHitRepository = $this->em->getRepository(Hit::class);
+        \assert($pageHitRepository instanceof HitRepository);
+
+        $hit = $pageHitRepository->findOneBy(['page' => $page]);
+        Assert::assertSame($contact->getId(), $hit->getLead()->getId());
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

We saw a lot of errors like this in the logs:
```
PHP Warning:  Trying to access array offset on value of type null in app/bundles/EmailBundle/EventListener/TrackingSubscriber.php on line 53
```
We identified that it can happen only if the request contains `ct` (click through) query param with email stat tracking hash but no email ID. For example a landing page link like this one:
```
/some-landing-page?ct=YToxOntzOjQ6InN0YXQiO3M6MjI6IjY3MTY3ZjU3YTRjMDUyNjU5MzYwOTEiO30%3D\
```
This click through value looks like this when base64 decoded:
```
a:1:{s:4:"stat";s:22:"67167f57a4c05265936091";}
```
Here is visible that it contains just the email stat hash, no email ID.

This PR fixes that if such request happens, it will correctly check that the request is coming from the contact who click on the link in the email and there will be no PHP warning. Right now the page hit gets associated to the contacts only if they have the cookie set already.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a Contact A with an email address
3. Create a Segment A
4. Add Contact A to the Segment A
5. Create a segment Email A that has a link to some URL.
6. Send Email A to Segment A.
7. Open the email in the email inbox and open the URL in an incognito browser window.
8. Check that the PHP warning is logged on the previous release, it is not logged with this patch.
9. Check that the page it is correctly associated with the contact who received the email.

#### Other areas of Mautic that may be affected by the change:
1. Any tracking coming from emails. (email open, email click, page hit, redirect)

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The functional test creates the database state like it is described in the steps that are in the steps to test section and then accesses the landing page with the click through value. It asserts that the contact who got the email also has the page hit associated.
