### PR TITLE
[UXUI-63] Campaign share tab shows all campaigns when viewing segment

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -183,6 +183,7 @@
                         </thead>
                         <tbody>
                         {% for stat in campaignStats %}
+                            {% if stat.share is not empty %}
                             <tr>
                                 <td>
                                     <a href="{{ path('mautic_campaign_action', {'objectAction': 'view', 'objectId': stat.id}) }}" data-toggle="ajax">
@@ -194,6 +195,7 @@
                                           id="campaign-share-stat-{{ stat.id }}">{{ stat.share }}</span> %
                                 </td>
                             </tr>
+                            {% endif %}
                         {% endfor %}
                         </tbody>
                     </table>

--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -174,31 +174,35 @@
 
             <div class="tab-pane bdr-w-0 page-list" id="campaign-container">
                 <div id="campaign-share-container" style="position: relative">
-                    <table id="campaign-share-table" class="table table-hover mb-0">
-                        <thead>
-                        <tr>
-                            <th>{{ 'mautic.campaign.campaign'|trans }}</th>
-                            <th>{{ 'mautic.lead.share'|trans }}</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for stat in campaignStats %}
-                            {% if stat.share is not empty %}
+                    {% if campaignStats|filter(stat => stat.share is not empty)|length > 0 %}
+                        <table id="campaign-share-table" class="table table-hover mb-0">
+                            <thead>
                             <tr>
-                                <td>
-                                    <a href="{{ path('mautic_campaign_action', {'objectAction': 'view', 'objectId': stat.id}) }}" data-toggle="ajax">
-                                        {{- stat.name -}}
-                                    </a>
-                                </td>
-                                <td width="20%">
-                                    <span class="campaign-share-stat" data-value="{{ stat.id }}"
-                                          id="campaign-share-stat-{{ stat.id }}">{{ stat.share }}</span> %
-                                </td>
+                                <th>{{ 'mautic.campaign.campaign'|trans }}</th>
+                                <th>{{ 'mautic.lead.share'|trans }}</th>
                             </tr>
-                            {% endif %}
-                        {% endfor %}
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                            {% for stat in campaignStats %}
+                                {% if stat.share is not empty %}
+                                <tr>
+                                    <td>
+                                        <a href="{{ path('mautic_campaign_action', {'objectAction': 'view', 'objectId': stat.id}) }}" data-toggle="ajax">
+                                            {{- stat.name -}}
+                                        </a>
+                                    </td>
+                                    <td width="20%">
+                                        <span class="campaign-share-stat" data-value="{{ stat.id }}"
+                                              id="campaign-share-stat-{{ stat.id }}">{{ stat.share }}</span> %
+                                    </td>
+                                </tr>
+                                {% endif %}
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        {{ include('@MauticCore/Helper/no_information.html.twig', {'tip': 'mautic.lead.campaign.share.no_results'|trans}) }}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/bundles/LeadBundle/Translations/en_US/messages.ini
+++ b/app/bundles/LeadBundle/Translations/en_US/messages.ini
@@ -1041,6 +1041,7 @@ mautic.channel.stat.leadcount.tooltip="Details may not match summary numbers if 
 mautic.lead.segments.usages="Segment usages"
 mautic.lead.segments.no_usages="Looks like this segment is not in use."
 mautic.lead.campaign.share="Campaign share"
+mautic.lead.campaign.share.no_results="This segment isn't being used in any campaigns yet. Add it to a campaign to start engaging with these contacts!"
 mautic.lead.share="Share"
 mautic.lead.field.notfound="Lead Field was not found"
 mautic.lead.field.column_was_created="Column with ID %id% was created"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

When viewing segments, you can see the Campaign share stats. The screen displays all existing active campaigns, even when the segment is not in use.
This PR hides campaigns without a share value and displays a message when no campaigns are available.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->

| Before                                 | After
| -------------------------------------- | ---
|  ![image](https://github.com/user-attachments/assets/98103576-e2a5-47ea-9917-a52fafc52715)                                      |  ![image](https://github.com/user-attachments/assets/cb54972c-15ff-42d2-8f8a-1b0642a424a0)




---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Segments > New > Fill info > Save & Close
3. Viewing the segment details, open the tab Campaign Share and see the no results message for a segment not in use

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->