### PR TITLE
Enforce an orderBy on the campaign contacts by segment query

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -400,7 +400,7 @@ class LeadRepository extends CommonRepository
                     $qb->expr()->eq('ll.manually_removed', 0),
                     $qb->expr()->in('ll.leadlist_id', $segments)
                 )
-            );
+            )->orderBy('ll.lead_id');
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
         $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
When querying for contacts in a campaign by segment, the query does not add an orderBy directive to the query. This can cause the results to come back in an indeterminate order, resulting in kickoff jobs being created with overlapping min/max contact ID's. That ends up being a problem when executing campaign actions because when multiple workers execute jobs for the same contacts, only one is successful. The other will fail, causing all contacts that would have been processed after the failure to instead not be processed. This means contacts are in a campaign without having any actions, decisions, or conditions executed.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to reproduce the bug:

1. Create 3 segments - A, B, and C. The total contacts in each combined should be over 20K. Segment A should contain contacts with ID's higher than those in Segment B. Segment C can contain anything.
2. Use these segments as a source for a campaign. Select A first, then B, then C.
3. Publish the campaign and check the allyde jobs table
4. Filter the table by tube=campaign, task=kickoff_campaign, primary_entity_id=the id of the campaign you're testing
5. You'll see multiple jobs. There is a chance the minId and maxId for one job will overlap with the minId and maxId of one of the others.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Redo steps, but you'll see that minId and maxId for each job does not overlap those numbers in another

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->