### PR TITLE
handle date and date time in report filters

### DIFF
--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -5,7 +5,6 @@ namespace Mautic\ReportBundle\Form\DataTransformer;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 
 /**

--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -36,7 +36,7 @@ class ReportFilterDataTransformer implements DataTransformerInterface
                 return $filters;
             }
             $type = $this->columns[$f['column']]['type'];
-            if (in_array($type, ['datetime', 'time', DateTimeType::class, DateType::class, TimeType::class])) {
+            if (in_array($type, ['datetime', 'time', DateTimeType::class, TimeType::class])) {
                 $dt         = new DateTimeHelper($f['value'], '', 'utc');
                 $f['value'] = $dt->toLocalString();
             }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR handle Date value in report filters. A random hour is put when selecting a date in the segment filter when this field is a date type.
Then on reporting if you use relative dates (yesterday) then it doesn't include the full day of yesterday because of the random hour.

### 📋 Steps to test this PR:
1. Create a custom field with Date type
2. Go to reports > Filters > Add your field and set "equals to some date"
3. On edit, the filter value should stay correct

![image](https://github.com/user-attachments/assets/5f79f61b-4897-4006-a286-eb17ce3e0d16)
