### PR TITLE
Add Transifex workflow

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -1,0 +1,35 @@
+name: Push translations to Transifex
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - '**/Translations/en_US/*.ini'
+
+permissions:
+  contents: read
+
+jobs:
+  push-to-transifex:
+    name: Push translations to Transifex
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.3
+        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+
+    - name: Install dependencies
+      uses: "ramsey/composer-install@v3"
+
+    - name: Push translations to Transifex
+      env:
+        MAUTIC_CONFIG_PARAMETERS: '{"transifex_api_token": "${{ secrets.TRANSIFEX_API_TOKEN }}" }'  
+      run: |
+        echo "MAUTIC_CONFIG_PARAMETERS=${MAUTIC_CONFIG_PARAMETERS}" >> $GITHUB_ENV
+        php bin/console mautic:transifex:push


### PR DESCRIPTION
## Description

This PR implements a workflow that pushes translations to Transifex.

The workflow will be triggered only when a PR modifies any translation file and is merged.

Currently, the release leader has to manually push new translations to Transifex during the release process, but that doesn’t make sense to me. Translations should be pushed immediately after a PR is merged to give translators enough time to work on them before the release. This way, users won’t see untranslated content.

Also, I’m not a fan of manual work, so I wanted to automate this step :)

After this PR is merged, the "Push new translations to Transifex" step can be removed from the Community Release Leader document.

Before merging this PR, a secret must be added to the repository.

The secret should be named `TRANSIFEX_API_TOKEN` and must contain Transifex API token.
The token can be obtained from: https://app.transifex.com/user/settings/api/

![image](https://github.com/user-attachments/assets/7bbaae5f-eaaa-462a-96e6-3cec7d84c1f3)