### PR TITLE
[5.2] Make sure to clear metadata before adding it.

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -356,7 +356,8 @@ class MailHelper
                     $tokens['{signature}'] = $ownerSignature;
                 }
 
-                // Set metadata if applicable
+                // Set metadata if applicable, make sure to start clean
+                $this->message->clearMetadata();
                 foreach ($this->queuedRecipients as $email => $name) {
                     $this->message->addMetadata($email, $this->buildMetadata($name, $tokens));
                 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️<!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

When sending out mails via broadcast:send we see that metadata (specifically tokens) are added to the body column of the messenger_messages table multiple times depending on the number of mails being send out in a batch. 

1. Create an email containing tokens, for example {unsubscribe_url}
2. Add segment to mail
3. Send out mail using broadcast:send command
4. Do not set up a messenger:consume process, so mails stay in the messenger_messages table. 

When you send out the mail, and for example you see 100 mails being send out, check the messenger_messages table. 
The first mail will contain the {unsubscribe_url) value 1 time, and replace it with that value. 
The second mail will contain the {unsubscribe_url} value twice, once for the mail above, and one for the current mail. It will replace it correctly with the last one. 
The third mail will contain the {unsubscribe_url} value 3 times, twice for the mails above, and one for the current mail. It will replace it correctly with the last one. 

This causes that each entry in the table is bigger than the previous one, and causes unexpected DB growth (in our case we even have custom tokens which are almost the entire mail content). 

This PR fixes this by making sure the metadata is clean for each submission.

---
### 📋 Steps to test this PR:

1. Reproduce the above scenario
5. Now see that each entry in the messenger_messages table does not contain the tokens multiple times. 