### PR TITLE
Remove MauticFactory::getEntityManager.

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -59,6 +59,7 @@ As the legacy builder was removed these JS libraries were removed as well:
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getTwig` use DI with the `\Twig\Environment` instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getTheme` use DI with the `\Mautic\CoreBundle\Helper\ThemeHelper` instead.
 - Removed `Mautic\CoreBundle\Factory\MauticFactory::getInstalledThemes` use DI with the `\Mautic\CoreBundle\Helper\ThemeHelper` instead.
+- Removed `Mautic\CoreBundle\Factory\MauticFactory::getEntityManager` use dependency injection instead.
 - Removed `Mautic\CampaignBundle\Entity::getEventsByChannel()` as unused and buggy. No replacement
 - Removed `Mautic\CoreBundle\Test::createAnotherClient()` as unused. No replacement.
 - Removed `Mautic\NotificationBundle\Entity::getLeadStats()` as unused and buggy. No replacment
@@ -83,6 +84,7 @@ As the legacy builder was removed these JS libraries were removed as well:
 - `getSession` was removed from `Mautic\PageBundle\Helper\TrackingHelper` No session for anonymous users. Use `getCacheItem`.
 - `updateSession` was removed from `Mautic\PageBundle\Helper\TrackingHelper` No session for anonymous users. Use `updateCacheItem`.
 - `getNewVsReturningPieChartData` was removed from `Mautic\PageBundle\Model\PageModel`. Use `getUniqueVsReturningPieChartData()` instead.
+- `Mautic\PageBundle\Helper\PointActionHelper::validateUrlHit` is no longer static.
 - Replaced the `tightenco/collect:^8.16.0` package with `illuminate/collections:^10.48`.
 - Form submissions now store data without HTML entity encoding instead of with encoded entities (e.g., `R&R` instead of `R&#x26;R`)
 - `FormFieldHelper::getTypes` signature has been changed

--- a/app/bundles/CoreBundle/Factory/MauticFactory.php
+++ b/app/bundles/CoreBundle/Factory/MauticFactory.php
@@ -2,8 +2,6 @@
 
 namespace Mautic\CoreBundle\Factory;
 
-use Doctrine\ORM\EntityManager;
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
 
 /**
@@ -16,7 +14,6 @@ class MauticFactory
      */
     public function __construct(
         private ModelFactory $modelFactory,
-        private ManagerRegistry $doctrine,
     ) {
     }
 
@@ -30,18 +27,5 @@ class MauticFactory
     public function getModel($modelNameKey): \Mautic\CoreBundle\Model\MauticModelInterface
     {
         return $this->modelFactory->getModel($modelNameKey);
-    }
-
-    /**
-     * Retrieves Doctrine EntityManager.
-     *
-     * @return EntityManager
-     */
-    public function getEntityManager()
-    {
-        $manager = $this->doctrine->getManager();
-        \assert($manager instanceof EntityManager);
-
-        return $manager;
     }
 }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -2,7 +2,8 @@
 
 namespace Mautic\EmailBundle\Helper;
 
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\ORMException;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -242,6 +243,7 @@ class MailHelper
         private PathsHelper $pathsHelper,
         private EventDispatcherInterface $dispatcher,
         private RequestStack $requestStack,
