### PR TITLE
Removing a link from a tooltip that was showing HTML markup

### DIFF
--- a/app/bundles/PageBundle/Translations/en_US/messages.ini
+++ b/app/bundles/PageBundle/Translations/en_US/messages.ini
@@ -220,7 +220,7 @@ mautic.page.config.form.tracking.trackingpage.enabled="Enabled on your tracking 
 mautic.page.config.form.tracking.anonymize.ip.enabled="Enabled IP Anonymization"
 mautic.page.config.form.tracking.anonymize.ip.enabled.tooltip="In some cases, you might need to anonymize the IP address of the hit sent to Google Analytics."
 mautic.page.form.preference_center="Set as preference center page"
-mautic.page.form.preference_center.tooltip="If selected, the page will be marked as a preference center landing page. When this page is configured as a preference center in a Mautic Email, recipients will be shown the page when clicking on the <strong><code>{unsubscribe_url}</code></strong> link.<br />See the <a href="https://www.mautic.org/docs/en/contacts/customize_preference_center.html" target="_blank">Mautic documentation</a> under Contacts / Preference Center for more information."
+mautic.page.form.preference_center.tooltip="If selected, the page will be marked as a preference center landing page. When this page is configured as a preference center in a Mautic Email, recipients will be shown the page when clicking on the <strong><code>{unsubscribe_url}</code></strong> link."
 mautic.page.config.no_index="Disable search indexing"
 mautic.email.form.preference_center="Preference center page"
 mautic.email.form.preference_center.tooltip="Display the selected page as the preference center if a user accesses it through this email."


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description
In Landing page UI a translation is breaking the UI.
![image](https://github.com/user-attachments/assets/8997205c-5b0f-4f6c-b77b-b3c2ca6ad370)

I changed the trans in French, but the issue is also in english. IMO this is because of the double quotes of HTML in translations.

I removed the entire part pushing to documentation because:
1. tootlip is not browsable (when you move it disapear you cannot click)
2. if some day the link changes and we don't have 3xx it is 404 for sure
3. we never add doc link in tooltip, why starting now.

### 📋 Steps to test this PR:
1. use FR trans
4. pages > new