### PR TITLE
Making campaign actions stats work with manual removal

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -1080,7 +1080,7 @@ class CampaignController extends AbstractStandardFormController
             /** @var LeadEventLogRepository $eventLogRepo */
             $eventLogRepo               = $this->doctrine->getManager()->getRepository(LeadEventLog::class);
             $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, true, $dateFrom, $dateToPlusOne);
-            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateToPlusOne);
+            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateToPlusOne);
         }
 
         return [

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -1079,7 +1079,7 @@ class CampaignController extends AbstractStandardFormController
         } else {
             /** @var LeadEventLogRepository $eventLogRepo */
             $eventLogRepo               = $this->doctrine->getManager()->getRepository(LeadEventLog::class);
-            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, true, $dateFrom, $dateToPlusOne);
+            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateToPlusOne);
             $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateToPlusOne);
         }
 

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -223,7 +223,7 @@ class LeadEventLogRepository extends CommonRepository
             'o',
             MAUTIC_TABLE_PREFIX.'campaign_leads',
             'l',
-            'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id'
+            'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id and o.is_scheduled = 0'
         );
 
         $expr = $q->expr()->and(

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -223,7 +223,7 @@ class LeadEventLogRepository extends CommonRepository
             'o',
             MAUTIC_TABLE_PREFIX.'campaign_leads',
             'l',
-            'l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0 and o.lead_id = l.lead_id and l.rotation = o.rotation'
+            'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id'
         );
 
         $expr = $q->expr()->and(
@@ -287,7 +287,7 @@ class LeadEventLogRepository extends CommonRepository
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile(600)
+                new QueryCacheProfile(2)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -223,7 +223,7 @@ class LeadEventLogRepository extends CommonRepository
             'o',
             MAUTIC_TABLE_PREFIX.'campaign_leads',
             'l',
-            'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id and o.is_scheduled = 0'
+            'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id'
         );
 
         $expr = $q->expr()->and(
@@ -287,7 +287,7 @@ class LeadEventLogRepository extends CommonRepository
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile(2)
+                new QueryCacheProfile(600)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -224,7 +224,6 @@ class LeadEventLogRepository extends CommonRepository
             MAUTIC_TABLE_PREFIX.'campaign_leads',
             'l',
             'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id'
-            //'l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0 and o.lead_id = l.lead_id and l.rotation = o.rotation'
         );
 
         $expr = $q->expr()->and(

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -224,6 +224,7 @@ class LeadEventLogRepository extends CommonRepository
             MAUTIC_TABLE_PREFIX.'campaign_leads',
             'l',
             'l.campaign_id = '.(int) $campaignId.' and o.lead_id = l.lead_id'
+            //'l.campaign_id = '.(int) $campaignId.' and l.manually_removed = 0 and o.lead_id = l.lead_id and l.rotation = o.rotation'
         );
 
         $expr = $q->expr()->and(

--- a/app/bundles/CampaignBundle/Entity/SummaryRepository.php
+++ b/app/bundles/CampaignBundle/Entity/SummaryRepository.php
@@ -113,7 +113,7 @@ class SummaryRepository extends CommonRepository
             '       SUM(IF((mclel.is_scheduled = 1 AND mclel.trigger_date > NOW()) OR mclel.non_action_path_taken, 0, mclefl.log_id IS NOT NULL)) AS failed_count_i, '.
             '       SUM(IF((mclel.is_scheduled = 1 AND mclel.trigger_date > NOW()) OR mclel.non_action_path_taken OR mclefl.log_id IS NOT NULL, 0, 1)) AS triggered_count_i, '.
             '       COUNT((SELECT mcl.campaign_id FROM '.MAUTIC_TABLE_PREFIX.'campaign_leads mcl '.
-            '           WHERE mcl.campaign_id = mclel.campaign_id AND mcl.manually_removed = 0 '.
+            '           WHERE mcl.campaign_id = mclel.campaign_id '.
             '           AND mclel.lead_id = mcl.lead_id AND mcl.rotation = mclel.rotation '.
             '           AND NOT EXISTS(SELECT NULL FROM '.MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log mclefl2 '.
             '               WHERE mclefl2.log_id = mclel.id AND mclefl2.date_added BETWEEN "'.$dateFromTs.'" AND "'.$dateToTs.'")'.

--- a/app/bundles/CampaignBundle/Entity/SummaryRepository.php
+++ b/app/bundles/CampaignBundle/Entity/SummaryRepository.php
@@ -112,12 +112,14 @@ class SummaryRepository extends CommonRepository
             '       SUM(IF(mclel.is_scheduled = 1 AND mclel.trigger_date > NOW(), 0, mclel.non_action_path_taken)) AS non_action_path_taken_count_i, '.
             '       SUM(IF((mclel.is_scheduled = 1 AND mclel.trigger_date > NOW()) OR mclel.non_action_path_taken, 0, mclefl.log_id IS NOT NULL)) AS failed_count_i, '.
             '       SUM(IF((mclel.is_scheduled = 1 AND mclel.trigger_date > NOW()) OR mclel.non_action_path_taken OR mclefl.log_id IS NOT NULL, 0, 1)) AS triggered_count_i, '.
-            '       COUNT((SELECT mcl.campaign_id FROM '.MAUTIC_TABLE_PREFIX.'campaign_leads mcl '.
-            '           WHERE mcl.campaign_id = mclel.campaign_id '.
-            '           AND mclel.lead_id = mcl.lead_id AND mcl.rotation = mclel.rotation '.
-            '           AND NOT EXISTS(SELECT NULL FROM '.MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log mclefl2 '.
-            '               WHERE mclefl2.log_id = mclel.id AND mclefl2.date_added BETWEEN "'.$dateFromTs.'" AND "'.$dateToTs.'")'.
-            '       )) AS log_counts_processed_i '.
+            '       COUNT((SELECT mcl.campaign_id FROM '.MAUTIC_TABLE_PREFIX.'campaign_leads mcl 
+                WHERE mcl.campaign_id = mclel.campaign_id 
+                AND mclel.lead_id = mcl.lead_id 
+                AND mclel.is_scheduled = 0 
+                AND mclel.date_triggered IS NOT NULL 
+                AND NOT EXISTS(SELECT NULL FROM '.MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log mclefl2 
+                    WHERE mclefl2.log_id = mclel.id AND mclefl2.date_added BETWEEN "'.$dateFromTs.'" AND "'.$dateToTs.'")
+            )) AS log_counts_processed_i '.
             ' FROM '.MAUTIC_TABLE_PREFIX.'campaign_lead_event_log mclel LEFT JOIN '.MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log mclefl ON mclefl.log_id = mclel.id '.
             ' WHERE (mclel.date_triggered BETWEEN "'.$dateFromTs.'" AND "'.$dateToTs.'") ';
             if ($campaignId) {

--- a/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
+++ b/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
@@ -17,7 +17,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 
 abstract class AbstractCampaignTest extends MauticMysqlTestCase
 {
-    protected function saveSomeCampaignLeadEventLogs(bool $emulatePendingCount = false, bool $addEventsOfRemovedLead = false): Campaign
+    protected function saveSomeCampaignLeadEventLogs(bool $withPendingAction = false, bool $withActionOfRemovedLead = false): Campaign
     {
         $relativeDate = date('Y-m-d', strtotime('-1 month'));
 
@@ -105,46 +105,56 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
 
         $campaignLeadsRepo->saveEntities([$campaignLeadsA, $campaignLeadsB]);
 
-        if ($addEventsOfRemovedLead) {
+        if ($withPendingAction) {
             $contactC = new Lead();
             $contactRepo->saveEntity($contactC);
 
-            $leadEventLogD = new LeadEventLog();
-            $leadEventLogD->setCampaign($campaign);
-            $leadEventLogD->setEvent($eventA);
-            $leadEventLogD->setLead($contactC);
-            $leadEventLogD->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
-            $leadEventLogD->setRotation(0);
-            $leadEventLogRepo->saveEntity($leadEventLogD);
+            $leadEventLogE = new LeadEventLog();
+            $leadEventLogE->setCampaign($campaign);
+            $leadEventLogE->setEvent($eventA);
+            $leadEventLogE->setLead($contactC);
+            $leadEventLogE->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
+            $leadEventLogE->setRotation(0);
+            $leadEventLogRepo->saveEntity($leadEventLogE);
+
+            $leadEventLogF = new LeadEventLog();
+            $leadEventLogF->setCampaign($campaign);
+            $leadEventLogF->setEvent($eventB);
+            $leadEventLogF->setLead($contactC);
+            $leadEventLogF->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
+            $leadEventLogF->setTriggerDate(new \DateTime($relativeDate.' 16:49:00', new \DateTimeZone('UTC')));
+            $leadEventLogF->setIsScheduled(true);
+            $leadEventLogF->setRotation(0);
+            $leadEventLogRepo->saveEntity($leadEventLogF);
 
             $campaignLeadsC = new CampaignLeads();
             $campaignLeadsC->setLead($contactC);
             $campaignLeadsC->setCampaign($campaign);
             $campaignLeadsC->setDateAdded(new \DateTime($relativeDate));
             $campaignLeadsC->setRotation(0);
-            $campaignLeadsC->setManuallyRemoved(true);
+            $campaignLeadsC->setManuallyRemoved(false);
             $campaignLeadsRepo->saveEntity($campaignLeadsC);
         }
 
-        if ($emulatePendingCount) {
+        if ($withActionOfRemovedLead) {
             $contactD = new Lead();
             $contactRepo->saveEntity($contactD);
 
-            $leadEventLogD = new LeadEventLog();
-            $leadEventLogD->setCampaign($campaign);
-            $leadEventLogD->setEvent($eventA);
-            $leadEventLogD->setLead($contactD);
-            $leadEventLogD->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
-            $leadEventLogD->setRotation(0);
-            $leadEventLogRepo->saveEntity($leadEventLogD);
+            $leadEventLogG = new LeadEventLog();
+            $leadEventLogG->setCampaign($campaign);
+            $leadEventLogG->setEvent($eventA);
+            $leadEventLogG->setLead($contactD);
+            $leadEventLogG->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
+            $leadEventLogG->setRotation(0);
+            $leadEventLogRepo->saveEntity($leadEventLogG);
 
-            $campaignLeadsC = new CampaignLeads();
-            $campaignLeadsC->setLead($contactD);
-            $campaignLeadsC->setCampaign($campaign);
-            $campaignLeadsC->setDateAdded(new \DateTime($relativeDate));
-            $campaignLeadsC->setRotation(0);
-            $campaignLeadsC->setManuallyRemoved(false);
-            $campaignLeadsRepo->saveEntity($campaignLeadsC);
+            $campaignLeadsD = new CampaignLeads();
+            $campaignLeadsD->setLead($contactD);
+            $campaignLeadsD->setCampaign($campaign);
+            $campaignLeadsD->setDateAdded(new \DateTime($relativeDate));
+            $campaignLeadsD->setRotation(0);
+            $campaignLeadsD->setManuallyRemoved(true);
+            $campaignLeadsRepo->saveEntity($campaignLeadsD);
         }
 
         return $campaign;

--- a/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
+++ b/app/bundles/CampaignBundle/Tests/Campaign/AbstractCampaignTest.php
@@ -17,7 +17,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 
 abstract class AbstractCampaignTest extends MauticMysqlTestCase
 {
-    protected function saveSomeCampaignLeadEventLogs(bool $emulatePendingCount = false): Campaign
+    protected function saveSomeCampaignLeadEventLogs(bool $emulatePendingCount = false, bool $addEventsOfRemovedLead = false): Campaign
     {
         $relativeDate = date('Y-m-d', strtotime('-1 month'));
 
@@ -105,7 +105,7 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
 
         $campaignLeadsRepo->saveEntities([$campaignLeadsA, $campaignLeadsB]);
 
-        if ($emulatePendingCount) {
+        if ($addEventsOfRemovedLead) {
             $contactC = new Lead();
             $contactRepo->saveEntity($contactC);
 
@@ -123,6 +123,27 @@ abstract class AbstractCampaignTest extends MauticMysqlTestCase
             $campaignLeadsC->setDateAdded(new \DateTime($relativeDate));
             $campaignLeadsC->setRotation(0);
             $campaignLeadsC->setManuallyRemoved(true);
+            $campaignLeadsRepo->saveEntity($campaignLeadsC);
+        }
+
+        if ($emulatePendingCount) {
+            $contactD = new Lead();
+            $contactRepo->saveEntity($contactD);
+
+            $leadEventLogD = new LeadEventLog();
+            $leadEventLogD->setCampaign($campaign);
+            $leadEventLogD->setEvent($eventA);
+            $leadEventLogD->setLead($contactD);
+            $leadEventLogD->setDateTriggered(new \DateTime($relativeDate.' 16:34:00', new \DateTimeZone('UTC')));
+            $leadEventLogD->setRotation(0);
+            $leadEventLogRepo->saveEntity($leadEventLogD);
+
+            $campaignLeadsC = new CampaignLeads();
+            $campaignLeadsC->setLead($contactD);
+            $campaignLeadsC->setCampaign($campaign);
+            $campaignLeadsC->setDateAdded(new \DateTime($relativeDate));
+            $campaignLeadsC->setRotation(0);
+            $campaignLeadsC->setManuallyRemoved(false);
             $campaignLeadsRepo->saveEntity($campaignLeadsC);
         }
 

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -83,62 +83,62 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
 
     public function testCampaignCountsBeforeSummarizeCommandWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, false, 100, 2, 0);
+        $this->getCountAndDetails(false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(false, false, 0, 0, 0);
+        $this->getCountAndDetails(false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(false, false, 100, 2, 0);
+        $this->getCountAndDetails(false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, false, 0, 0, 0);
+        $this->getCountAndDetails(false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, true, 100, 2, 0);
+        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(false, true, 100, 2, 0);
+        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(false, true, 100, 2, 0);
+        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, true, 100, 2, 0);
+        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignPendingCountsWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(true, true, 100, 2, 1);
+        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
     }
 
     public function testCampaignPendingCountsWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(true, true, 100, 2, 1);
+        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
     }
 
     public function testCampaignPendingCountsWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(true, true, 100, 2, 1);
+        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
     }
 
     public function testCampaignPendingCountsWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(true, true, 100, 2, 1);
+        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
     }
 
     private function getStatTotalContacts(int $campaignId): int
@@ -202,14 +202,30 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
     }
 
     /**
-     * @return array<string, string>
+     * @return array<array<string, string>>
      */
     private function getActionCounts(int $campaignId): array
     {
         $crawler        = $this->getCrawlers($campaignId);
-        $successPercent = trim($crawler->filter('#actions-container')->filter('span')->eq(0)->html());
-        $completed      = trim($crawler->filter('#actions-container')->filter('span')->eq(1)->html());
-        $pending        = trim($crawler->filter('#actions-container')->filter('span')->eq(2)->html());
+        dump(trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-success')->html()));
+        $successPercent = [
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-success')->html()),
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-success')->html()),
+            // Weitere Elemente nach Bedarf
+        ];
+
+        $completed = [
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-warning')->html()),
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-warning')->html()),
+            // Weitere Elemente nach Bedarf
+        ];
+
+        $pending = [
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-gray')->html()),
+            trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-gray')->html()),
+            // Weitere Elemente nach Bedarf
+        ];
+        dump($successPercent, $completed, $pending);
 
         return [
             'successPercent' => $successPercent,
@@ -235,7 +251,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         Assert::assertSame(2, $totalContacts);
     }
 
-    private function getCountAndDetails(bool $emulatePendingCount, bool $runCommand, int $expectedSuccessPercent, int $expectedCompleted, int $expectedPending): void
+    private function getCountAndDetails(bool $emulatePendingCount, bool $runCommand, array $expectedSuccessPercent, array $expectedCompleted, array $expectedPending): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs($emulatePendingCount);
         $campaignId = $campaign->getId();
@@ -251,9 +267,9 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         }
 
         $actionCounts = $this->getActionCounts($campaignId);
-        Assert::assertSame($expectedSuccessPercent.'%', $actionCounts['successPercent']);
-        Assert::assertSame($expectedCompleted, (int) $actionCounts['completed']);
-        Assert::assertSame($expectedPending, (int) $actionCounts['pending']);
+        Assert::assertSame($expectedSuccessPercent, $actionCounts['successPercent']);
+        Assert::assertSame($expectedCompleted, $actionCounts['completed']);
+        Assert::assertSame($expectedPending, $actionCounts['pending']);
     }
 
     public function testDeleteCampaign(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -38,11 +38,11 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
             'testCampaignContactCountOnCanvasWithSummaryWithoutRange', 'testCampaignContactCountOnCanvasWithSummaryAndRange',
             'testCampaignCountsBeforeSummarizeCommandWithSummaryWithoutRange', 'testCampaignCountsBeforeSummarizeCommandWithSummaryAndRange',
             'testCampaignCountsAfterSummarizeCommandWithSummaryWithoutRange', 'testCampaignCountsAfterSummarizeCommandWithSummaryAndRange',
-            'testCampaignPendingCountsWithSummaryWithoutRange', 'testCampaignPendingCountsWithSummaryAndRange', ];
+            'testCampaignPendingCountsWithSummaryWithoutRange', 'testCampaignPendingCountsWithSummaryAndRange', 'testCampaignRemovedLeadCountsWithSummaryAndRange', 'testCampaignRemovedLeadAndPendingCountsWithSummaryAndRange', ];
         $functionForUseRange = ['testCampaignContactCountOnCanvasWithoutSummaryWithRange', 'testCampaignContactCountOnCanvasWithSummaryAndRange',
             'testCampaignCountsBeforeSummarizeCommandWithoutSummaryWithRange', 'testCampaignCountsBeforeSummarizeCommandWithSummaryAndRange',
             'testCampaignCountsAfterSummarizeCommandWithoutSummaryWithRange', 'testCampaignCountsAfterSummarizeCommandWithSummaryAndRange',
-            'testCampaignPendingCountsWithoutSummaryAndRange', 'testCampaignPendingCountsWithoutSummaryWithRange', ];
+            'testCampaignPendingCountsWithoutSummaryAndRange', 'testCampaignPendingCountsWithoutSummaryWithRange', 'testCampaignRemovedLeadCountsWithoutSummaryWithRange', 'testCampaignRemovedLeadCountsWithSummaryAndRange', 'testCampaignRemovedLeadAndPendingCountsWithSummaryAndRange', 'testCampaignRemovedLeadAndPendingCountsWithoutSummaryWithRange', ];
         $this->configParams[self::CAMPAIGN_SUMMARY_PARAM] = in_array($this->getName(), $functionForUseSummary);
         $this->configParams[self::CAMPAIGN_RANGE_PARAM]   = in_array($this->getName(), $functionForUseRange);
         parent::setUp();
@@ -83,62 +83,82 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
 
     public function testCampaignCountsBeforeSummarizeCommandWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
+        $this->getCountAndDetails(false, false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, false, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsBeforeSummarizeCommandWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
+        $this->getCountAndDetails(false, false, false, ['0%', '0%'], ['0', '0'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignCountsAfterSummarizeCommandWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
+        $this->getCountAndDetails(false, false, true, ['100%', '100%'], ['2', '2'], ['0', '0']);
     }
 
     public function testCampaignPendingCountsWithoutSummaryAndRange(): void
     {
-        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+        $this->getCountAndDetails(true, false, true, ['100%', '100%'], ['3', '2'], ['0', '1']);
     }
 
     public function testCampaignPendingCountsWithSummaryWithoutRange(): void
     {
-        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+        $this->getCountAndDetails(true, false, true, ['100%', '100%'], ['3', '2'], ['0', '1']);
     }
 
     public function testCampaignPendingCountsWithoutSummaryWithRange(): void
     {
-        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+        $this->getCountAndDetails(true, false, true, ['100%', '100%'], ['3', '2'], ['0', '1']);
     }
 
     public function testCampaignPendingCountsWithSummaryAndRange(): void
     {
-        $this->getCountAndDetails(true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+        $this->getCountAndDetails(true, false, true, ['100%', '100%'], ['3', '2'], ['0', '1']);
+    }
+
+    public function testCampaignRemovedLeadCountsWithSummaryAndRange(): void
+    {
+        $this->getCountAndDetails(false, true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+    }
+
+    public function testCampaignRemovedLeadCountsWithoutSummaryWithRange(): void
+    {
+        $this->getCountAndDetails(false, true, true, ['100%', '100%'], ['3', '2'], ['0', '0']);
+    }
+
+    public function testCampaignRemovedLeadAndPendingCountsWithSummaryAndRange(): void
+    {
+        $this->getCountAndDetails(true, true, true, ['100%', '100%'], ['4', '2'], ['0', '1']);
+    }
+
+    public function testCampaignRemovedLeadAndPendingCountsWithoutSummaryWithRange(): void
+    {
+        $this->getCountAndDetails(true, true, true, ['100%', '100%'], ['4', '2'], ['0', '1']);
     }
 
     private function getStatTotalContacts(int $campaignId): int
@@ -202,30 +222,25 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
     }
 
     /**
-     * @return array<array<string, string>>
+     * @return array<string, array<int, string>>
      */
     private function getActionCounts(int $campaignId): array
     {
         $crawler        = $this->getCrawlers($campaignId);
-        dump(trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-success')->html()));
         $successPercent = [
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-success')->html()),
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-success')->html()),
-            // Weitere Elemente nach Bedarf
         ];
 
         $completed = [
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-warning')->html()),
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-warning')->html()),
-            // Weitere Elemente nach Bedarf
         ];
 
         $pending = [
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(1) .label-gray')->html()),
             trim($crawler->filter('#actions-container .campaign-event-list li:nth-child(2) .label-gray')->html()),
-            // Weitere Elemente nach Bedarf
         ];
-        dump($successPercent, $completed, $pending);
 
         return [
             'successPercent' => $successPercent,
@@ -251,9 +266,14 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTest
         Assert::assertSame(2, $totalContacts);
     }
 
-    private function getCountAndDetails(bool $emulatePendingCount, bool $runCommand, array $expectedSuccessPercent, array $expectedCompleted, array $expectedPending): void
+    /**
+     * @param array<int, string> $expectedSuccessPercent
+     * @param array<int, string> $expectedCompleted
+     * @param array<int, string> $expectedPending
+     */
+    private function getCountAndDetails(bool $withPendingAction, bool $withActionOfRemovedLead, bool $runCommand, array $expectedSuccessPercent, array $expectedCompleted, array $expectedPending): void
     {
-        $campaign   = $this->saveSomeCampaignLeadEventLogs($emulatePendingCount);
+        $campaign   = $this->saveSomeCampaignLeadEventLogs($withPendingAction, $withActionOfRemovedLead);
         $campaignId = $campaign->getId();
 
         if ($runCommand) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14761  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR fixes the issue https://github.com/mautic/mautic/issues/14761 and makes sure the campaign action statistics work properly even when manually removing a contact via the change campaigns action
<img width="912" alt="image" src="https://github.com/user-attachments/assets/40ee190e-6bda-4adc-bb72-07b390bee14d" />
Before the campaign actions of a lead where considered just as 'pending' when the lead was manually removed from a campaign even if the actions where already executed before.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a campaign with an arbitrary action (e.g. update contact) and the change campaigns action in which you remove the contact from the current campaign
3. Run the cron jobs mautic:campaigns:update and mautic:campaigns:trigger
4. Navigate to campaign action stats and check if both actions were registered there as successful 
<img width="906" alt="image" src="https://github.com/user-attachments/assets/b841ad1f-fc1a-4455-877f-7198356b46e6" />

5. Next create a campaign with two update contact actions. The second one should have a delay of 15min before being executed.
6. Run the cron jobs mautic:campaigns:update and mautic:campaigns:trigger
7. Next check the campaign action stats: Here for the first action one successful run should be registered and for the second action one 'pending' should be registered
8. Now remove the contact manually from the campaign

<img width="981" alt="image" src="https://github.com/user-attachments/assets/40c1e7aa-18eb-4304-a26e-b97dd6f164ae" />

9. Next check the campaign action stats again: For the first action there should be still registered on successful fun. However, for the second action the 'pending' shouldn't exist anymore. So there should be neither a completed action nor a pending action

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->