+        private EntityManagerInterface $entityManager,
     ) {
         $this->transport  = $this->getTransport();
         $this->returnPath = $coreParametersHelper->get('mailer_return_path');
@@ -1684,7 +1686,7 @@ class MailHelper
         // Note if a lead
         if (null !== $this->lead) {
             try {
-                $stat->setLead($this->factory->getEntityManager()->getReference(Lead::class, $this->lead['id']));
+                $stat->setLead($this->entityManager->getReference(Lead::class, $this->lead['id']));
             } catch (ORMException) {
                 // keep IDE happy
             }
@@ -1705,7 +1707,7 @@ class MailHelper
         // Note if sent from a lead list
         if (null !== $listId) {
             try {
-                $stat->setList($this->factory->getEntityManager()->getReference(\Mautic\LeadBundle\Entity\LeadList::class, $listId));
+                $stat->setList($this->entityManager->getReference(\Mautic\LeadBundle\Entity\LeadList::class, $listId));
             } catch (ORMException) {
                 // keep IDE happy
             }
@@ -1746,7 +1748,7 @@ class MailHelper
 
         if (isset($this->copies[$id])) {
             try {
-                $stat->setStoredCopy($this->factory->getEntityManager()->getReference(Copy::class, $this->copies[$id]));
+                $stat->setStoredCopy($this->entityManager->getReference(Copy::class, $this->copies[$id]));
             } catch (ORMException) {
                 // keep IDE happy
             }

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -307,7 +308,11 @@ CONTENT,
                     ['mailer_from_name', null, 'No Body'],
                 ]
             );
-        $mockFactory  = $this->createMock(MauticFactory::class); /** @phpstan-ignore-line MauticFactory is deprecated */
+        $mockFactory   = $this->createMock(MauticFactory::class); /** @phpstan-ignore-line MauticFactory is deprecated */
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $mailer       = new Mailer(new BatchTransport());
         $requestStack = new RequestStack();
         $mailHelper   = new MailHelper(
@@ -323,7 +328,8 @@ CONTENT,
             $themeHelper,
             $this->createMock(PathsHelper::class),
             $this->createMock(EventDispatcherInterface::class),
-            $requestStack
+            $requestStack,
+            $entityManager,
         );
 
         $email = new Email();

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\EmailBundle\Tests\EventListener;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
@@ -66,6 +67,10 @@ class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $tokens = ['{test}' => 'value'];
 
         $mailHelper = new MailHelper(
@@ -82,6 +87,7 @@ class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->createMock(PathsHelper::class),
             $this->createMock(EventDispatcherInterface::class),
             $requestStack,
+            $entityManager,
         );
         $mailHelper->setTokens($tokens);
 

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -3,6 +3,7 @@
 namespace Mautic\EmailBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
@@ -260,8 +261,12 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $themeHelper->expects(self::never())
             ->method('checkForTwigTemplate');
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack])
+            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack, $entityManager])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
@@ -342,8 +347,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             );
 
         $mockEm = $this->createMock(EntityManager::class);
-        $factoryMock->method('getEntityManager')
-            ->willReturn($mockEm);
 
         $mockDispatcher = $this->getMockBuilder(EventDispatcher::class)
             ->getMock();
@@ -383,7 +386,7 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $requestStack = new RequestStack();
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $mockDispatcher, $requestStack])
+            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $mockDispatcher, $requestStack, $mockEm])
             ->onlyMethods([])
             ->getMock();
 
@@ -450,10 +453,14 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $themeHelper->expects(self::never())
             ->method('checkForTwigTemplate');
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $requestStack = new RequestStack();
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack])
+            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $this->twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack, $entityManager])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
@@ -552,11 +559,15 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $themeHelper->expects(self::never())
             ->method('checkForTwigTemplate');
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $requestStack = new RequestStack();
 
         /** @var MockObject&MailHelper $mailHelper */
         $mailHelper = $this->getMockBuilder(MailHelper::class)
-            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack])
+            ->setConstructorArgs([$factoryMock, $mailer, $this->fromEmaiHelper, $this->coreParametersHelper, $this->mailbox, $this->loggerMock, $this->mailHashHelper, $routerMock, $twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack, $entityManager])
             ->onlyMethods(['createEmailStat'])
             ->getMock();
 
@@ -648,10 +659,14 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $requestStack = new RequestStack();
 
         $mailer         = new Mailer(new BatchTransport());
-        $mailHelper     = new MailHelper($mockFactory, $mailer, $fromEmailHelper, $coreParametersHelper, $mailbox, $logger, $this->mailHashHelper, $router, $twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack);
+        $mailHelper     = new MailHelper($mockFactory, $mailer, $fromEmailHelper, $coreParametersHelper, $mailbox, $logger, $this->mailHashHelper, $router, $twig, $themeHelper, $this->createMock(PathsHelper::class), $this->createMock(EventDispatcherInterface::class), $requestStack, $entityManager);
         $dncModel       = $this->createMock(DoNotContact::class);
         $translator     = $this->createMock(TranslatorInterface::class);
         $model          = new SendEmailToContact($mailHelper, $this->statHelper, $dncModel, $translator);

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tests\EventListener;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\TokenReplacementEvent;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -224,14 +225,12 @@ class OwnerSubscriberTest extends TestCase
             ->getMock();
 
         $mockLeadRepository->method('getLeadOwner')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],
