### PR TITLE
Backmerge 6.x into 6.0

### DIFF
--- a/app/bundles/CategoryBundle/Form/Type/CategoryType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryType.php
@@ -119,10 +119,7 @@ class CategoryType extends AbstractType
             ]
         );
 
-        $builder->add('buttons', FormButtonsType::class,
-            [
-                'apply_text' => false,
-            ]);
+        $builder->add('buttons', FormButtonsType::class);
 
         if (!empty($options['action'])) {
             $builder->setAction($options['action']);


### PR DESCRIPTION
## Description

This PR backmerges some PRs that were accidentally merged into the 6.x branch into the 6.0 branch.

After merging this PR, the 6.x branch should be locked to prevent further accidental merges.

There were no merge conflicts.