### PR TITLE
Duplicate title on campaign source change

### DIFF
--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -178,10 +178,11 @@
 
 .campaign-source-title {
     position: absolute;
-    top: -20px;
+    top: -32px;
     color: var(--text-primary);
     left: 50%;
     transform: translateX(-50%);
+    white-space: nowrap;
 }
 
 .live .list-campaign-event:hover, .live .list-campaign-source:hover, .live .list-campaign-event:active {

--- a/app/bundles/CampaignBundle/Resources/views/Source/_index.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Source/_index.html.twig
@@ -9,8 +9,8 @@
 {% if update is not defined or update is empty %}
   <div id="CampaignEvent_{{ sourceType }}" data-type="source" class="draggable list-campaign-source list-campaign-leadsource">
 {% endif %}
-<div class="h5 fw-b mb-5 campaign-source-title">{{'mautic.campaign.form.lead_source'|trans}}</div>
 <div class="campaign-event-content">
+    <div class="h5 fw-b mb-5 campaign-source-title">{{'mautic.campaign.form.lead_source'|trans}}</div>
     <div><span class="campaign-event-name ellipsis"><i class="mr-xs campaign-event-icon {% if 'lists' == sourceType %}ri-pie-chart-line{% else %}ri-survey-line{% endif %}"></i>{{ names|default(null) }}</span></div>
 </div>
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR fixes a duplicate title issue in campaigns when changing the segment source.

### 📋 Steps to test this PR:
- Create a campaign and assign one segment as the source.
- Save the campaign.

![Capture d’écran 2025-02-19 à 11 53 52](https://github.com/user-attachments/assets/72418f69-e948-4c46-b117-a5384c412f2d)

- Reopen the campaign and change the segment source.
- Save again.

**Before**: The title gets duplicated.
![Capture d’écran 2025-02-19 à 11 54 05](https://github.com/user-attachments/assets/cd128c2c-cbc5-445e-ab38-9ce97aa1c17c)


Now:

![Capture d’écran 2025-02-19 à 11 57 10](https://github.com/user-attachments/assets/c9dd6c2c-f8e2-4fc9-8522-fcd5d7f5255a)

