### PR TITLE
[UXUI-144] Show category when viewing resource details

### DIFF
--- a/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
@@ -18,6 +18,7 @@
             'targetLabel': 'mautic.asset.assets'|trans
         }
     ) -}}
+    {{ include('@MauticCore/Helper/category--inline.html.twig', {'category': activeAsset.category}) }}
 {% endblock %}
 
 {% block headerTitle %} {{ activeAsset.getTitle() }} {% endblock %}

--- a/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Asset/details.html.twig
@@ -1,7 +1,7 @@
 {% extends '@MauticCore/Default/content.html.twig' %}
 {% block mauticContent %}asset{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
         {
             'item'            : activeAsset,

--- a/app/bundles/AssetBundle/Resources/views/Asset/list.html.twig
+++ b/app/bundles/AssetBundle/Resources/views/Asset/list.html.twig
@@ -209,9 +209,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.getCategory() %}
-                        {% set catName, color = (category) ? category.getTitle() : 'mautic.core.form.uncategorized'|trans, (category) ? '#' ~ category.getColor() : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.getCategory()}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ item.getDownloadCount() }}</td>
                     <td class="visible-md visible-lg" title="{{ item.getDateAdded() ? dateToFullConcat(item.getDateAdded()) : '' }}">

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
@@ -13,6 +13,7 @@
     'routeBase': 'campaign',
     'targetLabel': 'mautic.campaign.campaigns'|trans
   }) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': campaign.category}) }}
 {% endblock %}
 
 {% block headerTitle %}{{ campaign.name }}{% endblock %}

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/details.html.twig
@@ -1,6 +1,6 @@
 {% extends '@MauticCore/Default/content.html.twig' %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig', {
     'item': campaign,
     'templateButtons': {

--- a/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Campaign/list.html.twig
@@ -159,9 +159,7 @@
                         {%- endif -%}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName, color = (category) ? category.title : 'mautic.core.form.uncategorized'|trans, (category) ? '#' ~ category.color : '#' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg" title="{{ item.dateAdded ? dateToFullConcat(item.dateAdded) : '' }}">
                         {{ item.dateAdded ? dateToDate(item.dateAdded) : '' }}

--- a/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
+++ b/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
@@ -7,7 +7,7 @@
 	{{ item.getName() }}
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : item,

--- a/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
+++ b/app/bundles/ChannelBundle/Resources/views/Message/details.html.twig
@@ -18,6 +18,7 @@
         'targetLabel'     : 'mautic.channel.messages'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': item.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -10019,6 +10019,26 @@ code:hover > .copy-icon {
 .rounded-corners-preview--32 {
   border-radius: 32px;
 }
+.category--inline-color {
+  width: 18px;
+  height: 8px;
+  border-radius: 10px;
+  background: var(--category-color);
+  transition: var(--transition-all-productive);
+}
+.category--inline-color i {
+  opacity: 0;
+  transition: var(--transition-all-productive);
+  filter: invert(100%) grayscale(100%) contrast(500%);
+  color: var(--category-color);
+}
+.category--inline:hover .category--inline-color {
+  height: 16px;
+  width: 26px;
+}
+.category--inline:hover .category--inline-color i {
+  opacity: 1;
+}
 .toggle {
   display: inline-block;
   -webkit-user-select: none;

--- a/app/bundles/CoreBundle/Assets/css/app/less/custom.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/custom.less
@@ -523,3 +523,25 @@ code:hover > .copy-icon {
 .rounded-corners-preview--32 {
   border-radius: 32px;
 }
+
+.category--inline-color {
+  width: 18px;
+  height: 8px;
+  border-radius: 10px;
+  background: var(--category-color);
+  transition: var(--transition-all-productive);
+
+  i { 
+    opacity: 0; 
+    transition: var(--transition-all-productive); 
+    filter: invert(100%) grayscale(100%) contrast(500%);
+    color: var(--category-color);
+  }
+}
+
+.category--inline:hover .category--inline-color {
+  height: 16px;
+  width: 26px;
+
+  i { opacity: 1; }
+}

--- a/app/bundles/CoreBundle/Resources/views/Default/content.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/content.html.twig
@@ -14,7 +14,7 @@
         content: block('content') is defined ? block('content') : content|default(''),
         modal: block('modal') is defined ? block('modal') : modal|default(''),
         headerTitle: block('headerTitle'),
-        indexButton: block('indexButton') is defined ? block('indexButton') : indexButton|default(''),
+        preHeader: block('preHeader') is defined ? block('preHeader') : preHeader|default(''),
         pageTitle: block('pageTitle') is defined ? block('pageTitle') : pageTitle|default(''),
         publishStatus: block('publishStatus') is defined ? block('publishStatus') : publishStatus|default(''),
         actions: block('actions') is defined ? block('actions') : actions|default(''),

--- a/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/pageheader.html.twig
@@ -2,7 +2,7 @@
 	<div class="row-no-gutters ai-center-md gap-md fw-nowrap-md fd-row-md fd-column-reverse">
 		<div class="col-xs-12 col-sm-6 col-md-5 va-m">
 			<div class="d-flex fd-column fw-wrap fw-nowrap-md">
-				{{ indexButton|raw }}
+				{{ preHeader|raw }}
 				<h1 class="pull-left page-header-title">{{ headerTitle|purify }}</h1>
 			<div class="mt-md d-flex gap-xs">{{ publishStatus|raw }}</div>
 			{{ customContent('page.header.left', _context) }}

--- a/app/bundles/CoreBundle/Resources/views/Helper/category--expanded.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/category--expanded.html.twig
@@ -1,0 +1,4 @@
+<div class="d-flex ai-center gap-xs">
+    <span class="label label-gray label-category" style="background: {% if category.color is defined and category.color %}#{{ category.color }}{% else %}var(--label-background-gray){% endif %};"> </span> 
+    {{ category.title|default('mautic.core.form.uncategorized'|trans) }}
+</div>

--- a/app/bundles/CoreBundle/Resources/views/Helper/category--inline.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/category--inline.html.twig
@@ -1,0 +1,7 @@
+<div class="d-flex ai-center mt-sm float-right">
+    <div class="category--inline d-inline-flex ai-center h-32 pr-xs" data-toggle="tooltip" data-placement="right" title="{{ (category.title|default('mautic.core.form.uncategorized'|trans)|striptags) }}">
+        <span class="category--inline-color d-inline-flex ai-center jc-center" style="--category-color: {% if category.color is defined and category.color %}#{{ category.color }}{% else %}var(--label-background-gray){% endif %};">
+            <i class="ri-folder-6-fill fs-10"></i>
+        </span>
+    </div>
+</div>

--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/_list.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/_list.html.twig
@@ -86,9 +86,7 @@
                     </td>
                     <td class="visible-md visible-lg">{{ item.slotName }}</td>
                     <td class="visible-md visible-lg">
-                        {% set catName = item.category is not empty ? item.category.title : 'mautic.core.form.uncategorized'|trans %}
-                        {% set color = item.category is not empty ? '#' ~ item.category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ item.id }}</td>
                 </tr>

--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
@@ -44,6 +44,7 @@
         'targetLabel'     : 'mautic.dynamicContent.dynamicContents'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': entity.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
+++ b/app/bundles/DynamicContentBundle/Resources/views/DynamicContent/details.html.twig
@@ -33,7 +33,7 @@
     {% include '@MauticCore/Helper/_tag.html.twig' with { tags: tags } %}
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : entity,

--- a/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
@@ -141,10 +141,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.getCategory() %}
-                        {% set catName  = category ? category.getTitle() : 'mautic.core.form.uncategorized'|trans %}
-                        {% set color = (category) ? '#' ~ category.getColor() : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-sm visible-md visible-lg col-stats" data-stats="{{ item.getId() }}">
                         {{ customContent('email.stats.above', mauticTemplateVars) }}

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -20,6 +20,7 @@
             'customButtons' : []
         }) -}}
     {% endif %}
