### PR TITLE
Fix #14240: Blank link shown in theme actions dropdown

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Theme/list.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Theme/list.html.twig
@@ -32,6 +32,7 @@
                         {% set hasThumbnail = (item['dir'] ~ '/thumbnail.png') is file %}
                         {% set visibilityButton = [] %}
                         {% set visibilityCss = '' %}
+                        {% set customButtons = [] %}
 
                         {% if item.visibility is defined %}
                             {% set btnText         = 'mautic.core.theme.hide' %}
@@ -74,11 +75,29 @@
                                     'btnText': 'mautic.asset.asset.preview'|trans,
                                     'iconClass': 'ri-image-line',
                                     } %}
-                                {% set previewButton = hasThumbnail ? previewButtonSettings : [] %}
+                                {% set customButtons = hasThumbnail 
+                                    ? customButtons|merge([previewButtonSettings]) 
+                                    : customButtons 
+                                %}
                                 {% set deleteButton = {
                                     'delete': permissions['core:themes:delete']
                                 } %}
                                 {% set templateButtons = (k not in defaultThemes) ? deleteButton : {} %}
+                                {% set downloadButton = {
+                                    'attr': {
+                                        'href': path('mautic_themes_action', {
+                                            objectAction: 'download',
+                                            objectId: k
+                                        }),
+                                        'data-toggle': '0',
+                                    },
+                                    'btnText': 'mautic.core.download'|trans,
+                                    'iconClass': 'ri-download-line',
+                                } %}
+                                {% set customButtons = customButtons|merge([downloadButton]) %}
+                                {% if visibilityButton is not empty %}
+                                    {% set customButtons = customButtons|merge([visibilityButton]) %}
+                                {% endif %}
 
                                 {{ include ('@MauticCore/Helper/list_actions.html.twig',
                                     {
@@ -86,21 +105,7 @@
                                         'templateButtons': templateButtons,
                                         'routeBase': 'themes',
                                         'langVar': 'core.theme',
-                                        'customButtons': [
-                                            {
-                                                'attr': {
-                                                    'href': path('mautic_themes_action', {
-                                                        objectAction: 'download',
-                                                        objectId: k
-                                                    }),
-                                                    'data-toggle': '0',
-                                                },
-                                                'btnText': 'mautic.core.download'|trans,
-                                                'iconClass': 'ri-download-line',
-                                            },
-                                            previewButton,
-                                            visibilityButton,
-                                        ],
+                                        'customButtons': customButtons,
                                     }
                                 ) }}
 

--- a/tests/_support/Page/Acceptance/ThemesPage.php
+++ b/tests/_support/Page/Acceptance/ThemesPage.php
@@ -6,8 +6,8 @@ class ThemesPage
 {
     public static $URL = '/s/themes';
 
-    public static string $dropDown = '#admin-menu';
+    public static string $dropDown        = '#admin-menu';
     public static string $dropDown_Themes = '#mautic_themes_index';
-    public static string $themeTable= '#themeTable';
-    public static string $themeRows= '#themeTable tbody tr';
+    public static string $themeTable      = '#themeTable';
+    public static string $themeRows       = '#themeTable tbody tr';
 }

--- a/tests/_support/Page/Acceptance/ThemesPage.php
+++ b/tests/_support/Page/Acceptance/ThemesPage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Page\Acceptance;
+
+class ThemesPage
+{
+    public static $URL = '/s/themes';
+
+    public static string $dropDown = '#admin-menu';
+    public static string $dropDown_Themes = '#mautic_themes_index';
+    public static string $themeTable= '#themeTable';
+    public static string $themeRows= '#themeTable tbody tr';
+}