-                        [2, ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 2']],
-                        [3, ['id' => 3, 'email' => 'owner3@owner.com', 'first_name' => 'John', 'last_name' => 'S&#39;mith', 'signature' => 'owner 2']],
-                    ]
-                )
+            ->willReturnMap(
+                [
+                    [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],
+                    [2, ['id' => 2, 'email' => 'owner2@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 2']],
+                    [3, ['id' => 3, 'email' => 'owner3@owner.com', 'first_name' => 'John', 'last_name' => 'S&#39;mith', 'signature' => 'owner 2']],
+                ]
             );
 
         $mockLeadModel = $this->getMockBuilder(LeadModel::class)
@@ -247,12 +246,10 @@ class OwnerSubscriberTest extends TestCase
             ->getMock();
 
         $mockFactory->method('getModel')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        ['lead', $mockLeadModel],
-                    ]
-                )
+            ->willReturnMap(
+                [
+                    ['lead', $mockLeadModel],
+                ]
             );
 
         $mockMailboxHelper = $this->getMockBuilder(Mailbox::class)
@@ -315,6 +312,10 @@ class OwnerSubscriberTest extends TestCase
         $themeHelper->expects(self::never())
             ->method('checkForTwigTemplate');
 
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->never()) // Never to make sure that the mock is properly tested if needed.
+            ->method('getReference');
+
         $transport    = new SmtpTransport();
         $mailer       = new Mailer($transport);
         $requestStack = new RequestStack();
@@ -332,6 +333,7 @@ class OwnerSubscriberTest extends TestCase
             $this->createMock(PathsHelper::class),
             $this->createMock(EventDispatcherInterface::class),
             $requestStack,
+            $entityManager,
         );
         $mailerHelper->setLead($lead);
 

--- a/app/bundles/PageBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PointSubscriber.php
@@ -16,6 +16,7 @@ class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private PointModel $pointModel,
+        private PointActionHelper $pointActionHelper,
     ) {
     }
 
@@ -43,7 +44,7 @@ class PointSubscriber implements EventSubscriberInterface
             'group'       => 'mautic.page.point.action',
             'label'       => 'mautic.page.point.action.urlhit',
             'description' => 'mautic.page.point.action.urlhit_descr',
-            'callback'    => [PointActionHelper::class, 'validateUrlHit'],
+            'callback'    => [$this->pointActionHelper, 'validateUrlHit'],
             'formType'    => PointActionUrlHitType::class,
             'formTheme'   => '@MauticPage/FormTheme/Point/pointaction_urlhit_widget.html.twig',
         ];

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -2,12 +2,17 @@
 
 namespace Mautic\PageBundle\Helper;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 
 class PointActionHelper
 {
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
     /**
      * @param MauticFactory $factory
      */
@@ -38,10 +43,7 @@ class PointActionHelper
         return true;
     }
 
-    /**
-     * @param MauticFactory $factory
-     */
-    public static function validateUrlHit($factory, $eventDetails, $action): bool
+    public function validateUrlHit($eventDetails, $action): bool
     {
         $changePoints = [];
         $url          = $eventDetails->getUrl();
@@ -52,7 +54,7 @@ class PointActionHelper
             return false;
         }
 
-        $hitRepository = $factory->getEntityManager()->getRepository(Hit::class);
+        $hitRepository = $this->entityManager->getRepository(Hit::class);
         $lead          = $eventDetails->getLead();
         $urlWithSqlWC  = str_replace('*', '%', $limitToUrl);
 
@@ -64,7 +66,7 @@ class PointActionHelper
                 $changePoints['first_time'] = true;
             }
         }
