### PR TITLE
Check permission on original entity for email cloning.

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -935,7 +935,7 @@ class EmailController extends FormController
             || !$this->security->hasEntityAccess(
                 'email:emails:viewown',
                 'email:emails:viewother',
-                $entity->getCreatedBy()
+                $emailEntity->getCreatedBy()
             )
         ) {
             return $this->accessDenied();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢

## Description

When cloning an email, users with the permissions to create an email and view the to clone email should be able to clone. 

However when cloning an email, the object get's cloned (See https://github.com/mautic/mautic/blob/64f4f466034defd37f1703b0dcbe0bf9ed121538/app/bundles/CoreBundle/Entity/FormEntity.php#L159) and this removes the authored by (which is correct, since it needs to be set to the current user. 
However the access checks check for that to define if the permissions is allowed, and since the author is always null, it fails. 
Therefore the access check should run on the original entity, not the cloned one. 

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create role with only permission create email and view own email. 
3. Create user with that role
4. Login as that created user
5. Create an email
6. Clone that email
7. Cloning should work (and not arrive on access denied page)