### PR TITLE
[UserBundle] Use username instead of email to find the created user.

### DIFF
--- a/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
@@ -14,23 +14,19 @@
 
 							{% set userPath = [] %}
 							{% set user_id = '1' %}
-							{% set usersEmail = log.details['email'][1] %}
-							{% set emailIsMatch = false %}
+							{% set usersUsername = log.details['username'][1] %}
 							{% set usernameIsMatch = false %}
 
 							{% for user in users %}
-								{% if usersEmail is defined and usersEmail is not empty and user.email == usersEmail %}
-									{% set emailIsMatch = true %}
-									{% set user_id = user.id %}
-								{% else %}
+								{% if usersUsername is defined and usersUsername is not empty and user.username == usersUsername %}
 									{% set usernameIsMatch = true %}
 									{% set user_id = user.id %}
 								{% endif %}
 							{% endfor %}
-							{% if log.details['username'][1] is defined and log.details['username'][1] is not empty %}
-								{% if emailIsMatch == true %}
-									{% set userPath = userPath|merge([user_id, log.details['username'][1]]) %}
-								{% endif %}
+							{% if usernameIsMatch %}
+							    {% set userPath = userPath|merge([user_id, log.details['username'][1]]) %}
+							{% else %}
+							    <!-- There should be a special management for that case, which should not normally happen -->
 							{% endif %}
 
 						{% elseif log.action == 'create' and log.object == 'role' %}


### PR DESCRIPTION
Find the matching user using the username, which is never modified, instead of the email, which can be modified. Use the corresponding id.

Fixes https://github.com/mautic/mautic/issues/14882
Fixes https://github.com/mautic/mautic/issues/14897

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 5.2 ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | No ✔️
| Deprecations?                          | No ✔️
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              |No  ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14882 Fixes #14897 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description
The previous code used the email to find a matching user and get the user id of the created user. This created bug 
#14882 when the email was modified by the created user.  The previous code, without explanation nor logic provided, considered that the username matched when the email did not match. So there was always a match and the last user id was always used. This created bug #14897. 