### PR TITLE
Drop support for PHP 8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -62,7 +62,7 @@ body:
     attributes:
       label: PHP version
       description: What PHP version are you using in your environment?
-      placeholder: ex. 8.1.0
+      placeholder: ex. 8.2.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.2
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Get tag name
@@ -140,7 +140,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.2
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Download full installation package from previous step
@@ -244,7 +244,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.2
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         commands: ['PHPSTAN', 'CS Fixer', 'Rector', 'Twig Lint', 'scaffolded files mismatch', 'PHPStan baseline changes', 'composer install', 'composer lock check']
-        php-versions: ['8.1']
+        php-versions: ['8.2']
 
     name: ${{ matrix.commands }} - ${{ matrix.php-versions }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3']
         db-types: ['mysql', 'mariadb']
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: PHPUnit cache
-      if: ${{matrix.php-versions == '8.1' && matrix.db-types == 'mariadb'}}
+      if: ${{matrix.php-versions == '8.2' && matrix.db-types == 'mariadb'}}
       uses: actions/cache@v4
       with:
         path: ./var/cache/phpunit
@@ -97,14 +97,14 @@ jobs:
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
-        if [[ "${{ matrix.php-versions }}" == "8.1" ]] && [[ "${{ matrix.db-types }}" == "mariadb" ]]; then
+        if [[ "${{ matrix.php-versions }}" == "8.2" ]] && [[ "${{ matrix.db-types }}" == "mariadb" ]]; then
           php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
         else
           php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
         fi
 
     - name: Upload coverage report
-      if: ${{ matrix.php-versions == '8.1' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
+      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
       uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
@@ -113,7 +113,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Save test results for future steps
-      if: ${{ matrix.php-versions == '8.1' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
+      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
       uses: actions/upload-artifact@v4
       with:
         name: test-results

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -265,7 +265,7 @@ class DynamicContentController extends FormController
 
         $action       = $this->generateUrl('mautic_dynamicContent_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $method       = $request->getMethod();
-        $dwc          = $request->request->all['dwc'] ?? [];
+        $dwc          = $request->request->all()['dwc'] ?? [];
         $updateSelect = 'POST' === $method
             ? ($dwc['updateSelect'] ?? false)
             : $request->get('updateSelect', false);

--- a/app/bundles/LeadBundle/Entity/OperatorListTrait.php
+++ b/app/bundles/LeadBundle/Entity/OperatorListTrait.php
@@ -198,7 +198,7 @@ trait OperatorListTrait
             $choices = array_diff_key($choices, array_flip($definition['exclude']));
         }
 
-        if (property_exists($this, 'translator')) {
+        if (property_exists($this, 'translator')) { // @phpstan-ignore-line based on https://github.com/phpstan/phpstan/issues/9095 (Call to function property_exists() with ...  'translator' will always evaluate to false.)
             foreach ($choices as $value => $label) {
                 $choices[$value] = $this->translator->trans($label);
             }

--- a/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
@@ -121,10 +121,7 @@ class BaseDecorator implements FilterDecoratorInterface
         return false;
     }
 
-    /**
-     * @return CompositeExpression|string|null
-     */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): null
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): CompositeExpression|string|null
     {
         return null;
     }

--- a/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/BaseDecorator.php
@@ -124,7 +124,7 @@ class BaseDecorator implements FilterDecoratorInterface
     /**
      * @return CompositeExpression|string|null
      */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate)
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): null
     {
         return null;
     }

--- a/app/bundles/LeadBundle/Segment/Decorator/CustomMappedDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/CustomMappedDecorator.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Exception\FilterNotFoundException;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterOperator;
@@ -63,10 +64,7 @@ class CustomMappedDecorator extends BaseDecorator implements ContactDecoratorFor
         }
     }
 
-    /**
-     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string|null
-     */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate)
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): CompositeExpression|string|null
     {
         $originalField = $contactSegmentFilterCrate->getField();
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateAnniversary.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator\Date\Other;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
@@ -69,10 +70,7 @@ class DateAnniversary implements FilterDecoratorInterface
         return $this->dateDecorator->getAggregateFunc($contactSegmentFilterCrate);
     }
 
-    /**
-     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string|null
-     */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate)
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): CompositeExpression|string|null
     {
         return $this->dateDecorator->getWhere($contactSegmentFilterCrate);
     }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateDefault.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateDefault.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator\Date\Other;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
@@ -74,10 +75,7 @@ class DateDefault implements FilterDecoratorInterface
         return $this->dateDecorator->getAggregateFunc($contactSegmentFilterCrate);
     }
 