-        $now       = new \DateTime();
+        $now = new \DateTime();
 
         if ($action['properties']['returns_within'] || $action['properties']['returns_after']) {
             // get the latest hit only when it's needed

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -7,6 +7,7 @@ use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageHitEvent;
 use Mautic\PageBundle\EventListener\PointSubscriber;
+use Mautic\PageBundle\Helper\PointActionHelper;
 use Mautic\PointBundle\Event\PointBuilderEvent;
 use Mautic\PointBundle\Model\PointModel;
 use PHPUnit\Framework\TestCase;
@@ -28,6 +29,7 @@ class PointSubscriberTest extends TestCase
     {
         $pointModel        = $this->createMock(PointModel::class);
         $pointBuilderEvent = $this->createMock(PointBuilderEvent::class);
+        $pointActionHelper = $this->createMock(PointActionHelper::class);
 
         $pointBuilderEvent->expects(self::exactly(2))->method('addAction')->withConsecutive(
             [
@@ -36,7 +38,7 @@ class PointSubscriberTest extends TestCase
                     'group'       => 'mautic.page.point.action',
                     'label'       => 'mautic.page.point.action.pagehit',
                     'description' => 'mautic.page.point.action.pagehit_descr',
-                    'callback'    => [\Mautic\PageBundle\Helper\PointActionHelper::class, 'validatePageHit'],
+                    'callback'    => [PointActionHelper::class, 'validatePageHit'],
                     'formType'    => \Mautic\PageBundle\Form\Type\PointActionPageHitType::class,
                 ],
             ],
@@ -46,47 +48,49 @@ class PointSubscriberTest extends TestCase
                     'group'       => 'mautic.page.point.action',
                     'label'       => 'mautic.page.point.action.urlhit',
                     'description' => 'mautic.page.point.action.urlhit_descr',
-                    'callback'    => [\Mautic\PageBundle\Helper\PointActionHelper::class, 'validateUrlHit'],
+                    'callback'    => [$pointActionHelper, 'validateUrlHit'],
                     'formType'    => \Mautic\PageBundle\Form\Type\PointActionUrlHitType::class,
                     'formTheme'   => '@MauticPage/FormTheme/Point/pointaction_urlhit_widget.html.twig',
                 ],
             ]
         );
 
-        $pointSubscriber = new PointSubscriber($pointModel);
+        $pointSubscriber = new PointSubscriber($pointModel, $pointActionHelper);
         $pointSubscriber->onPointBuild($pointBuilderEvent);
     }
 
     public function testPageHitTriggersPageHitWhenPageIsSet(): void
     {
-        $pageHitEvent = $this->createMock(PageHitEvent::class);
-        $page         = $this->createMock(Page::class);
-        $hit          = self::createMock(Hit::class);
-        $lead         = self::createMock(Lead::class);
-        $pointModel   = $this->createMock(PointModel::class);
+        $pageHitEvent      = $this->createMock(PageHitEvent::class);
+        $page              = $this->createMock(Page::class);
+        $hit               = $this->createMock(Hit::class);
+        $lead              = $this->createMock(Lead::class);
+        $pointModel        = $this->createMock(PointModel::class);
+        $pointActionHelper = $this->createMock(PointActionHelper::class);
 
         $pageHitEvent->expects(self::once())->method('getPage')->willReturn($page);
         $pageHitEvent->expects(self::once())->method('getHit')->willReturn($hit);
         $pageHitEvent->expects(self::once())->method('getLead')->willReturn($lead);
         $pointModel->expects(self::once())->method('triggerAction')->with('page.hit', $hit, null, $lead);
 
-        $pointSubscriber = new PointSubscriber($pointModel);
+        $pointSubscriber = new PointSubscriber($pointModel, $pointActionHelper);
         $pointSubscriber->onPageHit($pageHitEvent);
     }
 
     public function testURLHitTriggersPageHitWhenPageIsSet(): void
     {
-        $pageHitEvent = $this->createMock(PageHitEvent::class);
-        $hit          = self::createMock(Hit::class);
-        $lead         = self::createMock(Lead::class);
-        $pointModel   = $this->createMock(PointModel::class);
+        $pageHitEvent      = $this->createMock(PageHitEvent::class);
+        $hit               = $this->createMock(Hit::class);
+        $lead              = $this->createMock(Lead::class);
+        $pointModel        = $this->createMock(PointModel::class);
+        $pointActionHelper = $this->createMock(PointActionHelper::class);
 
         $pageHitEvent->expects(self::once())->method('getPage')->willReturn(null);
         $pageHitEvent->expects(self::once())->method('getHit')->willReturn($hit);
         $pageHitEvent->expects(self::once())->method('getLead')->willReturn($lead);
         $pointModel->expects(self::once())->method('triggerAction')->with('url.hit', $hit, null, $lead);
 
-        $pointSubscriber = new PointSubscriber($pointModel);
+        $pointSubscriber = new PointSubscriber($pointModel, $pointActionHelper);
         $pointSubscriber->onPageHit($pageHitEvent);
     }
 }

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\PageBundle\Tests\Helper;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
@@ -15,11 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class PointActionHelperTest extends TestCase
 {
-    /**
-     * @var MockObject|MauticFactory
-     */
-    private $factory;
-
     /**
      * @var MockObject|EntityManagerInterface
      */
@@ -42,14 +36,11 @@ class PointActionHelperTest extends TestCase
 
     protected function setUp(): void
     {
-        /** @phpstan-ignore-next-line */
-        $this->factory       = $this->createMock(MauticFactory::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->hitRepository = $this->createMock(HitRepository::class);
         $this->lead          = $this->createMock(Lead::class);
         $this->eventDetails  = $this->createMock(Hit::class);
 
-        $this->factory->method('getEntityManager')->willReturn($this->entityManager);
         $this->eventDetails->method('getLead')->willReturn($this->lead);
         $this->entityManager->method('getRepository')->willReturn($this->hitRepository);
     }
@@ -71,7 +62,8 @@ class PointActionHelperTest extends TestCase
         ]);
         $this->hitRepository->expects($this->never())->method('getLatestHit');
 
