### PR TITLE
[UXUI-71] Separate objects when viewing custom fields

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -6075,10 +6075,10 @@ input[style]:hover {
   box-shadow: none;
 }
 .form-control {
-  &:not(select) {
-    padding: var(--spacing-04) var(--spacing-05);
-  }
   color: var(--text-primary);
+}
+.form-control:not(select) {
+  padding: var(--spacing-04) var(--spacing-05);
 }
 .form-control + .help-text,
 .form-control + p {
@@ -7908,6 +7908,9 @@ lesshat-selector { -lh-property: 0 ;
 .bsh-xs {
   border-spacing: 5px 0;
   border-collapse: separate;
+}
+.pos-relative {
+  position: relative;
 }
 .bg-picture {
   position: relative;

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/utilities.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/utilities.less
@@ -111,6 +111,10 @@
   border-collapse: separate;
 }
 
+.pos-relative {
+  position: relative;
+}
+
 // background picture
 // ---------------------------------------------
 .bg-picture {

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -337,6 +337,19 @@ Mautic.onPageLoad = function (container, response, inModal) {
         Mautic.activateLiveSearch(mQuery(this), "lastSearchStr", "liveCache");
     });
 
+    // Re-focus whichever live-search field was active
+    if (MauticVars.lastUsedLiveSearch) {
+        const el = document.getElementById(MauticVars.lastUsedLiveSearch);
+        if (el) {
+            el.focus();
+            // put the cursor at the end
+            const val = el.value;
+            el.value = '';
+            el.value = val;
+        }
+        MauticVars.lastUsedLiveSearch = null;
+    }
+
     //initialize tooltips
     var pageTooltips = mQuery(container + " *[data-toggle='tooltip']");
     pageTooltips.tooltip({html: true, container: 'body'});
@@ -1351,6 +1364,12 @@ Mautic.activateLiveSearch = function (el, searchStrVar, liveCacheVar) {
     mQuery(el).on('focus', function () {
         Mautic.currentSearchString = mQuery(this).val().trim();
     });
+
+    // Add keydown handler to track last used live search
+    mQuery(el).on('keydown', function() {
+        MauticVars.lastUsedLiveSearch = mQuery(this).attr('id');
+    });
+
     mQuery(el).on('change keyup paste', {}, function (event) {
         var searchStr = mQuery(el).val().trim();
 

--- a/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
@@ -49,13 +49,18 @@
   {% if items|length > 0 %}
       {# Group items by object #}
       {% set groupedItems = {} %}
+      {% set objectTotals = {} %}
       {% for item in items %}
           {% set objectKey = item.object %}
           {% if groupedItems[objectKey] is not defined %}
               {% set groupedItems = groupedItems|merge({(objectKey): []}) %}
+              {% set objectTotals = objectTotals|merge({(objectKey): 0}) %}
           {% endif %}
           {% set groupedItems = groupedItems|merge({
               (objectKey): groupedItems[objectKey]|merge([item])
+          }) %}
+          {% set objectTotals = objectTotals|merge({
+              (objectKey): objectTotals[objectKey] + 1
           }) %}
       {% endfor %}
 
@@ -141,6 +146,16 @@
                       </tbody>
                   </table>
               </div>
+              <div class="panel-footer">
+                  {{ include('@MauticCore/Helper/pagination.html.twig', {
+                          'totalItems': objectTotals[objectKey],
+                          'page': page,
+                          'limit': limit,
+                          'baseUrl': path('mautic_contactfield_index', {'object': objectKey}),
+                          'sessionVar': 'leadfield.' ~ objectKey,
+                          'queryString': 'object=' ~ objectKey
+                  }) }}
+              </div>
           {% endset %}
 
           {% set tabsContent = tabsContent|merge([{
@@ -154,15 +169,6 @@
           'style': 'contained'
       }) }}
 
-      <div class="panel-footer">
-          {{ include('@MauticCore/Helper/pagination.html.twig', {
-                  'totalItems': totalItems,
-                  'page': page,
-                  'limit': limit,
-                  'baseUrl': path('mautic_contactfield_index'),
-                  'sessionVar': 'leadfield',
-          }) }}
-      </div>
   {% else %}
       {{ include('@MauticCore/Helper/noresults.html.twig') }}
   {% endif %}

--- a/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
@@ -23,52 +23,68 @@
 {% block headerTitle %}{{ 'mautic.lead.field.header.index'|trans }}{% endblock %}
 
 {% block content %}
-  {% if isIndex %}
-    <div id="page-list-wrapper" class="panel panel-default">
-        {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
-            'searchValue': searchValue,
-            'action': currentRoute,
-            'page_actions': {
-                'templateButtons': {
-                    'new': true,
-                },
-                'routeBase': 'contactfield',
-                'langVar': 'lead.field',
-            },
-            'bulk_actions': {
-                'langVar': 'lead.field',
-                'routeBase': 'contactfield',
-                'templateButtons': {
-                    'delete': permissions['lead:fields:full'],
-                },
-            },
-        }) }}
-        <div class="page-list">
-  {% endif %}
+{% if isIndex %}
+<div id="page-list-wrapper">
+    <div class="page-list">
+{% endif %}
 
-  {% if items|length > 0 %}
-      {# Group items by object #}
-      {% set groupedItems = {} %}
-      {% set objectTotals = {} %}
-      {% for item in items %}
-          {% set objectKey = item.object %}
-          {% if groupedItems[objectKey] is not defined %}
-              {% set groupedItems = groupedItems|merge({(objectKey): []}) %}
-              {% set objectTotals = objectTotals|merge({(objectKey): 0}) %}
-          {% endif %}
-          {% set groupedItems = groupedItems|merge({
-              (objectKey): groupedItems[objectKey]|merge([item])
-          }) %}
-          {% set objectTotals = objectTotals|merge({
-              (objectKey): objectTotals[objectKey] + 1
-          }) %}
-      {% endfor %}
+  {# Group items by object #}
+  {% set groupedItems = {} %}
+  {% set objectTotals = {} %}
+  {% set objects = ['lead', 'company'] %}
 
-      {# Prepare tabs array #}
-      {% set tabsContent = [] %}
-      {% for objectKey, objectItems in groupedItems %}
-          {% set tableContent %}
-              <div class="table-responsive">
+  {% for item in items %}
+      {% set objectKey = item.object %}
+      {% if objectKey not in objects %}
+          {% set objects = objects|merge([objectKey]) %}
+      {% endif %}
+      {% if groupedItems[objectKey] is not defined %}
+          {% set groupedItems = groupedItems|merge({(objectKey): []}) %}
+          {% set objectTotals = objectTotals|merge({(objectKey): 0}) %}
+      {% endif %}
+      {% set groupedItems = groupedItems|merge({
+          (objectKey): groupedItems[objectKey]|merge([item])
+      }) %}
+      {% set objectTotals = objectTotals|merge({
+          (objectKey): objectTotals[objectKey] + 1
+      }) %}
+  {% endfor %}
+
+  {# Prepare tabs array #}
+  {% set tabsContent = [] %}
+  {% for objectKey in objects %}
+      {% if groupedItems[objectKey] is not defined %}
+          {% set groupedItems = groupedItems|merge({(objectKey): []}) %}
+          {% set objectTotals = objectTotals|merge({(objectKey): 0}) %}
+      {% endif %}
+
+      {% set tableContent %}
+      <div class="panel panel-default mt-lg">
+          {{ include('@MauticCore/Helper/list_toolbar.html.twig', {
+              'searchValue': searchValue,
+              'overlayTarget': '.table-responsive',
+              'action': path('mautic_contactfield_index', {'object': objectKey}),
+              'searchHelp': 'mautic.lead.field.help.searchcommands',
+              'page_actions': {
+                  'templateButtons': {
+                      'new': true,
+                  },
+                  'routeBase': 'contactfield',
+                  'langVar': 'lead.field',
+                  'routeParameters': {'object': objectKey},
+              },
+              'bulk_actions': {
+                  'langVar': 'lead.field',
+                  'routeBase': 'contactfield',
+                  'templateButtons': {
+                      'delete': permissions['lead:fields:full'],
+                  },
+              },
+          }) }}
+
+          {% if groupedItems[objectKey]|length > 0 %}
+
+              <div class="table-responsive pos-relative">
                   <table class="table table-hover leadfield-list" id="leadFieldTable_{{ objectKey }}" class="overflow:auto">
                       <thead>
                       <tr>
@@ -86,7 +102,7 @@
                       </tr>
                       </thead>
                       <tbody>
-                      {% for item in objectItems %}
+                      {% for item in groupedItems[objectKey] %}
                           <tr id="field_{{ item.id }}">
                               <td><i class="ri-xl ri-draggable text-secondary"></i></td>
                               <td>
@@ -100,6 +116,7 @@
                                           'routeBase': 'contactfield',
                                           'langVar': 'lead.field',
                                           'pull': 'left',
+                                          'routeParameters': {'object': objectKey},
                                   }) }}
                               </td>
                               <td>
@@ -110,7 +127,7 @@
                                               'disableToggle': item.disablePublishChange,
                                               'aditionalLabel': (item.columnIsNotCreated ? 'mautic.lead.field.being_created_in_background'|trans : '') ~ (item.getColumnIsNotRemoved() ? 'mautic.lead.field.being_removed_in_background'|trans : ''),
                                   }) }}
