### PR TITLE
Resolving PHP 8.0 warnings

### DIFF
--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -161,7 +161,9 @@ class AjaxController extends CommonAjaxController
             $type    = 'error';
         }
 
-        $data = array_merge($responseData, ['message' => $message, 'type' => $type, 'success' => $success]);
+        $data = is_array($responseData)
+            ? array_merge($responseData, ['message' => $message, 'type' => $type, 'success' => $success])
+            : [];
 
         return $this->sendJsonResponse($data);
     }

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -730,8 +730,10 @@ SQL;
             );
 
             foreach ($segmentMembershipFilters as $filter) {
-                foreach ($filter['properties']['filter'] as $childSegmentId) {
-                    $childSegmentIds[] = ['item_id' => (string) $childSegmentId];
+                if (is_array($filter['properties']['filter'])) {
+                    foreach ($filter['properties']['filter'] as $childSegmentId) {
+                        $childSegmentIds[] = ['item_id' => (string) $childSegmentId];
+                    }
                 }
             }
         }

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -65,7 +65,7 @@ class ContactRequestHelper
             $queryFields['ct'] = (is_array($queryFields['ct'])) ? $queryFields['ct'] : ClickthroughHelper::decodeArrayFromUrl($queryFields['ct']);
         }
 
-        if (array_key_exists('ct', $queryFields) && array_key_exists('email', $queryFields['ct']) && array_key_exists('stat', $queryFields['ct'])) {
+        if (isset($queryFields['ct']['stat'])) {
             /** @var Stat $stat */
             $stat = $this->statRepository->findOneBy(['trackingHash' => $queryFields['ct']['stat']]);
             if (null !== $stat && $this->botRatioHelper->isHitByBot($stat, $dateTime, $ipAddress, (string) $userAgent)) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ (tested by existing tests)
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR resolves several PHP warnings that we could see in our logs. Such as:

```
PHP Warning: Invalid argument supplied for foreach() in app/bundles/LeadBundle/Entity/LeadListRepository.php on line 839
```

```
PHP Warning: array_key_exists() expects parameter 2 to be array, bool given in app/bundles/LeadBundle/Helper/ContactRequestHelper.php on line 12
```

The changes here are checking if the variable is type of the PHP function expect to avoid these warnings.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

We don't have a steps to test per se as this PR is resolving warnings from logs. But based on the code changes we can test:
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a form and submit it. Check it works as before.
3. Execute `bin/console mautic:segments:stat`
4. Create a landing page and check the tracking works as before.

All these actions are tested by existing functional tests.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->