### PR TITLE
Restore SSO authentication plugin functionality broken in v6

### DIFF
--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\LazyResponseException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -45,7 +46,7 @@ class ExceptionListener extends ErrorListener
         }
 
         // Check for exceptions we don't want to handle
-        if ($exception instanceof AuthenticationException || $exception instanceof AccessDeniedException || $exception instanceof LogoutException
+        if ($exception instanceof AuthenticationException || $exception instanceof AccessDeniedException || $exception instanceof LazyResponseException || $exception instanceof LogoutException
         ) {
             return;
         }

--- a/app/bundles/UserBundle/Exception/RespondingAuthenticationException.php
+++ b/app/bundles/UserBundle/Exception/RespondingAuthenticationException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\UserBundle\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class RespondingAuthenticationException extends AuthenticationException
+{
+    public function __construct(
+        private Response $response,
+        string $message = 'Authentication failed.',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+}

--- a/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PluginBadge.php
+++ b/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PluginBadge.php
@@ -31,6 +31,6 @@ class PluginBadge implements BadgeInterface
 
     public function isResolved(): bool
     {
-        return null !== $this->preAuthenticatedToken || null !== $this->pluginResponse;
+        return true;
     }
 }

--- a/app/bundles/UserBundle/Security/Authenticator/PluginAuthenticator.php
+++ b/app/bundles/UserBundle/Security/Authenticator/PluginAuthenticator.php
@@ -7,6 +7,7 @@ namespace Mautic\UserBundle\Security\Authenticator;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Event\AuthenticationEvent;
+use Mautic\UserBundle\Exception\RespondingAuthenticationException;
 use Mautic\UserBundle\Security\Authentication\AuthenticationHandler;
 use Mautic\UserBundle\Security\Authentication\Token\Permissions\TokenPermissions;
 use Mautic\UserBundle\Security\Authentication\Token\PluginToken;
@@ -83,6 +84,10 @@ final class PluginAuthenticator extends AbstractAuthenticator
                 }
 
                 $user = $authEvent->getUser();
+
+                if (!isset($user)) {
+                    throw new AuthenticationException('mautic.user.auth.error.invalidlogin');
+                }
             }
 
             $response = $authEvent->getResponse();
@@ -93,7 +98,11 @@ final class PluginAuthenticator extends AbstractAuthenticator
             }
         }
 
-        if (!$user instanceof User && !$authenticated && null === $response) {
+        if (!$authenticated && $response) {
+            throw new RespondingAuthenticationException($response);
+        }
+
+        if (!$authenticated && null === $response) {
             throw new AuthenticationException('mautic.user.auth.error.invalidlogin');
         }
 
@@ -166,6 +175,10 @@ final class PluginAuthenticator extends AbstractAuthenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
+        if ($exception instanceof RespondingAuthenticationException) {
+            return $exception->getResponse();
+        }
+
         $this->logger->info(sprintf('Authentication request failed: %s', $exception->getMessage()));
 
         // Gets app/bundles/UserBundle/Security/Firewall/AuthenticationListener.php:74 and till the end of the method referenced.


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

Haven't yet added tests because I don't know if this is right or not. Essentially there's a couple of issues I saw with one of my plugins when upgrading to Mautic v6 which I don't know if related to deprecated behaviour or if there is missing functionality in v6 - I've assumed the latter but welcome feedback on correct approaches.

My plugin is a SsoIntegration to allow login via a different system which it has to redirect to and then process response.

First issue was that my plugin sets a response on `AuthenticationEvent` during the pre auth event on `/s/sso_login/Integration` - however in Mautic v6 the `AuthenticationListener` is gone which used to handle this response. Instead it gets through to trying to create a `SelfValidatingPassport` but `$user` is `null` because authentication failed but a response is set - and because `null` is not allowed for the `string` constructor argument it 500s.

Second issue was that when calling `setIsAuthenticated` on the `AuthenticationEvent` it still hits the same code but now with a valid `$user` but the `PluginBadge` is given a `null` token and a `null` response and because of this its `isResolved` is false so it comes back invalid credentials even though it isn't.

Perhaps my plugin needs changes but I couldn't work out how to get it to work so looked at restoring functionality in Mautic v6 - happy to try get tests added if the patch is wrong or adjust as needed.

### 📋 Steps to test this PR:

Difficult for me to give instructions as I can't share the plugin as it's for some internal system.