-    /**
-     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string|null
-     */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate)
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): CompositeExpression|string|null
     {
         return $this->dateDecorator->getWhere($contactSegmentFilterCrate);
     }

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Other/DateRelativeInterval.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Decorator\Date\Other;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
@@ -84,10 +85,7 @@ class DateRelativeInterval implements FilterDecoratorInterface
         return $this->dateDecorator->getAggregateFunc($contactSegmentFilterCrate);
     }
 
-    /**
-     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string|null
-     */
-    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate)
+    public function getWhere(ContactSegmentFilterCrate $contactSegmentFilterCrate): CompositeExpression|string|null
     {
         return $this->dateDecorator->getWhere($contactSegmentFilterCrate);
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionParameters;
@@ -93,5 +94,73 @@ class DateAnniversaryTest extends \PHPUnit\Framework\TestCase
         $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
 
         $this->assertEquals('%-03-04%', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary::getWhere
+     */
+    public function testGetWhereReturnsCompositeExpression(): void
+    {
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
+        $filter                    = ['field' => 'last_active'];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+
+        $dateOptionParameters = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->with($contactSegmentFilterCrate)
+            ->willReturn(CompositeExpression::and('expr1', 'expr2'));
+
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
+
+        $this->assertInstanceOf(
+            CompositeExpression::class,
+            $filterDecorator->getWhere($contactSegmentFilterCrate)
+        );
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary::getWhere
+     */
+    public function testGetWhereReturnsString(): void
+    {
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
+        $filter                    = ['field' => 'last_active'];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
+        // Configure to return a string
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->willReturn('WHERE clause');
+
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
+        $this->assertSame('WHERE clause', $filterDecorator->getWhere($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateAnniversary::getWhere
+     */
+    public function testGetWhereReturnsNull(): void
+    {
+        $dateDecorator    = $this->createMock(DateDecorator::class);
+        $timezoneResolver = $this->createMock(TimezoneResolver::class);
+
+        $filter                    = ['field' => 'last_active'];
+        $contactSegmentFilterCrate = new ContactSegmentFilterCrate($filter);
+        $dateOptionParameters      = new DateOptionParameters($contactSegmentFilterCrate, [], $timezoneResolver);
+
+        // Configure to return null
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->willReturn(null);
+
+        $filterDecorator = new DateAnniversary($dateDecorator, $dateOptionParameters);
+        $this->assertNull($filterDecorator->getWhere($contactSegmentFilterCrate));
     }
 }

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateDefaultTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateDefaultTest.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\Other\DateDefault;
 use Mautic\LeadBundle\Segment\Decorator\DateDecorator;
@@ -19,5 +20,66 @@ class DateDefaultTest extends \PHPUnit\Framework\TestCase
         $filterDecorator = new DateDefault($dateDecorator, '2018-03-02 01:02:03');
 
         $this->assertEquals('2018-03-02 01:02:03', $filterDecorator->getParameterValue($contactSegmentFilterCrate));
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateDefault::getWhere
+     */
+    public function testGetWhereReturnsCompositeExpression(): void
+    {
+        $dateDecorator = $this->createMock(DateDecorator::class);
+        $filterCrate   = new ContactSegmentFilterCrate(['field' => 'last_active']);
+
+        // Configure DateDecorator mock to return CompositeExpression
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->with($filterCrate)
+            ->willReturn(CompositeExpression::and('field = 1', 'field = 2'));
+
+        $filterDecorator = new DateDefault($dateDecorator, '2025-01-01');
+
+        $this->assertInstanceOf(
+            CompositeExpression::class,
+            $filterDecorator->getWhere($filterCrate)
+        );
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateDefault::getWhere
+     */
+    public function testGetWhereReturnsString(): void
+    {
+        $dateDecorator = $this->createMock(DateDecorator::class);
+        $filterCrate   = new ContactSegmentFilterCrate(['field' => 'last_active']);
+
+        // Configure to return string
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->willReturn("date_field > '2025-01-01'");
+
+        $filterDecorator = new DateDefault($dateDecorator, '2025-01-01');
+
+        $this->assertSame(
+            "date_field > '2025-01-01'",
+            $filterDecorator->getWhere($filterCrate)
+        );
+    }
+
+    /**
+     * @covers \Mautic\LeadBundle\Segment\Decorator\Date\Other\DateDefault::getWhere
+     */
+    public function testGetWhereReturnsNull(): void
+    {
+        $dateDecorator = $this->createMock(DateDecorator::class);
+        $filterCrate   = new ContactSegmentFilterCrate(['field' => 'last_active']);
+
+        // Configure to return null
+        $dateDecorator->expects($this->once())
+            ->method('getWhere')
+            ->willReturn(null);
+
+        $filterDecorator = new DateDefault($dateDecorator, '2025-01-01');
+
+        $this->assertNull($filterDecorator->getWhere($filterCrate));
     }
 }

--- a/app/composer.json
+++ b/app/composer.json
@@ -18,7 +18,7 @@
     ]
   },
   "require": {
-    "php": "~8.1",
+    "php": "~8.2",
     "ext-zlib": "*",
     "ext-zip": "*",
     "ext-imap": "*",

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,11 +1,11 @@
 {
   "version": "6.0.0-beta",
   "stability": "beta",
-  "minimum_php_version": "8.1.0",
+  "minimum_php_version": "8.2.0",
   "maximum_php_version": "8.3.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
-  "show_php_version_warning_if_under": "8.1.0",
+  "show_php_version_warning_if_under": "8.2.0",
   "minimum_mautic_version": "5.0.0",
   "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0-beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.1.0"
+      "php": "8.2.0"
     },
     "bin-dir": "bin",
     "component-dir": "media/assets",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b857a5569943cfe90c3640c06613d635",
+    "content-hash": "62c26039da8f289b38a82a91fb1fd8bb",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3076,16 +3076,16 @@
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
-            "version": "v1.0.16",
+            "version": "v1.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/proxy-manager-lts.git",
-                "reference": "ecadbdc9052e4ad08c60c8a02268712e50427f7c"
+                "reference": "2c8a6cffc3220e99352ad958fe7cf06bf6f7690f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/ecadbdc9052e4ad08c60c8a02268712e50427f7c",
-                "reference": "ecadbdc9052e4ad08c60c8a02268712e50427f7c",
+                "url": "https://api.github.com/repos/FriendsOfPHP/proxy-manager-lts/zipball/2c8a6cffc3220e99352ad958fe7cf06bf6f7690f",
+                "reference": "2c8a6cffc3220e99352ad958fe7cf06bf6f7690f",
                 "shasum": ""
             },
             "require": {
@@ -3142,7 +3142,7 @@
             ],
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/proxy-manager-lts/issues",
-                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.16"
+                "source": "https://github.com/FriendsOfPHP/proxy-manager-lts/tree/v1.0.18"
             },
             "funding": [
                 {
@@ -3154,7 +3154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-24T07:17:17+00:00"
+            "time": "2024-03-20T12:50:41+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",
@@ -5473,29 +5473,29 @@
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.7.1",
+            "version": "4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "91aabc066d5620428120800c0eafc0411e441a62"
+                "reference": "1793e78dad4108b594084d05d1fb818b85b110af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/91aabc066d5620428120800c0eafc0411e441a62",
-                "reference": "91aabc066d5620428120800c0eafc0411e441a62",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/1793e78dad4108b594084d05d1fb818b85b110af",
+                "reference": "1793e78dad4108b594084d05d1fb818b85b110af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4, <8.2"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13.2",
+                "doctrine/annotations": "^2.0.1",
                 "ext-phar": "*",
-                "laminas/laminas-coding-standard": "^2.3.0",
-                "laminas/laminas-stdlib": "^3.6.1",
-                "phpunit/phpunit": "^9.5.10",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.13.1"
+                "laminas/laminas-coding-standard": "^3.0.0",
+                "laminas/laminas-stdlib": "^3.18.0",
+                "phpunit/phpunit": "^10.5.37",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.15.0"
             },
             "suggest": {
                 "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
@@ -5503,9 +5503,6 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "polyfill/ReflectionEnumPolyfill.php"
-                ],
                 "psr-4": {
                     "Laminas\\Code\\": "src/"
                 }
@@ -5535,7 +5532,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-21T01:32:31+00:00"
+            "time": "2024-11-20T13:15:13+00:00"
         },
         {
             "name": "league/flysystem",
@@ -6209,7 +6206,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "eabbf65f642f7e25813e18f21299057b4959fc7b"
+                "reference": "5d8f26f51dc68fe02c15aafddea0f6acd50b7d31"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -6255,7 +6252,7 @@
                 "matthiasmullie/minify": "^1.3",
                 "noxlogic/ratelimit-bundle": "^1.19",
                 "oneup/uploader-bundle": "^3.1.0",
-                "php": "~8.1",
+                "php": "~8.2",
                 "php-amqplib/rabbitmq-bundle": "^2.5.1",
                 "php-http/guzzle7-adapter": "^1.0",
                 "phpoffice/phpspreadsheet": "^1.15 < 1.28",
@@ -12505,16 +12502,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.15",
+            "version": "v6.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392"
+                "reference": "7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/3cb242f059c14ae08591c5c4087d1fe443564392",
-                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392",
+                "url": "https://api.github.com/repos/symfony/process/zipball/7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3",
+                "reference": "7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3",
                 "shasum": ""
             },
             "require": {
@@ -12546,7 +12543,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.15"
+                "source": "https://github.com/symfony/process/tree/v6.4.19"
             },
             "funding": [
                 {
@@ -12562,7 +12559,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:19:14+00:00"
+            "time": "2025-02-04T13:35:48+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -19225,13 +19222,13 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.0"
+        "php": "8.2.0"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
@@ -283,7 +283,7 @@ class FoursquareIntegration extends SocialIntegration
         return false;
     }
 
-    public function getFormType()
+    public function getFormType(): null
     {
         return null;
     }

--- a/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -133,7 +133,7 @@ class InstagramIntegration extends SocialIntegration
         return false;
     }
 
-    public function getFormType()
+    public function getFormType(): null
     {
         return null;
     }

--- a/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
+use MauticPlugin\MauticSocialBundle\Integration\FoursquareIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class FoursquareIntegrationTest extends AbstractIntegrationTestCase
+{
+    private FoursquareIntegration $integration;
+
+    /**
+     * @var Translator&MockObject
+     */
+    protected $coreTranslator;
+
+    /**
+     * @var IntegrationHelper&MockObject
+     */
+    protected $integrationHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->coreTranslator    = $this->createMock(Translator::class);
+        $this->integrationHelper = $this->createMock(IntegrationHelper::class);
+
+        $this->integration = new FoursquareIntegration(
+            $this->dispatcher,
+            $this->cache,
+            $this->em,
+            $this->request,
+            $this->router,
+            $this->coreTranslator,
+            $this->logger,
+            $this->encryptionHelper,
+            $this->leadModel,
+            $this->companyModel,
+            $this->pathsHelper,
+            $this->notificationModel,
+            $this->fieldModel,
+            $this->fieldsWithUniqueIdentifier,
+            $this->integrationEntityModel,
+            $this->doNotContact,
+            $this->integrationHelper,
+        );
+    }
+
+    /**
+     * @covers \MauticPlugin\MauticSocialBundle\Integration\FoursquareIntegration::getFormType
+     */
+    public function testGetFormTypeReturnsNull(): void
+    {
+        // @phpstan-ignore-next-line - Intentional null check
+        $this->assertNull($this->integration->getFormType());
+    }
+}

--- a/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
+use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
+use MauticPlugin\MauticSocialBundle\Integration\InstagramIntegration;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class InstagramIntegrationTest extends AbstractIntegrationTestCase
+{
+    private InstagramIntegration $integration;
+
+    /**
+     * @var Translator&MockObject
+     */
+    protected $coreTranslator;
+
+    /**
+     * @var IntegrationHelper&MockObject
+     */
+    protected $integrationHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->coreTranslator    = $this->createMock(Translator::class);
+        $this->integrationHelper = $this->createMock(IntegrationHelper::class);
+
+        $this->integration = new InstagramIntegration(
+            $this->dispatcher,
+            $this->cache,
+            $this->em,
+            $this->request,
+            $this->router,
+            $this->coreTranslator,
+            $this->logger,
+            $this->encryptionHelper,
+            $this->leadModel,
+            $this->companyModel,
+            $this->pathsHelper,
+            $this->notificationModel,
+            $this->fieldModel,
+            $this->fieldsWithUniqueIdentifier,
+            $this->integrationEntityModel,
+            $this->doNotContact,
+            $this->integrationHelper,
+        );
+    }
+
+    /**
+     * @covers \MauticPlugin\MauticSocialBundle\Integration\InstagramIntegration::getFormType
+     */
+    public function testGetFormTypeReturnsNull(): void
+    {
+        // @phpstan-ignore-next-line - Intentional null check
+        $this->assertNull($this->integration->getFormType());
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR drops support for PHP 8.1 because Mautic will be upgraded to Symfony 7.2, which requires PHP 8.2 or higher.

https://symfony.com/releases/7.2
> Requires: PHP 8.2.0 or higher

~~The 7.x branch does not exist yet. I will rebase to the 7.x branch once it is created.~~

Updated dependencies for PHP 8.2:
- `friendsofphp/proxy-manager-lts:^1.0.16` to `friendsofphp/proxy-manager-lts:^1.0.18`
- `laminas/laminas-code:^4.7.1` to `laminas/laminas-code:^4.16.0`
- `symfony/process:^6.4.15` to `symfony/process:^6.4.19`

After applying Rector fixes for return type declarations, Codecov started complaining (failing the test), so I had to cover them with tests.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->