### PR TITLE
Fix FinalizeUpdateStep

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -59,7 +59,7 @@ class FinalizeUpdateStepTest extends AbstractStepTest
         file_put_contents(__DIR__.'/resources/upgrade.php', '');
         file_put_contents(__DIR__.'/resources/lastUpdateCheck.txt', '');
 
-        $wrappingUpKey       = 'mautic.core.update.step.wrapping_up';
+        $wrappingUpKey       = 'mautic.core.command.update.step.wrapping_up';
         $updateSuccessfulKey = 'mautic.core.update.update_successful';
 
         $this->translator->expects($this->exactly(2))

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -6,6 +6,7 @@ use Mautic\CoreBundle\Helper\AppVersion;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Update\Step\FinalizeUpdateStep;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -28,6 +29,11 @@ class FinalizeUpdateStepTest extends AbstractStepTest
     private MockObject $session;
 
     /**
+     * @var MockObject&Request
+     */
+    private MockObject $request;
+
+    /**
      * @var MockObject&RequestStack
      */
     private MockObject $requestStack;
@@ -48,8 +54,12 @@ class FinalizeUpdateStepTest extends AbstractStepTest
         $this->session      = $this->createMock(Session::class);
         $this->requestStack = $this->createMock(RequestStack::class);
         $this->appVersion   = $this->createMock(AppVersion::class);
+        $this->request      = $this->createMock(Request::class);
 
+        $this->request->method('hasSession')->willReturn(true);
+        $this->request->method('getSession')->willReturn($this->session);
         $this->requestStack->method('getSession')->willReturn($this->session);
+        $this->requestStack->method('getCurrentRequest')->willReturn($this->request);
 
         $this->step = new FinalizeUpdateStep($this->translator, $this->pathsHelper, $this->requestStack, $this->appVersion);
     }

--- a/app/bundles/CoreBundle/Update/Step/FinalizeUpdateStep.php
+++ b/app/bundles/CoreBundle/Update/Step/FinalizeUpdateStep.php
@@ -32,7 +32,7 @@ final class FinalizeUpdateStep implements StepInterface
 
     public function execute(ProgressBar $progressBar, InputInterface $input, OutputInterface $output): void
     {
-        $progressBar->setMessage($this->translator->trans('mautic.core.update.step.wrapping_up'));
+        $progressBar->setMessage($this->translator->trans('mautic.core.command.update.step.wrapping_up'));
         $progressBar->advance();
 
         // Clear the cached update data and the download package now that we've updated

--- a/app/bundles/CoreBundle/Update/Step/FinalizeUpdateStep.php
+++ b/app/bundles/CoreBundle/Update/Step/FinalizeUpdateStep.php
@@ -46,10 +46,13 @@ final class FinalizeUpdateStep implements StepInterface
         $progressBar->finish();
 
         // Check for a post install message from migrations
-        if ($postMessage = $this->requestStack->getSession()->get('post_upgrade_message')) {
-            $postMessage = strip_tags($postMessage);
-            $this->requestStack->getSession()->remove('post_upgrade_message');
-            $output->writeln("\n\n<info>$postMessage</info>");
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request && $request->hasSession()) {
+            if ($postMessage = $this->requestStack->getSession()->get('post_upgrade_message')) {
+                $postMessage = strip_tags($postMessage);
+                $this->requestStack->getSession()->remove('post_upgrade_message');
+                $output->writeln("\n\n<info>$postMessage</info>");
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR resolves the error: 'There is currently no session available.' Since the CLI does not use a session, it adds a check to verify whether a session exists before accessing it. It also fixes a typo in the translation key. This PR is necessary to resolve one of the release pipeline errors.

![image](https://github.com/user-attachments/assets/a4a6809e-1c53-4b12-af4a-1df009dcef6d)

https://github.com/mautic/mautic/blob/1fba7e8b00da00af6942a55a9be4bed40d1bce43/app/bundles/CoreBundle/Translations/en_US/messages.ini#L112

https://github.com/mautic/mautic/blob/1fba7e8b00da00af6942a55a9be4bed40d1bce43/app/bundles/CoreBundle/Update/Step/FinalizeUpdateStep.php#L35

With this fix applied, the error no longer appears:
![image](https://github.com/user-attachments/assets/c887ecf7-1c0d-4cf4-9c86-8f49c3d15041)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Code review and check tests

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->