### PR TITLE
fix: Fix contact preview lookup on email not performing a lookup

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/14.content.preview.js
+++ b/app/bundles/CoreBundle/Assets/js/14.content.preview.js
@@ -94,7 +94,7 @@ Mautic.contentPreviewUrlGenerator = {
 /**
  * Used in data-lookup-callback attr of form field in ContentPreviewSettingsType
  */
-Mautic.updateContactLookupListFilter = function(field, item) {
+Mautic.updatePreviewContactLookupListFilter = function(field, item) {
     if (item && item.id) {
         mQuery('#content_preview_settings_contact_id').val(item.id);
         mQuery(field).val(item.value);
@@ -109,7 +109,7 @@ Mautic.updateContactLookupListFilter = function(field, item) {
  * Used in data-lookup-callback attr of form field in ContentPreviewSettingsType
  * Take a look at https://github.com/twitter/typeahead.js/
  */
-Mautic.activateContactLookupField = function(fieldOptions, filterId) {
+Mautic.activatePreviewContactLookupField = function(fieldOptions, filterId) {
 
     const lookupElementId = 'content_preview_settings_contact';
     const action          = mQuery('#'+ lookupElementId).attr('data-chosen-lookup');

--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -51,9 +51,9 @@ class ContentPreviewSettingsType extends AbstractType
                 [
                     'attr' => [
                         'class'                => 'form-control',
-                        'data-callback'        => 'activateContactLookupField',
+                        'data-callback'        => 'activatePreviewContactLookupField',
                         'data-toggle'          => 'field-lookup',
-                        'data-lookup-callback' => 'updateContactLookupListFilter',
+                        'data-lookup-callback' => 'updatePreviewContactLookupListFilter',
                         'data-chosen-lookup'   => 'lead:contactList',
                         'placeholder'          => $this->translator->trans(
                             'mautic.lead.list.form.startTyping'

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -369,9 +369,9 @@ class ContentPreviewSettingsTypeTest extends TestCase
             [
                 'attr' => [
                     'class'                   => 'form-control',
-                    'data-callback'           => 'activateContactLookupField',
+                    'data-callback'           => 'activatePreviewContactLookupField',
                     'data-toggle'             => 'field-lookup',
-                    'data-lookup-callback'    => 'updateContactLookupListFilter',
+                    'data-lookup-callback'    => 'updatePreviewContactLookupListFilter',
                     'data-chosen-lookup'      => 'lead:contactList',
                     'placeholder'             => 'startTyping',
                     'data-no-record-message'  => 'nomatches',

--- a/app/bundles/EmailBundle/Assets/js/send.example.js
+++ b/app/bundles/EmailBundle/Assets/js/send.example.js
@@ -2,7 +2,7 @@
  * Used in data-lookup-callback attr of form field in ExampleSendType
  * Take a look at https://github.com/twitter/typeahead.js/
  */
-Mautic.activateContactLookupField = function(fieldOptions, filterId) {
+Mautic.activateExampleContactLookupField = function(fieldOptions, filterId) {
 
     const lookupElementId = 'example_send_contact';
     const action          = mQuery('#'+ lookupElementId).attr('data-chosen-lookup');
@@ -25,7 +25,7 @@ Mautic.activateContactLookupField = function(fieldOptions, filterId) {
 /**
  * Used in data-lookup-callback attr of form field in ExampleSendType
  */
-Mautic.updateContactLookupListFilter = function(field, item) {
+Mautic.updateExampleContactLookupListFilter = function(field, item) {
     if (item && item.id) {
         mQuery('#example_send_contact_id').val(item.id);
         mQuery(field).val(item.value);

--- a/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
@@ -47,9 +47,9 @@ class ExampleSendType extends AbstractType
                 [
                     'attr' => [
                         'class'                => 'form-control',
-                        'data-callback'        => 'activateContactLookupField',
+                        'data-callback'        => 'activateExampleContactLookupField',
                         'data-toggle'          => 'field-lookup',
-                        'data-lookup-callback' => 'updateContactLookupListFilter',
+                        'data-lookup-callback' => 'updateExampleContactLookupListFilter',
                         'data-chosen-lookup'   => 'lead:contactList',
                         'placeholder'          => $this->translator->trans(
                             'mautic.lead.list.form.startTyping'

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -129,9 +129,9 @@ class ExampleSendTypeTest extends TestCase
                     [
                         'attr' => [
                             'class'                  => 'form-control',
-                            'data-callback'          => 'activateContactLookupField',
+                            'data-callback'          => 'activateExampleContactLookupField',
                             'data-toggle'            => 'field-lookup',
-                            'data-lookup-callback'   => 'updateContactLookupListFilter',
+                            'data-lookup-callback'   => 'updateExampleContactLookupListFilter',
                             'data-chosen-lookup'     => 'lead:contactList',
                             'placeholder'            => 'startTyping',
                             'data-no-record-message' => 'nomatches',


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️

## Description

When viewing an email summary screen the lookup for a contact next to the Preview does not work due to a JS conflict with the same feature in the Send Example dialog. This PR splits separates the function names so they don't conflict.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an email and save it
3. Create a contact named "John Doe"
4. View the summary screen of the email and try to type John in the Show preview for contact field, it should perform a lookup and allow you to select John Doe and then update the preview URL beneath to contact the contactId as a query parameter
5. On the same summary screen, click the down arrow in the top right and select Send Example. Typing John into the Contact field should perform a lookup and allow you to select John Doe. Sending the Example should use that contact. (This should be tested as the JS functions were renamed to be clear as to their source, but that could be restored if desired)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->