### PR TITLE
Bump in readiness for release of 6.0.0-beta2

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.0-beta",
+  "version": "6.0.0-beta2",
   "stability": "beta",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "5.0.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0-beta"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0-beta2"
 }


### PR DESCRIPTION
This bumps the version ready for the release of 6.0.0-beta2 (as there were problems with the release pipeline which prevented us releasing last week)