### PR TITLE
Fixing attaching an asset to an email

### DIFF
--- a/app/bundles/AssetBundle/Tests/Asset/AbstractAssetTest.php
+++ b/app/bundles/AssetBundle/Tests/Asset/AbstractAssetTest.php
@@ -70,6 +70,7 @@ abstract class AbstractAssetTest extends MauticMysqlTestCase
         $asset->setStorageLocation($assetData['storage'] ?? 'local');
         $asset->setPath($assetData['path'] ?? '');
         $asset->setExtension($assetData['extension'] ?? '');
+        $asset->setSize($this->csvPath ? filesize($this->csvPath) : 0);
 
         $this->em->persist($asset);
         $this->em->flush();

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -48,6 +48,13 @@ class AssetControllerFunctionalTest extends AbstractAssetTest
         $this->getControllerColumnTests($urlAlias, $routeAlias, $column, $tableAlias, $column2);
     }
 
+    public function testAssetSizes(): void
+    {
+        $this->client->request('GET', '/s/ajax?action=email:getAttachmentsSize&assets%5B%5D='.$this->asset->getId());
+        $this->assertResponseIsSuccessful();
+        Assert::assertSame('{"size":"178 bytes"}', $this->client->getResponse()->getContent());
+    }
+
     /**
      * Preview action should return the file content.
      */

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -116,7 +116,7 @@ class AjaxController extends CommonAjaxController
 
     public function getAttachmentsSizeAction(Request $request, AssetModel $assetModel): JsonResponse
     {
-        $assets = $request->query->get('assets') ?? [];
+        $assets = $request->query->all()['assets'] ?? [];
         $size   = 0;
         if ($assets) {
             $size = $assetModel->getTotalFilesize($assets);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Attaching an asset to an email was broken due to forgotten refactoring after Symfony 6 upgrade. This PR fixes it and adds a functional test so the AJAX request that is checking the asset file size will always work.

![image (4)](https://github.com/user-attachments/assets/fa446c56-909a-40a2-9b3a-c0d2c4c4b48d)
![image (3)](https://github.com/user-attachments/assets/7feb7f5b-97ad-4137-9705-954cc85275e7)


### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an asset
3. Create a new email
4. Go to the Advanced tab
5. Try to attach the asset to the email - it used to throw a 500 error - this was fixed.

<img width="750" alt="Screenshot 2025-03-10 at 16 33 45" src="https://github.com/user-attachments/assets/1009a7dd-bbb0-443b-b32d-e624a805d028" />


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->