### PR TITLE
[UXUI-138] Contact history and auditlog shows toggle for details even when no details are available

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -2194,6 +2194,10 @@ a:focus {
   text-decoration: none;
   outline: 2px solid transparent;
 }
+a.disabled {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+}
 h1,
 h2,
 h3,
@@ -6088,13 +6092,9 @@ input[style]:hover {
   padding: var(--spacing-01) var(--spacing-04);
 }
 .form-control[disabled],
+.form-control[readonly],
 fieldset[disabled] .form-control {
   color: var(--text-disabled);
-}
-.form-control[readonly]{
-  color: var(--text-primary);
-  background-color: var(--field);
-  border-color: var(--border-subtle);
 }
 .form-control[disabled] {
   cursor: not-allowed;

--- a/app/bundles/CoreBundle/Assets/css/app/less/components/scaffolding.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/components/scaffolding.less
@@ -77,4 +77,9 @@ a {
     text-decoration: none;
     outline: 2px solid transparent;
   }
+
+  &.disabled {
+    color: var(--text-disabled);
+    cursor: not-allowed;
+  }
 }

--- a/app/bundles/LeadBundle/Resources/views/Auditlog/_list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Auditlog/_list.html.twig
@@ -121,7 +121,7 @@
                   <td class="table-expand np">
                       <a href="javascript:void(0);"
                          data-activate-details="{{ counter }}"
-                         class="table-expand-button {% if event.contentTemplate is not defined or hasDetails == false %}disabled{% endif %}"
+                         class="table-expand-button {% if event.contentTemplate is not defined or hasDetails == false %}hide{% endif %}"
                          data-toggle="tooltip"
                          title="{{ 'mautic.lead.timeline.toggle_details'|trans }}">
                          <span class="ri-arrow-down-s-line"></span>

--- a/app/bundles/LeadBundle/Resources/views/Timeline/_list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Timeline/_list.html.twig
@@ -60,7 +60,7 @@
                 <td class="table-expand np">
                     <a href="javascript:void(0);"
                        data-activate-details="{{ loop.index }}"
-                       class="table-expand-button {% if details is empty %}disabled{% endif %}"
+                       class="table-expand-button {% if details is empty %}hide{% endif %}"
                        data-toggle="tooltip" title="{{ 'mautic.lead.timeline.toggle_details'|trans }}">
                        <span class="ri-arrow-down-s-line"></span>
                     </a>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

### Impact

Users see a toggle for details in the contact history even when no details are available. This can lead to confusion as users may expect to see more information.

### Expected behaviour

The toggle for details should be hidden when no details are available. This simplifies the user interface and avoids unnecessary complexity.

### Actual behaviour

The toggle for details is visible even when there are no details to expand.

### Steps to reproduce

1. Navigate to the contact history.
2. Observe the toggle for details when no details are available.

### Environment

N/A

### Workarounds

N/A

### Other information

N/A

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->

After:
![image](https://github.com/user-attachments/assets/2475a194-30aa-4582-8de2-89c0ecf3dd66)


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Contacts > Import > Import some mock data
3. Go back to Contacts and open any profile
4. Check the history for expandable items

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->