### PR TITLE
fix: sidebar not working in mobile view

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -2017,6 +2017,13 @@ body > #app-wrapper {
     margin-left: 60px;
   }
 }
+.app-sidebar {
+  left: -230px;
+  transition: left 0.3s ease;
+}
+.app-sidebar.open {
+  left: 0px;
+}
 .csstransforms3d.sidebar-open-ltr #app-content {
   -webkit-transform: translate3d(230px, 0, 0);
   transform: translate3d(230px, 0, 0);
@@ -6075,10 +6082,10 @@ input[style]:hover {
   box-shadow: none;
 }
 .form-control {
-  &:not(select) {
-    padding: var(--spacing-04) var(--spacing-05);
-  }
   color: var(--text-primary);
+}
+.form-control:not(select) {
+  padding: var(--spacing-04) var(--spacing-05);
 }
 .form-control + .help-text,
 .form-control + p {
@@ -6088,13 +6095,9 @@ input[style]:hover {
   padding: var(--spacing-01) var(--spacing-04);
 }
 .form-control[disabled],
+.form-control[readonly],
 fieldset[disabled] .form-control {
   color: var(--text-disabled);
-}
-.form-control[readonly]{
-  color: var(--text-primary);
-  background-color: var(--field);
-  border-color: var(--border-subtle);
 }
 .form-control[disabled] {
   cursor: not-allowed;

--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -1761,11 +1761,6 @@ body > #app-wrapper {
   z-index: 990;
   top: 0;
   bottom: 0;
-  left: -230px;
-  transition: left 0.3s ease;
-}
-.app-sidebar.open {
-  left: 0px;
 }
 .app-sidebar.sidebar-left {
   width: 230px;
@@ -2004,6 +1999,9 @@ body > #app-wrapper {
 }
 .app-sidebar .nav-sidebar > .nav .nav-heading:first-child {
   padding-top: 20px;
+}
+html.responsejs.sidebar-open-ltr .sidebar-left {
+  left: 0px;
 }
 @media (min-width: 768px) {
   .app-sidebar.sidebar-left {

--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -1761,6 +1761,11 @@ body > #app-wrapper {
   z-index: 990;
   top: 0;
   bottom: 0;
+  left: -230px;
+  transition: left 0.3s ease;
+}
+.app-sidebar.open {
+  left: 0px;
 }
 .app-sidebar.sidebar-left {
   width: 230px;
@@ -2016,13 +2021,6 @@ body > #app-wrapper {
   .sidebar-left-collapse .app-sidebar.sidebar-left ~ #app-footer {
     margin-left: 60px;
   }
-}
-.app-sidebar {
-  left: -230px;
-  transition: left 0.3s ease;
-}
-.app-sidebar.open {
-  left: 0px;
 }
 .csstransforms3d.sidebar-open-ltr #app-content {
   -webkit-transform: translate3d(230px, 0, 0);

--- a/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
@@ -297,3 +297,11 @@
     }
   }
 }
+.app-sidebar {
+  left: -230px;
+  transition: left 0.3s ease;
+}
+
+.app-sidebar.open {
+  left: 0px;
+}

--- a/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
@@ -30,12 +30,6 @@
   z-index: @sidebar-zindex;
   top: 0;
   bottom: 0;
-  left: -230px;
-  transition: left 0.3s ease;
-
-  &.open {
-    left: 0px;
-  }
 
   // sidebar left
   // -------------------------
@@ -267,6 +261,11 @@
       }
     }
   }
+}
+
+// sidebar nav
+html.responsejs.sidebar-open-ltr .sidebar-left {
+  left: 0px;
 }
 
 // breakpoint screen-sm and up

--- a/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/layouts/sidebar.less
@@ -30,6 +30,12 @@
   z-index: @sidebar-zindex;
   top: 0;
   bottom: 0;
+  left: -230px;
+  transition: left 0.3s ease;
+
+  &.open {
+    left: 0px;
+  }
 
   // sidebar left
   // -------------------------
@@ -73,15 +79,11 @@
     padding-left: 15px;
     padding-right: 15px;
 
-    // sidebar header fixed
     .header-fixed & {
       position: absolute;
       top: 0;
-
-      //box-shadow: 0 5px 5px -5px rgba(0,0,0,0.15), 0 1px 0 rgba(0,0,0,0.03);
     }
 
-    // add top space to `sidebar-content` if header is present
     ~ .sidebar-content {
       top: @header-height;
     }
@@ -101,7 +103,6 @@
       color: transparent;
     }
 