-                                  <a href="{{ path('mautic_contactfield_action', {'objectAction': 'edit', 'objectId': item.id}) }}">{{ item.label }}</a>
+                                  <a href="{{ path('mautic_contactfield_action', {'objectAction': 'edit', 'objectId': item.id, 'object': objectKey}) }}">{{ item.label }}</a>
                                   {{ customContent('lead.field.name', _context) }}
                               </span>
                               </td>
@@ -156,22 +173,26 @@
                           'queryString': 'object=' ~ objectKey
                   }) }}
               </div>
-          {% endset %}
+          {% else %}
+              {{ include('@MauticCore/Helper/noresults.html.twig', {
+                  'message': 'mautic.core.noresults.tip'|trans({
+                      '%searchValue%': searchValue
+                  })
+              }) }}
+          {% endif %}
+      </div>
+      {% endset %}
 
-          {% set tabsContent = tabsContent|merge([{
-              'title': 'mautic.' ~ objectKey ~ '.' ~ objectKey,
-              'content': tableContent
-          }]) %}
-      {% endfor %}
+      {% set tabsContent = tabsContent|merge([{
+          'title': 'mautic.' ~ objectKey ~ '.' ~ objectKey,
+          'content': tableContent
+      }]) %}
+  {% endfor %}
 
