### PR TITLE
Add GitHub Codespaces support with .devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	"features": {
+	  "ghcr.io/ddev/ddev/install-ddev:latest": {}
+	},
+	"portsAttributes": {
+	  "3306": {
+		"label": "database"
+	  },
+	  "8027": {
+		"label": "mailpit"
+	  },
+	  "8036": {
+		"label": "phpmyadmin"
+	  },
+	  "80": {
+		"label": "mautic (http)"
+	  },
+	  "8443": {
+		"label": "mautic (https)"
+	  }
+	},
+	"postCreateCommand": "chmod +x .devcontainer/setup-project.sh && .devcontainer/setup-project.sh"
+  }

--- a/.devcontainer/setup-project.sh
+++ b/.devcontainer/setup-project.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+# Wait for Docker to be ready
+wait_for_docker() {
+  while true; do
+    docker ps > /dev/null 2>&1 && break
+    sleep 1
+  done
+  echo "Docker is ready."
+}
+
+wait_for_docker
+
+# This file is called in three scenarios:
+# 1. fresh creation of devcontainer
+# 2. rebuild
+# 3. full rebuild
+
+ddev debug download-images
+
+ddev poweroff
+
+ddev -v
+
+ddev config global --web-environment="MAUTIC_URL=https://${CODESPACE_NAME}-80.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN},PHPMYADMIN_URL=https://${CODESPACE_NAME}-8036.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN},MAILHOG_URL=https://${CODESPACE_NAME}-8025.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+
+cat <<EOF >.ddev/docker-compose.phpmyadmin_norouter.yaml
+services:
+  phpmyadmin:
+    ports:
+      - 8036:80
+EOF
+
+ddev start -y


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds support for GitHub Codespaces by introducing a `.devcontainer` configuration that utilizes DDEV.

> **GitHub Codespaces**
> Spin up fully configured dev environments in the cloud with the power of your favorite editor. A "core hour" denotes compute usage. **On a 2-core machine, you would get 60 hours free. On a 4-core machine, you would get 30 hours free, etc. Free hours are assigned to personal accounts, rather than free organizations.**

Source: https://github.com/pricing

This is per month, i.e., 60 hours free every month.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Click the **Code** dropdown button on this PR.

<details>
<summary>Click here to see the image</summary>

![image](https://github.com/user-attachments/assets/03709a95-2d4d-46f3-85c7-ec5aa60bb91d)

</details>

2. Go to the **Codespaces** tab.

3. Click **Create codespace on setup-codespaces**.

<details>
<summary>Click here to see the image</summary>

![image](https://github.com/user-attachments/assets/8cd5adb3-36b8-4c20-9856-8d2517c2f6a6)

</details>

4. Wait until Mautic is fully set up and ready to use.

<details>
<summary>Click here to see the image</summary>

![image](https://github.com/user-attachments/assets/b3636164-d098-43ae-af90-f44ac8915b54)
![Screenshot 2025-02-18 091608](https://github.com/user-attachments/assets/3563538c-3fc1-46ac-914f-1f00bd4f8f55)

</details>

5. Open the Ports tab. Alternatively, run `ddev describe` to view the relevant port information.

<details>
<summary>Click here to see the image</summary>

![Screenshot 2025-02-18 091640](https://github.com/user-attachments/assets/0842ee76-159f-4cf9-a06f-5df25a09489f)
![image](https://github.com/user-attachments/assets/4d03c8c0-316f-46c5-8a52-7708c75e141c)

</details>

6. Visit the URL on port 80 (Mautic HTTP).
7. Log in with `admin` / `Maut1cR0cks!`
8. You should be logged in, and everything should work as expected.
9. (Optional) Try other services such as phpMyAdmin and Mailpit.
10. Delete the codespace at GitHub Codespaces: https://github.com/codespaces

<details>
<summary>Click here to see the image</summary>

![image](https://github.com/user-attachments/assets/52ccb649-aaa0-423a-80f1-7691fac545c6)

</details>
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->

https://github.com/user-attachments/assets/375527e9-64ab-4368-a206-22269812aa8b