### PR TITLE
[UX] Add successful submit animation in Eclipse theme

### DIFF
--- a/themes/eclipse/html/MauticFormBundle/Builder/_style.html.twig
+++ b/themes/eclipse/html/MauticFormBundle/Builder/_style.html.twig
@@ -3,7 +3,6 @@
         --form-primary-60: #{{ getBrandPrimaryColor() }};
         --form-primary-70: color-mix(in hsl, var(--form-primary-60), black 10%);
         --form-primary-80: color-mix(in hsl, var(--form-primary-60), black 20%);
-        --form-font-family: Arial, Helvetica, sans-serif;
 
         --form-field: #EBEBEB;
         --form-field-hover: #e5e5e5;
@@ -76,7 +75,7 @@
     .mauticform_wrapper {
         max-width: 600px;
         margin: 20px;
-        font-family: var(--form-font-family);
+        font-family: inherit;
         font-size: 14px;
         width: 100%;
     }
@@ -103,7 +102,7 @@
 
     .mauticform-message {
         margin-bottom: 10px;
-        color: var(--form-support-success);
+        color: var(--form-primary-60);
     }
 
     .mauticform-row {
@@ -360,6 +359,128 @@
     @media only screen and (max-width: 600px) {
         .autoComplete_wrapper>input {
             width: 18rem;
+        }
+    }
+
+    /*
+    * With message defined
+    */
+
+    .mauticform-post-success .mauticform-message:not(:empty) {
+        font-size: 14pt;
+        padding-left: 60px;
+        position: relative;
+    }
+
+    .mauticform-post-success:has(.mauticform-message:not(:empty)) .mauticform-innerform {
+        display: none;
+    }
+
+    .mauticform-post-success .mauticform-message:not(:empty):before {
+        content: "";
+        position: absolute;
+        width: 50px;
+        height: 45px;
+        background-color: transparent;
+        z-index: 1;
+        top: 50%;
+        left: 0;
+        background-image: url("data:image/svg+xml,%3Csvg height='45' viewBox='0 0 120 115' width='50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M107.332 72.938c-1.798 5.557 4.564 15.334 1.21 19.96-3.387 4.674-14.646 1.605-19.298 5.003-4.61 3.368-5.163 15.074-10.695 16.878-5.344 1.743-12.628-7.35-18.545-7.35-5.922 0-13.206 9.088-18.543 7.345-5.538-1.804-6.09-13.515-10.696-16.877-4.657-3.398-15.91-.334-19.297-5.002-3.356-4.627 3.006-14.404 1.208-19.962C10.93 67.576 0 63.442 0 57.5c0-5.943 10.93-10.076 12.668-15.438 1.798-5.557-4.564-15.334-1.21-19.96 3.387-4.674 14.646-1.605 19.298-5.003C35.366 13.73 35.92 2.025 41.45.22c5.344-1.743 12.628 7.35 18.545 7.35 5.922 0 13.206-9.088 18.543-7.345 5.538 1.804 6.09 13.515 10.696 16.877 4.657 3.398 15.91.334 19.297 5.002 3.356 4.627-3.006 14.404-1.208 19.962C109.07 47.424 120 51.562 120 57.5c0 5.943-10.93 10.076-12.668 15.438z' fill='%23{{ getBrandPrimaryColor() }}'/%3E%3C/svg%3E");
+        animation: checkbox-message 35s linear infinite;
+        transform-origin: top;
+    }
+
+    .mauticform-post-success .mauticform-message:not(:empty):after {
+        content: "";
+        position: absolute;
+        width: 24px;
+        height: 12px;
+        z-index: 10;
+        top: 50%;
+        left: 13px;
+        background-image: url("data:image/svg+xml,%3Csvg height='12' viewBox='0 0 48 36' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M47.248 3.9L43.906.667a2.428 2.428 0 0 0-3.344 0l-23.63 23.09-9.554-9.338a2.432 2.432 0 0 0-3.345 0L.692 17.654a2.236 2.236 0 0 0 .002 3.233l14.567 14.175c.926.894 2.42.894 3.342.01L47.248 7.128c.922-.89.922-2.34 0-3.23' fill='%23{{ getTextOnBrandColor() }}'/%3E%3C/svg%3E");
+        animation: checkmark-message 5.6s cubic-bezier(0.420, 0.000, 0.275, 1.155);
+        transform: scale(1) translateY(-50%);
+    }
+
+    @keyframes checkmark-message {
+        0% {
+            opacity: 0;
+            transform: scale(0) translateY(-50%);
+        }
+        10%, 50%, 90% {
+            opacity: 1;
+            transform: scale(1) translateY(-50%);
+        }
+    }
+
+    @keyframes checkbox-message {
+        0% {
+            transform: rotate(0deg) translateY(-50%);
+        }
+        100% {
+            transform: rotate(360deg) translateY(-50%);
+        }
+    }
+
+
+    /*
+    * When simply remaining on the form
+    */
+
+    .mauticform-post-success:has(.mauticform-message:empty) {
+        position: relative;
+    }
+
+    .mauticform-post-success:has(.mauticform-message:empty) .mauticform-innerform {
+        visibility: hidden;
+        opacity: 0;
+    }
+
+    .mauticform-post-success .mauticform-message:empty:before {
+        content: "";
+        position: absolute;
+        width: 120px;
+        height: 115px;
+        background-color: transparent;
+        z-index: 1;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background-image: url("data:image/svg+xml,%3Csvg height='115' viewBox='0 0 120 115' width='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M107.332 72.938c-1.798 5.557 4.564 15.334 1.21 19.96-3.387 4.674-14.646 1.605-19.298 5.003-4.61 3.368-5.163 15.074-10.695 16.878-5.344 1.743-12.628-7.35-18.545-7.35-5.922 0-13.206 9.088-18.543 7.345-5.538-1.804-6.09-13.515-10.696-16.877-4.657-3.398-15.91-.334-19.297-5.002-3.356-4.627 3.006-14.404 1.208-19.962C10.93 67.576 0 63.442 0 57.5c0-5.943 10.93-10.076 12.668-15.438 1.798-5.557-4.564-15.334-1.21-19.96 3.387-4.674 14.646-1.605 19.298-5.003C35.366 13.73 35.92 2.025 41.45.22c5.344-1.743 12.628 7.35 18.545 7.35 5.922 0 13.206-9.088 18.543-7.345 5.538 1.804 6.09 13.515 10.696 16.877 4.657 3.398 15.91.334 19.297 5.002 3.356 4.627-3.006 14.404-1.208 19.962C109.07 47.424 120 51.562 120 57.5c0 5.943-10.93 10.076-12.668 15.438z' fill='%23{{ getBrandPrimaryColor() }}'/%3E%3C/svg%3E");
+        animation: checkbox-return 35s linear infinite;
+    }
+
+    .mauticform-post-success .mauticform-message:empty:after {
+        content: "";
+        position: absolute;
+        width: 48px;
+        height: 36px;
+        z-index: 10;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background-image: url("data:image/svg+xml,%3Csvg height='36' viewBox='0 0 48 36' width='48' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M47.248 3.9L43.906.667a2.428 2.428 0 0 0-3.344 0l-23.63 23.09-9.554-9.338a2.432 2.432 0 0 0-3.345 0L.692 17.654a2.236 2.236 0 0 0 .002 3.233l14.567 14.175c.926.894 2.42.894 3.342.01L47.248 7.128c.922-.89.922-2.34 0-3.23' fill='%23{{ getTextOnBrandColor() }}'/%3E%3C/svg%3E");
+        animation: checkmark-return 5.6s cubic-bezier(0.420, 0.000, 0.275, 1.155);
+    }
+
+    @keyframes checkmark-return {
+        0% {
+            opacity: 0;
+            transform: translate(-50%, -50%) scale(0);
+        }
+        10%, 50%, 90% {
+            opacity: 1;
+            transform: translate(-50%, -50%) scale(1);
+        }
+    }
+
+    @keyframes checkbox-return {
+        0% {
+            transform: translate(-50%, -50%) rotate(0deg);
+        }
+        100% {
+            transform: translate(-50%, -50%) rotate(360deg);
         }
     }
 </style>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds animations upon submission for the Eclipse theme.

Dependency (needs to be merged first):
- #14649 

When Successful Submit Action is Display message (hides all form fields, add badge on the side of message):

https://github.com/user-attachments/assets/22925264-0590-4f5a-870b-55b398229413



When Successful Submit Action is Remain at form (hides all form fields, centralizing a big check symbol vertically and horizontally):


https://github.com/user-attachments/assets/3d81a315-f522-4c6c-8d7a-5aee36544e63


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Forms > New > Pick theme Eclipse 
3. Select "Display message" on Successful Submit Action
4. Open Fields tab > Add fields > Save > Preview your form
5. Repeat from step 3, picking "Remain at form" as Successful Submit Action

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->