### PR TITLE
Deprecating EoL DB versions, support for more DB versions

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -4,7 +4,7 @@ php_version: "8.3"
 webserver_type: apache-fpm
 database:
     type: mariadb
-    version: "10.3"
+    version: "10.11"
 hooks:
     post-start:
         - exec: sed -i -e 's/\r$//' ./.ddev/mautic-setup.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: mautictest
@@ -181,7 +181,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: mautictest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,13 +22,13 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.3']
-        db-types: ['mysql', 'mariadb']
+        db-types: ['mysql:8.4', 'mysql:9.2', 'mariadb:10.11', 'mariadb:11.4']
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}
 
     services:
       database:
-        image: ${{ matrix.db-types == 'mysql' && 'mysql:5.7' || 'mariadb:10.3' }}
+        image: ${{ matrix.db-types }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: mautictest
@@ -36,9 +36,8 @@ jobs:
           - 3306
         options: >-
           --shm-size=2gb
-          --name=${{ matrix.db-types }}
           --tmpfs=/var/lib/mysql
-          --health-cmd="mysqladmin ping"
+          --health-cmd "${{ startsWith(matrix.db-types, 'mysql:') && 'mysqladmin ping' || 'healthcheck.sh --connect --innodb_initialized' }}"
           --health-interval=10s 
           --health-timeout=5s 
           --health-retries=3
@@ -58,7 +57,7 @@ jobs:
         fetch-depth: 0
 
     - name: PHPUnit cache
-      if: ${{matrix.php-versions == '8.2' && matrix.db-types == 'mariadb'}}
+      if: ${{matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11'}}
       uses: actions/cache@v4
       with:
         path: ./var/cache/phpunit
@@ -81,6 +80,8 @@ jobs:
         mysqldump --print-defaults
         cp .github/ci-files/.my.cnf ~/.my.cnf
         mysqldump --print-defaults
+        DB_LOG_NAME="${{ matrix.db-types }}"
+        echo "DB_LOG_NAME=${DB_LOG_NAME/:/_}" >> $GITHUB_ENV
 
     - name: Set SYMFONY_ENV to test
       run: |
@@ -97,14 +98,14 @@ jobs:
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
-        if [[ "${{ matrix.php-versions }}" == "8.2" ]] && [[ "${{ matrix.db-types }}" == "mariadb" ]]; then
+        if [[ "${{ matrix.php-versions }}" == "8.2" ]] && [[ "${{ matrix.db-types }}" == "mariadb:10.11" ]]; then
           php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
         else
           php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
         fi
 
     - name: Upload coverage report
-      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
+      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
       uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
@@ -113,7 +114,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Save test results for future steps
-      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb' && github.repository == 'mautic/mautic' }}
+      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
       uses: actions/upload-artifact@v4
       with:
         name: test-results
@@ -132,7 +133,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: logs-${{ matrix.php-versions }}-${{ matrix.db-types }}
+        name: logs-${{ matrix.php-versions }}-${{ env.DB_LOG_NAME }}
         path: ./var/logs/*
 
   e2e-tests:

--- a/UPGRADE-7.0.md
+++ b/UPGRADE-7.0.md
@@ -2,6 +2,8 @@
 
 ## Platform requirements
 - The minimum required PHP version has been increased from **8.1** to **8.2**.
+- The minimum required MySQL version has been increased from **5.7.14** to **8.4.0**.
+- The minimum required MariaDB version has been increased from **10.2.7** to **10.11.0**.
 
 ## Removed features
 - The ability to update Mautic in the browser (via user interface) has been removed. To update Mautic, use the **command line** instead.

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -51,7 +51,7 @@ class AppKernel extends Kernel
          */
         if (!defined('MAUTIC_DB_SERVER_VERSION')) {
             $localConfigFile = ParameterLoader::getLocalConfigFile($this->getApplicationDir().'/app', false);
-            define('MAUTIC_DB_SERVER_VERSION', file_exists($localConfigFile) ? null : '5.7');
+            define('MAUTIC_DB_SERVER_VERSION', file_exists($localConfigFile) ? null : '8.4');
         }
 
         parent::__construct($environment, $debug);

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -622,6 +622,7 @@ class LeadRepository extends CommonRepository
         ->andWhere("$leadCampaignAlias.manually_removed = :false")
         ->andWhere("$leadCampaignAlias.date_added BETWEEN :dateFrom AND :dateTo")
         ->groupBy("$leadAlias.country")
+        ->orderBy("$leadAlias.country", 'ASC')
         ->setParameter('campaign', $campaign->getId())
         ->setParameter('false', false)
         ->setParameter('dateFrom', $dateFromObject->format('Y-m-d H:i:s'))

--- a/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
@@ -120,7 +120,7 @@ class DoctrineEventsSubscriber implements EventSubscriber
             // Check tables for obsolete indexes.
             // Single column indexes that are the leftmost column of another index are obsolete.
             // That leftmost column is available to look up rows.
-            // @see https://dev.mysql.com/doc/refman/5.7/en/multiple-column-indexes.html
+            // @see https://dev.mysql.com/doc/refman/8.4/en/multiple-column-indexes.html
             $pk              = $table->getPrimaryKey();
             $pk_first_column = $this->trimQuotes(strtolower($pk->getColumns()[0]));
 

--- a/app/bundles/CoreBundle/Resources/views/Helper/usage.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/usage.html.twig
@@ -14,7 +14,7 @@ Variables
             {% set hasDependences = false %}
             {% for stat in stats %}
                 {% if stat.ids|length > 0 %}
-                    <a href="{{ path(stat.route, {'search': 'mautic.core.searchcommand.ids'|trans~':'~stat.ids|join(',')}) }}"
+                    <a href="{{ path(stat.route, {'search': 'mautic.core.searchcommand.ids'|trans~':'~stat.ids|sort|join(',')}) }}"
                        class="btn btn-ghost mt-4">
                         {{ stat.label|trans }}
                         <span class="mt-xs label label-primary">{{ stat.ids|length }}</span>

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -160,7 +160,9 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
         $prefix = MAUTIC_TABLE_PREFIX;
 
         foreach ($tables as $table) {
-            $this->connection->executeQuery("SET FOREIGN_KEY_CHECKS = 0; TRUNCATE TABLE `{$prefix}{$table}`; SET FOREIGN_KEY_CHECKS = 1;");
+            $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS = 0');
+            $this->connection->executeQuery("TRUNCATE TABLE `{$prefix}{$table}`");
+            $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS = 1');
         }
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Provider/VersionProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Provider/VersionProviderTest.php
@@ -41,11 +41,11 @@ class VersionProviderTest extends \PHPUnit\Framework\TestCase
 
         $this->result->expects($this->once())
             ->method('fetchOne')
-            ->willReturn('5.7.23-23-log');
+            ->willReturn('8.4.0-23-log');
 
         $version = $this->provider->getVersion();
 
-        $this->assertSame('5.7.23-23-log', $version);
+        $this->assertSame('8.4.0-23-log', $version);
         $this->assertFalse($this->provider->isMariaDb());
         $this->assertTrue($this->provider->isMySql());
     }
@@ -59,11 +59,11 @@ class VersionProviderTest extends \PHPUnit\Framework\TestCase
 
         $this->result->expects($this->once())
             ->method('fetchOne')
-            ->willReturn('10.3.9-MariaDB');
+            ->willReturn('10.11.0-MariaDB');
 
         $version = $this->provider->getVersion();
 
-        $this->assertSame('10.3.9-MariaDB', $version);
+        $this->assertSame('10.11.0-MariaDB', $version);
         $this->assertTrue($this->provider->isMariaDb());
         $this->assertFalse($this->provider->isMySql());
     }

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -835,7 +835,8 @@ class StatRepository extends CommonRepository
                     ->setParameter('emails', $emailsIds, ArrayParameterType::INTEGER);
         }
 
