### PR TITLE
Set Mautic configuration param via .env file

### DIFF
--- a/app/bundles/CoreBundle/Loader/EnvVars/ConfigEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/ConfigEnvVars.php
@@ -9,10 +9,6 @@ class ConfigEnvVars implements EnvVarsInterface
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {
         foreach ($config->all() as $key => $value) {
-            if (!empty($value) && is_string($value) && preg_match('/getenv\((.*?)\)/', $value, $match)) {
-                $value = (string) getenv($match[1]);
-            }
-
             // JSON encode arrays
             $defaultValue = $defaultConfig->get($key);
             if (is_array($value) || is_array($defaultValue)) {

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -71,13 +71,43 @@ class ParameterLoader
         EnvVars\TwigEnvVars::load($this->parameterBag, $defaultParameters, $envVariables);
 
         // Load the values into the environment for cache use
-        $dotenv = new Dotenv(MAUTIC_ENV);
         foreach ($envVariables->all() as $key => $value) {
             if (null === $value) {
                 $envVariables->set($key, '');
             }
         }
-        $dotenv->populate($envVariables->all());
+        $this->populate($envVariables->all());
+    }
+
+    /**
+     * Load all configuration parameters from local configuration files into the environment
+     * that have not yet been loaded via the system environment or .env files.
+     *
+     * @see Dotenv::populate()
+     *
+     * @param array<string, mixed> $values
+     */
+    private function populate(array $values): void
+    {
+        $updateLoadedVars = false;
+        $loadedVars       = array_flip(explode(',', $_SERVER['MAUTIC_PARAMS'] ?? $_ENV['MAUTIC_PARAMS'] ?? ''));
+
+        foreach ($values as $name => $value) {
+            if (!isset($loadedVars[$name]) && isset($_ENV[$name])) {
+                continue;
+            }
+
+            $_ENV[$name] = $_SERVER[$name] = $value;
+
+            if (!isset($loadedVars[$name])) {
+                $loadedVars[$name] = $updateLoadedVars = true;
+            }
+        }
+
+        if ($updateLoadedVars) {
+            $loadedVars            = implode(',', array_keys($loadedVars));
+            $_ENV['MAUTIC_PARAMS'] = $_SERVER['MAUTIC_PARAMS'] = $loadedVars;
+        }
     }
 
     public static function getLocalConfigFile(string $root, bool $updateDefaultParameters = true): string

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -71,43 +71,13 @@ class ParameterLoader
         EnvVars\TwigEnvVars::load($this->parameterBag, $defaultParameters, $envVariables);
 
         // Load the values into the environment for cache use
+        $dotenv = new Dotenv(MAUTIC_ENV);
         foreach ($envVariables->all() as $key => $value) {
             if (null === $value) {
                 $envVariables->set($key, '');
             }
         }
-        $this->populate($envVariables->all());
-    }
-
-    /**
-     * Load all configuration parameters from local configuration files into the environment
-     * that have not yet been loaded via the system environment or .env files.
-     *
-     * @see Dotenv::populate()
-     *
-     * @param array<string, mixed> $values
-     */
-    private function populate(array $values): void
-    {
-        $updateLoadedVars = false;
-        $loadedVars       = array_flip(explode(',', $_SERVER['MAUTIC_PARAMS'] ?? $_ENV['MAUTIC_PARAMS'] ?? ''));
-
-        foreach ($values as $name => $value) {
-            if (!isset($loadedVars[$name]) && isset($_ENV[$name])) {
-                continue;
-            }
-
-            $_ENV[$name] = $_SERVER[$name] = $value;
-
-            if (!isset($loadedVars[$name])) {
-                $loadedVars[$name] = $updateLoadedVars = true;
-            }
-        }
-
-        if ($updateLoadedVars) {
-            $loadedVars            = implode(',', array_keys($loadedVars));
-            $_ENV['MAUTIC_PARAMS'] = $_SERVER['MAUTIC_PARAMS'] = $loadedVars;
-        }
+        $dotenv->populate($envVariables->all());
     }
 
     public static function getLocalConfigFile(string $root, bool $updateDefaultParameters = true): string

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -171,11 +171,8 @@ class ParameterLoader
             $compiledParameters = array_merge($compiledParameters, $parameters);
         }
 
