### PR TITLE
Remove Factory::getParameter.

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -26,6 +26,7 @@
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getDebugMode` use dependency injection instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getMauticBundles` use BundleHelper instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getKernel` use dependency injection instead.
+- Removed `Mautic\CoreBundle\Factory\MauticFactory::getParameter` use DI with the `\Mautic\CoreBundle\Helper\CoreParametersHelper` instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getVersion` use dependency injection with KernelInterface, which will retrieve \AppKernel, then invoke getVersion() method.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getPluginBundles` use BundleHelper instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getBundleConfig` use BundleHelper instead.

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -5,7 +5,6 @@ namespace Mautic\CoreBundle\Factory;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @deprecated 2.0 to be removed in 3.0
@@ -16,7 +15,6 @@ class MauticFactory
      * @param ModelFactory<object> $modelFactory
      */
     public function __construct(
-        private ContainerInterface $container,
         private ModelFactory $modelFactory,
         private ManagerRegistry $doctrine,
     ) {
@@ -45,17 +43,5 @@ class MauticFactory
         \assert($manager instanceof EntityManager);
 
         return $manager;
-    }
-
-    /**
-     * Retrieves a Mautic parameter.
-     *
-     * @param mixed $default
-     *
-     * @return bool|mixed
-     */
-    public function getParameter($id, $default = false)
-    {
-        return $this->container->get('mautic.helper.core_parameters')->get($id, $default);
     }
 }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -701,7 +701,7 @@ class MailHelper
         }
 
         if ($asset->isPublished()) {
-            $asset->setUploadDir($this->factory->getParameter('upload_dir'));
+            $asset->setUploadDir($this->coreParametersHelper->get('upload_dir'));
             $this->assets[$asset->getId()] = $asset;
         }
     }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -153,7 +153,7 @@ class MailHelperTest extends TestCase
     {
         $this->expectException(BatchQueueMaxException::class);
 
-        $this->mockFactory->method('getParameter')
+        $this->coreParametersHelper->method('get')
             ->willReturnMap(
                 [
                     ['mailer_return_path', false, null],
@@ -172,7 +172,7 @@ class MailHelperTest extends TestCase
 
     public function testQueueModeDisabledDoesNotThrowsExceptionWhenBatchLimitHit(): void
     {
-        $this->mockFactory->method('getParameter')
+        $this->coreParametersHelper->method('get')
             ->willReturnMap(
                 [
                     ['mailer_return_path', false, null],
@@ -915,7 +915,9 @@ class MailHelperTest extends TestCase
             $parameterMap
         );
 
-        $mockFactory->method('getParameter')->willReturnMap($parameterMap);
+        $coreParametersHelper = $this->coreParametersHelper;
+
+        $coreParametersHelper->method('get')->willReturnMap($parameterMap);
         $mockFactory->method('getModel')->willReturnMap([['lead', $mockLeadModel]]);
 
         $mockMailboxHelper = $this->getMockBuilder(Mailbox::class)
@@ -929,8 +931,8 @@ class MailHelperTest extends TestCase
 
     public function testArrayOfAddressesAreRemappedIntoEmailToNameKeyValuePair(): void
     {
-        $mockFactory = $this->mockFactory;
-        $mockFactory->method('getParameter')
+        $coreParametersHelper = $this->coreParametersHelper;
+        $coreParametersHelper->method('get')
             ->willReturnMap(
                 [
                     ['mailer_return_path', false, null],

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -239,22 +239,22 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        // Mock factory to remove when factory is completely gone.
         $factoryMock = $this->createMock(MauticFactory::class);
-        $factoryMock->method('getParameter')
-            ->willReturnCallback(
-                fn ($param) => match ($param) {
-                    default => '',
-                }
-            );
-        $routerMock = $this->createMock(Router::class);
+        $routerMock  = $this->createMock(Router::class);
 
         $requestStack = new RequestStack();
 
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
-        $this->coreParametersHelper->method('get')->will($this->returnValueMap([['mailer_from_email', null, 'nobody@nowhere.com'], ['secret_key', null, 'secret']]));
+        $this->coreParametersHelper->method('get')->willReturnCallback(
+            fn ($param) => match ($param) {
+                'mailer_from_email' => 'nobody@nowhere.com',
+                'secret_key'        => 'secret',
+                default             => '',
+            }
+        );
 
         $themeHelper = $this->createMock(ThemeHelper::class);
         $themeHelper->expects(self::never())
@@ -332,9 +332,9 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        // Mock factory to remove when factory is completely gone.
         $factoryMock = $this->createMock(MauticFactory::class);
-        $factoryMock->method('getParameter')
+        $this->coreParametersHelper->method('get')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
                     default => '',
@@ -433,9 +433,9 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $transport = new BatchTransport(false, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        // Mock factory to remove when factory is completely gone.
         $factoryMock = $this->createMock(MauticFactory::class);
-        $factoryMock->method('getParameter')
+        $this->coreParametersHelper->method('get')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
                     default => '',
@@ -535,9 +535,9 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $transport = new BatchTransport(true, 1);
         $mailer    = new Mailer($transport);
 
-        // Mock factory to ensure that queue mode is handled until MailHelper is refactored completely away from MauticFactory
+        // Mock factory to remove when factory is completely gone.
         $factoryMock = $this->createMock(MauticFactory::class);
-        $factoryMock->method('getParameter')
+        $this->coreParametersHelper->method('get')
             ->willReturnCallback(
                 fn ($param) => match ($param) {
                     default => '',
@@ -616,14 +616,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
         /** @var MockObject&MauticFactory $mockFactory */
         $mockFactory = $this->createMock(MauticFactory::class);
-        $mockFactory->method('getParameter')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['mailer_return_path', false, null],
-                    ]
-                )
-            );
 
         /** @var MockObject&FromEmailHelper $fromEmailHelper */
         $fromEmailHelper = $this->createMock(FromEmailHelper::class);
@@ -652,6 +644,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                 [
                     ['mailer_from_email', null, 'nobody@nowhere.com'],
                     ['mailer_from_name', null, 'No Body'],
+                    ['mailer_return_path', false, null],
                 ]
             );
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🟢
| Deprecations?                          | 🟢
| BC breaks? (use the c.x branch)        | 🟢
| Automated tests included?              | 🟢 <!-- All PRs must maintain or improve code coverage -->
<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Remove Factory::getParameter.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Code review only.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->