### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,11 +1,11 @@
 {
-  "version": "6.0.0-rc",
-  "stability": "rc",
+  "version": "6.0.0",
+  "stability": "stable",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
   "minimum_mysql_version": "5.7.14",
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "5.0.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0-rc"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0"
 }


### PR DESCRIPTION
This PR bumps the version to 6.0.0 in preparation for the release.