### PR TITLE
handle date and date time in report filters #14710

### DIFF
--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -5,7 +5,6 @@ namespace Mautic\ReportBundle\Form\DataTransformer;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 
 /**

--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -36,7 +36,7 @@ class ReportFilterDataTransformer implements DataTransformerInterface
                 return $filters;
             }
             $type = $this->columns[$f['column']]['type'];
-            if (in_array($type, ['datetime', 'time', DateTimeType::class, DateType::class, TimeType::class])) {
+            if (in_array($type, ['datetime', 'time', DateTimeType::class, TimeType::class])) {
                 $dt         = new DateTimeHelper($f['value'], '', 'utc');
                 $f['value'] = $dt->toLocalString();
             }

--- a/app/bundles/ReportBundle/Tests/Form/ReportFilterDataTransformerTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/ReportFilterDataTransformerTest.php
@@ -13,7 +13,7 @@ class ReportFilterDataTransformerTest extends TestCase
     {
         $columns = [
             'date_only' => ['type' => DateType::class],
-            'datetime' => ['type' => DateTimeType::class],
+            'datetime'  => ['type' => DateTimeType::class],
         ];
 
         $transformer = new ReportFilterDataTransformer($columns);
@@ -33,19 +33,19 @@ class ReportFilterDataTransformerTest extends TestCase
     }
 
     /**
-     * Test that this change also works correctly in the reverseTransform method
+     * Test that this change also works correctly in the reverseTransform method.
      */
     public function testReverseTransformWithDateType(): void
     {
         $columns = [
-            'date_column' => ['type' => DateType::class],
+            'date_column'     => ['type' => DateType::class],
             'datetime_column' => ['type' => 'datetime'],
         ];
 
         $transformer = new ReportFilterDataTransformer($columns);
 
         $dateValue = '2023-05-15';
-        $filters = [
+        $filters   = [
             ['column' => 'date_column', 'value' => $dateValue],
             ['column' => 'datetime_column', 'value' => $dateValue],
         ];

--- a/app/bundles/ReportBundle/Tests/Form/ReportFilterDataTransformerTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/ReportFilterDataTransformerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Mautic\ReportBundle\Tests\Form;
+
+use Mautic\ReportBundle\Form\DataTransformer\ReportFilterDataTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+class ReportFilterDataTransformerTest extends TestCase
+{
+    public function testDateTypeKeepsOriginalFormat(): void
+    {
+        $columns = [
+            'date_only' => ['type' => DateType::class],
+            'datetime' => ['type' => DateTimeType::class],
+        ];
+
+        $transformer = new ReportFilterDataTransformer($columns);
+
+        $dateOnlyValue = '2023-05-15';
+
+        $filters = [
+            ['column' => 'date_only', 'value' => $dateOnlyValue],
+            ['column' => 'datetime', 'value' => $dateOnlyValue],
+        ];
+
+        $transformedFilters = $transformer->transform($filters);
+
+        // DateType should preserve the original format without adding a time component
+        $this->assertEquals($dateOnlyValue, $transformedFilters[0]['value'],
+            'DateType should preserve the exact format without time component');
+    }
+
+    /**
+     * Test that this change also works correctly in the reverseTransform method
+     */
+    public function testReverseTransformWithDateType(): void
+    {
+        $columns = [
+            'date_column' => ['type' => DateType::class],
+            'datetime_column' => ['type' => 'datetime'],
+        ];
+
+        $transformer = new ReportFilterDataTransformer($columns);
+
+        $dateValue = '2023-05-15';
+        $filters = [
+            ['column' => 'date_column', 'value' => $dateValue],
+            ['column' => 'datetime_column', 'value' => $dateValue],
+        ];
+
+        $transformedFilters = $transformer->reverseTransform($filters);
+
+        // DateType should not be transformed in reverse transformation either
+        $this->assertEquals($dateValue, $transformedFilters[0]['value'],
+            'DateType should not be transformed in reverseTransform');
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Update https://github.com/mautic/mautic/pull/14710 with tests



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->

This PR handle Date value in report filters. A random hour is put when selecting a date in the segment filter when this field is a date type.
Then on reporting if you use relative dates (yesterday) then it doesn't include the full day of yesterday because of the random hour.


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Create a custom field with Date type
2. Go to reports > Filters > Add your field and set "equals to some date"
3. On edit, the filter value should stay correct