-    // add bottom space to `sidebar-content` if footer is present
     ~ .sidebar-content {
       bottom: @footer-height;
     }
@@ -115,12 +116,13 @@
     width: 100%;
     margin-top: @navbar-height;
 
-    // nav tab
     .nav.nav-tabs {
       border-bottom: 1px solid darken(@sidebar-right-bg, 1%);
       box-shadow: none;
+
       > li {
         margin-bottom: 0;
+
         > a {
           border-width: 0;
           border-radius: 0;
@@ -129,20 +131,24 @@
           padding-bottom: 12px;
           color: var(--text-secondary);
           background-color: transparent;
+
           &:hover,
           &:focus {
             color: var(--text-primary);
             background-color: transparent;
           }
         }
+
         &.active > a {
           overflow: visible;
+
           &,
           &:hover,
           &:focus {
             color: var(--text-primary);
             background-color: var(--layer-hover);
           }
+
           &:after {
             top: auto;
             bottom: -1px;
@@ -154,7 +160,6 @@
   }
 
   // sidebar nav
-  // -------------------------
   .nav-sidebar {
     > .nav {
       > li {
@@ -162,6 +167,7 @@
           overflow: hidden;
           padding: 12px 22px;
           .transition(all .15s ease);
+
           .text {
             .transition(~"opacity var(--duration-expressive) ease .1s, line-height");
             opacity: 1;
@@ -172,6 +178,7 @@
             display: block;
             line-height: 18px;
           }
+
           .icon {
             font-weight: normal;
             font-size: 14px;
@@ -179,6 +186,7 @@
             display: block;
             transition: var(--transition-all-expressive);
           }
+
           .arrow {
             .transition(var(--transition-all-expressive));
             opacity: 1;
@@ -188,7 +196,7 @@
             display: block;
           }
         }
-        // Open and active state
+
         &.open,
         &.active {
           > a {
@@ -201,13 +209,10 @@
           }
         }
 
-        // nav-submenu style
         > .nav-submenu {
           position: relative;
           padding-left: 50px;
 
-
-          // the line
           &:after {
             content: '';
             position: absolute;
@@ -226,7 +231,6 @@
               padding-bottom: var(--spacing-05);
             }
 
-            // the dot
             &:after {
               content: '';
               position: absolute;
@@ -237,8 +241,8 @@
               height: 7px;
               border-radius: 7px;
             }
+
             &.active {
-              // the dot
               &:after {
                 background-color: @brand-warning !important;
               }
@@ -253,10 +257,10 @@
         }
       }
 
-      // nav-heading
       .nav-heading {
         text-transform: uppercase;
         padding: 10px 18px;
+
         &:first-child {
           padding-top: 20px;
         }
@@ -266,42 +270,26 @@
 }
 
 // breakpoint screen-sm and up
-// -------------------------
 @media (min-width: @screen-sm-min) {
-  // sidebar
-  // -------------------------
   .app-sidebar {
-    // sidebar left
-    // -------------------------
     &.sidebar-left {
       left: 0;
 
-      // reset app-content
       ~ #app-content {
         margin-left: @sidebar-left-width;
 
-        // sidebar is on collapse state
         .sidebar-left-collapse & {
           margin-left: @sidebar-left-collapse-width;
         }
       }
-      // reset app-footer
+
       ~ #app-footer {
         margin-left: @sidebar-left-width;
 
-        // reset app-footer on sidebar collapse
         .sidebar-left-collapse & {
           margin-left: @sidebar-left-collapse-width;
         }
       }
     }
   }
-}
-.app-sidebar {
-  left: -230px;
-  transition: left 0.3s ease;
-}
-
-.app-sidebar.open {
-  left: 0px;
 }

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -719,6 +719,14 @@ Mautic.onPageLoad = function (container, response, inModal) {
             }
         }, false));
     }
+
+    // Sidebar toggle for elements with data-toggle="sidebar"
+    mQuery(container + " [data-toggle='sidebar']").off('click.sidebarToggle').on('click.sidebarToggle', function () {
+        const sidebar = document.querySelector('.app-sidebar');
+        if (sidebar) {
+            sidebar.classList.toggle('open');
+        }
+    });
 };
 
 Mautic.setDynamicContentEditors = function(container) {
@@ -1956,3 +1964,15 @@ document.addEventListener('DOMContentLoaded', function () {
     Mautic.initFilterCommands();
     Mautic.handlePopoverInsertion();
 });
+
+// document.addEventListener('DOMContentLoaded', function () {
+//     const toggles = document.querySelectorAll('[data-toggle="sidebar"]');
+//     toggles.forEach(function (toggle) {
+//         toggle.addEventListener('click', function () {
+//             const sidebar = document.querySelector('.app-sidebar');
+//             if (sidebar) {
+//                 sidebar.classList.toggle('open');
+//             }
+//         });
+//     });
+// });

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -719,14 +719,6 @@ Mautic.onPageLoad = function (container, response, inModal) {
             }
         }, false));
     }
