### PR TITLE
[UserBundle] Use u.loginName instead of r.name to order by login name

### DIFF
--- a/app/bundles/UserBundle/Resources/views/User/list.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/list.html.twig
@@ -96,7 +96,7 @@
 
 					{{- include('@MauticCore/Helper/tableheader.html.twig', {
                     'sessionVar' : 'user',
-                    'orderBy'    : 'r.name',
+                    'orderBy'    : 'u.lastLogin',
                     'text'       : 'mautic.user.lastlogin',
                     'class'      : 'visible-md visible-lg col-user-lastlogin',
                 }) -}}


### PR DESCRIPTION
Fixes #14910

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Issue(s) addressed                     | Fixes #14910

## Description
The code (before this change) uses  `r.name`, the role name, to order by last login. 
The new  code uses `u.lastLogin`, the time of last login.

 