-      {{ include('@MauticCore/Helper/nav_tabs.html.twig', {
-          'tabs': tabsContent,
-          'style': 'contained'
-      }) }}
-
-  {% else %}
-      {{ include('@MauticCore/Helper/noresults.html.twig') }}
-  {% endif %}
+  {{ include('@MauticCore/Helper/nav_tabs.html.twig', {
+      'tabs': tabsContent,
+      'style': 'line'
+  }) }}
 
   {% if isIndex %}
         </div>

--- a/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
@@ -47,86 +47,113 @@
   {% endif %}
 
   {% if items|length > 0 %}
-      <div class="table-responsive">
-          <table class="table table-hover leadfield-list" id="leadFieldTable" class="overflow:auto">
-              <thead>
-              <tr>
-                  <th class="col-leadfield-orderhandle"></th>
-                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
-                    'checkall': 'true',
-                    'target': '#leadFieldTable',
-                }) }}
-                  <th class="col-leadfield-label">{{ 'mautic.lead.field.label'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-alias">{{ 'mautic.core.alias'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-group">{{ 'mautic.lead.field.object'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-group">{{ 'mautic.lead.field.group'|trans }}</th>
-                  <th class="col-leadfield-type">{{ 'mautic.lead.field.type'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-id">{{ 'mautic.core.id'|trans }}</th>
-                  <th class="visible-sm visible-md visible-lg col-leadfield-statusicons"></th>
-              </tr>
-              </thead>
-              <tbody>
-              {% for item in items %}
-                  <tr id="field_{{ item.id }}">
-                      <td><i class="ri-xl ri-draggable text-secondary"></i></td>
-                      <td>
-                          {{ include('@MauticCore/Helper/list_actions.html.twig', {
-                                  'item': item,
-                                  'templateButtons': {
-                                      'edit': item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
-                                      'clone': item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
-                                      'delete': item.isFixed or item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
-                                  },
-                                  'routeBase': 'contactfield',
-                                  'langVar': 'lead.field',
-                                  'pull': 'left',
+      {# Group items by object #}
+      {% set groupedItems = {} %}
+      {% for item in items %}
+          {% set objectKey = item.object %}
+          {% if groupedItems[objectKey] is not defined %}
+              {% set groupedItems = groupedItems|merge({(objectKey): []}) %}
+          {% endif %}
+          {% set groupedItems = groupedItems|merge({
+              (objectKey): groupedItems[objectKey]|merge([item])
+          }) %}
+      {% endfor %}
+
+      {# Prepare tabs array #}
+      {% set tabsContent = [] %}
+      {% for objectKey, objectItems in groupedItems %}
+          {% set tableContent %}
+              <div class="table-responsive">
+                  <table class="table table-hover leadfield-list" id="leadFieldTable_{{ objectKey }}" class="overflow:auto">
+                      <thead>
+                      <tr>
+                          <th class="col-leadfield-orderhandle"></th>
+                          {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                              'checkall': 'true',
+                              'target': '#leadFieldTable_' ~ objectKey,
                           }) }}
-                      </td>
-                      <td>
-                      <span class="ellipsis">
-                          {{ include('@MauticCore/Helper/publishstatus_icon.html.twig', {
-                                      'item': item,
-                                      'model': 'lead.field',
-                                      'disableToggle': item.disablePublishChange,
-                                      'aditionalLabel': (item.columnIsNotCreated ? 'mautic.lead.field.being_created_in_background'|trans : '') ~ (item.getColumnIsNotRemoved() ? 'mautic.lead.field.being_removed_in_background'|trans : ''),
-                          }) }}
-                          <a href="{{ path('mautic_contactfield_action', {'objectAction': 'edit', 'objectId': item.id}) }}">{{ item.label }}</a>
-                          {{ customContent('lead.field.name', _context) }}
-                      </span>
-                      </td>
-                      <td class="visible-md visible-lg">{{ item.alias }}</td>
-                      <td class="visible-md visible-lg">{{ ('mautic.'~item.object~'.'~item.object)|trans }}</td>
-                      <td class="visible-md visible-lg">{{ ('mautic.lead.field.group.'~item.group)|trans }}</td>
-                      <td>{{ translatorConditional('mautic.core.type.'~item.type, 'mautic.lead.field.type.'~item.type) }}</td>
-                      <td class="visible-md visible-lg">{{ item.id }}</td>
-                      <td class="visible-sm visible-md visible-lg">
-                          {% if item.isRequired %}
-                              <i class="ri-asterisk" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.required'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isVisible %}
-                              <i class="ri-eye-line-slash" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.invisible'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isFixed %}
-                              <i class="ri-lock-fill" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.fixed'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isListable %}
-                              <i class="ri-list-check " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.listable'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isPubliclyUpdatable %}
-                              <i class="ri-earth-line text-danger " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.public'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isUniqueIdentifer %}
-                              <i class="ri-key-2-line " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.isuniqueidentifer'|trans }}"></i>
-                          {% endif %}
-                          {% if item.isIsIndex %}
-                              <i class="ri-key-2-line " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.isindex'|trans }}"></i>
-                          {% endif %}
-                      </td>
-                  </tr>
-              {% endfor %}
-              </tbody>
-          </table>
-      </div>
+                          <th class="col-leadfield-label">{{ 'mautic.lead.field.label'|trans }}</th>
+                          <th class="visible-md visible-lg col-leadfield-alias">{{ 'mautic.core.alias'|trans }}</th>
+                          <th class="visible-md visible-lg col-leadfield-group">{{ 'mautic.lead.field.group'|trans }}</th>
+                          <th class="col-leadfield-type">{{ 'mautic.lead.field.type'|trans }}</th>
+                          <th class="visible-md visible-lg col-leadfield-id">{{ 'mautic.core.id'|trans }}</th>
+                          <th class="visible-sm visible-md visible-lg col-leadfield-statusicons"></th>
+                      </tr>
+                      </thead>
+                      <tbody>
+                      {% for item in objectItems %}
+                          <tr id="field_{{ item.id }}">
+                              <td><i class="ri-xl ri-draggable text-secondary"></i></td>
+                              <td>
+                                  {{ include('@MauticCore/Helper/list_actions.html.twig', {
+                                          'item': item,
+                                          'templateButtons': {
+                                              'edit': item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
+                                              'clone': item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
+                                              'delete': item.isFixed or item.getColumnIsNotRemoved() ? false : permissions['lead:fields:full'],
+                                          },
+                                          'routeBase': 'contactfield',
+                                          'langVar': 'lead.field',
+                                          'pull': 'left',
+                                  }) }}
+                              </td>
+                              <td>
+                              <span class="ellipsis">
+                                  {{ include('@MauticCore/Helper/publishstatus_icon.html.twig', {
+                                              'item': item,
+                                              'model': 'lead.field',
+                                              'disableToggle': item.disablePublishChange,
+                                              'aditionalLabel': (item.columnIsNotCreated ? 'mautic.lead.field.being_created_in_background'|trans : '') ~ (item.getColumnIsNotRemoved() ? 'mautic.lead.field.being_removed_in_background'|trans : ''),
+                                  }) }}
+                                  <a href="{{ path('mautic_contactfield_action', {'objectAction': 'edit', 'objectId': item.id}) }}">{{ item.label }}</a>
+                                  {{ customContent('lead.field.name', _context) }}
+                              </span>
+                              </td>
+                              <td class="visible-md visible-lg">{{ item.alias }}</td>
+                              <td class="visible-md visible-lg">{{ ('mautic.lead.field.group.'~item.group)|trans }}</td>
+                              <td>{{ translatorConditional('mautic.core.type.'~item.type, 'mautic.lead.field.type.'~item.type) }}</td>
+                              <td class="visible-md visible-lg">{{ item.id }}</td>
+                              <td class="visible-sm visible-md visible-lg">
+                                  {% if item.isRequired %}
+                                      <i class="ri-asterisk" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.required'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isVisible %}
+                                      <i class="ri-eye-line-slash" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.invisible'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isFixed %}
+                                      <i class="ri-lock-fill" data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.fixed'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isListable %}
+                                      <i class="ri-list-check " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.listable'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isPubliclyUpdatable %}
+                                      <i class="ri-earth-line text-danger " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.public'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isUniqueIdentifer %}
+                                      <i class="ri-key-2-line " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.isuniqueidentifer'|trans }}"></i>
+                                  {% endif %}
+                                  {% if item.isIsIndex %}
+                                      <i class="ri-key-2-line " data-toggle="tooltip" data-placement="left" title="{{ 'mautic.lead.field.tooltip.isindex'|trans }}"></i>
+                                  {% endif %}
+                              </td>
+                          </tr>
+                      {% endfor %}
+                      </tbody>
+                  </table>
+              </div>
+          {% endset %}
+
+          {% set tabsContent = tabsContent|merge([{
+              'title': 'mautic.' ~ objectKey ~ '.' ~ objectKey,
+              'content': tableContent
+          }]) %}
+      {% endfor %}
+
+      {{ include('@MauticCore/Helper/nav_tabs.html.twig', {
+          'tabs': tabsContent,
+          'style': 'contained'
+      }) }}
+
       <div class="panel-footer">
           {{ include('@MauticCore/Helper/pagination.html.twig', {
                   'totalItems': totalItems,

--- a/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
@@ -88,7 +88,6 @@
                   <table class="table table-hover leadfield-list" id="leadFieldTable_{{ objectKey }}" class="overflow:auto">
                       <thead>
                       <tr>
-                          <th class="col-leadfield-orderhandle"></th>
                           {{ include('@MauticCore/Helper/tableheader.html.twig', {
                               'checkall': 'true',
                               'target': '#leadFieldTable_' ~ objectKey,
@@ -104,7 +103,6 @@
                       <tbody>
                       {% for item in groupedItems[objectKey] %}
                           <tr id="field_{{ item.id }}">
-                              <td><i class="ri-xl ri-draggable text-secondary"></i></td>
                               <td>
                                   {{ include('@MauticCore/Helper/list_actions.html.twig', {
                                           'item': item,

--- a/plugins/MauticFocusBundle/Assets/css/focus.css
+++ b/plugins/MauticFocusBundle/Assets/css/focus.css
@@ -24,6 +24,7 @@
   right: 0;
   left: 0;
   margin: auto;
+  z-index: 0;
 }
 .focus-builder #websiteScreenshot .screenshot-container {
   overflow: hidden;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR makes the custom fields page separate different object in tabs

![image](https://github.com/user-attachments/assets/e974ebad-5771-46a3-9d5b-604a0c841831)

Also removes ordering that doesn't work at all; supports custom objects

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Custom fields
3. Open both tabs

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->