### PR TITLE
[UXUI-113] Move Landing pages and Focus items location under menus

### DIFF
--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -75,7 +75,7 @@ return [
                 'mautic.page.pages' => [
                     'route'    => 'mautic_page_index',
                     'access'   => ['page:pages:viewown', 'page:pages:viewother'],
-                    'parent'   => 'mautic.core.components',
+                    'parent'   => 'mautic.core.channels',
                     'priority' => 100,
                 ],
             ],

--- a/plugins/MauticFocusBundle/Config/config.php
+++ b/plugins/MauticFocusBundle/Config/config.php
@@ -66,7 +66,7 @@ return [
             'mautic.focus' => [
                 'route'    => 'mautic_focus_index',
                 'access'   => 'focus:items:view',
-                'parent'   => 'mautic.core.channels',
+                'parent'   => 'mautic.core.components',
                 'priority' => 10,
             ],
         ],


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

### Impact

The bug affects the organization of landing pages and focus items in the system. Users may find it confusing as landing pages are not placed under Channels and focus items are not under Components.

### Expected behaviour

Landing pages should be located under Channels. Focus items should be placed under Components.

### Actual behaviour

Currently, landing pages and focus items are not organized correctly. They are not placed under their respective categories.

### Other information

This change considers Channels as self-contained items. Landing pages do not need to be placed on a website or similar workflow. Components depend on a container where they will be placed. Focus items need to be inserted into a website or page to work. This organization aligns with other resources, and only these two need changes.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to the Channels menu where landing pages are now listed.
3. Check the current location of landing pages.
4. Navigate to the Components menu where focus items are now listed.
5. Check the current location of focus items.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->