### PR TITLE
Salesforce campaign segment filter select fixed

### DIFF
--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -56,6 +56,10 @@ class LeadListSubscriber implements EventSubscriberInterface
                     }
                     $integrationChoices                      = FormFieldHelper::parseListForChoices($integrationChoices);
                     $choices[$integration->getDisplayName()] = $integrationChoices;
+                    $choices[$integration->getDisplayName()] = array_combine(
+                        array_column($integrationChoices, 'label'),
+                        array_column($integrationChoices, 'value')
+                    );
                 }
             }
         }


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description
There is an issue with value|label array for salesforce campaign segment filter
![Capture d’écran 2025-03-10 à 15 02 45](https://github.com/user-attachments/assets/859ac640-be3e-44df-9abb-fed84524d114)


### 📋 Steps to test this PR:
1. Connect your SF account
2. Try segment with the Integration Campaign Member filter
3. See the issue