-
-    // Sidebar toggle for elements with data-toggle="sidebar"
-    mQuery(container + " [data-toggle='sidebar']").off('click.sidebarToggle').on('click.sidebarToggle', function () {
-        const sidebar = document.querySelector('.app-sidebar');
-        if (sidebar) {
-            sidebar.classList.toggle('open');
-        }
-    });
 };
 
 Mautic.setDynamicContentEditors = function(container) {

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -1964,15 +1964,3 @@ document.addEventListener('DOMContentLoaded', function () {
     Mautic.initFilterCommands();
     Mautic.handlePopoverInsertion();
 });
-
-// document.addEventListener('DOMContentLoaded', function () {
-//     const toggles = document.querySelectorAll('[data-toggle="sidebar"]');
-//     toggles.forEach(function (toggle) {
-//         toggle.addEventListener('click', function () {
-//             const sidebar = document.querySelector('.app-sidebar');
-//             if (sidebar) {
-//                 sidebar.classList.toggle('open');
-//             }
-//         });
-//     });
-// });

--- a/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
@@ -85,30 +85,6 @@
     {{ buttonReset(constant('Mautic\\CoreBundle\\Twig\\Helper\\ButtonHelper::LOCATION_NAVBAR')) }}
     {{ buttonsRender() }}
     </div>
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            const toggles = document.querySelectorAll('[data-toggle="sidebar"]');
-            toggles.forEach(function (toggle) {
-                toggle.addEventListener('click', function () {
-                    const sidebar = document.querySelector('.app-sidebar');
-                    if (sidebar) {
-                        sidebar.classList.toggle('open');
-                    }
-                });
-            });
-        });
-    </script>
-    <style>
-        .app-sidebar {
-            left: -230px;
-            transition: left 0.3s ease;
-        }
-
-        .app-sidebar.open {
-            left: 0px;
-        }
-
-    </style>
     <!--/ end: right nav -->
 </div>
 <!--/ end: navbar nocollapse -->

--- a/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/navbar.html.twig
@@ -85,7 +85,30 @@
     {{ buttonReset(constant('Mautic\\CoreBundle\\Twig\\Helper\\ButtonHelper::LOCATION_NAVBAR')) }}
     {{ buttonsRender() }}
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const toggles = document.querySelectorAll('[data-toggle="sidebar"]');
+            toggles.forEach(function (toggle) {
+                toggle.addEventListener('click', function () {
+                    const sidebar = document.querySelector('.app-sidebar');
+                    if (sidebar) {
+                        sidebar.classList.toggle('open');
+                    }
+                });
+            });
+        });
+    </script>
+    <style>
+        .app-sidebar {
+            left: -230px;
+            transition: left 0.3s ease;
+        }
 
+        .app-sidebar.open {
+            left: 0px;
+        }
+
+    </style>
     <!--/ end: right nav -->
 </div>
 <!--/ end: navbar nocollapse -->

--- a/plugins/MauticFocusBundle/Assets/css/focus.css
+++ b/plugins/MauticFocusBundle/Assets/css/focus.css
@@ -24,6 +24,7 @@
   right: 0;
   left: 0;
   margin: auto;
+  z-index: 0;
 }
 .focus-builder #websiteScreenshot .screenshot-container {
   overflow: hidden;


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix?           | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14804

Description

This PR fixes an issue where the sidebar toggle (hamburger menu) was not functioning in mobile view.

The root cause was missing JS logic to toggle the sidebar element and incorrect sidebar styles that were hiding it off-canvas in mobile width without allowing it to be opened via the toggle button.

The fix includes:
- Adding JavaScript to listen for `[data-toggle="sidebar"]` clicks and toggle `.open` class on `.app-sidebar`
- Ensuring the sidebar can visually shift in and out of view on mobile screens

This resolves a critical UX bug that made navigation unusable in smaller devices.

---

📋 Steps to test this PR:

1. Resize your browser window to a mobile width (≤ 768px)
2. Observe that the hamburger icon appears (top-left)
3. Click the hamburger icon
4. Sidebar should slide in (open)
5. Click again and sidebar should slide out (close)

Test in both desktop and mobile to ensure normal sidebar visibility and responsiveness.

---

