### PR TITLE
Fixing company links

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Company/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/list.html.twig
@@ -128,7 +128,7 @@
                       <td>
                           <div>
                           {% if securityHasEntityAccess(permissions['lead:leads:editown'], permissions['lead:leads:editother'], item.createdBy) %}
-                              <a href="{{ url('mautic_company_action', {'objectAction': 'view', 'objectId': item.id}) }}" data-toggle="ajax">
+                              <a href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': item.id}) }}" data-toggle="ajax">
                                 {% if fields.core.companyname is defined %}
                                   {{ fields.core.companyname.value|purify }}
                                 {% endif %}
@@ -174,7 +174,7 @@
                   'page': page,
                   'limit': limit,
                   'menuLinkId': 'mautic_company_index',
-                  'baseUrl': url('mautic_company_index'),
+                  'baseUrl': path('mautic_company_index'),
                   'sessionVar': 'company',
           }) }}
       </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 5.x)
* a.b for any bug fixes (e.g. 4.4, 5.1)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
When the site url in Mautic is changed in system settings, then the new site url is also used for company details view and company pagination. 

Steps to reproduce the error:
1. Change the site url a new url (in this case: https://newsite.ddev.site)
![image](https://github.com/user-attachments/assets/cec0a647-44ca-4f6b-bc0d-cf4bbfa86368)
2. Now lets verify the wrong behavior. If you now open the 'Companies' tab and hover over a company in your list you should see that the link displayed will use the new site url and not the Mautic url
<img width="269" alt="image" src="https://github.com/user-attachments/assets/23f0e141-d6b4-4817-bfa1-0dd2d4adcb5f" />

The same happens when you try to switch to page two in your company list
<img width="304" alt="image" src="https://github.com/user-attachments/assets/556b546d-b615-4604-9948-f01b99dba02f" />

This results in you not being able to open neither the company details nor a new page in your company views



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Change the site url a new url (in this case: https://newsite.ddev.site)
![image](https://github.com/user-attachments/assets/cec0a647-44ca-4f6b-bc0d-cf4bbfa86368)
3. Try to open a company and another page in your company list, both should work


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->