### PR TITLE
Hide "User management" menu item for users without permissions

### DIFF
--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -6,6 +6,7 @@ return [
             'mautic.user_management' => [
                 'id'        => 'mautic_user_management_root',
                 'priority'  => 17,
+                'access'    => ['user:users:view', 'user:roles:view'],
             ],
             'mautic.user.users' => [
                 'access'    => 'user:users:view',


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14345 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The "User management" header remained visible even when users had no access to Users or Roles, leading to UI confusion. The change in the config.php file adds permission checks for "user:users:view" and "user:roles:view", ensuring that the header is only displayed when the user has the appropriate access. This fix prevents the header from showing up for unauthorized users.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1.Open Roles
2.Create new
3.Set all Contact permissions to full, leaving with no permissions related to Users or Roles
4.Open the Users page and create one, assigning the role you just created
5.In an incognito window, open your Mautic and log in on the created user
6.Click on the cog icon to open the admin panel and check there is no "User management" header there anymore

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->