### PR TITLE
[UserBundle] Use username instead of email to find the created user

### DIFF
--- a/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
@@ -12,22 +12,17 @@
 
 						{% if log.action == 'create' and log.object == 'user' %}
 
-							{% set userPath = [] %}
-							{% set user_id = '1' %}
-							{% set usersUsername = log.details['username'][1] %}
-							{% set usernameIsMatch = false %}
+							{% set user_username = '' %}
+							{% set user_id = '0' %}
+							{% set usersEmail = log.details['email'][1] %}
+							{% set usersName  = log.details['username'][1] %}
 
 							{% for user in users %}
-								{% if usersUsername is defined and usersUsername is not empty and user.username == usersUsername %}
-									{% set usernameIsMatch = true %}
+								{% if usersEmail is defined and usersEmail is not empty and user.email == usersEmail %}
+									{% set user_username = user.userName %}
 									{% set user_id = user.id %}
 								{% endif %}
 							{% endfor %}
-							{% if usernameIsMatch %}
-							    {% set userPath = userPath|merge([user_id, log.details['username'][1]]) %}
-							{% else %}
-							    <!-- There should be a special management for that case, which should not normally happen -->
-							{% endif %}
 
 						{% elseif log.action == 'create' and log.object == 'role' %}
 
@@ -139,9 +134,14 @@
 										{{ 'mautic.user.role.form.updated_by'|trans }}
 
 									{% elseif log.action == 'create' %}
-										<a href="{{ path('mautic_user_action', {objectAction: 'edit', objectId: userPath[0]}) }}" data-toggle="ajax">
-											{{ userPath[1] }}</a>
-										{{ 'mautic.user.user.form.created_by'|trans }}
+										{% if not user_id == '0' %}
+											<a href="{{ path('mautic_user_action', {objectAction: 'edit', objectId: user_id}) }}" data-toggle="ajax">
+												{{ user_username }}</a>
+											{{ 'mautic.user.user.form.created_by'|trans }}
+										{% else %}
+											{{ usersName }}
+											{{ 'mautic.user.user.form.created_by'|trans }}
+										{% endif %}
 									{% endif %}
 
 								{% elseif log.object == 'role' %}

--- a/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
@@ -14,23 +14,19 @@
 
 							{% set userPath = [] %}
 							{% set user_id = '1' %}
-							{% set usersEmail = log.details['email'][1] %}
-							{% set emailIsMatch = false %}
+							{% set usersUsername = log.details['username'][1] %}
 							{% set usernameIsMatch = false %}
 
 							{% for user in users %}
-								{% if usersEmail is defined and usersEmail is not empty and user.email == usersEmail %}
-									{% set emailIsMatch = true %}
-									{% set user_id = user.id %}
-								{% else %}
+								{% if usersUsername is defined and usersUsername is not empty and user.username == usersUsername %}
 									{% set usernameIsMatch = true %}
 									{% set user_id = user.id %}
 								{% endif %}
 							{% endfor %}
-							{% if log.details['username'][1] is defined and log.details['username'][1] is not empty %}
-								{% if emailIsMatch == true %}
-									{% set userPath = userPath|merge([user_id, log.details['username'][1]]) %}
-								{% endif %}
+							{% if usernameIsMatch %}
+							    {% set userPath = userPath|merge([user_id, log.details['username'][1]]) %}
+							{% else %}
+							    <!-- There should be a special management for that case, which should not normally happen -->
 							{% endif %}
 
 						{% elseif log.action == 'create' and log.object == 'role' %}


### PR DESCRIPTION
Find the matching user using the username, which is never modified, instead of the email, which can be modified. Use the corresponding id.

Fixes mautic#14882
Fixes mautic#14897

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 7.x ✔️<!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | No✔️
| Deprecations?                          | No✔️
| BC breaks? (use the c.x branch)        | No ✔️
| Automated tests included?              | No ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #14882 Fixes #14897 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Same as commit 286f2ab284aa6c41345feba5e745e4692ff4e5c6, which is for 5.2