-        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
+        $pointActionHelper = new PointActionHelper($this->entityManager);
+        $result            = $pointActionHelper->validateUrlHit($this->eventDetails, $action);
 
         $this->assertSame($expectedResult, $result);
     }
@@ -145,7 +137,8 @@ class PointActionHelperTest extends TestCase
         $latestHit->setTimestamp($threeHoursAgoTimestamp);
         $this->hitRepository->method('getLatestHit')->willReturn($latestHit);
 
-        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
+        $pointActionHelper = new PointActionHelper($this->entityManager);
+        $result            = $pointActionHelper->validateUrlHit($this->eventDetails, $action);
 
         $this->assertSame($expectedResult, $result);
     }

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -31,12 +31,18 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @extends CommonFormModel<Point>
  */
-class PointModel extends CommonFormModel implements GlobalSearchInterface
+class PointModel extends CommonFormModel implements GlobalSearchInterface, ResetInterface
 {
+    /**
+     * @var array<string, mixed>
+     */
+    private array $actions = [];
+
     public function __construct(
         protected RequestStack $requestStack,
         protected IpLookupHelper $ipLookupHelper,
@@ -148,19 +154,17 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface
      */
     public function getPointActions()
     {
-        static $actions;
-
-        if (empty($actions)) {
+        if ([] === $this->actions) {
             // build them
-            $actions = [];
-            $event   = new PointBuilderEvent($this->translator);
+            $this->actions = [];
+            $event         = new PointBuilderEvent($this->translator);
             $this->dispatcher->dispatch($event, PointEvents::POINT_ON_BUILD);
-            $actions['actions'] = $event->getActions();
-            $actions['list']    = $event->getActionList();
-            $actions['choices'] = $event->getActionChoices();
+            $this->actions['actions'] = $event->getActions();
+            $this->actions['list']    = $event->getActionList();
+            $this->actions['choices'] = $event->getActionChoices();
         }
 
-        return $actions;
+        return $this->actions;
     }
 
     /**
@@ -240,8 +244,12 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface
             $callback = $settings['callback'] ?? [\Mautic\PointBundle\Helper\EventHelper::class, 'engagePointAction'];
 
             if (is_callable($callback)) {
+                $object = null;
                 if (is_array($callback)) {
                     $reflection = new \ReflectionMethod($callback[0], $callback[1]);
+                    if (is_object($callback[0])) {
+                        $object = $callback[0];
+                    }
                 } elseif (str_contains($callback, '::')) {
                     $parts      = explode('::', $callback);
                     $reflection = new \ReflectionMethod($parts[0], $parts[1]);
@@ -251,17 +259,14 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface
 
                 $pass = [];
                 foreach ($reflection->getParameters() as $param) {
-                    if ('factory' === $param->getName()) {
-                        @\trigger_error('Using "factory" parameter is deprecated. Use dependency injection instead. Usage of "factory" parameter will be removed in 6.0.', \E_USER_DEPRECATED);
-                    }
-
                     if (isset($args[$param->getName()])) {
                         $pass[] = $args[$param->getName()];
                     } else {
                         $pass[] = null;
                     }
                 }
-                $pointsChange = $reflection->invokeArgs($this, $pass);
+
+                $pointsChange = $reflection->invokeArgs($object, $pass);
 
                 if ($pointsChange) {
                     $delta = $action->getDelta();
@@ -360,5 +365,10 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface
         }
 
         return array_unique($pointActionIds);
+    }
+
+    public function reset(): void
+    {
+        $this->actions = [];
     }
 }

--- a/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PointBundle\Tests\Unit\Model;
+
+use Doctrine\ORM\EntityManager;
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Helper\PointActionHelper;
+use Mautic\PointBundle\Entity\Point;
+use Mautic\PointBundle\Entity\PointRepository;
+use Mautic\PointBundle\Event\PointActionEvent;
+use Mautic\PointBundle\Event\PointBuilderEvent;
+use Mautic\PointBundle\Model\PointGroupModel;
+use Mautic\PointBundle\Model\PointModel;
+use Mautic\PointBundle\PointEvents;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PointModelTest extends TestCase
+{
+    private RequestStack&MockObject $requestStack;
+    private IpLookupHelper&MockObject $ipLookupHelper;
+    private LeadModel&MockObject $leadModel;
+    private MauticFactory&MockObject $mauticFactory;
+    private ContactTracker&MockObject $contactTracker;
+    private EntityManager&MockObject $em;
+    private CorePermissions&MockObject $security;
+    private EventDispatcherInterface&MockObject $dispatcher;
+    private UrlGeneratorInterface&MockObject $router;
+    private Translator&MockObject $translator;
+    private UserHelper&MockObject $userHelper;
+    private LoggerInterface&MockObject $mauticLogger;
+    private CoreParametersHelper&MockObject $coreParametersHelper;
+    private PointGroupModel&MockObject $pointGroupModel;
+    private PointModel $pointModel;
+
+    protected function setUp(): void
+    {
+        $this->requestStack         = $this->createMock(RequestStack::class);
+        $this->ipLookupHelper       = $this->createMock(IpLookupHelper::class);
+        $this->leadModel            = $this->createMock(LeadModel::class);
+        $this->mauticFactory        = $this->createMock(MauticFactory::class); // @phpstan-ignore-line MauticFactory is deprecated.
+        $this->contactTracker       = $this->createMock(ContactTracker::class);
+        $this->em                   = $this->createMock(EntityManager::class);
+        $this->security             = $this->createMock(CorePermissions::class);
+        $this->dispatcher           = $this->createMock(EventDispatcherInterface::class);
+        $this->router               = $this->createMock(RouterInterface::class);
+        $this->translator           = $this->createMock(Translator::class);
+        $this->userHelper           = $this->createMock(UserHelper::class);
+        $this->mauticLogger         = $this->createMock(LoggerInterface::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->pointGroupModel      = $this->createMock(PointGroupModel::class);
+        $this->pointModel           = new PointModel(
+            $this->requestStack,
+            $this->ipLookupHelper,
+            $this->leadModel,
+            $this->mauticFactory,
+            $this->contactTracker,
+            $this->em,
+            $this->security,
+            $this->dispatcher,
+            $this->router,
+            $this->translator,
+            $this->userHelper,
+            $this->mauticLogger,
+            $this->coreParametersHelper,
+            $this->pointGroupModel,
+        );
+    }
+
+    public function testTriggerUrlHitWithCallbackObject(): void
+    {
+        $type            = 'url.hit';
+        $pointId         = 98783;
+        $pointName       = 'Point name';
+        $pointProperties = ['property' => 'value'];
+        $pointDelta      = 7;
+        $pointGroup      = null;
+        $ip              = $this->createMock(IpAddress::class);
+        $this->security->method('isAnonymous')->willReturn(true);
+        $this->ipLookupHelper->method('getIpAddress')->willReturn($ip);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->expects(self::once())
+            ->method('adjustPoints')
+            ->with($pointDelta);
+        $lead->expects(self::once())
+            ->method('addPointsChangeLogEntry')
+            ->with(
+                'url',
+                $pointId.': '.$pointName,
+                'hit',
+                $pointDelta,
+                $ip,
+                $pointGroup
+            );
+        $eventDetails = $this->createMock(Hit::class);
+
+        $repository = $this->createMock(PointRepository::class);
+        $this->em->expects(self::once())
+            ->method('getRepository')
+            ->with(Point::class)
+            ->willReturn($repository);
+
+        $pointActionHelper = $this->createMock(PointActionHelper::class);
+        $pointActionHelper->expects(self::once())
+            ->method('validateUrlHit')
+            ->with(
+                $eventDetails,
+                [
+                    'id'         => $pointId,
+                    'type'       => $type,
+                    'name'       => $pointName,
+                    'properties' => $pointProperties,
+                    'points'     => $pointDelta,
+                ]
+            )
+            ->willReturn(true);
+
+        $point = $this->createMock(Point::class);
+        $point->method('getRepeatable')->willReturn(true);
+        $point->method('getType')->willReturn($type);
+        $point->method('getId')->willReturn($pointId);
+        $point->method('getName')->willReturn($pointName);
+        $point->method('getProperties')->willReturn($pointProperties);
+        $point->method('getDelta')->willReturn($pointDelta);
+        $point->method('getGroup')->willReturn($pointGroup);
+
+        $repository->expects(self::once())
+            ->method('getPublishedByType')
+            ->with($type)
+            ->willReturn([$point]);
+        $repository->expects(self::once())
+            ->method('getCompletedLeadActions')
+            ->willReturn([]);
+        $repository->expects(self::never())
+            ->method('saveEntities');
+        $repository->expects(self::never())
+            ->method('detachEntities');
+
+        $this->dispatcher->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (Event $event, string $eventName) use ($pointActionHelper, $type, $lead, $point): Event {
+                if (PointEvents::POINT_ON_BUILD === $eventName) {
+                    self::assertInstanceOf(PointBuilderEvent::class, $event);
+                    self::assertEquals(new PointBuilderEvent($this->translator), $event);
+                    $event->addAction(
+                        $type,
+                        [
+                            'callback' => [
+                                $pointActionHelper,
+                                'validateUrlHit',
+                            ],
+                            'group' => 'group',
+                            'label' => 'label',
+                        ],
+                    );
+
+                    return $event;
+                }
+
+                if (PointEvents::POINT_ON_ACTION === $eventName) {
+                    $pointActionEvent = new PointActionEvent($point, $lead);
+                    self::assertEquals($pointActionEvent, $event);
+
+                    return $pointActionEvent;
+                }
+
+                self::fail('Unknown event called: '.$eventName);
+            });
+
+        $this->leadModel->expects(self::once())
+            ->method('saveEntity')
+            ->with($lead);
+
+        $this->pointModel->triggerAction($type, $eventDetails, null, $lead);
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ✔️
| BC breaks? (use the c.x branch)        | ✔️
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Removal of the `getEntityManager` from deprecated `MauticFactory`.
The only userspace part affected is the points trigger on URL hit.
Other parts please code review.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a pint -> action with the parameters: 
  1. Change points: 1
  2. Action taken: Visits specific URL
  3. Page URL: https://_HOST_NAME_/mtracking.gif
3. Create a page, and insert a tracking pixel: https://_HOST_NAME_/mtracking.gif
4. Open the page in anonymous browser/window.
5. See there are no errors while displaying the tracking pixel (HTTP code is 200)
6. Check points were added.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->