### PR TITLE
DPMMA-3096 Fix report boolean fields

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
@@ -31,9 +31,13 @@ class ReportNormalizeSubscriber implements EventSubscriberInterface
         $fields = $this->fieldModel->getRepository()->getFields();
         $rows   = $event->getData();
         foreach ($rows as $key => $row) {
-            foreach ($row as $key2 => $value) {
-                if (isset($fields[$key2])) {
-                    $rows[$key][$key2] = CustomFieldValueHelper::normalize($value, $fields[$key2]['type'] ?? null, $fields[$key2]['properties'] ?? []);
+            foreach ($row as $alias => $value) {
+                if (isset($fields[$alias])) {
+                    $type               = $fields[$alias]['type'] ?? null;
+                    $rows[$key][$alias] = CustomFieldValueHelper::normalize($value, $type, $fields[$alias]['properties'] ?? []);
+                    if ('boolean' === $type) {
+                        $event->updateColumnType($alias, 'normalized_bool');
+                    }
                 }
             }
         }

--- a/app/bundles/ReportBundle/Event/ReportDataEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportDataEvent.php
@@ -47,4 +47,14 @@ class ReportDataEvent extends AbstractReportEvent
     {
         return $this->totalResults;
     }
+
+    public function updateColumnType(string $alias, string $type): void
+    {
+        foreach ($this->options['columns'] as &$column) {
+            if ($column['alias'] === $alias) {
+                $column['type'] = $type;
+                break;
+            }
+        }
+    }
 }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -613,7 +613,8 @@ class ReportModel extends FormModel
             // Allow plugin to manipulate the data
             $event = new ReportDataEvent($entity, $data, $totalResults, $dataOptions);
             $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_DISPLAY);
-            $data = $event->getData();
+            $data        = $event->getData();
+            $dataOptions = $event->getOptions();
         }
 
         if ($this->isDebugMode()) {
@@ -642,7 +643,7 @@ class ReportModel extends FormModel
             'dataColumns'       => $dataColumns,
             'graphs'            => $graphs,
             'contentTemplate'   => $contentTemplate,
-            'columns'           => $tableDetails['columns'],
+            'columns'           => $dataOptions['columns'],
             'limit'             => ($paginate) ? $limit : 0,
             'page'              => ($paginate) ? $reportPage : 1,
             'dateFrom'          => $dataOptions['dateFrom'],


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14487. <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR addresses the issue where boolean custom fields in the Contact entity always showed as "Yes" in reports. It ensures that the correct boolean values are accurately displayed.

Before this PR:
The boolean fields were normalized in ReportNormalizeSubscriber to string values and then again passed to FormatterHelper::_ in the template. In result any normalized string was mapped to Yes.

This PR changes:
When the boolean fields are normalized in the `ReportNormalizeSubscriber`, the column type is changed to `normalized_bool` to prevent the double normalization in the template.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Repeat the steps from #14487

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->