### PR TITLE
Fix segment merged filters

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -44,21 +44,23 @@ class ContactSegmentFilterFactory
 
         foreach ($filters as $filter) {
             if (self::CUSTOM_OPERATOR === $filter['operator']) {
-                $mergedProperty      = $filter['merged_property'];
-                $factorSegmentFilter = null;
+                $mergedProperty           = $filter['merged_property'];
+                $factorSegmentFilter      = null;
+                $firstFactorSegmentFilter = null;
                 foreach ($filter['properties'] as $index => $nestedFilter) {
                     if (!in_array($nestedFilter['operator'], $this->operatorsWithEmptyValuesAllowed) && empty($nestedFilter['filter']) && !is_numeric($nestedFilter['filter'])) {
                         continue; // If no value set for the filter, don't consider it
                     }
-                    $factorSegmentFilter                    = $this->factorSegmentFilter($nestedFilter, $batchLimiters);
+                    $factorSegmentFilter      = $this->factorSegmentFilter($nestedFilter);
+                    $firstFactorSegmentFilter ??= $factorSegmentFilter;
                     $mergedProperty[$index]['filter_value'] = $factorSegmentFilter->getParameterValue();
                     $mergedProperty[$index]['operator']     = $factorSegmentFilter->getOperator();
                     $mergedProperty[$index]['field']        = $factorSegmentFilter->getField();
                     $mergedProperty[$index]['type']         = $factorSegmentFilter->getType();
                 }
-                if ($factorSegmentFilter) {
-                    $factorSegmentFilter->contactSegmentFilterCrate->setMergedProperty($mergedProperty);
-                    $contactSegmentFilters->addContactSegmentFilter($factorSegmentFilter);
+                if ($firstFactorSegmentFilter) {
+                    $firstFactorSegmentFilter->contactSegmentFilterCrate->setMergedProperty($mergedProperty);
+                    $contactSegmentFilters->addContactSegmentFilter($firstFactorSegmentFilter);
                 }
             } else {
                 $contactSegmentFilters->addContactSegmentFilter($this->factorSegmentFilter($filter, $batchLimiters));


### PR DESCRIPTION
…ntFilterFactory

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Noticed segment filters with enabled merged filters Custom Objects handling OR statement in wrong way.  It happen once If you use custom_objects_merge_filter enabled https://github.com/acquia/mc-cs-plugin-custom-objects/pull/333

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Once If we use for example complex segment fitlers, OR statement was not set (AND instead of it)

![image](https://github.com/user-attachments/assets/b683f279-ebf5-4c77-86fd-665545742234)

3. It need setup Custom Objects with custom_object_merge_filter key to true and also custom_object_item_value_to_contact_relation_limit key to 0.

4. At the moment any core features use merged filters, then only Acquia can test it / approve it


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->