-        // Load from environment
-        $envParameters = getenv('MAUTIC_CONFIG_PARAMETERS');
-        if ($envParameters) {
-            $compiledParameters = array_merge($compiledParameters, json_decode($envParameters, true));
-        }
+        // Resolve local params via environment variables
+        Parameters\EnvVarParameters::load($compiledParameters, self::$defaultParameters);
 
         // Hardcode the db_driver to pdo_mysql, as it is currently the only supported driver.
         // We set in here, to ensure it is always set to this value.

--- a/app/bundles/CoreBundle/Loader/Parameters/EnvVarParameters.php
+++ b/app/bundles/CoreBundle/Loader/Parameters/EnvVarParameters.php
@@ -4,6 +4,10 @@ namespace Mautic\CoreBundle\Loader\Parameters;
 
 class EnvVarParameters implements ParametersInterface
 {
+    /**
+     * @param array<mixed, mixed>  $compiledParameters
+     * @param array<string, mixed> $defaultParameters
+     */
     public static function load(array &$compiledParameters, array $defaultParameters): void
     {
         // Overrule parameters via environment variable

--- a/app/bundles/CoreBundle/Loader/Parameters/EnvVarParameters.php
+++ b/app/bundles/CoreBundle/Loader/Parameters/EnvVarParameters.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mautic\CoreBundle\Loader\Parameters;
+
+class EnvVarParameters implements ParametersInterface
+{
+    public static function load(array &$compiledParameters, array $defaultParameters): void
+    {
+        // Overrule parameters via environment variable
+        $envParameters = getenv('MAUTIC_CONFIG_PARAMETERS') ?: $_ENV['MAUTIC_CONFIG_PARAMETERS'] ?? false;
+        if ($envParameters) {
+            $compiledParameters = array_merge($compiledParameters, json_decode($envParameters, true));
+        }
+
+        // Resolve parameters from environment variables
+        foreach ($compiledParameters as $key => $value) {
+            if (!empty($value) && is_string($value) && str_starts_with($value, 'getenv(') && preg_match('/getenv\((.*?)\)/', $value, $match)) {
+                $value = (string) getenv($match[1]) ?: $_ENV[$match[1]] ?? '';
+
+                // JSON decode arrays
+                if (is_array($defaultParameters[$key] ?? null)) {
+                    $value = json_decode($value, true);
+                }
+
+                $compiledParameters[$key] = $value;
+            }
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Loader/Parameters/ParametersInterface.php
+++ b/app/bundles/CoreBundle/Loader/Parameters/ParametersInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mautic\CoreBundle\Loader\Parameters;
+
+interface ParametersInterface
+{
+    /**
+     * @param array $compiledParameters Mautic local parameters
+     * @param array $defaultParameters  Bundle and plugin's default parameters
+     */
+    public static function load(array &$compiledParameters, array $defaultParameters): void;
+}

--- a/app/bundles/CoreBundle/Loader/Parameters/ParametersInterface.php
+++ b/app/bundles/CoreBundle/Loader/Parameters/ParametersInterface.php
@@ -5,8 +5,8 @@ namespace Mautic\CoreBundle\Loader\Parameters;
 interface ParametersInterface
 {
     /**
-     * @param array $compiledParameters Mautic local parameters
-     * @param array $defaultParameters  Bundle and plugin's default parameters
+     * @param array<mixed, mixed>  $compiledParameters Mautic local parameters
+     * @param array<string, mixed> $defaultParameters  Bundle and plugin's default parameters
      */
     public static function load(array &$compiledParameters, array $defaultParameters): void;
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ConfigEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ConfigEnvVarsTest.php
@@ -30,16 +30,6 @@ class ConfigEnvVarsTest extends TestCase
         $this->envVars       = new ParameterBag();
     }
 
-    public function testGetEnvWorks(): void
-    {
-        putenv('MAUTIC_FOOBAR=bar');
-        $this->config->set('foo', 'getenv(MAUTIC_FOOBAR)');
-
-        ConfigEnvVars::load($this->config, $this->defaultConfig, $this->envVars);
-
-        $this->assertEquals('bar', $this->envVars->get('MAUTIC_FOO'));
-    }
-
     public function testLocalValueIsSet(): void
     {
         $this->config->set('foo', 'bar');

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -4,32 +4,56 @@ namespace Mautic\CoreBundle\Tests\Unit\Loader;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Dotenv\Dotenv;
 
 class ParameterLoaderTest extends TestCase
 {
-    public function testParametersAreLoaded(): void
+    protected function tearDown(): void
     {
-        $envParameters = json_encode(['default_daterange_filter' => '-1 day']);
-        putenv('MAUTIC_CONFIG_PARAMETERS='.$envParameters);
-
-        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
-        $loader->loadIntoEnvironment();
-
-        $parameterBag = $loader->getParameterBag();
-
-        $this->assertEquals('https://language-packs.mautic.com/', $parameterBag->get('translations_fetch_url'));
-        $this->assertEquals('https://language-packs.mautic.com/', $_ENV['MAUTIC_TRANSLATIONS_FETCH_URL']);
-
-        $this->assertEquals('-1 day', $parameterBag->get('default_daterange_filter'));
-        $this->assertEquals('-1 day', $_ENV['MAUTIC_DEFAULT_DATERANGE_FILTER']);
+        parent::tearDown();
 
         putenv('MAUTIC_CONFIG_PARAMETERS=');
+        putenv('MAUTIC_TRANSLATIONS_FETCH_URL=');
+        putenv('MAUTIC_ALLOWED_EXTENSIONS=');
     }
 
     public function testDefaultParametersAreLoaded(): void
     {
         $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
-        $this->assertIsArray($loader->getDefaultParameters());
-        $this->assertFalse($loader->getDefaultParameters()['api_enabled']);
+        $this->assertEquals('smtp://localhost:25', $loader->getDefaultParameters()['mailer_dsn']);
+        $this->assertEquals('https://language-packs.mautic.com/', $loader->getDefaultParameters()['translations_fetch_url']);
+        $this->assertIsArray($loader->getDefaultParameters()['allowed_extensions']);
+    }
+
+    public function testParametersAreLoadedFromLocalConfig(): void
+    {
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $this->assertEquals('foobar.com', $loader->getParameterBag()->get('mailer_dsn'));
+        $this->assertEquals('', $loader->getParameterBag()->get('translations_fetch_url'));
+        $this->assertEquals('', $loader->getParameterBag()->get('allowed_extensions'));
+    }
+
+    public function testParametersAreLoadedFromDotEnvFile(): void
+    {
+        $dotEnv = new Dotenv();
+        $dotEnv->loadEnv(__DIR__.'/TestRoot/.env');
+
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $this->assertEquals('bar.com', $loader->getParameterBag()->get('mailer_dsn'));
+        $this->assertEquals('https://language-packs.bar.com/', $loader->getParameterBag()->get('translations_fetch_url'));
+        $this->assertEquals(['png'], $loader->getParameterBag()->get('allowed_extensions'));
+    }
+
+    public function testParametersAreLoadedFromSystemEnvironment(): void
+    {
+        $envParameters = json_encode(['mailer_dsn' => 'foo.com']);
+        putenv('MAUTIC_CONFIG_PARAMETERS='.$envParameters);
+        putenv('MAUTIC_TRANSLATIONS_FETCH_URL=https://language-packs.foo.com/');
+        putenv('MAUTIC_ALLOWED_EXTENSIONS=["jpg"]');
+
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $this->assertEquals('foo.com', $loader->getParameterBag()->get('mailer_dsn'));
+        $this->assertEquals('https://language-packs.foo.com/', $loader->getParameterBag()->get('translations_fetch_url'));
+        $this->assertEquals(['jpg'], $loader->getParameterBag()->get('allowed_extensions'));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -8,13 +8,39 @@ use Symfony\Component\Dotenv\Dotenv;
 
 class ParameterLoaderTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        parent::tearDown();
+    protected static array $backupDotEnv;
+    protected static array $backupSysEnv;
+    protected static array $backupEnvVars;
 
-        putenv('MAUTIC_CONFIG_PARAMETERS=');
-        putenv('MAUTIC_TRANSLATIONS_FETCH_URL=');
-        putenv('MAUTIC_ALLOWED_EXTENSIONS=');
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$backupEnvVars = [
+            'MAUTIC_CONFIG_PARAMETERS',
+            'MAUTIC_TRANSLATIONS_FETCH_URL',
+            'MAUTIC_ALLOWED_EXTENSIONS',
+        ];
+        self::$backupSysEnv = array_intersect_key(getenv(), array_flip(self::$backupEnvVars));
+        self::$backupDotEnv = array_intersect_key($_ENV, array_flip(self::$backupEnvVars));
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        array_walk(self::$backupSysEnv, function ($value, $key) { putenv("{$key}={$value}"); });
+        array_walk(self::$backupDotEnv, function ($value, $key) { $_ENV[$key] = $value; });
+
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (self::$backupEnvVars as $key) {
+            putenv("{$key}=");
+            unset($_ENV[$key]);
+        }
     }
 
     public function testDefaultParametersAreLoaded(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -8,8 +8,19 @@ use Symfony\Component\Dotenv\Dotenv;
 
 class ParameterLoaderTest extends TestCase
 {
+    /**
+     * @var array<string, mixed>
+     */
     protected static array $backupDotEnv;
+
+    /**
+     * @var array<string, mixed>
+     */
     protected static array $backupSysEnv;
+
+    /**
+     * @var array<int, string>
+     */
     protected static array $backupEnvVars;
 
     public static function setUpBeforeClass(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -4,36 +4,9 @@ namespace Mautic\CoreBundle\Tests\Unit\Loader;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Dotenv\Dotenv;
 
 class ParameterLoaderTest extends TestCase
 {
-    /**
-     * @var array<string, mixed>
-     */
-    public array $env;
-
-    /**
-     * @var array<string, mixed>
-     */
-    public array $server;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->env    = $_ENV;
-        $this->server = $_SERVER;
-    }
-
-    public function tearDown(): void
-    {
-        $_ENV    = $this->env;
-        $_SERVER = $this->server;
-
-        parent::tearDown();
-    }
-
     public function testParametersAreLoaded(): void
     {
         $envParameters = json_encode(['default_daterange_filter' => '-1 day']);
@@ -58,28 +31,5 @@ class ParameterLoaderTest extends TestCase
         $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
         $this->assertIsArray($loader->getDefaultParameters());
         $this->assertFalse($loader->getDefaultParameters()['api_enabled']);
-    }
-
-    public function testEnvironmentVariablesOverruleParameters(): void
-    {
-        $_ENV['MAUTIC_MAILER_DSN'] = 'mailer-dsn-system-environment';
-
-        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
-        $loader->loadIntoEnvironment();
-
-        $this->assertEquals('foobar.com', $loader->getParameterBag()->get('mailer_dsn'));
-        $this->assertEquals('mailer-dsn-system-environment', $_ENV['MAUTIC_MAILER_DSN']);
-    }
-
-    public function testDotEnvVariablesOverruleParameters(): void
-    {
-        $dotenv = new Dotenv();
-        $dotenv->load(__DIR__.'/TestRoot/.env');
-
-        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
-        $loader->loadIntoEnvironment();
-
-        $this->assertEquals('foobar.com', $loader->getParameterBag()->get('mailer_dsn'));
-        $this->assertEquals('mailer-dsn-dotenv', $_ENV['MAUTIC_MAILER_DSN']);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -4,9 +4,36 @@ namespace Mautic\CoreBundle\Tests\Unit\Loader;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Dotenv\Dotenv;
 
 class ParameterLoaderTest extends TestCase
 {
+    /**
+     * @var array<string, mixed>
+     */
+    public array $env;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $server;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->env    = $_ENV;
+        $this->server = $_SERVER;
+    }
+
+    public function tearDown(): void
+    {
+        $_ENV    = $this->env;
+        $_SERVER = $this->server;
+
+        parent::tearDown();
+    }
+
     public function testParametersAreLoaded(): void
     {
         $envParameters = json_encode(['default_daterange_filter' => '-1 day']);
@@ -31,5 +58,28 @@ class ParameterLoaderTest extends TestCase
         $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
         $this->assertIsArray($loader->getDefaultParameters());
         $this->assertFalse($loader->getDefaultParameters()['api_enabled']);
+    }
+
+    public function testEnvironmentVariablesOverruleParameters(): void
+    {
+        $_ENV['MAUTIC_MAILER_DSN'] = 'mailer-dsn-system-environment';
+
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $loader->loadIntoEnvironment();
+
+        $this->assertEquals('foobar.com', $loader->getParameterBag()->get('mailer_dsn'));
+        $this->assertEquals('mailer-dsn-system-environment', $_ENV['MAUTIC_MAILER_DSN']);
+    }
+
+    public function testDotEnvVariablesOverruleParameters(): void
+    {
+        $dotenv = new Dotenv();
+        $dotenv->load(__DIR__.'/TestRoot/.env');
+
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $loader->loadIntoEnvironment();
+
+        $this->assertEquals('foobar.com', $loader->getParameterBag()->get('mailer_dsn'));
+        $this->assertEquals('mailer-dsn-dotenv', $_ENV['MAUTIC_MAILER_DSN']);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
@@ -1,1 +1,0 @@
-MAUTIC_MAILER_DSN=mailer-dsn-dotenv

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
@@ -1,0 +1,3 @@
+MAUTIC_CONFIG_PARAMETERS='{"mailer_dsn":"bar.com"}'
+MAUTIC_TRANSLATIONS_FETCH_URL=https://language-packs.bar.com/
+MAUTIC_ALLOWED_EXTENSIONS='["png"]'

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/.env
@@ -1,0 +1,1 @@
+MAUTIC_MAILER_DSN=mailer-dsn-dotenv

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/config/local.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/TestRoot/config/local.php
@@ -1,5 +1,7 @@
 <?php
 
 $parameters = [
-    'mailer_dsn' => 'foobar.com',
+    'mailer_dsn'                => 'foobar.com',
+    'translations_fetch_url'    => 'getenv(MAUTIC_TRANSLATIONS_FETCH_URL)',
+    'allowed_extensions'        => 'getenv(MAUTIC_ALLOWED_EXTENSIONS)',
 ];


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14500  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Override Mautic configuration param via system and DotEnv environment variable "MAUTIC_CONFIG_PARAMETERS".
Resolve Mautic configuration param "getenv(..)" function via system and DotEnv environment variables.

For example set the context-specific database configuration via .env.local:

    MAUTIC_DB_HOST=..
    MAUTIC_DB_NAME=..
    MAUTIC_DB_USER=..
    MAUTIC_DB_PASSWORD=..
    MAUTIC_DB_PORT=..

and resolve in local.php via:

    'db_host' => 'getenv(MAUTIC_DB_HOST)',
    'db_name' => 'getenv(MAUTIC_DB_NAME)',
    'db_user' => 'getenv(MAUTIC_DB_USER)',
    'db_password' => 'getenv(MAUTIC_DB_PASSWORD)',
    'db_port' => 'getenv(MAUTIC_DB_PORT)',

or override the same parameters via .env.local:

    MAUTIC_CONFIG_PARAMETERS='{"db_host":"..","db_name":"..","db_user":"..","db_password":"..","db_port":".."}'

Previously this was only supported via system environment variables. 

Furthermore "getenv()" parameter values get resolved for the final parameter bags as well as for the final parameter environment variables.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Confirm that the Mautic frontend is rendering fine in your browser.
3. In the .env.local file, add "MAUTIC_DB_HOST=&lt;db-host&gt;" with &lt;db-host&gt; being a non-existing hostname.
4. In the local.php file, set "'db_host' => 'getenv(MAUTIC_DB_HOST)'".
5. Confirm that the Mautic frontend is throwing an error in your browser.
6. Revert and confirm that the Mautic frontend is rendering fine in your browser again.
7. In the system environment, e.g. via the docker-compose file, add "MAUTIC_DB_HOST=&lt;db-host&gt;" with &lt;db-host&gt; being a non-existing hostname. Restart the system.
8. Confirm that the Mautic frontend is throwing an error in your browser.
9. Revert and confirm that the Mautic frontend is rendering fine in your browser again.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->