### PR TITLE
Fixing a 500 error when an asset was not found

### DIFF
--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -87,8 +87,6 @@ class PublicController extends CommonFormController
             return $response;
         }
 
-        $model->trackDownload($entity, $request, 404);
-
         return $this->notFound();
     }
 }

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -253,7 +253,7 @@ class AssetModel extends FormModel
 
         $download->setTrackingId($trackingId);
 
-        if (!empty($asset) && empty($systemEntry)) {
+        if (empty($systemEntry)) {
             $download->setAsset($asset);
 
             $this->getRepository()->upDownloadCount($asset->getId(), 1, $isUnique);

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -107,8 +107,10 @@ class AssetModel extends FormModel
     }
 
     /**
-     * @param string $code
-     * @param array  $systemEntry
+     * @param Asset               $asset
+     * @param ?Request            $request
+     * @param string              $code
+     * @param array<string,mixed> $systemEntry
      *
      * @throws \Doctrine\ORM\ORMException
      * @throws \Exception

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\AssetBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AssetDownloadFunctionalTest extends MauticMysqlTestCase
+{
+    public function testDownloadOfNotFoundAsset(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/s/logout');
+
+        // The 500 error happened only on the second request.
+        // It happened only if the device was already tracked.
+        $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returns 404 correctly
+        $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returned 500 but it should return 404
+        
+        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
@@ -19,7 +19,7 @@ final class AssetDownloadFunctionalTest extends MauticMysqlTestCase
         // It happened only if the device was already tracked.
         $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returns 404 correctly
         $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returned 500 but it should return 404
-        
+
         Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR resolves this error:
```
500 Internal Server Error - Call to a member function getId() on null 
/app/bundles/AssetBundle/Model/AssetModel.php:272 at
/app/bundles/AssetBundle/Controller/PublicController.php:89 at Mautic\AssetBundle\Model\AssetModel -> trackDownload ( null, object(Request), '404' )
/vendor/symfony/http-kernel/HttpKernel.php:169 at Mautic\AssetBundle\Controller\PublicController -> downloadAction ( 'unicorn' )
/vendor/symfony/http-kernel/HttpKernel.php:81 at Symfony\Component\HttpKernel\HttpKernel -> handleRaw ( object(Request), '1' )
/vendor/symfony/http-kernel/Kernel.php:201 at Symfony\Component\HttpKernel\HttpKernel -> handle ( object(Request), '1', true )
/app/AppKernel.php:103 at Symfony\Component\HttpKernel\Kernel -> handle ( object(Request), '1', true )
/app/middlewares/CORSMiddleware.php:82 at AppKernel -> handle ( object(Request), '1', true )
/app/middlewares/CatchExceptionMiddleware.php:34 at Mautic\Middleware\CloudMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/Dev/IpRestrictMiddleware.php:52 at Mautic\Middleware\CatchExceptionMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/VersionCheckMiddleware.php:58 at Mautic\Middleware\Dev\IpRestrictMiddleware -> handle ( object(Request), '1', true )
/app/middlewares/TrustMiddleware.php:42 at Mautic\Middleware\VersionCheckMiddleware -> handle ( object(Request), '1', true )
/vendor/stack/builder/src/Stack/StackedHttpKernel.php:23 at Mautic\Middleware\TrustMiddleware -> handle ( object(Request), '1', true )
/vendor/stack/run/src/Stack/run.php:13 at Stack\StackedHttpKernel -> handle ( object(Request) )
/index_dev.php:25 at Stack\run ( object(StackedHttpKernel) )
```
It happens when a contact is trying to download an asset that do not exist.

From the behavior change perspective, this is how the contact history was before this change:
![Screenshot 2025-01-09 at 09 48 47](https://github.com/user-attachments/assets/b62eb6c3-b456-4218-a6ce-d091bfa79e4d)

The consecutive asset download records couldn't be shown as it ended up with the 500 error. The first request worked only if the contact device wasn't tracked yet.

This is how it looks with this change:
![Screenshot 2025-01-09 at 09 52 41](https://github.com/user-attachments/assets/9683d144-9196-458a-a2b9-5ba9cff2c989)

Now the consecutive tries to download the asset will be tracked.

##### Notes about 404 tracking
If you wish to track the 404 attempts for download then make sure you have a 404 custom page selected and 404 page tracking enabled if you want to track the first tracking requests for anonymous contacts.

![Screenshot 2025-02-13 at 16 46 15](https://github.com/user-attachments/assets/fa5239cf-071c-40aa-8aa5-2ef2f8823d72)
![Screenshot 2025-02-13 at 16 45 21](https://github.com/user-attachments/assets/befe953c-b98a-47b4-8b66-943a28266647)

#### Steps to test

1. Access https://mautic.ddev.site/asset/unicorn (on your Mautic instance you test with) as an anonymous contact. The unicorn asset alias should not exist so it will replicate the 500 error. If it does exist, you live is so, so amazing! 🦄 
2. I found out that you must access this route twice or more to trigger this error. It happens only if the device is already tracked.

#### Other areas of Mautic that may be affected by the change:
1. Just asset download

#### List deprecations along with the new alternative:
1. None


[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The functional test is testing accessing a download page for not existing asset twice and checks that it returns 404 code for the second time.