+    {{ include('@MauticCore/Helper/category--inline.html.twig', {'category': email.category}) }}
 {% endblock %}
 
 {% set variantContent = include('@MauticCore/Variant/index.html.twig', {

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -4,7 +4,7 @@
 
 {% block mauticContent 'email' %}
 
-{% block indexButton %}
+{% block preHeader %}
     {% if not isEmbedded %}
         {{- include('@MauticCore/Helper/page_actions.html.twig', {
             'item'            : email,

--- a/app/bundles/FormBundle/Resources/views/Form/_list.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Form/_list.html.twig
@@ -122,10 +122,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category ? category.title : 'mautic.core.form.uncategorized'|trans %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">
                         <a href="{{ path('mautic_form_action', {'objectAction': 'results', 'objectId': item.id}) }}" data-toggle="ajax" data-menu-link="mautic_form_index" size="sm" class="label label-gray" {% if 0 == i.submission_count %}disabled="disabled"{% endif %}>

--- a/app/bundles/FormBundle/Resources/views/Form/details.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Form/details.html.twig
@@ -27,6 +27,7 @@
     'langVar': 'form',
     'targetLabel': 'mautic.form.forms'|trans
 }) }}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': activeForm.category}) }}
 {% endblock %}
 
 {% block headerTitle %}{{ activeForm.name }}{% endblock %}

--- a/app/bundles/FormBundle/Resources/views/Form/details.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Form/details.html.twig
@@ -17,7 +17,7 @@
 
 {% block mauticContent %}form{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{ include('@MauticCore/Helper/page_actions.html.twig', {
     'item': activeForm,
     'templateButtons': {

--- a/app/bundles/LeadBundle/Resources/views/Company/company.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/company.html.twig
@@ -15,7 +15,7 @@
 
 {% block headerTitle %}{{ company.name }}{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : company,

--- a/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
@@ -15,7 +15,7 @@
   {{ include('@MauticCore/Helper/publishstatus_badge.html.twig', {'entity': item}) }}
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
     {{ include('@MauticCore/Helper/page_actions.html.twig', {
             'routeBase': 'import',
             'langVar': 'lead.import',

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -23,7 +23,7 @@
     {{ lead.secondaryIdentifier|purify }}</span></div>
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : lead,

--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -28,6 +28,7 @@
     'routeBase': 'segment',
     'targetLabel': 'mautic.lead.lead.lists'|trans
 }) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': list.category}) }}
 {% endblock %}
 
 {% block headerTitle %}{{ list.name }}{% endblock %}

--- a/app/bundles/LeadBundle/Resources/views/List/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/details.html.twig
@@ -18,7 +18,7 @@
 
 {% block mauticContent %}list{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig', {
     'item': list,
     'customButtons': customButtons|default([]),

--- a/app/bundles/MarketplaceBundle/Resources/views/Package/detail.html.twig
+++ b/app/bundles/MarketplaceBundle/Resources/views/Package/detail.html.twig
@@ -7,7 +7,7 @@
     {% set latestVersion = packageDetail.versions.findLatestVersionPackage() %}
 {% endif %}
 
-{% block indexButton %}
+{% block preHeader %}
     {% include '@MauticCore/Helper/button.html.twig' with {
         buttons: [
             {

--- a/app/bundles/NotificationBundle/Resources/views/MobileNotification/_list.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/MobileNotification/_list.html.twig
@@ -88,10 +88,7 @@
                         </div>
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-sm visible-md visible-lg col-stats">
                         <span class="mt-xs label label-green"

--- a/app/bundles/NotificationBundle/Resources/views/MobileNotification/details.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/MobileNotification/details.html.twig
@@ -15,7 +15,7 @@
 
 {% block headerTitle %}{{ notification.name }}{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : notification,

--- a/app/bundles/NotificationBundle/Resources/views/MobileNotification/details.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/MobileNotification/details.html.twig
@@ -26,6 +26,7 @@
         'targetLabel'     : 'mautic.notification.mobile_notifications'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': notification.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/app/bundles/NotificationBundle/Resources/views/Notification/_list.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/Notification/_list.html.twig
@@ -89,10 +89,7 @@
                         </div>
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-sm visible-md visible-lg col-stats">
                         <span class="mt-xs label label-green"

--- a/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
@@ -26,6 +26,7 @@
         'targetLabel'     : 'mautic.notification.notifications'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': notification.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
+++ b/app/bundles/NotificationBundle/Resources/views/Notification/details.html.twig
@@ -15,7 +15,7 @@
 
 {% block headerTitle %}{{ notification.name }}{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : notification,

--- a/app/bundles/PageBundle/Resources/views/Page/_list.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Page/_list.html.twig
@@ -126,10 +126,7 @@
                         {{ customContent('page.name', _context) }}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ item.hits }}</td>
                     <td class="visible-md visible-lg" title="{% if item.dateAdded %}{{ dateToFullConcat(item.dateAdded) }}{% endif %}">

--- a/app/bundles/PageBundle/Resources/views/Page/details.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Page/details.html.twig
@@ -21,7 +21,7 @@
 
 {% block mauticContent %}page{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{ include('@MauticCore/Helper/page_actions.html.twig', {
     'item': activePage,
     'customButtons': customButtons|default([]),

--- a/app/bundles/PageBundle/Resources/views/Page/details.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Page/details.html.twig
@@ -31,6 +31,7 @@
     'routeBase': 'page',
     'targetLabel': 'mautic.page.pages'|trans
 }) }}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': activePage.category}) }}
 {% endblock %}
 
 {% block headerTitle %}{{ activePage.title }}{% endblock %}

--- a/app/bundles/PointBundle/Resources/views/Point/_list.html.twig
+++ b/app/bundles/PointBundle/Resources/views/Point/_list.html.twig
@@ -80,10 +80,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">
                         {% set group = item.group %}

--- a/app/bundles/PointBundle/Resources/views/Trigger/_list.html.twig
+++ b/app/bundles/PointBundle/Resources/views/Trigger/_list.html.twig
@@ -8,8 +8,6 @@
                     'target': '#triggerTable',
                 }) }}
 
-                <th class='col-pointtrigger-color'></th>
-
                 {{ include('@MauticCore/Helper/tableheader.html.twig', {
                         'sessionVar': 'point.trigger',
                         'orderBy': 't.name',
@@ -63,9 +61,6 @@
                         }) }}
                     </td>
                     <td>
-                        <span class="label label-gray label-category" style="background: {{ '#' not in item.color ? '#' : ''}}{{ item.color }};"> </span>
-                    </td>
-                    <td>
                         <div>
                             {{ include('@MauticCore/Helper/publishstatus_icon.html.twig', {'item': item, 'model': 'point.trigger'}) }}
                             {% if permissions['point:triggers:edit'] %}
@@ -84,10 +79,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">
                         {{ item.group.name|default('mautic.point.group.form.nogroup'|trans) }}

--- a/app/bundles/ReportBundle/Resources/views/Report/details.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/details.html.twig
@@ -13,7 +13,7 @@
     }) -}}
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : report,

--- a/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
@@ -5,7 +5,7 @@
 {% block mauticContent %}sms{% endblock %}
 {% block headerTitle %}{{sms.getName()}}{% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : sms,

--- a/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/Sms/details.html.twig
@@ -20,6 +20,7 @@
         'targetLabel': 'mautic.sms.smses'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': sms.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/app/bundles/SmsBundle/Resources/views/Sms/list.html.twig
+++ b/app/bundles/SmsBundle/Resources/views/Sms/list.html.twig
@@ -169,10 +169,7 @@
                         </div>
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.getCategory() %}
-                        {% set catName  = category is not empty ? category.getTitle() : 'mautic.core.form.uncategorized'|trans %}
-                        {% set color    = category is not empty ? '#' ~ category.getColor() : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.getCategory()}) }}
                     </td>
                         {{- include('@MauticSms/Sms/list_stats.html.twig', { 'item' : item }) -}}
                     <td class="visible-md visible-lg">{{ item.getId() }}</td>

--- a/app/bundles/StageBundle/Resources/views/Stage/list.html.twig
+++ b/app/bundles/StageBundle/Resources/views/Stage/list.html.twig
@@ -136,10 +136,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.getCategory() %}
-                        {% set catName = category ? category.getTitle() : 'mautic.core.form.uncategorized'|trans %}
-                        {% set color = category ? '#' ~ category.getColor() : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ item.getId() }}</td>
                 </tr>

--- a/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
+++ b/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
@@ -14,6 +14,7 @@
         routeBase: 'webhook',
         'targetLabel': 'mautic.webhook.webhooks'|trans
 }) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': item.category}) }}
 {% endblock %}
 
 {% block headerTitle %}{{ item.getName() }}{% endblock %}

--- a/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
+++ b/app/bundles/WebhookBundle/Resources/views/Webhook/details.html.twig
@@ -1,6 +1,6 @@
 {% extends '@MauticCore/Default/content.html.twig' %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include(
     '@MauticCore/Helper/page_actions.html.twig', {
         item: item,

--- a/app/bundles/WebhookBundle/Resources/views/Webhook/list.html.twig
+++ b/app/bundles/WebhookBundle/Resources/views/Webhook/list.html.twig
@@ -81,6 +81,13 @@
                 {{- include(
                     '@MauticCore/Helper/tableheader.html.twig', {
                         sessionVar: 'mautic_webhook',
+                        orderBy: 'c.title',
+                        text: 'mautic.core.category',
+                        class: 'visible-md visible-lg col-webhook-category',
+                }) -}}
+                {{- include(
+                    '@MauticCore/Helper/tableheader.html.twig', {
+                        sessionVar: 'mautic_webhook',
                         orderBy: 'e.webhookUrl',
                         text: 'mautic.webhook.webhook_url',
                         class: 'col-webhook-id visible-md visible-lg'
@@ -137,6 +144,9 @@
                             </div>
                             {% endif %}
                         </div>
+                    </td>
+                    <td class="visible-md visible-lg">
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.getCategory()}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ item.getWebhookUrl() }}</td>
                     <td class="visible-md visible-lg">{{ item.getId() }} </td>

--- a/plugins/MauticFocusBundle/Resources/views/Focus/_list.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/_list.html.twig
@@ -76,10 +76,7 @@
                         {% endif %}
                     </td>
                     <td class="visible-md visible-lg">
-                        {% set category = item.category %}
-                        {% set catName  = category.title|default('mautic.core.form.uncategorized'|trans) %}
-                        {% set color    = category ? '#' ~ category.color : '' %}
-                        <div class="d-flex ai-center gap-xs"><span class="label label-gray label-category" style="background: {{ color }};"> </span> {{ catName }}</div>
+                        {{ include('@MauticCore/Helper/category--expanded.html.twig', {'category': item.category}) }}
                     </td>
                     <td class="visible-md visible-lg">{{ ('mautic.focus.type.' ~ item.type)|trans }}</td>
                     <td class="visible-md visible-lg">{{ ('mautic.focus.style.' ~ item.style)|trans }}</td>

--- a/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
@@ -19,6 +19,7 @@
         'targetLabel': 'mautic.focus.focus_items'|trans
     }
 ) -}}
+{{ include('@MauticCore/Helper/category--inline.html.twig', {'category': item.category}) }}
 {% endblock %}
 
 {% block actions %}

--- a/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
+++ b/plugins/MauticFocusBundle/Resources/views/Focus/details.html.twig
@@ -8,7 +8,7 @@
     {{- include('@MauticCore/Helper/publishstatus_badge.html.twig', {'entity' : item}) -}}
 {% endblock %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : item,

--- a/plugins/MauticSocialBundle/Resources/views/Monitoring/details.html.twig
+++ b/plugins/MauticSocialBundle/Resources/views/Monitoring/details.html.twig
@@ -9,7 +9,7 @@
 
 {% block headerTitle activeMonitoring.title %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         'item'            : activeMonitoring,

--- a/plugins/MauticTagManagerBundle/Resources/views/Tag/details.html.twig
+++ b/plugins/MauticTagManagerBundle/Resources/views/Tag/details.html.twig
@@ -5,7 +5,7 @@
 
 {% set customButtons = {} %}
 
-{% block indexButton %}
+{% block preHeader %}
 {{- include('@MauticCore/Helper/page_actions.html.twig',
     {
         item            : tag,


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds a new component to show category when viewing resource details
- the background color matches the category color
- the icon automatically appears with enough contrast to ensure visibility (black or white)

[Screencast From 2025-04-02 16-05-38.webm](https://github.com/user-attachments/assets/5f9d556d-b9c0-4206-9e40-d4ce1f653d54)


![image](https://github.com/user-attachments/assets/035ec763-f8d3-4ea1-9936-1d0f4a973b07)

![image](https://github.com/user-attachments/assets/36303eb6-a064-46db-a783-a9eda03dcfd0)

It also refactors hardcoded category labels in tables to use a reusable twig template

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open Categories
3. Create a new category assigning a color
4. Create a resource that can be categorized, such as an email
5. Set the category when creating
6. Save & Close to see the details screen
7. Check the element above the title/resource name

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->