### PR TITLE
Fix Transifex workflow

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   push-to-transifex:
+    if: github.repository == 'mautic/mautic'
     name: Push translations to Transifex
     runs-on: ubuntu-latest
 
@@ -30,7 +31,7 @@ jobs:
 
     - name: Push translations to Transifex
       env:
-        MAUTIC_CONFIG_PARAMETERS: '{"transifex_api_token": "${{ secrets.TRANSIFEX_API_TOKEN }}" }'  
+        MAUTIC_CONFIG_PARAMETERS: '{"transifex_api_token": "${{ secrets.TRANSIFEX_API_TOKEN }}"}'
       run: |
         echo "MAUTIC_CONFIG_PARAMETERS=${MAUTIC_CONFIG_PARAMETERS}" >> $GITHUB_ENV
         php bin/console mautic:transifex:push

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -1,10 +1,12 @@
 name: Push translations to Transifex
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - '[0-9].*'
     paths:
       - '**/Translations/en_US/*.ini'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,7 +15,6 @@ jobs:
   push-to-transifex:
     name: Push translations to Transifex
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR addresses an issue with the Transifex workflow. Apparently secrets cannot be accessed when using the `pull_request` event due to security restrictions. The new approach uses the `push` event, which allows access to secrets. I’ve added the `workflow_dispatch` event so that the workflow can be manually triggered via the GitHub Actions UI.