### PR TITLE
Fix space between toggle and campaign name 

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
@@ -140,13 +140,13 @@
                     </td>
                     <td>
                         <div>
-                          {{- include('@MauticCore/Helper/publishstatus_icon.html.twig', {
+                          {{ include('@MauticCore/Helper/publishstatus_icon.html.twig', {
                               'item': item,
                               'model': 'campaign',
                               'onclick': item.onclickMethod,
                               'attributes': item.dataAttributes,
                               'transKeys': item.translationKeysDataAttributes,
-                          }) -}}
+                          }) }}
                             <a href="{{ path('mautic_campaign_action', {'objectAction': 'view', 'objectId': item.id}) }}" data-toggle="ajax">
                                 {{- item.name -}}
                                 {{- customContent('campaign.name', _context|merge({'item': item})) -}}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This irritated me too much

Before

![image](https://github.com/user-attachments/assets/79bf688a-9934-497c-a3e7-5ec2d0059dd8)

After

![image](https://github.com/user-attachments/assets/36e68663-6b89-461c-81a9-a460ae5fb8bc)


Steps:

just  check campaign lists works like before

