### PR TITLE
Numeric segment filters with or glue bug + boolean regex fix

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -108,10 +108,12 @@ class ContactSegmentFilterCrate
         ];
 
         if (!in_array($this->operator, $excludeTypecastOperators)) {
-            return match ((string) $this->getType()) {
-                'number'  => (float) $this->filter,
-                'boolean' => (bool) $this->filter,
-            };
+            switch ($this->getType()) {
+                case 'number':
+                    return (float) $this->filter;
+                case 'boolean':
+                    return (bool) $this->filter;
+            }
         }
 
         return $this->filter;

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -100,6 +100,22 @@ class ContactSegmentFilterCrate
      */
     public function getFilter()
     {
+        $excludeTypecastOperators = [
+            OperatorOptions::IN,
+            OperatorOptions::NOT_IN,
+            OperatorOptions::REGEXP,
+            OperatorOptions::NOT_REGEXP,
+        ];
+
+        if (!in_array($this->operator, $excludeTypecastOperators)) {
+            switch ($this->getType()) {
+                case 'number':
+                    return (float) $this->filter;
+                case 'boolean':
+                    return (bool) $this->filter;
+            }
+        }
+
         return $this->filter;
     }
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -100,11 +100,7 @@ class ContactSegmentFilterCrate
      */
     public function getFilter()
     {
-        return match ($this->getType()) {
-            'number'  => (float) $this->filter,
-            'boolean' => (bool) $this->filter,
-            default   => $this->filter,
-        };
+        return $this->filter;
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -108,7 +108,7 @@ class ContactSegmentFilterCrate
         ];
 
         if (!in_array($this->operator, $excludeTypecastOperators)) {
-            return match ($this->getType()) {
+            return match ((string) $this->getType()) {
                 'number'  => (float) $this->filter,
                 'boolean' => (bool) $this->filter,
             };

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterCrate.php
@@ -108,12 +108,10 @@ class ContactSegmentFilterCrate
         ];
 
         if (!in_array($this->operator, $excludeTypecastOperators)) {
-            switch ($this->getType()) {
-                case 'number':
-                    return (float) $this->filter;
-                case 'boolean':
-                    return (bool) $this->filter;
-            }
+            return match ($this->getType()) {
+                'number'  => (float) $this->filter,
+                'boolean' => (bool) $this->filter,
+            };
         }
 
         return $this->filter;

--- a/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
@@ -29,6 +29,7 @@ final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlT
 
         $segment = new LeadList();
         $segment->setName('Segment A');
+        $segment->setPublicName('Segment A');
         $segment->setAlias('segment-a');
         $segment->setFilters([
             [
@@ -79,6 +80,7 @@ final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlT
 
         $segment = new LeadList();
         $segment->setName('Segment A');
+        $segment->setPublicName('Segment A');
         $segment->setAlias('segment-a');
         $segment->setFilters([
             [

--- a/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Command;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+
+final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlTestCase
+{
+    public function testSegmentNuberFilterWithOrsCommand(): void
+    {
+        $contact1 = new Lead();
+        $contact1->setPoints(1);
+        $contact2 = new Lead();
+        $contact2->setPoints(2);
+        $contact3 = new Lead();
+        $contact3->setPoints(3);
+        $contact4 = new Lead();
+        $contact4->setPoints(4);
+
+        $this->em->persist($contact1);
+        $this->em->persist($contact2);
+        $this->em->persist($contact3);
+        $this->em->persist($contact4);
+
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setAlias('segment-a');
+        $segment->setFilters([
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'points',
+                'type'       => 'number',
+                'operator'   => '=',
+                'properties' => ['filter' => 1],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'points',
+                'type'       => 'number',
+                'operator'   => '=',
+                'properties' => ['filter' => 2],
+            ],
+            [
+                'object'     => 'lead',
+                'glue'       => 'or',
+                'field'      => 'points',
+                'type'       => 'number',
+                'operator'   => '=',
+                'properties' => ['filter' => 3],
+            ],
+        ]);
+
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
+        self::assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
+    }
+
+    public function testSegmentNuberFilterWithRegexCommand(): void
+    {
+        $contact1 = new Lead();
+        $contact1->setPoints(1);
+        $contact2 = new Lead();
+        $contact2->setPoints(2);
+        $contact3 = new Lead();
+        $contact3->setPoints(3);
+
+        $this->em->persist($contact1);
+        $this->em->persist($contact2);
+        $this->em->persist($contact3);
+
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setAlias('segment-a');
+        $segment->setFilters([
+            [
+                'object'     => 'lead',
+                'glue'       => 'and',
+                'field'      => 'points',
+                'type'       => 'number',
+                'operator'   => 'regexp',
+                'properties' => ['filter' => '^(1|3)$'],
+            ],
+        ]);
+
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
+        self::assertCount(2, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | /

#### Description:

I couldn't find why the casting is there. It doesn't make sense for IN operator nor for REGEX.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create 4 contacts with points = 1, points = 2, points = 3, points = 4.
3. Create Segment A with filters: Points = 1 OR Points = 2 OR Points = 3.
4. Run the segment. There should be 3 of those contacts in the segment. They aren't because the segment query looks like this: `SELECT l.id FROM mautic_leads l WHERE (l.points = 1) OR (l.points IN (1))`. The other 2 filters were suppose to be optimized into `l.points IN (2,3)` but instead this array was casted to `float` and resulted in `1`.

##### The Regex bug
1. Create a segment with a filter Points REGEX `^(1|3)$`
2. There should be 2 contacts in the segment but it's not the case. Because the regex string was converted into float again.

#### Other areas of Mautic that may be affected by the change:
1. Numeric and boolean filters

#### List deprecations along with the new alternative:
1. 
2. 

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. Numeric fields with = and regex filters.
