### PR TITLE
Update contact action - max characters

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -345,7 +345,12 @@ class CampaignSubscriber implements EventSubscriberInterface
             $tokenizedValues = [];
             foreach ($values as $field => $value) {
                 if (is_string($value)) {
-                    $tokenizedValues[$field] = TokenHelper::findLeadTokens($value, $lead->getProfileFields(), true);
+                    $tokenizedValue = TokenHelper::findLeadTokens($value, $lead->getProfileFields(), true);
+                    $fieldEntity    = $this->leadFieldModel->getEntityByAlias($field);
+                    if ($fieldEntity && ($charLimit = $fieldEntity->getCharLengthLimit()) && mb_strlen($tokenizedValue) > $charLimit) {
+                        $tokenizedValue = mb_substr($tokenizedValue, 0, $charLimit);
+                    }
+                    $tokenizedValues[$field] = $tokenizedValue;
                 } else {
                     $tokenizedValues[$field] = $value;
                 }

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -299,6 +299,12 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $applicationTester = new ApplicationTester($application);
 
         $contactIds = $this->createContacts();
+
+        $contact = $this->contactRepository->getEntity($contactIds[0]);
+        $contact->setAddress1('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadddd');
+        $this->em->persist($contact);
+        $this->em->flush();
+
         $campaign   = $this->createCampaignWithTokens($contactIds);
 
         $this->em->clear();
@@ -316,6 +322,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
         $positionValue = $contact->getFieldValue('position');
         $cityValue     = $contact->getFieldValue('city');
+        $address1Value = $contact->getAddress1();
 
         $this->assertNotNull($positionValue, 'Position value should not be null');
         $this->assertNotNull($cityValue, 'City value should not be null');
@@ -324,6 +331,8 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
         $expectedCityValue = 'Hello '.$today->format('Y-m-d H:i:s').' '.$this->contacts[0]['firstname'];
         $this->assertEquals($expectedCityValue, $cityValue);
+
+        $this->assertEquals('abcdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $address1Value, 'Shortening too long messages did not work properly');
     }
 
     /**
@@ -952,6 +961,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
             [
                 'position'                   => '{datetime=today}',
                 'city'                       => 'Hello {datetime=today} {contactfield=firstname}',
+                'address1'                   => 'abcd{contactfield=address1}',
             ]
         );
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR solves a bug that came with the PR https://github.com/mautic/mautic/pull/14460
Here it was made possible to use variables in the update contact action. This change made it possible to exceed the max character length of a field:
Example: 
You update the field firstname (limit of 64 characters) with 'My firstname is {contactfield=customvariable}'. Now lets assume customvariable has a length of 60 characters. Then the actual update value will exceed 64 characters even though the value in the update contact field has less than 64 characters.
This results in bad behavior. For example, after letting the contact run through the campaign (so the first name is longer than 64 characters), the contact be saved when edited afterwards because the firstname is too long:
![image](https://github.com/user-attachments/assets/cfeb99f3-dcbd-4647-91fd-e4fa7c29b298)

The solution is to just cut of every character that exceeds 64 characters in case a field gets too long. 



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a contact with a lastname 'asdfasdfsdfasdfasdfasdfasdfsafasdfsadfasdfsadfsadfsdafsadfsa' (60 characters)
3. Build a campaign with an update contact action. Update the firstname with 'The lastname is {contactfield=firstname}'
4. When now executing the campaign action the first name should be updated to 'The lastname is asdfasdfsdfasdfasdfasdfasdfsafasdfsadfasdfsadfsa' (64 characters) instead of 'The lastname is asdfasdfsdfasdfasdfasdfasdfsafasdfsadfasdfsadfsadfsdafsadfsa' (76 characters)

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->