### PR TITLE
Revert "Dynamic Content for pages: off campaign based by default"

### DIFF
--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -102,7 +102,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     /**
      * @var bool
      */
-    private $isCampaignBased = false;
+    private $isCampaignBased = true;
 
     /**
      * @var string|null

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
@@ -72,9 +72,8 @@ class DynamicContentApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testCreateDwc(): void
     {
         $payload = [
-            'name'            => 'API test',
-            'content'         => 'API test',
-            'isCampaignBased' => true,
+            'name'    => 'API test',
+            'content' => 'API test',
         ];
 
         $this->client->request(Request::METHOD_POST, '/api/dynamiccontents/new', $payload);


### PR DESCRIPTION
Reverts mautic/mautic#14678 because the [API library tests](https://github.com/mautic/api-library/commit/75b0b1ecd1dbc2fdf9f6bebd5c24d26980ac83f9/checks) started to fail with errors like 
```
14) Mautic\Tests\Api\DynamicContentsTest::testBatchEndpoints
slotName: Please enter a slot name., filters: At least one filter is required.; slotName: Please enter a slot name., filters: At least one filter is required.; slotName: Please enter a slot name., filters: At least one filter is required.

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:92
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:107
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:269
/home/runner/work/api-library/api-library/tests/Api/DynamicContentsTest.php:54

FAILURES!
Tests: 315, Assertions: 4851, Failures: 14, Skipped: 7.
```
So https://github.com/mautic/mautic/pull/14678 was in fact a BC break and shouldn't be added on the last minute to the M6.0.0. Let's plan that for M7.

This is essential as we cannot release Mautic 6.0.0 which is scheduled for today when the API Library tests are failing.