### PR TITLE
Incorrect date value being calculating when the segment filter value is yesterday/today/tomorrow and operator is gt or lte for date and datetime field

### DIFF
--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayToday.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayToday.php
@@ -8,5 +8,6 @@ class DateDayToday extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper)
     {
+        $dateTimeHelper->modify('midnight today');
     }
 }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayTomorrow.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayTomorrow.php
@@ -8,6 +8,6 @@ class DateDayTomorrow extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper)
     {
-        $dateTimeHelper->modify('+1 day');
+        $dateTimeHelper->modify('midnight tomorrow');
     }
 }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayYesterday.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayYesterday.php
@@ -8,6 +8,6 @@ class DateDayYesterday extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper)
     {
-        $dateTimeHelper->modify('-1 day');
+        $dateTimeHelper->modify('midnight yesterday');
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
@@ -80,6 +80,7 @@ class DateDayTodayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayToday::getParameterValue
+     *
      * @dataProvider dataProviderForOperatorAndType
      */
     public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
@@ -80,26 +80,43 @@ class DateDayTodayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayToday::getParameterValue
+     * @dataProvider dataProviderForOperatorAndType
      */
-    public function testGetParameterValueSingle(): void
+    public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void
     {
         $dateDecorator    = $this->createMock(DateDecorator::class);
         $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
-        $date = new DateTimeHelper('2018-03-02', null, 'local');
+        $date = new DateTimeHelper('2018-03-02 08:00:09', null, 'local');
 
         $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
         $filter        = [
-            'operator' => 'lt',
+            'operator' => $operator,
+            'type'     => $type,
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
         $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayToday($dateDecorator, $dateOptionParameters);
 
-        $this->assertEquals('2018-03-02', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+        $this->assertEquals($expectedDateValue, $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function dataProviderForOperatorAndType(): iterable
+    {
+        yield ['lt', 'date', '2018-03-02'];
+        yield ['lte', 'date', '2018-03-02'];
+        yield ['gt', 'date', '2018-03-02'];
+        yield ['gte', 'date', '2018-03-02'];
+        yield ['lt', 'datetime', '2018-03-02 00:00:00'];
+        yield ['lte', 'datetime', '2018-03-02 23:59:59'];
+        yield ['gt', 'datetime', '2018-03-02 23:59:59'];
+        yield ['gte', 'datetime', '2018-03-02 00:00:00'];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
@@ -80,6 +80,7 @@ class DateDayTomorrowTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayTomorrow::getParameterValue
+     *
      * @dataProvider dataProviderForOperatorAndType
      */
     public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
@@ -80,26 +80,43 @@ class DateDayTomorrowTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayTomorrow::getParameterValue
+     * @dataProvider dataProviderForOperatorAndType
      */
-    public function testGetParameterValueSingle(): void
+    public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void
     {
         $dateDecorator    = $this->createMock(DateDecorator::class);
         $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
-        $date = new DateTimeHelper('2018-03-02', null, 'local');
+        $date = new DateTimeHelper('2018-03-02 08:00:09', null, 'local');
 
         $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
         $filter        = [
-            'operator' => 'lt',
+            'operator' => $operator,
+            'type'     => $type,
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
         $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayTomorrow($dateDecorator, $dateOptionParameters);
 
-        $this->assertEquals('2018-03-03', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+        $this->assertEquals($expectedDateValue, $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function dataProviderForOperatorAndType(): iterable
+    {
+        yield ['lt', 'date', '2018-03-03'];
+        yield ['lte', 'date', '2018-03-03'];
+        yield ['gt', 'date', '2018-03-03'];
+        yield ['gte', 'date', '2018-03-03'];
+        yield ['lt', 'datetime', '2018-03-03 00:00:00'];
+        yield ['lte', 'datetime', '2018-03-03 23:59:59'];
+        yield ['gt', 'datetime', '2018-03-03 23:59:59'];
+        yield ['gte', 'datetime', '2018-03-03 00:00:00'];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
@@ -80,26 +80,43 @@ class DateDayYesterdayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayYesterday::getParameterValue
+     * @dataProvider dataProviderForOperatorAndType
      */
-    public function testGetParameterValueSingle(): void
+    public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void
     {
         $dateDecorator    = $this->createMock(DateDecorator::class);
         $timezoneResolver = $this->createMock(TimezoneResolver::class);
 
-        $date = new DateTimeHelper('2018-03-02', null, 'local');
+        $date = new DateTimeHelper('2018-03-02 08:00:09', null, 'local');
 
         $timezoneResolver->method('getDefaultDate')
             ->with()
             ->willReturn($date);
 
         $filter        = [
-            'operator' => 'lt',
+            'operator' => $operator,
+            'type'     => $type,
         ];
         $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
         $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
 
         $filterDecorator = new DateDayYesterday($dateDecorator, $dateOptionParameters);
 
-        $this->assertEquals('2018-03-01', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+        $this->assertEquals($expectedDateValue, $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function dataProviderForOperatorAndType(): iterable
+    {
+        yield ['lt', 'date', '2018-03-01'];
+        yield ['lte', 'date', '2018-03-01'];
+        yield ['gt', 'date', '2018-03-01'];
+        yield ['gte', 'date', '2018-03-01'];
+        yield ['lt', 'datetime', '2018-03-01 00:00:00'];
+        yield ['lte', 'datetime', '2018-03-01 23:59:59'];
+        yield ['gt', 'datetime', '2018-03-01 23:59:59'];
+        yield ['gte', 'datetime', '2018-03-01 00:00:00'];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
@@ -80,6 +80,7 @@ class DateDayYesterdayTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Day\DateDayYesterday::getParameterValue
+     *
      * @dataProvider dataProviderForOperatorAndType
      */
     public function testGetParameterValueSingle(string $operator, string $type, string $expectedDateValue): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Incorrect date value being calculating when the segment filter value is yesterday/today/tomorrow and operator is gt or lte for date and datetime field


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create segment filters as per Field Type, Operator and Filter value from below table
3. Leads should be added/removed based on Actual Date (2024-08-28) value for filter from below table

Field Type | Operator | Filter value | Actual Date value for filter
-- | -- | -- | --
Date | Greater than | yesterday | 2024-08-27
Date | Greater than or equal | yesterday | 2024-08-27
Date | Less than | yesterday | 2024-08-27
Date | Less than or equal | yesterday | 2024-08-27
Datetime | Greater than | yesterday | 2024-08-27 23:59:59
Datetime | Greater than or equal | yesterday | 2024-08-27 0:00:00
Datetime | Less than | yesterday | 2024-08-27 0:00:00
Datetime | Less than or equal | yesterday | 2024-08-27 23:59:59
Date | Greater than | today | 2024-08-28
Date | Greater than or equal | today | 2024-08-28
Date | Less than | today | 2024-08-28
Date | Less than or equal | today | 2024-08-28
Datetime | Greater than | today | 2024-08-28 23:59:59
Datetime | Greater than or equal | today | 2024-08-28 0:00:00
Datetime | Less than | today | 2024-08-28 0:00:00
Datetime | Less than or equal | today | 2024-08-28 23:59:59
Date | Greater than | tomorrow | 2024-08-29
Date | Greater than or equal | tomorrow | 2024-08-29
Date | Less than | tomorrow | 2024-08-29
Date | Less than or equal | tomorrow | 2024-08-29
Datetime | Greater than | tomorrow | 2024-08-29 23:59:59
Datetime | Greater than or equal | tomorrow | 2024-08-29 0:00:00
Datetime | Less than | tomorrow | 2024-08-29 0:00:00
Datetime | Less than or equal | tomorrow | 2024-08-29 23:59:59
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->