### PR TITLE
DPMMA-3090 Fix sortable list after removing element

### DIFF
--- a/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
@@ -55,6 +55,9 @@ class SortableListTransformer implements DataTransformerInterface
             return ['list' => []];
         }
 
+        // Reindex the array before processing
+        $array['list'] = array_values($array['list']);
+
         $array['list'] = AbstractFormFieldHelper::parseList($array['list']);
 
         if (!$this->withLabels) {

--- a/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Form\DataTransformer;
+
+use Mautic\CoreBundle\Form\DataTransformer\SortableListTransformer;
+use PHPUnit\Framework\TestCase;
+
+class SortableListTransformerTest extends TestCase
+{
+    /**
+     * @dataProvider standardListProvider
+     */
+    public function testTransformStandardListWithLabels(array $input, array $expected): void
+    {
+        $transformer = new SortableListTransformer(withLabels: true, useKeyValuePairs: false);
+        $result      = $transformer->transform($input);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider keyValuePairProvider
+     */
+    public function testTransformKeyValuePairs(array $input, array $expected): void
+    {
+        $transformer = new SortableListTransformer(withLabels: true, useKeyValuePairs: true);
+        $result      = $transformer->transform($input);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider standardListWithoutLabelsProvider
+     */
+    public function testTransformListWithoutLabels(array $input, array $expected): void
+    {
+        $transformer = new SortableListTransformer(withLabels: false, useKeyValuePairs: false);
+        $result      = $transformer->transform($input);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testTransformHandlesNullInput(): void
+    {
+        $transformer = new SortableListTransformer();
+        $result      = $transformer->transform(null);
+
+        $this->assertEquals(['list' => []], $result);
+    }
+
+    public function testReverseTransformHandlesNullInput(): void
+    {
+        $transformer = new SortableListTransformer(useKeyValuePairs: true);
+        $result      = $transformer->reverseTransform(null);
+
+        $this->assertEquals([], $result);
+    }
+
+    /**
+     * @dataProvider reverseKeyValuePairProvider
+     */
+    public function testReverseTransformKeyValuePairs(array $input, array $expected): void
+    {
+        $transformer = new SortableListTransformer(withLabels: true, useKeyValuePairs: true);
+        $result      = $transformer->reverseTransform($input);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testReverseTransformHandlesMissingLabels(): void
+    {
+        $transformer = new SortableListTransformer(useKeyValuePairs: true);
+        $input       = [
+            'list' => [
+                ['value' => 'test1'], // missing label
+                ['label' => 'key2', 'value' => 'test2'],
+            ],
+        ];
+        $expected = ['key2' => 'test2'];
+
+        $result = $transformer->reverseTransform($input);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function standardListProvider(): array
+    {
+        return [
+            'simple list' => [
+                'input' => [
+                    'list' => [
+                        3 => 'a@example.com',
+                        2 => 'b@example.com',
+                    ],
+                ],
+                'expected' => [
+                    'list' => [
+                        ['label' => 'a@example.com', 'value' => 'a@example.com'],
+                        ['label' => 'b@example.com', 'value' => 'b@example.com'],
+                    ],
+                ],
+            ],
+            'non sequential indexes' => [
+                'input' => [
+                    'list' => ['item1', 'item2', 'item3'],
+                ],
+                'expected' => [
+                    'list' => [
+                        ['label' => 'item1', 'value' => 'item1'],
+                        ['label' => 'item2', 'value' => 'item2'],
+                        ['label' => 'item3', 'value' => 'item3'],
+                    ],
+                ],
+            ],
+            'empty list' => [
+                'input'    => ['list' => []],
+                'expected' => ['list' => []],
+            ],
+        ];
+    }
+
+    public function standardListWithoutLabelsProvider(): array
+    {
+        return [
+            'simple list without labels' => [
+                'input' => [
+                    'list' => ['item1', 'item2', 'item3'],
+                ],
+                'expected' => [
+                    'list' => ['item1', 'item2', 'item3'],
+                ],
+            ],
+            'non sequential indexes' => [
+                'input' => [
+                    'list' => [
+                        6 => 'item1',
+                        3 => 'item2',
+                        4 => 'item3',
+                    ],
+                ],
+                'expected' => [
+                    'list' => ['item1', 'item2', 'item3'],
+                ],
+            ],
+            'empty list' => [
+                'input'    => ['list' => []],
+                'expected' => ['list' => []],
+            ],
+        ];
+    }
+
+    public function keyValuePairProvider(): array
+    {
+        return [
+            'key value pairs' => [
+                'input' => [
+                    'key1' => 'value1',
+                    'key2' => 'value2',
+                ],
+                'expected' => [
+                    'list' => [
+                        ['label' => 'key1', 'value' => 'value1'],
+                        ['label' => 'key2', 'value' => 'value2'],
+                    ],
+                ],
+            ],
+            'empty array' => [
+                'input'    => [],
+                'expected' => ['list' => []],
+            ],
+        ];
+    }
+
+    public function reverseKeyValuePairProvider(): array
+    {
+        return [
+            'standard key-value pairs' => [
+                'input' => [
+                    'list' => [
+                        ['label' => 'key1', 'value' => 'value1'],
+                        ['label' => 'key2', 'value' => 'value2'],
+                    ],
+                ],
+                'expected' => [
+                    'key1' => 'value1',
+                    'key2' => 'value2',
+                ],
+            ],
+            'empty list' => [
+                'input'    => ['list' => []],
+                'expected' => [],
+            ],
+        ];
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
@@ -11,6 +11,9 @@ class SortableListTransformerTest extends TestCase
 {
     /**
      * @dataProvider standardListProvider
+     *
+     * @param array<string, array<int|string, string>>    $input
+     * @param array<string, array<array<string, string>>> $expected
      */
     public function testTransformStandardListWithLabels(array $input, array $expected): void
     {
@@ -22,6 +25,9 @@ class SortableListTransformerTest extends TestCase
 
     /**
      * @dataProvider keyValuePairProvider
+     *
+     * @param array<string, string>                       $input
+     * @param array<string, array<array<string, string>>> $expected
      */
     public function testTransformKeyValuePairs(array $input, array $expected): void
     {
@@ -33,6 +39,9 @@ class SortableListTransformerTest extends TestCase
 
     /**
      * @dataProvider standardListWithoutLabelsProvider
+     *
+     * @param array<string, array<int|string, string>> $input
+     * @param array<string, array<string>>             $expected
      */
     public function testTransformListWithoutLabels(array $input, array $expected): void
     {
@@ -60,6 +69,9 @@ class SortableListTransformerTest extends TestCase
 
     /**
      * @dataProvider reverseKeyValuePairProvider
+     *
+     * @param array<string, array<array<string, string>>> $input
+     * @param array<string, string>                       $expected
      */
     public function testReverseTransformKeyValuePairs(array $input, array $expected): void
     {
@@ -85,6 +97,9 @@ class SortableListTransformerTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @return array<string, array{input: array<string, array<int|string, string>>, expected: array<string, array<array<string, string>>>}>
+     */
     public function standardListProvider(): array
     {
         return [
@@ -121,6 +136,9 @@ class SortableListTransformerTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<string, array{input: array<string, array<int|string, string>>, expected: array<string, array<string>>}>
+     */
     public function standardListWithoutLabelsProvider(): array
     {
         return [
@@ -151,6 +169,9 @@ class SortableListTransformerTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<string, array{input: array<string, string>, expected: array<string, array<array<string, string>>>}>
+     */
     public function keyValuePairProvider(): array
     {
         return [
@@ -173,6 +194,9 @@ class SortableListTransformerTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<string, array{input: array<string, array<array<string, string>>>, expected: array<string, string>}>
+     */
     public function reverseKeyValuePairProvider(): array
     {
         return [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14456 https://forum.mautic.org/t/500-error-when-sending-test-email/35237

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR fixes the problem with submitting the sortable list when one of the elements are removed and the indexes and not sequential. This leads to errors like this #14456:
```
[2025-01-14T10:30:25.706423+00:00] mautic.CRITICAL: Uncaught PHP Exception Symfony\Component\Mime\Exception\RfcComplianceException: "Email "1" does not comply with addr-spec of RFC 2822." at /home/www/mautic/www/vendor/symfony/mime/Address.php line 56 {"exception":"[object] (Symfony\\Component\\Mime\\Exception\\RfcComplianceException(code: 0): Email \"1\" does not comply with addr-spec of RFC 2822. at /home/www/mautic/www/vendor/symfony/mime/Address.php:56)"} {"hostname":"mautic.local","pid":5301}
```


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
Step 1: On 'Emails' page, select some email channel
Step 2: Click the dropdown icon, and then select 'Send Example'
Step 3: Remove existing recipient from 'Recipients' list
Step 4: Click 'Add recipient'
Step 5: On the new field, type desired email address
Step 6: Click 'Send' button - the email should be sent successfully

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->