### PR TITLE
call_user_func_array() array keys will now be interpreted as parameter names, instead of being silently ignored

### DIFF
--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -219,9 +219,9 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
         // Check if the method exists in the model
         $methodName = $this->options['model_lookup_method'] ?? null;
         if ($methodName && method_exists($model, $methodName)) {
-            $choices = call_user_func_array([$model, $this->options['model_lookup_method']], $args);
+            $choices = call_user_func_array([$model, $this->options['model_lookup_method']], array_values($args));
         } elseif (isset($this->options['repo_lookup_method'])) {
-            $choices = call_user_func_array([$model->getRepository(), $this->options['repo_lookup_method']], $args);
+            $choices = call_user_func_array([$model->getRepository(), $this->options['repo_lookup_method']], array_values($args));
         } else {
             // rewrite query to use expression builder
             $alias     = $model->getRepository()->getTableAlias();


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢 <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴 <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
`call_user_func_array()` array keys will now be interpreted as parameter names, instead of being silently ignored

https://www.php.net/manual/en/migration80.incompatible.php

When calling the function `call_user_func_array` in PHP8, if the calling function doesn’t have arguments from the array keys, it will generate error.

We've searched `call_user_func_array` in entire project and fix all such instances.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
