### PR TITLE
fixed:#14485 =>Fields on modal popup for dashboard widget creation are too small

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -6066,6 +6066,9 @@ input[style]:hover {
   padding: var(--spacing-04) var(--spacing-05);
   color: var(--text-primary);
 }
+.form-control.form-control-widget {
+  padding: 0 var(--spacing-05);
+}
 .form-control + .help-text,
 .form-control + p {
   margin-top: 5px;

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -33,7 +33,7 @@ class WidgetType extends AbstractType
             [
                 'label'      => 'mautic.dashboard.widget.form.name',
                 'label_attr' => ['class' => 'control-label'],
-                'attr'       => ['class' => 'form-control'],
+                'attr'       => ['class' => 'form-control form-control-widget'],
                 'required'   => false,
             ]
         );
@@ -53,7 +53,7 @@ class WidgetType extends AbstractType
                 'label_attr'        => ['class' => 'control-label'],
                 'placeholder'       => 'mautic.core.select',
                 'attr'              => [
-                    'class'    => 'form-control',
+                    'class'    => 'form-control form-control-widget',
                     'onchange' => 'Mautic.updateWidgetForm(this)',
                 ],
             ]
@@ -72,7 +72,7 @@ class WidgetType extends AbstractType
                 ],
                 'empty_data'        => '100',
                 'label_attr'        => ['class' => 'control-label'],
-                'attr'              => ['class' => 'form-control'],
+                'attr'              => ['class' => 'form-control form-control-widget'],
                 'required'          => false,
             ]
         );
@@ -91,7 +91,7 @@ class WidgetType extends AbstractType
                 ],
                 'empty_data'        => '330',
                 'label_attr'        => ['class' => 'control-label'],
-                'attr'              => ['class' => 'form-control'],
+                'attr'              => ['class' => 'form-control form-control-widget'],
                 'required'          => false,
             ]
         );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🟢
| BC breaks? (use the c.x branch)        | 🟢
| Automated tests included?              | 🟢 
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14485 
<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
fixed the padding in the dropdown of widget
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->