### PR TITLE
Updating library oneup/uploader-bundle

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -74,7 +74,7 @@
     "klapaudius/oauth-server-bundle": "^4.0.0",
     "jms/serializer-bundle": "^5.4",
     "joomla/filter": "~1.4.4",
-    "oneup/uploader-bundle": "^3.1.0",
+    "oneup/uploader-bundle": "^5.0",
     "jbroadway/urlify": "^1.0",
     "geoip2/geoip2": "~2.0",
     "ip2location/ip2location-php": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -6057,7 +6057,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "63e8910fa3584704990993662624d47c12c4f6ee"
+                "reference": "ef871da62c9165833aebeb6bc3219e4e834559e1"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -6102,7 +6102,7 @@
                 "matomo/device-detector": "^4.0",
                 "matthiasmullie/minify": "^1.3",
                 "noxlogic/ratelimit-bundle": "^1.19",
-                "oneup/uploader-bundle": "^3.1.0",
+                "oneup/uploader-bundle": "^5.0",
                 "php": "~8.2",
                 "php-amqplib/rabbitmq-bundle": "^2.5.1",
                 "php-http/guzzle7-adapter": "^1.0",
@@ -6677,51 +6677,50 @@
         },
         {
             "name": "oneup/uploader-bundle",
-            "version": "3.2.1",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/1up-lab/OneupUploaderBundle.git",
-                "reference": "b11ea2060d4d76b7202d24ae170162b70c7a88b6"
+                "reference": "470b11eeee82946fbf93d5944c63749bcdf65f6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/1up-lab/OneupUploaderBundle/zipball/b11ea2060d4d76b7202d24ae170162b70c7a88b6",
-                "reference": "b11ea2060d4d76b7202d24ae170162b70c7a88b6",
+                "url": "https://api.github.com/repos/1up-lab/OneupUploaderBundle/zipball/470b11eeee82946fbf93d5944c63749bcdf65f6f",
+                "reference": "470b11eeee82946fbf93d5944c63749bcdf65f6f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "symfony/asset": "^4.4 || ^5.4 || ^6.0",
+                "php": "^8.0",
+                "symfony/asset": "^5.4 || ^6.0 || ^7.0",
                 "symfony/event-dispatcher-contracts": "^1.0 || ^2.0 || ^3.0",
-                "symfony/finder": "^4.4 || ^5.4 || ^6.0",
-                "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
-                "symfony/mime": "^4.4 || ^5.4 || ^6.0",
-                "symfony/templating": "^4.4 || ^5.4 || ^6.0",
-                "symfony/translation": "^4.4 || ^5.4 || ^6.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+                "symfony/translation": "^5.4 || ^6.0 || ^7.0",
                 "symfony/translation-contracts": "^1.0 || ^2.0 || ^3.0",
-                "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
                 "twig/twig": "^2.4 || ^3.0"
             },
             "require-dev": {
                 "amazonwebservices/aws-sdk-for-php": "1.5.*",
                 "doctrine/common": "^2.12 || ^3.0",
                 "doctrine/doctrine-bundle": "^2.4",
-                "friendsofphp/php-cs-fixer": "^2.16",
+                "friendsofphp/php-cs-fixer": "^3.40",
                 "knplabs/gaufrette": "^0.9",
-                "oneup/flysystem-bundle": "^1.2 || ^2.0 || ^3.0",
-                "phpstan/phpstan": "^0.12.10",
+                "m2mtech/flysystem-stream-wrapper": "^1.0",
+                "oneup/flysystem-bundle": "^4.1",
+                "phpstan/phpstan": "^1.8",
                 "phpunit/phpunit": "^9.5",
-                "sensio/framework-extra-bundle": "^5.0 || ^6.0",
-                "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
-                "symfony/phpunit-bridge": "^5.4",
-                "symfony/security-bundle": "^4.4 || ^5.4 || ^6.0",
-                "symfony/var-dumper": "^4.4 || ^5.4 || ^6.0",
+                "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^6.0.17 || ^7.0",
+                "symfony/security-bundle": "^5.4 || ^6.0 || ^7.0",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
                 "twistor/flysystem-stream-wrapper": "^1.0"
             },
             "suggest": {
                 "knplabs/knp-gaufrette-bundle": "0.1.*",
-                "oneup/flysystem-bundle": "^3.0",
-                "twistor/flysystem-stream-wrapper": "^1.0 (Required when using Flysystem)"
+                "m2mtech/flysystem-stream-wrapper": "^1.0 (Required when using Flysystem)",
+                "oneup/flysystem-bundle": "^3.0"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -6764,9 +6763,9 @@
             ],
             "support": {
                 "issues": "https://github.com/1up-lab/OneupUploaderBundle/issues",
-                "source": "https://github.com/1up-lab/OneupUploaderBundle/tree/3.2.1"
+                "source": "https://github.com/1up-lab/OneupUploaderBundle/tree/5.0.1"
             },
-            "time": "2022-07-25T07:48:07+00:00"
+            "time": "2024-04-04T06:57:10+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | possibly as the library jumped 2 major versions
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description


This is another step to update the Mautic dependencies to be able to jump to Symfony 7. This is the objective of this PR:

```diff
$ composer why-not symfony/translation ^7.2
mautic/core-lib       7.0.0-dev requires symfony/translation (^6.4)                 
- oneup/uploader-bundle 3.2.1     requires symfony/translation (^4.4 || ^5.4 || ^6.0)
```
The `oneup/uploader-bundle` blocks updating the `symfony/translation` to v7.2. This PR changes that as the diff suggests.

This is the output from composer after running `composer update oneup/uploader-bundle`
```
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading mautic/core-lib (7.0.0-dev 63e8910 => 7.0.0-dev ef871da)
  - Upgrading oneup/uploader-bundle (3.2.1 => 5.0.1)
```
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test that asset uploads still work.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->