### PR TITLE
Fix redirects with trailing whitespace

### DIFF
--- a/app/bundles/PageBundle/Entity/Redirect.php
+++ b/app/bundles/PageBundle/Entity/Redirect.php
@@ -116,10 +116,7 @@ class Redirect extends FormEntity
         $this->redirectId = $redirectId;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): string
     {
         return trim($this->url);
     }
@@ -136,10 +133,8 @@ class Redirect extends FormEntity
      * Set hits.
      *
      * @param int $hits
-     *
-     * @return Redirect
      */
-    public function setHits($hits)
+    public function setHits($hits): Redirect
     {
         $this->hits = $hits;
 
@@ -160,10 +155,8 @@ class Redirect extends FormEntity
      * Set uniqueHits.
      *
      * @param int $uniqueHits
-     *
-     * @return Redirect
      */
-    public function setUniqueHits($uniqueHits)
+    public function setUniqueHits($uniqueHits): Redirect
     {
         $this->uniqueHits = $uniqueHits;
 

--- a/app/bundles/PageBundle/Entity/Redirect.php
+++ b/app/bundles/PageBundle/Entity/Redirect.php
@@ -121,7 +121,7 @@ class Redirect extends FormEntity
      */
     public function getUrl()
     {
-        return $this->url;
+        return trim($this->url);
     }
 
     /**
@@ -129,7 +129,7 @@ class Redirect extends FormEntity
      */
     public function setUrl($url): void
     {
-        $this->url = $url;
+        $this->url = trim($url);
     }
 
     /**
@@ -137,7 +137,7 @@ class Redirect extends FormEntity
      *
      * @param int $hits
      *
-     * @return Page
+     * @return Redirect
      */
     public function setHits($hits)
     {
@@ -161,7 +161,7 @@ class Redirect extends FormEntity
      *
      * @param int $uniqueHits
      *
-     * @return Page
+     * @return Redirect
      */
     public function setUniqueHits($uniqueHits)
     {

--- a/app/bundles/PageBundle/Tests/Entity/RedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/RedirectTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Entity;
+
+use Mautic\PageBundle\Entity\Redirect;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class RedirectTest extends TestCase
+{
+    public function testGetUrlRemovesWhitespace(): void
+    {
+        $redirect  = new Redirect();
+        $reflected = new \ReflectionClass(Redirect::class);
+        $property  = $reflected->getProperty('url');
+
+        $property->setAccessible(true);
+        $property->setValue($redirect, 'https://example.com '); // trailing whitespace
+
+        Assert::assertSame('https://example.com', $redirect->getUrl());
+    }
+
+    public function testSetUrlRemovesWhitespace(): void
+    {
+        $redirect  = new Redirect();
+        $reflected = new \ReflectionClass(Redirect::class);
+        $property  = $reflected->getProperty('url');
+
+        $property->setAccessible(true);
+        $redirect->setUrl('https://example.com '); // trailing whitespace
+
+        Assert::assertSame('https://example.com', $property->getValue($redirect));
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
When we encounter a redirect in ACS, we pull the URL destination for the redirect from the `page_redirects` table. We then run `filter_var($url, FILTER_VALIDATE_URL)`. That filter disallows trailing whitespace, and URL's with trailing whitespace fail validation, causing the redirect link to also fail. 

We address this by trimming the whitespace both during read (existing redirects that may have whitespace) and write (creating new redirect links). 


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. Create an email with an embedded link.
2. Manually add a space character at the end of the link within the href
3. Send the email
4. Click the link in the email, and see that you receive a 404 instead of being redirected

#### Steps to test this PR:
1. Redo steps
2. See that you are redirected instead of receiving a 404

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->