### PR TITLE
DPMMA-1850 Fix boolean Field default value

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -209,8 +209,7 @@ class FieldType extends AbstractType
                 'attr'        => ['class' => 'form-control'],
                 'required'    => false,
                 'mapped'      => false,
-                'data'        => '',
-                'placeholder' => ' x ',
+                'data'        => 0,
             ]
         );
 

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -159,6 +159,21 @@ class FieldFunctionalTest extends MauticMysqlTestCase
         ];
     }
 
+    public function testCheckDefaultBooleanFieldSetting(): void
+    {
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        // Check if the radio button with value 0 is checked and value 1 is not
+        Assert::assertNotNull(
+            $crawler->filter('#leadfield_default_template_boolean_0')->attr('checked')
+        );
+        Assert::assertNull(
+            $crawler->filter('#leadfield_default_template_boolean_1')->attr('checked')
+        );
+    }
+
     /**
      * @param array<string, mixed> $parameters
      */


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR addresses an issue with the creation of boolean type fields in Mautic. Previously, when a boolean field was created with the default value set to "No," it was not stored in the database. As a result, the default value was an empty string, which led to incorrect mapping of false values when importing contacts or creating contacts through forms.

**Changes Made:**
- Ensure that the default value "No" for boolean fields is correctly stored as `0` in the database.

**Impact:**
- This fix ensures that boolean fields with a default value of "No" are correctly initialized, preventing issues with contact imports and form submissions where false values are not mapped correctly.

![image](https://github.com/user-attachments/assets/8d49f530-beef-4a94-b7be-4bdc8819fdee)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))

2. **Create a new custom field:**
   - Navigate to the custom fields section in Mautic.
   - Create a new field, select the type as boolean, and leave the default value as "No."

3. **Import a contact or submit a form:**
   - Import a contact or submit a form that will create a new contact.
   - Ensure that the custom boolean field is not included in the form or import process.

4. **Verify the default value:**
   - Go to the contact view in Mautic.
   - Check that the default value for the boolean field is set to "No" (stored as `0` in the database).

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->