### PR TITLE
Fix report schedule icon

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/_list.html.twig
@@ -74,7 +74,7 @@
                                 'data-toggle': 'ajax',
                                 'href'        : path('mautic_email_action', {'objectAction' : 'send', 'objectId' : item.getId()}),
                             },
-                            'iconClass': 'ri-send-plane-line-o',
+                            'iconClass': 'ri-send-plane-line',
                             'btnText': 'mautic.email.send'
                         } %}
 

--- a/app/bundles/ReportBundle/Resources/views/Report/_list.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/_list.html.twig
@@ -65,7 +65,7 @@
                                       'href': path('mautic_report_schedule', {'reportId': item.id}),
                                   },
                                   'btnText': 'mautic.report.export.and.send'|trans,
-                                  'iconClass': 'ri-send-plane-line-o',
+                                  'iconClass': 'ri-send-plane-line',
                               },
                           ] %}
                         {% endif %}
@@ -91,7 +91,7 @@
                                 <label class="control-label" data-toggle="tooltip"
                                        data-container="body" data-placement="top" title=""
                                        data-original-title="{{ 'mautic.report.is.scheduled'|trans }}">
-                                    <i class="ri-fw ri-send-plane-line-o"></i></label>
+                                    <i class="ri-fw ri-send-plane-line"></i></label>
                             {% endif %}
                         </div>
                         {% if item.description %}


### PR DESCRIPTION
 < /dev/null |  Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description
Fix report schedule and email send icons by removing the -o suffix from ri-send-plane-line-o icon class to match the Remixicon naming convention. The -o suffix does not exist in the Remixicon library.

Before

![image](https://github.com/user-attachments/assets/39c604eb-32e2-4a72-97fb-a48953eb7de1)

After

![image](https://github.com/user-attachments/assets/ca1758e6-a048-42ff-8713-ce2dc769c4d9)


## 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Go to Reports page
3. Check if the scheduled report icon is displayed correctly
4. Go to Emails page
5. Check if the send email button icon is displayed correctly
