### PR TITLE
Fix #12795: Missing class on Points > Manage Group menu

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -923,7 +923,7 @@ Mautic.ajaxifyLink = function (el, event) {
 
     var link = mQuery(el).attr('data-menu-link');
     if (link !== undefined && link.charAt(0) != '#') {
-        link = "#" + link;
+        link = "#" + CSS.escape(link);
     }
 
     var method = mQuery(el).attr('data-method');

--- a/tests/_support/Page/Acceptance/MenuPage.php
+++ b/tests/_support/Page/Acceptance/MenuPage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Page\Acceptance;
+
+class MenuPage
+{
+    public static $ADMIN_USER       = 'admin';
+    public static $ADMIN_PASSWORD   = 'Maut1cR0cks!';
+    public static $URL              = '/s/dashboard';
+    public static $POINTS           = 'Points';
+    public static $MANAGE_GROUPS    = 'Manage Groups';
+    public static $MANAGE_GROUPS_ID = '#mautic_point.group_index';
+    public static $ACTIVE_NAV_GROUP = '.nav-group.last.active';
+}

--- a/tests/_support/Step/Acceptance/MenuStep.php
+++ b/tests/_support/Step/Acceptance/MenuStep.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Step\Acceptance;
+
+use Page\Acceptance\MenuPage;
+
+class MenuStep extends \AcceptanceTester
+{
+    public function loginAsAdmin($I): void
+    {
+        $I->login(MenuPage::$ADMIN_USER, MenuPage::$ADMIN_PASSWORD);
+        $I->amOnPage(MenuPage::$URL);
+    }
+
+    public function navigateToManageGroups(): void
+    {
+        $I = $this;
+        $I->click(MenuPage::$POINTS);
+        $I->waitForElementClickable(MenuPage::$MANAGE_GROUPS_ID, 10);
+        $I->click(MenuPage::$MANAGE_GROUPS);
+        $I->waitForElementVisible(MenuPage::$ACTIVE_NAV_GROUP, 10);
+        $I->seeElement(MenuPage::$ACTIVE_NAV_GROUP);
+    }
+}

--- a/tests/acceptance/MenuNavigationCest.php
+++ b/tests/acceptance/MenuNavigationCest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acceptance;
+
+use Step\Acceptance\MenuStep;
+
+final class MenuNavigationCest
+{
+    public function _before(\AcceptanceTester $I, MenuStep $menuStep): void
+    {
+        $menuStep->loginAsAdmin($I);
+    }
+
+    public function ensureManageGroupsHighlights(MenuStep $menuStep): void
+    {
+        $menuStep->navigateToManageGroups();
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #12795 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
The "Manage Groups" menu item under "Points" didn’t display the expected active state. The visual indicator (dot) before the item was missing, making it unclear which page was selected.


The issue occurred because CSS misinterpreted the group’s ID (mautic_point.group_index), treating the dot as a class separator instead of part of the ID. This was fixed by applying CSS.escape() to ensure proper handling. Tests were also added to verify the fix and prevent regressions.

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/user-attachments/assets/a7d42729-8748-4939-81ec-3c826b2eead7) | ![After Image](https://github.com/user-attachments/assets/35afa17f-fdf0-4289-b3ff-84955d267117) |

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Click on the “Points” side menu
3. Click on “Manage Groups”
4. Check the visual indicator (dot)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->