### PR TITLE
Fixing the delete list actions UI bug

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
@@ -76,7 +76,7 @@
                     message: (translationBase ~ '.form.confirmdelete')|trans({'%name%': (name ~ ' (' ~ id ~ ')')}),
                     confirmAction: path(
                         actionRoute,
-                        query|merge({objectAction: 'delete', objectId: id})
+                        query|filter((v, k) => k != 'tmpl')|merge({objectAction: 'delete', objectId: id})
                     ),
                     template: 'delete'
                 },

--- a/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
@@ -76,7 +76,7 @@
                     message: (translationBase ~ '.form.confirmdelete')|trans({'%name%': (name ~ ' (' ~ id ~ ')')}),
                     confirmAction: path(
                         actionRoute,
-                        {objectAction: 'delete', objectId: id}
+                        query|merge({objectAction: 'delete', objectId: id})
                     ),
                     template: 'delete'
                 },

--- a/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
@@ -76,7 +76,7 @@
                     message: (translationBase ~ '.form.confirmdelete')|trans({'%name%': (name ~ ' (' ~ id ~ ')')}),
                     confirmAction: path(
                         actionRoute,
-                        query|merge({objectAction: 'delete', objectId: id})
+                        {objectAction: 'delete', objectId: id}
                     ),
                     template: 'delete'
                 },

--- a/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
@@ -24,7 +24,7 @@
                     message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                         ? (translationBase ~ '.form.confirmbatchdelete')|trans
                         : 'mautic.core.form.confirmbatchdelete'|trans,
-                    confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
+                    confirmAction: path(actionRoute, query|filter((v, k) => k != 'tmpl')|merge({objectAction: 'batchDelete'})),
                     template: 'batchdelete'
                 },
                 priority: -1

--- a/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
@@ -24,7 +24,7 @@
                     message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                         ? (translationBase ~ '.form.confirmbatchdelete')|trans
                         : 'mautic.core.form.confirmbatchdelete'|trans,
-                    confirmAction: path(actionRoute, {objectAction: 'batchDelete'}),
+                    confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
                     template: 'batchdelete'
                 },
                 priority: -1

--- a/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/tableheader.html.twig
@@ -24,7 +24,7 @@
                     message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                         ? (translationBase ~ '.form.confirmbatchdelete')|trans
                         : 'mautic.core.form.confirmbatchdelete'|trans,
-                    confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
+                    confirmAction: path(actionRoute, {objectAction: 'batchDelete'}),
                     template: 'batchdelete'
                 },
                 priority: -1

--- a/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
@@ -12,7 +12,7 @@
             message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                 ? (translationBase ~ '.form.confirmbatchdelete')|trans
                 : 'mautic.core.form.confirmbatchdelete'|trans,
-            confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
+            confirmAction: path(actionRoute, query|filter((v, k) => k != 'tmpl')|merge({objectAction: 'batchDelete'})),
             template: 'batchdelete'
         },
         priority: 1

--- a/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
@@ -12,7 +12,7 @@
             message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                 ? (translationBase ~ '.form.confirmbatchdelete')|trans
                 : 'mautic.core.form.confirmbatchdelete'|trans,
-            confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
+            confirmAction: path(actionRoute, {objectAction: 'batchDelete'}),
             template: 'batchdelete'
         },
         priority: 1

--- a/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/toolbar_bulk_actions.html.twig
@@ -12,7 +12,7 @@
             message: translatorHasId(translationBase ~ '.form.confirmbatchdelete')
                 ? (translationBase ~ '.form.confirmbatchdelete')|trans
                 : 'mautic.core.form.confirmbatchdelete'|trans,
-            confirmAction: path(actionRoute, {objectAction: 'batchDelete'}),
+            confirmAction: path(actionRoute, query|merge({objectAction: 'batchDelete'})),
             template: 'batchdelete'
         },
         priority: 1


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14401

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

When deleting an item from a list the table header got lost after the table was refreshed. This started happening after the Symfony 6 upgrade. It took me a while to find the reason. I was comparing with earlier Mautic version and found that the delete URL started having `?tmpl=list` query param. It didn't have that before. So in this PR I'm removing the tmpl key from the `query` array. This array with the tmpl key is being defined in the `action_button_helper.html.twig` if anyone wants to look deeper. It took me a while to figure that out.

I can't figure out why it started misbehaving like this after the Symfony 6 upgrade though which is a bit scary. But I'm out of ideas where to look next.

The same issue happened with batch delete option so I did the same fix there.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to any list page. Examples: contacts, companies, pages, emails, etc.
3. You need to have some rows there.
4. On a row open the context menu and select the delete option. 
5. A confirmation popup will show up. Confirm the delete

Notice that the table header with the search box is missing before applying this fix and it's there afterwards.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->