### PR TITLE
Do not replace special chars with HTML entities

### DIFF
--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -253,7 +253,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      */
     protected function getWhereFromRequest(Request $request)
     {
-        $where = InputHelper::cleanArray($request->query->all()['where'] ?? []);
+        $where = $request->query->all()['where'] ?? [];
 
         $this->sanitizeWhereClauseArrayFromRequest($where);
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-11799

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When searching for a contact via API with a where condition value with some special character like `'` then it won't find such contact even if it exists. The problem is that we "clean" the values in

`app/bundles/ApiBundle/Controller/FetchCommonApiController.php`

which is then mutating the values with `filter_var($value, FILTER_SANITIZE_SPECIAL_CHARS);`:

https://github.com/mautic/mautic/blob/6.x/app/bundles/CoreBundle/Helper/InputHelper.php#L175

The [PHP docs](https://www.php.net/manual/en/filter.constants.php#constant.filter-sanitize-special-chars) aren't describing what this does very well, but here's an explanation from GPT:

> The FILTER_SANITIZE_SPECIAL_CHARS filter is useful for preventing Cross-Site Scripting (XSS) attacks by ensuring that special characters are safely encoded when outputting data to a webpage. This can help protect applications from malicious input that attempts to disrupt the integrity of the HTML.

Since these values from the where API condition aren't going to be visible in any UI we don't need to worry about XSS. Another security issue could be SQL injection but that is handled by Doctrine when setting the values as parameters to the query builder which is happening here:

https://github.com/mautic/mautic/blob/6.x/app/bundles/CoreBundle/Entity/CommonRepository.php#L1600

So from the security point of view we are OK and there is no need to encode characters into HTML entities.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a contact with Email contac't2@mailtest.mautic.com.
3. Search the contact using API endpoint `https://mautic-cloud.ddev.site/api/contacts?start=0&orderBy=id&minimal=true&where[0][col]=email&where[0][expr]=like&where[0][val]=contac%27t%` it should return the contact details but it is returning 0 contacts.

#### Other areas of Mautic that may be affected by the change:
1. This will affect searching for all the entities via API. Not just contacts. As the change was done in a class used by the rest of the API controllers.

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The functional test is checking that a contact with an `'` in the first name can be found with API.