--- a/tests/acceptance/ThemeManagementCest.php
+++ b/tests/acceptance/ThemeManagementCest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Acceptance;
+
+use \AcceptanceTester;
+use Page\Acceptance\ThemesPage;
+
+class ThemeManagementCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->login('admin', 'Maut1cR0cks!');
+
+        $I->click(ThemesPage::$dropDown); // gear icon
+        $I->waitForElementVisible(ThemesPage::$dropDown_Themes, 30);
+
+        $I->click(ThemesPage::$dropDown_Themes);
+        $I->waitForText('Themes', 30); // let the page render
+    }
+
+    public function themesHaveNoBlankActions(AcceptanceTester $I): void
+    {
+        $I->amOnPage(ThemesPage::$URL);
+        $I->waitForElementVisible(ThemesPage::$themeTable, 30);
+
+        $rows = $I->grabMultiple(ThemesPage::$themeRows);
+        for ($i = 1; $i <= count($rows); $i++) {
+            // Grab all AJAX links in this row
+            $ajaxXpathBase = '(//table[@id="themeTable"]//tr)['.$i.']//a[@data-toggle="ajax"]';
+            $ajaxLinks = $I->grabMultiple($ajaxXpathBase);
+
+            $ajaxCount = count($ajaxLinks);
+            for ($j = 1; $j <= $ajaxCount; $j++) {
+                $linkXpath = $ajaxXpathBase . '[' . $j . ']';
+
+                // Fail only if there's no href attribute
+                if (!$I->seeElement($linkXpath . '[@href]')) {
+                    $I->fail("AJAX link in row $i (link $j) is missing an href.");
+                }
+            }
+        }
+    }
+
+}

--- a/tests/acceptance/ThemeManagementCest.php
+++ b/tests/acceptance/ThemeManagementCest.php
@@ -2,12 +2,11 @@
 
 namespace Acceptance;
 
-use \AcceptanceTester;
 use Page\Acceptance\ThemesPage;
 
 class ThemeManagementCest
 {
-    public function _before(AcceptanceTester $I)
+    public function _before(\AcceptanceTester $I)
     {
         $I->login('admin', 'Maut1cR0cks!');
 
@@ -18,27 +17,26 @@ class ThemeManagementCest
         $I->waitForText('Themes', 30); // let the page render
     }
 
-    public function themesHaveNoBlankActions(AcceptanceTester $I): void
+    public function themesHaveNoBlankActions(\AcceptanceTester $I): void
     {
         $I->amOnPage(ThemesPage::$URL);
         $I->waitForElementVisible(ThemesPage::$themeTable, 30);
 
         $rows = $I->grabMultiple(ThemesPage::$themeRows);
-        for ($i = 1; $i <= count($rows); $i++) {
+        for ($i = 1; $i <= count($rows); ++$i) {
             // Grab all AJAX links in this row
             $ajaxXpathBase = '(//table[@id="themeTable"]//tr)['.$i.']//a[@data-toggle="ajax"]';
-            $ajaxLinks = $I->grabMultiple($ajaxXpathBase);
+            $ajaxLinks     = $I->grabMultiple($ajaxXpathBase);
 
             $ajaxCount = count($ajaxLinks);
-            for ($j = 1; $j <= $ajaxCount; $j++) {
-                $linkXpath = $ajaxXpathBase . '[' . $j . ']';
+            for ($j = 1; $j <= $ajaxCount; ++$j) {
+                $linkXpath = $ajaxXpathBase.'['.$j.']';
 
                 // Fail only if there's no href attribute
-                if (!$I->seeElement($linkXpath . '[@href]')) {
+                if (!$I->seeElement($linkXpath.'[@href]')) {
                     $I->fail("AJAX link in row $i (link $j) is missing an href.");
                 }
             }
         }
     }
-
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #14240 



## Description

This PR fixes an issue where the dropdown menu for individual non-system themes showed a blank link in the list of available actions. The issue was caused by empty button definitions being passed to the `customButtons` array in the Twig template.

To fix this, the `list.html.twig` file was updated to ensure that only properly defined buttons are merged into the `customButtons` array. Buttons such as the preview or visibility toggles are now conditionally added only when they are not empty, preventing malformed entries from being rendered.

An E2E test is included to ensure that no action link with `data-toggle="ajax"` is rendered without a corresponding `href` attribute.

| Before                                 | After
| -------------------------------------- | ---
| ![Before](https://github.com/user-attachments/assets/4536894f-ebf7-4db5-aee5-8201fac2709e) | ![After](https://github.com/user-attachments/assets/fd08095c-dfef-4e3a-81e4-aa3a6d4e6cf2)  |


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to the **Themes** Page
3. Locate a theme that is **not set as system theme** (that can be removed).
4. Click the dropdown for actions.
5. Confirm the result
