### PR TITLE
Adding index to speed up the integration sync as it overloads DB servers

### DIFF
--- a/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
@@ -66,6 +66,7 @@ class ObjectMapping
         $builder
             ->setTable('sync_object_mapping')
             ->setCustomRepositoryClass(ObjectMappingRepository::class)
+            ->addIndex(['internal_object_id'], 'internal_object_id_idx')
             ->addIndex(['integration', 'integration_object_name', 'integration_object_id', 'integration_reference_id'], 'integration_object')
             ->addIndex(['integration', 'integration_object_name', 'integration_reference_id', 'integration_object_id'], 'integration_reference')
             ->addIndex(['integration', 'internal_object_name', 'last_sync_date'], 'integration_integration_object_name_last_sync_date')

--- a/app/migrations/Version20241212090146.php
+++ b/app/migrations/Version20241212090146.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+
+final class Version20241212090146 extends PreUpAssertionMigration
+{
+    protected const TABLE_NAME = 'sync_object_mapping';
+
+    private string $indexName = MAUTIC_TABLE_PREFIX.'internal_object_id_idx';
+
+    protected function preUpAssertions(): void
+    {
+        $this->skipAssertion(
+            fn (Schema $schema) => !$schema->hasTable($this->getPrefixedTableName(self::TABLE_NAME)),
+            "Table {$this->getPrefixedTableName(self::TABLE_NAME)} does not exist"
+        );
+
+        $this->skipAssertion(
+            fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(self::TABLE_NAME))->hasIndex($this->indexName),
+            "Index {$this->indexName} already exists"
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE INDEX {$this->indexName} ON {$this->getPrefixedTableName(self::TABLE_NAME)} (internal_object_id);");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DROP INDEX {$this->indexName} ON {$this->getPrefixedTableName(self::TABLE_NAME)};");
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ ]
| New feature/enhancement? (use the a.x branch)      | [x]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] no, just index added. Not testeable
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://acquia.atlassian.net/browse/MAUT-12107

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

An integration sync is overloading our DB servers.

This query use no useful indexes:
```sql
SELECT 1 
FROM mautic_sync_object_mapping som 
WHERE (som.integration = "AnIntegration") 
	AND (som.internal_object_name = "lead") 
	AND (som.is_deleted = 0) 
	AND (som.internal_object_id = '2137351') 
	AND (som.integration_object_name IN ('Lead', 'Contact'));
```
See the explain:
<img width="1443" alt="Screenshot 2024-12-12 at 10 06 11" src="https://github.com/user-attachments/assets/a16e224a-5147-4922-a354-d234d05f977a" />

This is how the explain looks like with the new index:
<img width="1447" alt="Screenshot 2024-12-12 at 13 48 57" src="https://github.com/user-attachments/assets/189f83f3-42f1-41fc-a0f5-8aead9907dbd" />

This query takes over 30 seconds on the overloaded database and there is a lot of them. At first I tried to create an index containing all the fields in the where condition in this specific order. But Mysql still didn’t want to use it. Then I tried to create an index on the column with the most unique value which is the `internal_object_id`. On a calm local database the query took 2.5s. With this new simple index it take 2.9ms. It’s **1000 times faste**r.

#### Steps to test this PR:

This is not testable via UI and it does not change any behaviour. Just adds a new index to a DB table.

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Have over 1.6M rows in the sync_object_mapping table. (Or just use the `explain`)
2. Run the above query without this change applied. It should be way slower than after this change is applied.

#### Other areas of Mautic that may be affected by the change:
1. Just the sync query

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1.
2. 