-        $queryBuilder->groupBy("{$leadAlias}.country");
+        $queryBuilder->groupBy("{$leadAlias}.country")
+                    ->orderBy("{$leadAlias}.country", 'ASC');
         $queryBuilder->andWhere("{$statsAlias}.date_sent BETWEEN :dateFrom AND :dateTo");
         $queryBuilder->setParameter('dateFrom', $dateFrom->format(DateTimeHelper::FORMAT_DB));
         $queryBuilder->setParameter('dateTo', $dateTo->setTime(23, 59, 59)->format('Y-m-d H:i:s'));

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
@@ -123,7 +123,7 @@ class ObjectMappingRepository extends CommonRepository
             ->setParameter('internalObjectName', $internalObjectName)
             ->setParameter('internalObjectId', $internalObjectId)
             ->setParameter('date', $createdAt->format(DateTimeHelper::FORMAT_DB))
-            ->setParameter('isDeleted', [], Types::BOOLEAN)
+            ->setParameter('isDeleted', false, Types::BOOLEAN)
             ->setParameter('internalStorage', [], Types::JSON);
 
         return $qb->executeStatement();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -42,14 +42,14 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             'regexp',
             '^{Test|Test string)', // invalid regex: the first parantheses should not be curly
             Response::HTTP_BAD_REQUEST,
