### PR TITLE
Unpublish campaign when events fail, regardless of which contact caus…

### DIFF
--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -434,4 +434,19 @@ class EventRepository extends CommonRepository
 
         return (int) $q->executeQuery()->fetchOne();
     }
+
+    /**
+     * Get the count of failed event for Event.
+     */
+    public function getFailedCountEvent(int $eventId): int
+    {
+        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q->select('count(le.id)')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'le')
+            ->innerJoin('le', MAUTIC_TABLE_PREFIX.'campaign_lead_event_failed_log', 'fle', 'le.id = fle.log_id')
+            ->where('le.event_id = :eventId')
+            ->setParameters(['eventId' => $eventId]);
+
+        return (int) $q->executeQuery()->fetchOne();
+    }
 }

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -16,6 +16,8 @@ class CampaignEventSubscriber implements EventSubscriberInterface
 {
     public const LOOPS_TO_FAIL = 100;
 
+    public const MINIMUM_CONTACTS_FOR_DISABLE = 100;
+
     private float $disableCampaignThreshold = 0.35;
 
     public function __construct(private EventRepository $eventRepository, private NotificationHelper $notificationHelper, private CampaignRepository $campaignRepository, private LeadEventLogRepository $leadEventLogRepository)
@@ -67,24 +69,13 @@ class CampaignEventSubscriber implements EventSubscriberInterface
         $failedEvent          = $log->getEvent();
         $campaign             = $failedEvent->getCampaign();
         $lead                 = $log->getLead();
-        $countFailedLeadEvent = $this->eventRepository->getFailedCountLeadEvent($lead->getId(), $failedEvent->getId());
-        if ($countFailedLeadEvent < self::LOOPS_TO_FAIL) {
-            // Do not increase if under LOOPS_TO_FAIL
-            return;
-        } elseif ($countFailedLeadEvent > self::LOOPS_TO_FAIL
-            && $this->leadEventLogRepository->isLastFailed($lead->getId(), $failedEvent->getId())
-        ) {
-            // Do not increase twice
-            return;
-        }
-        // Increase if LOOPS_TO_FAIL or last success
-        $failedCount   = $this->eventRepository->incrementFailedCount($failedEvent);
-        $contactCount  = $campaign->getLeads()->count();
-        $failedPercent = $contactCount ? ($failedCount / $contactCount) : 1;
+        $failedCount          = $this->eventRepository->getFailedCountEvent($failedEvent->getId());
+        $contactCount         = $campaign->getLeads()->count();
+        $failedPercent        = $contactCount ? ($failedCount / $contactCount) : 1;
 
         $this->notificationHelper->notifyOfFailure($lead, $failedEvent);
 
-        if ($failedPercent >= $this->disableCampaignThreshold && $campaign->isPublished()) {
+        if ($contactCount >= self::MINIMUM_CONTACTS_FOR_DISABLE && $failedPercent >= $this->disableCampaignThreshold && $campaign->isPublished()) {
             $this->notificationHelper->notifyOfUnpublish($failedEvent);
             $campaign->setIsPublished(false);
             $this->campaignRepository->saveEntity($campaign);

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -98,11 +98,6 @@ class CampaignEventSubscriberTest extends TestCase
 
     public function testFailedEventGeneratesANotification(): void
     {
-        $this->leadEventLogRepositoryMock->expects($this->once())
-            ->method('isLastFailed')
-            ->with(42, 42)
-            ->willReturn(false);
-
         $mockLead     = $this->createMock(Lead::class);
         $mockLead->expects($this->any())
             ->method('getId')
@@ -110,7 +105,7 @@ class CampaignEventSubscriberTest extends TestCase
         $mockCampaign = $this->createMock(Campaign::class);
         $mockCampaign->expects($this->once())
             ->method('getLeads')
-            ->willReturn(new ArrayCollection(range(0, 99)));
+            ->willReturn(new ArrayCollection(range(0, 90)));
 
         $mockEvent = $this->createMock(Event::class);
         $mockEvent->expects($this->once())
@@ -130,19 +125,16 @@ class CampaignEventSubscriberTest extends TestCase
             ->willReturn($mockLead);
 
         $this->eventRepo->expects($this->once())
-            ->method('getFailedCountLeadEvent')
+            ->method('getFailedCountEvent')
             ->withAnyParameters()
-            ->willReturn(105);
-
-        // Set failed count to 5% of getLeads()->count()
-        $this->eventRepo->expects($this->once())
-            ->method('incrementFailedCount')
-            ->with($mockEvent)
-            ->willReturn(5);
+            ->willReturn(10);
 
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')
             ->with($mockLead, $mockEvent);
+            
+        $this->notificationHelper->expects($this->never())
+            ->method('notifyOfUnpublish');
 
         $failedEvent = new FailedEvent($this->createMock(AbstractEventAccessor::class), $mockEventLog);
 
@@ -151,11 +143,6 @@ class CampaignEventSubscriberTest extends TestCase
 
     public function testFailedCountOverDisableCampaignThresholdDisablesTheCampaign(): void
     {
-        $this->leadEventLogRepositoryMock->expects($this->once())
-            ->method('isLastFailed')
-            ->with(42, 42)
-            ->willReturn(false);
-
         $mockLead     = $this->createMock(Lead::class);
         $mockLead->expects($this->any())
             ->method('getId')
@@ -187,14 +174,8 @@ class CampaignEventSubscriberTest extends TestCase
             ->willReturn($mockLead);
 
         $this->eventRepo->expects($this->once())
-            ->method('getFailedCountLeadEvent')
+            ->method('getFailedCountEvent')
             ->withAnyParameters()
-            ->willReturn(200);
-
-        // Set failed count to 35% of getLeads()->count()
-        $this->eventRepo->expects($this->once())
-            ->method('incrementFailedCount')
-            ->with($mockEvent)
             ->willReturn(35);
 
         $this->notificationHelper->expects($this->once())

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -132,7 +132,7 @@ class CampaignEventSubscriberTest extends TestCase
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')
             ->with($mockLead, $mockEvent);
-            
+
         $this->notificationHelper->expects($this->never())
             ->method('notifyOfUnpublish');
 
@@ -176,7 +176,7 @@ class CampaignEventSubscriberTest extends TestCase
         $this->eventRepo->expects($this->once())
             ->method('getFailedCountEvent')
             ->withAnyParameters()
-            ->willReturn(35);
+            ->willReturn(90);
 
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Application never fails campaign even if the campaign events are failed for multiple users



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->

#### Steps to reproduce the bug:
1. Create a segment with minimum 100 contacts
2. Create an email
3. Create a Campaign with sources as created segment
4. Add send email to user.
5. Unpublish email
6. Publish campaign
7. campaign should not be unpublished due to fail events. 


#### Steps to test this PR:
1. Create a segment with minimum 100 contacts
2. Create an email
3. Create a Campaign with sources as created segment
4. Add send email to user.
5. Unpublish email
6. Publish campaign
7. campaign should be unpublished due to fail events. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->