### PR TITLE
fix: prevent page reload prompt when inserting form field tokens in Send form results action

### DIFF
--- a/app/bundles/FormBundle/Resources/views/FormTheme/FormAction/_formaction_properties_row.html.twig
+++ b/app/bundles/FormBundle/Resources/views/FormTheme/FormAction/_formaction_properties_row.html.twig
@@ -14,7 +14,7 @@
           <label class="control-label">{{ 'mautic.form.action.sendemail.dragfield'|trans }}</label>
           <div id="formFieldTokens" class="list-group" style="max-height: 250px; overflow-y: auto;">
               {% for token, field in formFields %}
-                <a class="list-group-item ellipsis" href="#" onclick="Mautic.insertTextInEditor(mQuery('#formaction_properties_message'), '{{ token }}');">{{ field }}</a>
+                <a class="list-group-item ellipsis" onclick="Mautic.insertTextInEditor(mQuery('#formaction_properties_message'), '{{ token }}');">{{ field }}</a>
               {% endfor %}
           </div>
       </div>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release  
b = current minor release  
c = future major release

* a.x for any features and enhancements (e.g. 7.x)  
* a.b for any bug fixes (e.g. 5.2, 6.0)  
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | <!-- Optional: Fixes #xxxx -->

## Description

In the "Send form results" action editor within forms, clicking a token from the right-hand list (`{formfield=label_test}` etc.) triggers a browser reload confirmation (`Are you sure you want to leave this page?`) in **Safari** and **Chrome**, which can confuse users or even cause them to lose changes.

This was caused by `<a href="#">` triggering default navigation.

This PR removes the `href` attribute entirely from those token links to prevent this behavior, while keeping the token insertion functionality intact.

No change is observed in Firefox, which never showed the reload confirmation.

<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
| Before                                 | After
| -------------------------------------- | ---
| ![before](https://github.com/user-attachments/assets/9fb61a90-714c-4209-8c20-33a8faf1c394)         | ![after](https://github.com/user-attachments/assets/a8a332c5-cbfd-4583-b4c3-81bbad9bb782)



---

### 📋 Steps to test this PR:

1. Go to **Components > Forms**
2. Create or edit a form
3. Add action: **Send form results**
4. Type something in the "Message" box
5. Click a field token from the right panel (e.g., `label_test`)
6. Confirm that:
   - ✅ No reload prompt appears (Safari / Chrome)
   - ✅ Token is inserted into the message
   - ✅ Firefox still works as before

✅ This fix has been tested in:

| Browser | Result |
|--------|--------|
| Safari | ✅ Prompt removed |
| Chrome | ✅ Prompt removed |
| Firefox | ✅ Not affected |

---

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->

