### PR TITLE
Fix #14379: Provided options in multiselect fields consolidate users, segments, etc. with same name

### DIFF
--- a/app/bundles/CategoryBundle/Controller/BatchContactController.php
+++ b/app/bundles/CategoryBundle/Controller/BatchContactController.php
@@ -77,7 +77,7 @@ class BatchContactController extends AbstractFormController
         $items = [];
 
         foreach ($rows as $category) {
-            $items[$category['title']] = $category['id'];
+            $items[$category['title'].' ('.$category['id'].')'] = $category['id'];
         }
 
         return $this->delegateView(

--- a/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
@@ -42,7 +42,7 @@ class CategoryListType extends AbstractType
                 $categories = $this->model->getLookupResults($options['bundle'], '', 0);
                 $choices    = [];
                 foreach ($categories as $l) {
-                    $choices[$l['title']] = $l['id'];
+                    $choices[$l['title'].' ('.$l['id'].')'] = $l['id'];
                 }
                 $choices[$createNew] = 'new';
 

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -44,7 +44,7 @@ class FormListType extends AbstractType
 
                 $forms = $repo->getFormList('', 0, 0, $viewOther, $options['form_type']);
                 foreach ($forms as $form) {
-                    $choices[$form['name']] = $form['id'];
+                    $choices[$form['name'].' ('.$form['id'].')'] = $form['id'];
                 }
 
                 // sort by language

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -81,7 +81,7 @@ class BatchSegmentController extends AbstractFormController
         $items = [];
 
         foreach ($lists as $list) {
-            $items[$list['name']] = $list['id'];
+            $items[$list['name'].' ('.$list['id'].')'] = $list['id'];
         }
 
         return $this->delegateView(

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1667,7 +1667,7 @@ class LeadController extends FormController
             $campaigns = $campaignModel->getPublishedCampaigns(true);
             $items     = [];
             foreach ($campaigns as $campaign) {
-                $items[$campaign['name']] = $campaign['id'];
+                $items[$campaign['name'].' ('.$campaign['id'].')'] = $campaign['id'];
             }
 
             $route = $this->generateUrl(
@@ -1849,7 +1849,7 @@ class LeadController extends FormController
             $stages = $model->getUserStages();
             $items  = [];
             foreach ($stages as $stage) {
-                $items[$stage['name']] = $stage['id'];
+                $items[$stage['name'].' ('.$stage['id'].')'] = $stage['id'];
             }
 
             $route = $this->generateUrl(
@@ -1951,7 +1951,7 @@ class LeadController extends FormController
             $users = $userModel->getRepository()->getUserList('', 0);
             $items = [];
             foreach ($users as $user) {
-                $items[$user['firstName'].' '.$user['lastName']] = $user['id'];
+                $items[$user['firstName'].' '.$user['lastName'].' ('.$user['id'].')'] = $user['id'];
             }
 
             $route = $this->generateUrl(

--- a/app/bundles/LeadBundle/Form/Type/LeadListType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadListType.php
@@ -28,9 +28,9 @@ class LeadListType extends AbstractType
                 $choices = [];
                 foreach ($lists as $l) {
                     if (empty($options['preference_center_only'])) {
-                        $choices[$l['name']] = $l['id'];
+                        $choices[$l['name'].' ('.$l['id'].')'] = $l['id'];
                     } else {
-                        $choices[empty($l['publicName']) ? $l['name'] : $l['publicName']] = $l['id'];
+                        $choices[empty($l['publicName']) ? $l['name'].' ('.$l['id'].')' : $l['publicName'].' ('.$l['id'].')'] = $l['id'];
                     }
                 }
 

--- a/app/bundles/PointBundle/Form/Type/GroupListType.php
+++ b/app/bundles/PointBundle/Form/Type/GroupListType.php
@@ -38,7 +38,7 @@ class GroupListType extends AbstractType
                 $groups  = $this->repo->getEntities();
                 $choices = [];
                 foreach ($groups as $l) {
-                    $choices[$l->getName()] = $l->getId();
+                    $choices[$l->getName().' ('.$l->getId().')'] = $l->getId();
                 }
 
                 return $choices;

--- a/app/bundles/UserBundle/Form/Type/UserListType.php
+++ b/app/bundles/UserBundle/Form/Type/UserListType.php
@@ -67,7 +67,7 @@ class UserListType extends AbstractType
         );
 
         foreach ($users as $user) {
-            $this->choices[$user->getName(true)] = $user->getId();
+            $this->choices[$user->getName(true).' ('.$user->getId().')'] = $user->getId();
         }
 
         // sort by user name

--- a/tests/acceptance/DisplayTestCest.php
+++ b/tests/acceptance/DisplayTestCest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Acceptance;
+
+use Page\Acceptance\EmailsPage;
+
+class DisplayTestCest
+{
+    public function _before(\AcceptanceTester $I)
+    {
+        $I->login('admin', 'Maut1cR0cks!');
+    }
+
+    // tests
+    public function testCampaignDisplay(\AcceptanceTester $I): void
+    {
+        // Go directly to the batch campaign selection page
+        $I->amOnPage('/s/contacts/batchCampaigns');
+
+        // Wait for the form to load
+        $I->waitForElementVisible('#lead_batch_add', 5);
+
+        // Grab the options inside the dropdown
+        $campaigns = $I->grabMultiple('#lead_batch_add option');
+
+        // Assert that each campaign follows the format "name (id)"
+        foreach ($campaigns as $campaign) {
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $campaign);
+        }
+    }
+
+    public function testCategoryDisplay(\AcceptanceTester $I): void
+    {
+        // Go directly to the batch category selection page
+        $I->amOnPage('/s/categories/batch/contact/view');
+
+        // Wait for the form to load
+        $I->waitForElementVisible('#lead_batch_add', 5);
+
+        // Grab the options inside the dropdown
+        $categories = $I->grabMultiple('#lead_batch_add option');
+
+        // Assert that each category follows the format "name (id)"
+        foreach ($categories as $category) {
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $category);
+        }
+    }
+
+    public function testOwnerDisplay(\AcceptanceTester $I): void
+    {
+        // Go directly to the batch owner selection page
+        $I->amOnPage('/s/contacts/batchOwners');
+
+        // Wait for the dropdown to be visible
+        $I->waitForElementVisible('#lead_batch_owner_addowner', 5);
+
+        // Grab the owner options from the dropdown
+        $owners = $I->grabMultiple('#lead_batch_owner_addowner option');
+
+        // Assert that each owner follows the format "name (id)"
+        foreach ($owners as $owner) {
+            if (empty($owner)) {
+                continue;
+            }
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $owner);
+        }
+    }
+
+    public function segmentDisplayTest(\AcceptanceTester $I): void
+    {
+        // Go directly to the batch segment selection page
+        $I->amOnPage('/s/segments/batch/contact/view');
+
+        // Wait for the form to load
+        $I->waitForElementVisible('#lead_batch_add', 5);
+
+        // Grab the options inside the dropdown
+        $segments = $I->grabMultiple('#lead_batch_add option');
+
+        // Assert that each segment follows the format "name (id)"
+        foreach ($segments as $segment) {
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $segment);
+        }
+    }
+
+    public function testStageDisplay(\AcceptanceTester $I): void
+    {
+        // Go directly to the batch stage selection page
+        $I->amOnPage('/s/contacts/batchStages');
+
+        // Wait for the form to load
+        $I->waitForElementVisible('#lead_batch_stage_addstage', 5);
+
+        // Grab the options inside the dropdown
+        $stages = $I->grabMultiple('#lead_batch_stage_addstage option');
+
+        // Assert that each stage follows the format "name (id)"
+        foreach ($stages as $stage) {
+            if (empty($stage)) {
+                continue;
+            }
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $stage);
+        }
+    }
+
+    public function testPointGroupDisplay(\AcceptanceTester $I): void
+    {
+        // Go to the page where point groups are managed
+        $I->amOnPage('/s/points/triggers/new');
+
+        // Wait for the dropdown to be visible
+        $I->waitForElementVisible('#pointtrigger_group_chosen', 5);
+
+        // Grab the point group options from the dropdown
+        $pointGroups = $I->grabMultiple('#pointtrigger_group_chosen option');
+
+        // Assert that each point group follows the format "name (id)"
+        foreach ($pointGroups as $pointGroup) {
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $pointGroup);
+        }
+    }
+
+    public function testFormDisplay(\AcceptanceTester $I): void
+    {
+        // Go to the page where point groups are managed
+        $I->amOnPage('/s/emails/new');
+
+        // Wait for the select button to appear
+        $I->waitForElementVisible(EmailsPage::$SELECT_SEGMENT_EMAIL, 5);
+
+        // Click the "Select" button to choose the email type
+        $I->click(EmailsPage::$SELECT_SEGMENT_EMAIL);
+
+        // Wait for the dropdown to be visible
+        $I->waitForElementVisible('#emailform_unsubscribeForm_chosen', 5);
+
+        // Grab the point group options from the dropdown
+        $I->click('#emailform_unsubscribeForm_chosen a.chosen-single');
+
+        $I->click('#emailform_unsubscribeForm_chosen'); // Open dropdown
+
+        // Grab all dropdown options
+        $forms = $I->grabMultiple('#emailform_unsubscribeForm_chosen .chosen-results li');
+
+        // Assert that each point group follows the format "name (id)"
+        foreach ($forms as $form) {
+            \PHPUnit\Framework\Assert::assertMatchesRegularExpression('/^.+ \(\d+\)$/', $form);
+        }
+    }
+}


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14379 


## Description

When multiple objects share the same name in the multiselect fields only one of them would be displayed, making it difficult to select the correct object. This issue affected segments, campaigns, categories, and other entities, leading to user confusion and selection errors.

The problem was caused by the way object lists were indexed using names as keys, which led to duplicate entries being overwritten. To fix this, the logic was updated to append each object's unique ID in parentheses, ensuring clear differentiation. The changes were applied consistently across all affected areas and tests were created to verify that the objects are now properly distinguishable.


<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1.  Go to **Segments** in the side menu and create two segments with the same name
2.  Go to **Contacts** in the side menu and if there is no contact than create one
3.  Mark the checkbox next to the contact 
4.  Click the three dots in the table header
5.  Select **Change Segments** from the list
6.  See that the two segments are displayed in the format 'name (id)' when you click the search bar