-            'filter: Got error \'unmatched parentheses at offset 18\' from regexp',
+            'error',
         ];
 
         yield [
             '!regexp',
             '^(Test|Test string))', // invalid regex: 2 ending parantheses
             Response::HTTP_BAD_REQUEST,
-            'filter: Got error \'unmatched parentheses at offset 19\' from regexp',
+            'error',
         ];
 
         yield [
@@ -89,7 +89,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($expectedResponseCode, $this->client->getResponse()->getStatusCode());
 
         if ($expectedErrorMessage) {
-            Assert::assertSame(
+            Assert::assertStringContainsString(
                 $expectedErrorMessage,
                 json_decode($this->client->getResponse()->getContent(), true)['errors'][0]['message'],
                 $this->client->getResponse()->getContent()

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -65,9 +65,6 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testRegexOperatorValidation(string $operator, string $regex, int $expectedResponseCode, ?string $expectedErrorMessage): void
     {
-        $version = $this->connection->executeQuery('SELECT VERSION()')->fetchOne();
-        version_compare($version, '8.0.0', '<') ? $this->markTestSkipped('MySQL 5.7.0 does not throw error for invalid REGEXP') : null;
-
         $this->client->request(
             Request::METHOD_POST,
             '/api/segments/new',

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -115,7 +115,6 @@ $connectionSettings = [
     'charset'               => 'utf8mb4',
     'default_table_options' => [
         'charset'    => 'utf8mb4',
-        'collate'    => 'utf8mb4_unicode_ci',
         'row_format' => 'DYNAMIC',
     ],
     // Prevent Doctrine from crapping out with "unsupported type" errors due to it examining all tables in the database and not just Mautic's

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -3,8 +3,8 @@
   "stability": "rc",
   "minimum_php_version": "8.2.0",
   "maximum_php_version": "8.3.99",
-  "minimum_mysql_version": "5.7.14",
-  "minimum_mariadb_version": "10.2.7",
+  "minimum_mysql_version": "8.4.0",
+  "minimum_mariadb_version": "10.11.0",
   "show_php_version_warning_if_under": "8.2.0",
   "minimum_mautic_version": "5.0.0",
   "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.0"

--- a/plugins/MauticFocusBundle/EventListener/ReportSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/ReportSubscriber.php
@@ -131,7 +131,9 @@ final class ReportSubscriber implements EventSubscriberInterface
                 self::PREFIX_TRACKABLES.'.channel = "focus"')
             ->leftJoin(self::PREFIX_STATS, MAUTIC_TABLE_PREFIX.'page_redirects', self::PREFIX_REDIRECTS,
                 self::PREFIX_REDIRECTS.'.id = '.self::PREFIX_TRACKABLES.'.redirect_id')
-            ->groupBy(self::PREFIX_STATS.'.focus_id', self::PREFIX_STATS.'.type');
+            ->groupBy(self::PREFIX_STATS.'.focus_id', self::PREFIX_STATS.'.type')
+            ->orderBy(self::PREFIX_FOCUS.'.name', 'ASC')
+            ->addOrderBy(self::PREFIX_STATS.'.type', 'ASC');
 
         $event->applyDateFilters($queryBuilder, 'date_added', self::PREFIX_STATS);
         $event->setQueryBuilder($queryBuilder);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #13262 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR aims to make Mautic officially compatible with newer Mysql and Mariadb versions.
This PR adds / changes to LTS versions of MariaDB and MySQL.

The main changes are related to sorting, as there is a change on how MySQL 8 approaches this.

When merged, this also needs to be adapted on the [website](https://mautic.org/mautic-requirements/#:~:text=Mautic%20supports%20MySQL%20and%20MariaDB%20out%20of%20the%20box.&text=Minimum%20MySQL%20version%20is%205.7%20or%20MariaDB%2010.2.) 

This PR can be rebased easily on 6.x (and most likely 5.x too if needed)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->