### PR TITLE
Fix Transifex workflow

### DIFF
--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -13,20 +13,22 @@ permissions:
 
 jobs:
   push-to-transifex:
-    if: github.repository == 'mautic/mautic'
+    # Run only in the 'mautic/mautic' repository and on the default branch (or manually triggered via UI)
+    if: github.repository == 'mautic/mautic' && (github.ref_name == github.event.repository.default_branch || github.event_name == 'workflow_dispatch')
     name: Push translations to Transifex
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-    - name: Setup PHP, with composer and extensions
+    - name: Setup PHP with extensions
       uses: shivammathur/setup-php@v2
       with:
         php-version: 8.3
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
-    - name: Install dependencies
+    - name: Install Composer dependencies
       uses: "ramsey/composer-install@v3"
 
     - name: Push translations to Transifex


### PR DESCRIPTION
When the `6.0` or `7.x` branches contains newer translations, and the `5.2` branch pushes its translations to Transifex, then it can overwrite the newer translations with the older ones. To prevent this, I added a check to ensure that Transifex workflow runs only on the default branch, which is currently `7.x`. This means that if translations are modified or added in other branches (eg `5.2` or `6.0`), those changes must be merged into the default branch. Only then they will be pushed to Transifex, ensuring that the latest translations are preserved. This change will also be merged into the `6.0` and `7.x` branches.

This became an issue when John received an email listing numerous changes.
Running the following command:
```bash
git diff --name-only 5.2..7.x -- '**/Translations/en_US/*.ini'
```
returns 27 changed translation files. This means that pushing from the 5.2 branch first, and then 7.x (or opposite), would result in many translation changes being reflected in Transifex.