### PR TITLE
Fixing segment building with default timezone

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php
@@ -28,7 +28,7 @@ class TimezoneResolver
          *
          * Later we use toLocalString() method - it gives us midnight in UTC for first condition and midnight in local timezone for second option.
          */
-        $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->get('default_timezone', 'UTC');
+        $timezone = $hasTimePart ? 'UTC' : $this->coreParametersHelper->get('default_timezone', 'UTC') ?? 'UTC';
 
         $date = new \DateTime('midnight today', new \DateTimeZone($timezone));
 

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/TimezoneResolverTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/TimezoneResolverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
+
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\LeadBundle\Segment\Decorator\Date\TimezoneResolver;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class TimezoneResolverTest extends TestCase
+{
+    /**
+     * @dataProvider dataTimezones
+     */
+    public function testTimezones(?string $configuredTimezone, string $expectedTimezone): void
+    {
+        $coreParametersHelper = new class($configuredTimezone) extends CoreParametersHelper {
+            public function __construct(private ?string $configuredTimezone)
+            {
+            }
+
+            public function get($name, $default = null)
+            {
+                Assert::assertSame('default_timezone', $name);
+
+                return $this->configuredTimezone;
+            }
+        };
+
+        $timezoneResolver = new TimezoneResolver($coreParametersHelper);
+        Assert::assertSame(
+            $expectedTimezone,
+            $timezoneResolver->getDefaultDate(false)->getDateTime()->getTimezone()->getName()
+        );
+    }
+
+    /**
+     * @return iterable<string, array<?string>>
+     */
+    public function dataTimezones(): iterable
+    {
+        yield 'Default timezone' => [null, 'UTC'];
+        yield 'UTC timezone'     => ['UTC', 'UTC'];
+        yield 'Prague timezone'  => ['Europe/Prague', 'Europe/Prague'];
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When the timezone is set to "default"
![Screenshot 2024-10-23 at 14 28 03](https://github.com/user-attachments/assets/dd5a5561-9e21-4ee5-9857-37d44739ad8a)
And executing a segment with a relative date like
![Screenshot 2024-10-23 at 14 28 21](https://github.com/user-attachments/assets/94ced776-5e10-44ea-8749-d95961e01263)
Then the segment rebuild fails with
```
Exception: DateTimeZone::__construct(): Unknown or bad timezone () (uncaught exception) at app/bundles/LeadBundle/Segment/Decorator/Date/TimezoneResolver.php line 41 while running console command `mautic:segments:update`
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a segment with a “Date Added Before 3 months” filter.
3. Set the timezone to “System Default Timezone”
4. Run bin/console m:s:u to execute the segment

#### Other areas of Mautic that may be affected by the change:
1. This may be fixing other date manipulations when the default timezone is set.

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The test covers that if the timezone value in the configuration is NULL then it will use `UTC` instead. It also tests other timezone values like `UTC` and `Europe/Prague` to ensure the code works correctly with the correct timezone names.
