### PR TITLE
Validation to prevent using DWC within DWC

### DIFF
--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -16,6 +16,7 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Entity\VariantEntityTrait;
+use Mautic\DynamicContentBundle\Validator\Constraints\NoNesting;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -201,6 +202,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     public static function loadValidatorMetaData(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new NotBlank(['message' => 'mautic.core.name.required']));
+        $metadata->addPropertyConstraint('content', new NoNesting());
 
         $metadata->addConstraint(new Callback([
             'callback' => function (self $dwc, ExecutionContextInterface $context): void {

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\DynamicContentBundle\Tests\Unit\Validator\Constraints;
+
+use Mautic\DynamicContentBundle\Validator\Constraints\NoNesting;
+use Mautic\DynamicContentBundle\Validator\Constraints\NoNestingValidator;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class NoNestingValidatorTest extends TestCase
+{
+    private const TRANSLATED_MESSAGE = 'DWC tokens cannot be used within another DWC.';
+    private NoNesting $constraint;
+    private NoNestingValidator $validator;
+    private ExecutionContextInterface $context;
+
+    protected function setUp(): void
+    {
+        $this->constraint = new NoNesting();
+        $this->validator  = new NoNestingValidator();
+        $this->context    = $this->createContext();
+        $this->context->setConstraint($this->constraint);
+        $this->validator->initialize($this->context);
+    }
+
+    public function testValidateWithInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage(sprintf('Expected argument of type "%s"', NoNesting::class));
+        $this->validator->validate('value', new NotBlank());
+    }
+
+    public function testValidateWithInvalidType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "string", "stdClass" given');
+        $this->validator->validate(new \stdClass(), $this->constraint);
+    }
+
+    public function testValidateWithNull(): void
+    {
+        $this->validator->validate(null, $this->constraint);
+        Assert::assertCount(0, $this->context->getViolations(), 'No violation should be added for a null value.');
+    }
+
+    public function testValidateWithValidValue(): void
+    {
+        $this->validator->validate('Some valid value', $this->constraint);
+        Assert::assertCount(0, $this->context->getViolations(), 'No violation should be added for a valid value.');
+    }
+
+    public function testValidateWithInvalidValue(): void
+    {
+        $this->validator->validate('Some invalid value {dwc=some}', $this->constraint);
+        Assert::assertCount(1, $this->context->getViolations(), 'There should be one violation for an invalid value.');
+        Assert::assertSame(self::TRANSLATED_MESSAGE, $this->context->getViolations()->get(0)->getMessage());
+    }
+
+    private function createContext(): ExecutionContextInterface
+    {
+        $locale     = 'en_US';
+        $validator  = $this->createMock(ValidatorInterface::class);
+        $translator = new Translator($locale);
+        $translator->addLoader('array', new ArrayLoader());
+
+        $translator->addResource('array', [
+            'mautic.dynamicContent.no_nesting' => self::TRANSLATED_MESSAGE,
+        ], $locale, 'validators');
+
+        return new ExecutionContext($validator, null, $translator, 'validators');
+    }
+}

--- a/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
+++ b/app/bundles/DynamicContentBundle/Translations/en_US/messages.ini
@@ -1,5 +1,5 @@
-mautic.dynamicContent.dynamicContent="Dynamic Content"
-mautic.dynamicContent.dynamicContents="Dynamic Contents"
+mautic.dynamicContent.dynamicContent="Dynamic Web Content"
+mautic.dynamicContent.dynamicContents="Dynamic Web Content"
 
 mautic.placeholder_tokens.dynamic_content_tokens="Dynamic Content"
 mautic.placeholder_tokens.dynamic_content.example="[Dynamic Content 1] | for example User-defined variable name"

--- a/app/bundles/DynamicContentBundle/Translations/en_US/validators.ini
+++ b/app/bundles/DynamicContentBundle/Translations/en_US/validators.ini
@@ -1,3 +1,4 @@
 mautic.dynamicContent.name.notblank="Please enter a name."
 mautic.dynamicContent.slot_name.notblank="Please enter a slot name."
 mautic.dynamicContent.filter.options.empty="At least one filter is required."
+mautic.dynamicContent.no_nesting="DWC tokens cannot be used within another DWC. Please remove any DWC tokens from the content to proceed."

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\DynamicContentBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * This constraint checks if the content does not include another DWC token.
+ */
+class NoNesting extends Constraint
+{
+    public string $message = 'mautic.dynamicContent.no_nesting';
+}

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/NoNestingValidator.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/NoNestingValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\DynamicContentBundle\Validator\Constraints;
+
+use Mautic\DynamicContentBundle\Helper\DynamicContentHelper;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class NoNestingValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof NoNesting) {
+            throw new UnexpectedTypeException($constraint, NoNesting::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (preg_match(DynamicContentHelper::DYNAMIC_WEB_CONTENT_REGEX, $value)) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds a new validation that prevents putting a dynamic web content token into another dynamic web content. It also renames the menu item from Dynamic Content to Dynamic Web Content.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Navigate to `/s/dwc/new`.
2. Enter `{dwc=some}` into the `Content` field.
3. Click the `Save` button.
4. You should see the following validation error message below the `Content` field.
    ```
    DWC tokens cannot be used within another DWC. Please remove any DWC tokens from the content to proceed.
    ```
5. Validate the above steps for editing an existing dynamic web content.
6. Make sure that the menu item no longer reads `Dynamic Content`. It should be renamed to `Dynamic Web Content`.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->