### PR TITLE
Fix: More trust settings: shows labels without inputs

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -655,9 +655,9 @@ class ConfigType extends AbstractType
                 'label' => 'mautic.core.config.response.headers.sts.expire_time',
                 'data'  => $options['data']['headers_sts_expire_time'] ?? 60,
                 'attr'  => [
-                    'class'        => 'form-control',
-                    'data-show-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
-                    'min'          => 60,
+                    'class'          => 'form-control',
+                    'data-enable-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
+                    'min'            => 60,
                 ],
             ]
         );
@@ -669,9 +669,9 @@ class ConfigType extends AbstractType
                 'label' => 'mautic.core.config.response.headers.sts.subdomains',
                 'data'  => (array_key_exists('headers_sts_subdomains', $options['data']) && !empty($options['data']['headers_sts_subdomains'])),
                 'attr'  => [
-                    'class'        => 'form-control',
-                    'tooltip'      => 'mautic.core.config.response.headers.sts.subdomains.tooltip',
-                    'data-show-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
+                    'class'          => 'form-control',
+                    'tooltip'        => 'mautic.core.config.response.headers.sts.subdomains.tooltip',
+                    'data-enable-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
                 ],
             ]
         );
@@ -683,9 +683,9 @@ class ConfigType extends AbstractType
                 'label' => 'mautic.core.config.response.headers.sts.preload',
                 'data'  => (array_key_exists('headers_sts_preload', $options['data']) && !empty($options['data']['headers_sts_preload'])),
                 'attr'  => [
-                    'class'        => 'form-control',
-                    'tooltip'      => 'mautic.core.config.response.headers.sts.preload.tooltip',
-                    'data-show-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
+                    'class'          => 'form-control',
+                    'tooltip'        => 'mautic.core.config.response.headers.sts.preload.tooltip',
+                    'data-enable-on' => '{"config_coreconfig_headers_sts_1":"checked"}',
                 ],
             ]
         );


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ | Related user documentation PR URL      | mautic/user-documentation#... | Related developer documentation PR URL | mautic/developer-documentation-new#...
| Issue(s) addressed                     | Fixes #14787

## Description

This PR addresses issue #14787, which reported that the additional HTTP Strict Transport Security (STS) configuration fields (expire time, include subdomains, preload) were not being displayed correctly when the main "Enable STS" setting was toggled in the Mautic configuration.

The root cause of this issue was the incorrect usage of the `data-show-on` attribute in the form definition for these dependent fields. This attribute prevented them from becoming visible when the "Enable STS" checkbox was checked.

This PR corrects this by replacing `data-show-on` with the correct `data-enable-on` attribute in the `buildForm()` method of the relevant FormType. This ensures that the STS sub-settings are properly revealed to the user when STS is enabled, allowing them to configure these options.

---
### 📋 Steps to test this PR:

1. Open this PR on Github or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to the Mautic Configuration page.
3. Go to the "System Settings" tab (or the relevant configuration section where CORS/Response Headers are located).
4. Locate the "HTTP Strict Transport Security (STS)" setting and enable it.
5. **Verify that the "Max Age", "Include Subdomains", and "Preload" options now become visible and configurable.**
6. Try disabling the "HTTP Strict Transport Security (STS)" setting and confirm that the additional options are disabled and not hidden.