### PR TITLE
Focus Builder placeholder overlaps the modal preview

### DIFF
--- a/plugins/MauticFocusBundle/Assets/css/focus.css
+++ b/plugins/MauticFocusBundle/Assets/css/focus.css
@@ -24,7 +24,6 @@
   right: 0;
   left: 0;
   margin: auto;
-  z-index: 0;
 }
 .focus-builder #websiteScreenshot .screenshot-container {
   overflow: hidden;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->


<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
When no URL is provided, the Focus Builder placeholder overlaps the modal preview.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

- Navigate to Focus object builder without preview URL
- Select any notification and style type and check the position of the placeholder modal.


**Before:**

![Capture d’écran 2025-02-07 à 10 41 40](https://github.com/user-attachments/assets/c780269e-7fdd-4641-ac5c-ea70fee3f47d)

**After:**

![Capture d’écran 2025-02-07 à 10 36 40](https://github.com/user-attachments/assets/f2cf4129-1652-42bd-9957-179184b042d3)

With a preview URL, it works as before:

![Capture d’écran 2025-02-07 à 10 36 14](https://github.com/user-attachments/assets/9664e51e-5c82-44bb-8962-6685ab881422)
