### PR TITLE
SQL queries constructed with string concatenation [security]

### DIFF
--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -56,11 +56,13 @@ class DownloadRepository extends CommonRepository
             ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
 
         if ($leadId) {
-            $query->where('d.lead_id = '.(int) $leadId);
+            $query->where('d.lead_id = :leadId')
+                ->setParameter('leadId', (int) $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere($query->expr()->like('a.title', $query->expr()->literal('%'.$options['search'].'%')));
+            $query->andWhere('a.title LIKE :search')
+                  ->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'a.title', 'd.date_download', [], ['date_download'], null, 'd.id');

--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -57,7 +57,7 @@ class DownloadRepository extends CommonRepository
 
         if ($leadId) {
             $query->where('d.lead_id = :leadId')
-                ->setParameter('leadId', (int) $leadId);
+                ->setParameter('leadId', $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -366,33 +366,27 @@ class LeadEventLogRepository extends CommonRepository
             ->join('ll', MAUTIC_TABLE_PREFIX.'campaign_events', 'e', 'e.id = ll.event_id');
 
         if (isset($options['channel'])) {
-            $query->andWhere('e.channel = :channel')
-                ->setParameter('channel', $options['channel']);
+            $query->andWhere('e.channel = ' . $query->expr()->literal($options['channel']));
         }
 
         if (isset($options['channelId'])) {
-            $query->andWhere('e.channel_id = :channelId')
-                ->setParameter('channelId', (int) $options['channelId']);
+            $query->andWhere('e.channel_id = ' . (int) $options['channelId']);
         }
 
         if (isset($options['type'])) {
-            $query->andWhere('e.type = :type')
-                ->setParameter('type', $options['type']);
+            $query->andWhere('e.type = ' . $query->expr()->literal($options['type']));
         }
 
         if (isset($options['logChannel'])) {
-            $query->andWhere('ll.channel = :logChannel')
-                ->setParameter('logChannel', $options['logChannel']);
+            $query->andWhere('ll.channel = ' . $query->expr()->literal($options['logChannel']));
         }
 
         if (isset($options['logChannelId'])) {
-            $query->andWhere('ll.channel_id = :logChannelId')
-                ->setParameter('logChannelId', (int) $options['logChannelId']);
+            $query->andWhere('ll.channel_id = ' . (int) $options['logChannelId']);
         }
 
-        $query->andWhere(
-            $query->expr()->eq('ll.is_scheduled', ':isScheduled')
-        )->setParameter('isScheduled', isset($options['is_scheduled']) ? 1 : 0);
+        $isScheduled = isset($options['is_scheduled']) ? 1 : 0;
+        $query->andWhere('ll.is_scheduled = ' . $isScheduled);
 
         return $chartQuery->fetchTimeData('('.$query.')', 'date_triggered');
     }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -97,7 +97,8 @@ class LeadEventLogRepository extends CommonRepository
                         ->setParameter('eventType', 'decision');
 
         if ($leadId) {
-            $query->where('ll.lead_id = '.(int) $leadId);
+            $query->where('ll.lead_id = :leadId')
+                ->setParameter('leadId', (int) $leadId);
         }
 
         if (isset($options['scheduledState'])) {
@@ -123,12 +124,12 @@ class LeadEventLogRepository extends CommonRepository
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
                 $query->expr()->or(
-                    $query->expr()->like('e.name', $query->expr()->literal('%'.$options['search'].'%')),
-                    $query->expr()->like('e.description', $query->expr()->literal('%'.$options['search'].'%')),
-                    $query->expr()->like('c.name', $query->expr()->literal('%'.$options['search'].'%')),
-                    $query->expr()->like('c.description', $query->expr()->literal('%'.$options['search'].'%'))
+                    $query->expr()->like('e.name', ':search'),
+                    $query->expr()->like('e.description', ':search'),
+                    $query->expr()->like('c.name', ':search'),
+                    $query->expr()->like('c.description', ':search')
                 )
-            );
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'e.name', 'll.date_triggered', ['metadata'], ['dateTriggered', 'triggerDate'], null, 'll.id');
@@ -365,30 +366,33 @@ class LeadEventLogRepository extends CommonRepository
             ->join('ll', MAUTIC_TABLE_PREFIX.'campaign_events', 'e', 'e.id = ll.event_id');
 
         if (isset($options['channel'])) {
-            $query->andwhere("e.channel = '".$options['channel']."'");
+            $query->andWhere('e.channel = :channel')
+                ->setParameter('channel', $options['channel']);
         }
 
         if (isset($options['channelId'])) {
-            $query->andwhere('e.channel_id = '.(int) $options['channelId']);
+            $query->andWhere('e.channel_id = :channelId')
+                ->setParameter('channelId', (int) $options['channelId']);
         }
 
         if (isset($options['type'])) {
-            $query->andwhere("e.type = '".$options['type']."'");
+            $query->andWhere('e.type = :type')
+                ->setParameter('type', $options['type']);
         }
 
         if (isset($options['logChannel'])) {
-            $query->andwhere("ll.channel = '".$options['logChannel']."'");
+            $query->andWhere('ll.channel = :logChannel')
+                ->setParameter('logChannel', $options['logChannel']);
         }
 
         if (isset($options['logChannelId'])) {
-            $query->andwhere('ll.channel_id = '.(int) $options['logChannelId']);
+            $query->andWhere('ll.channel_id = :logChannelId')
+                ->setParameter('logChannelId', (int) $options['logChannelId']);
         }
 
-        if (!isset($options['is_scheduled'])) {
-            $query->andWhere($query->expr()->eq('ll.is_scheduled', 0));
-        } else {
-            $query->andWhere($query->expr()->eq('ll.is_scheduled', 1));
-        }
+        $query->andWhere(
+            $query->expr()->eq('ll.is_scheduled', ':isScheduled')
+        )->setParameter('isScheduled', isset($options['is_scheduled']) ? 1 : 0);
 
         return $chartQuery->fetchTimeData('('.$query.')', 'date_triggered');
     }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -98,7 +98,7 @@ class LeadEventLogRepository extends CommonRepository
 
         if ($leadId) {
             $query->where('ll.lead_id = :leadId')
-                ->setParameter('leadId', (int) $leadId);
+                ->setParameter('leadId', $leadId);
         }
 
         if (isset($options['scheduledState'])) {

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -366,27 +366,27 @@ class LeadEventLogRepository extends CommonRepository
             ->join('ll', MAUTIC_TABLE_PREFIX.'campaign_events', 'e', 'e.id = ll.event_id');
 
         if (isset($options['channel'])) {
-            $query->andWhere('e.channel = ' . $query->expr()->literal($options['channel']));
+            $query->andWhere('e.channel = '.$query->expr()->literal($options['channel']));
         }
 
         if (isset($options['channelId'])) {
-            $query->andWhere('e.channel_id = ' . (int) $options['channelId']);
+            $query->andWhere('e.channel_id = '.(int) $options['channelId']);
         }
 
         if (isset($options['type'])) {
-            $query->andWhere('e.type = ' . $query->expr()->literal($options['type']));
+            $query->andWhere('e.type = '.$query->expr()->literal($options['type']));
         }
 
         if (isset($options['logChannel'])) {
-            $query->andWhere('ll.channel = ' . $query->expr()->literal($options['logChannel']));
+            $query->andWhere('ll.channel = '.$query->expr()->literal($options['logChannel']));
         }
 
         if (isset($options['logChannelId'])) {
-            $query->andWhere('ll.channel_id = ' . (int) $options['logChannelId']);
+            $query->andWhere('ll.channel_id = '.(int) $options['logChannelId']);
         }
 
         $isScheduled = isset($options['is_scheduled']) ? 1 : 0;
-        $query->andWhere('ll.is_scheduled = ' . $isScheduled);
+        $query->andWhere('ll.is_scheduled = '.$isScheduled);
 
         return $chartQuery->fetchTimeData('('.$query.')', 'date_triggered');
     }

--- a/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
@@ -104,7 +104,7 @@ class MessageQueueRepository extends CommonRepository
 
         if ($leadId) {
             $query->where('mq.lead_id = :leadId')
-                ->setParameter('leadId', (int) $leadId);
+                ->setParameter('leadId', $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {

--- a/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
@@ -103,13 +103,14 @@ class MessageQueueRepository extends CommonRepository
             mq.scheduled_date as scheduledDate, mq.last_attempt as lastAttempt, mq.date_sent as dateSent');
 
         if ($leadId) {
-            $query->where('mq.lead_id = '.(int) $leadId);
+            $query->where('mq.lead_id = :leadId')
+                ->setParameter('leadId', (int) $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere($query->expr()->or(
-                $query->expr()->like('mq.channel', $query->expr()->literal('%'.$options['search'].'%'))
-            ));
+            $query->andWhere(
+                $query->expr()->like('mq.channel', ':search')
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'mq.channel', 'mq.date_published', [], ['dateAdded'], null, 'mq.id');

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -29,7 +29,8 @@ class AuditLogRepository extends CommonRepository
             ->setParameter('id', $lead->getId());
 
         if (is_array($filters) && !empty($filters['search'])) {
-            $query->andWhere('al.details like \'%'.$filters['search'].'%\'');
+            $query->andWhere('al.details LIKE :search')
+                ->setParameter('search', '%'.$filters['search'].'%');
         }
 
         if (is_array($filters) && !empty($filters['includeEvents'])) {
@@ -61,7 +62,8 @@ class AuditLogRepository extends CommonRepository
             ->setParameter('id', $lead->getId());
 
         if (is_array($filters) && !empty($filters['search'])) {
-            $query->andWhere('al.details like \'%'.$filters['search'].'%\'');
+            $query->andWhere('al.details LIKE :search')
+                ->setParameter('search', '%'.$filters['search'].'%');
         }
 
         if (is_array($filters) && !empty($filters['includeEvents'])) {
@@ -112,7 +114,8 @@ class AuditLogRepository extends CommonRepository
             ->andWhere($query->expr()->in('al.objectId', $listOfContacts));
 
         if (is_array($filters) && !empty($filters['search'])) {
-            $query->andWhere('al.details like \'%'.$filters['search'].'%\'');
+            $query->andWhere('al.details LIKE :search')
+                ->setParameter('search', '%'.$filters['search'].'%');
         }
 
         if (is_array($filters) && !empty($filters['includeEvents'])) {

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -115,13 +115,13 @@ class StatRepository extends CommonRepository
             ->leftJoin('s', MAUTIC_TABLE_PREFIX.'dynamic_content', 'dc', 'dc.id = s.dynamic_content_id');
 
         if ($leadId) {
-            $query->where($query->expr()->eq('s.lead_id', (int) $leadId));
+            $query->where('s.lead_id = :leadId')
+                ->setParameter('leadId', (int) $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere(
-                $query->expr()->like('dc.name', $query->expr()->literal('%'.$options['search'].'%'))
-            );
+            $query->andWhere('dc.name LIKE :search')
+                ->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'dc.name', 's.date_sent', ['sentDetails'], ['dateSent'], null, 's.id');

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -116,7 +116,7 @@ class StatRepository extends CommonRepository
 
         if ($leadId) {
             $query->where('s.lead_id = :leadId')
-                ->setParameter('leadId', (int) $leadId);
+                ->setParameter('leadId', $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -428,7 +428,7 @@ class StatRepository extends CommonRepository
 
         if ($leadId) {
             $query->andWhere('s.lead_id = :leadId')
-                ->setParameter('leadId', (int) $leadId);
+                ->setParameter('leadId', $leadId);
         }
 
         if (!empty($options['basic_select'])) {

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -427,9 +427,8 @@ class StatRepository extends CommonRepository
             ->leftJoin('s', MAUTIC_TABLE_PREFIX.'email_copies', 'ec', 's.copy_id = ec.id');
 
         if ($leadId) {
-            $query->andWhere(
-                $query->expr()->eq('s.lead_id', (int) $leadId)
-            );
+            $query->andWhere('s.lead_id = :leadId')
+                ->setParameter('leadId', (int) $leadId);
         }
 
         if (!empty($options['basic_select'])) {
@@ -462,18 +461,18 @@ class StatRepository extends CommonRepository
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
                 $query->expr()->or(
-                    $query->expr()->like('ec.subject', $query->expr()->literal('%'.$options['search'].'%')),
-                    $query->expr()->like('e.subject', $query->expr()->literal('%'.$options['search'].'%')),
-                    $query->expr()->like('e.name', $query->expr()->literal('%'.$options['search'].'%'))
+                    $query->expr()->like('ec.subject', ':search'),
+                    $query->expr()->like('e.subject', ':search'),
+                    $query->expr()->like('e.name', ':search')
                 )
-            );
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         if (isset($options['fromDate']) && $options['fromDate']) {
             $dt = new DateTimeHelper($options['fromDate']);
             $query->andWhere(
-                $query->expr()->gte($timestampColumn, $query->expr()->literal($dt->toUtcString()))
-            );
+                $query->expr()->gte($timestampColumn, ':fromDate')
+            )->setParameter('fromDate', $dt->toUtcString());
         }
 
         $timeToReadParser = function (&$stat): void {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -198,7 +198,8 @@ class FormRepository extends CommonRepository
             ->setParameter('formId', $form->getId());
 
         if (!empty($options['leadId'])) {
-            $query->andWhere('fs.lead_id = '.(int) $options['leadId']);
+            $query->andWhere('fs.lead_id = :leadId')
+                ->setParameter('leadId', (int) $options['leadId']);
         }
 
         if (!empty($options['formId'])) {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -199,7 +199,7 @@ class FormRepository extends CommonRepository
 
         if (!empty($options['leadId'])) {
             $query->andWhere('fs.lead_id = :leadId')
-                ->setParameter('leadId', (int) $options['leadId']);
+                ->setParameter('leadId', $options['leadId']);
         }
 
         if (!empty($options['formId'])) {

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -287,7 +287,7 @@ class SubmissionRepository extends CommonRepository
 
         if (!empty($options['leadId'])) {
             $query->andWhere('fs.lead_id = :leadId')
-                ->setParameter('leadId', (int) $options['leadId']);
+                ->setParameter('leadId', $options['leadId']);
         }
 
         if (!empty($options['id'])) {

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -286,7 +286,8 @@ class SubmissionRepository extends CommonRepository
             ->leftJoin('fs', MAUTIC_TABLE_PREFIX.'forms', 'f', 'f.id = fs.form_id');
 
         if (!empty($options['leadId'])) {
-            $query->andWhere('fs.lead_id = '.(int) $options['leadId']);
+            $query->andWhere('fs.lead_id = :leadId')
+                ->setParameter('leadId', (int) $options['leadId']);
         }
 
         if (!empty($options['id'])) {
@@ -296,8 +297,8 @@ class SubmissionRepository extends CommonRepository
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
-                $query->expr()->like('f.name', $query->expr()->literal('%'.$options['search'].'%'))
-            );
+                $query->expr()->like('f.name', ':search')
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'f.name', 'fs.date_submitted', [], ['dateSubmitted'], null, 'fs.id');

--- a/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/PointsChangeLogRepository.php
@@ -32,10 +32,12 @@ class PointsChangeLogRepository extends CommonRepository
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere($query->expr()->or(
-                $query->expr()->like('lp.event_name', $query->expr()->literal('%'.$options['search'].'%')),
-                $query->expr()->like('lp.action_name', $query->expr()->literal('%'.$options['search'].'%'))
-            ));
+            $query->andWhere(
+                $query->expr()->or(
+                    $query->expr()->like('lp.event_name', ':search'),
+                    $query->expr()->like('lp.action_name', ':search')
+                )
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'lp.event_name', 'lp.date_added', [], ['dateAdded'], null, 'lp.id');

--- a/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
+++ b/app/bundles/LeadBundle/Entity/StagesChangeLogRepository.php
@@ -29,10 +29,12 @@ class StagesChangeLogRepository extends CommonRepository
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere($query->expr()->or(
-                $query->expr()->like('ls.event_name', $query->expr()->literal('%'.$options['search'].'%')),
-                $query->expr()->like('ls.action_name', $query->expr()->literal('%'.$options['search'].'%'))
-            ));
+            $query->andWhere(
+                $query->expr()->or(
+                    $query->expr()->like('ls.event_name', ':search'),
+                    $query->expr()->like('ls.action_name', ':search')
+                )
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'ls.event_name', 'ls.date_added', [], ['dateAdded'], null, 'ls.id');

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -72,7 +72,7 @@ class HitRepository extends CommonRepository
 
         if ($leadId) {
             $query->where('h.lead_id = :leadId')
-            ->setParameter('leadId', (int) $leadId);
+            ->setParameter('leadId', $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {
@@ -105,7 +105,7 @@ class HitRepository extends CommonRepository
                     ->setParameter('sourceIds', $sourceId);
             } else {
                 $query->andWhere('h.sourceId = :sourceId')
-                ->setParameter('sourceId', (int) $sourceId);
+                ->setParameter('sourceId', $sourceId);
             }
         }
 
@@ -115,7 +115,7 @@ class HitRepository extends CommonRepository
         }
 
         $query->andWhere('h.code = :code')
-        ->setParameter('code', (int) $code);
+        ->setParameter('code', $code);
 
         return $query->getQuery()->getArrayResult();
     }

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -71,11 +71,14 @@ class HitRepository extends CommonRepository
             ->leftJoin('h', MAUTIC_TABLE_PREFIX.'pages', 'p', 'h.page_id = p.id');
 
         if ($leadId) {
-            $query->where('h.lead_id = '.(int) $leadId);
+            $query->where('h.lead_id = :leadId')
+            ->setParameter('leadId', (int) $leadId);
         }
 
         if (isset($options['search']) && $options['search']) {
-            $query->andWhere($query->expr()->like('p.title', $query->expr()->literal('%'.$options['search'].'%')));
+            $query->andWhere(
+                $query->expr()->like('p.title', ':search')
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         $query->leftjoin('h', MAUTIC_TABLE_PREFIX.'lead_devices', 'ds', 'ds.id = h.device_id');
@@ -101,7 +104,8 @@ class HitRepository extends CommonRepository
                 $query->andWhere($query->expr()->in('h.sourceId', ':sourceIds'))
                     ->setParameter('sourceIds', $sourceId);
             } else {
-                $query->andWhere($query->expr()->eq('h.sourceId', (int) $sourceId));
+                $query->andWhere('h.sourceId = :sourceId')
+                ->setParameter('sourceId', (int) $sourceId);
             }
         }
 
@@ -110,7 +114,8 @@ class HitRepository extends CommonRepository
                 ->setParameter('date', $fromDate);
         }
 
-        $query->andWhere($query->expr()->eq('h.code', (int) $code));
+        $query->andWhere('h.code = :code')
+        ->setParameter('code', (int) $code);
 
         return $query->getQuery()->getArrayResult();
     }

--- a/app/bundles/PageBundle/Entity/VideoHitRepository.php
+++ b/app/bundles/PageBundle/Entity/VideoHitRepository.php
@@ -33,8 +33,8 @@ class VideoHitRepository extends CommonRepository
 
         if (isset($options['search']) && $options['search']) {
             $query->andWhere(
-                $query->expr()->like('h.url', $query->expr()->literal('%'.$options['search'].'%'))
-            );
+                $query->expr()->like('h.url', ':search')
+            )->setParameter('search', '%'.$options['search'].'%');
         }
 
         return $this->getTimelineResults($query, $options, 'h.url', 'h.date_hit', [], ['date_hit'], null, 'h.id');

--- a/app/bundles/SmsBundle/Entity/StatRepository.php
+++ b/app/bundles/SmsBundle/Entity/StatRepository.php
@@ -114,7 +114,7 @@ class StatRepository extends CommonRepository
         if ($leadId) {
             $query->andWhere(
                 $query->expr()->eq('s.lead_id', ':leadId')
-            )->setParameter('leadId', (int) $leadId);
+            )->setParameter('leadId', $leadId);
         }
 
         if (!empty($options['basic_select'])) {

--- a/app/bundles/SmsBundle/Entity/StatRepository.php
+++ b/app/bundles/SmsBundle/Entity/StatRepository.php
@@ -113,8 +113,8 @@ class StatRepository extends CommonRepository
 
         if ($leadId) {
             $query->andWhere(
-                $query->expr()->eq('s.lead_id', (int) $leadId)
-            );
+                $query->expr()->eq('s.lead_id', ':leadId')
+            )->setParameter('leadId', (int) $leadId);
         }
 
         if (!empty($options['basic_select'])) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->

## Description

Some SQL query strings are built using potentially unsafe string concatenation rather than parameter binding.

In \Mautic\CampaignBundle\Entity\LeadEventLogRepository::getChartQuery(), several query conditions are built using direct string concatenation and manual quoting, both of which are potentially unsafe. For example:



$query->andwhere("e.channel = '".$options['channel']."'");
This has the potential for problems if the value in $options['channel'] contains single quotes or other metacharacters. It is difficult to work backwards reliably from such a condition string to form a query constraint; It's much safer to give Doctrine the parameter separately, allowing it to escape, quote, and bind the value safely, so this would become:



$query->andWhere('e.channel = :channel')
  ->setParameter('channel', $options['channel']) |
This pattern appears in several other places.

We did not investigate whether it's possible to exploit this, and these specific cases may be sanitised or made safe somewhere upstream of this method call, but this string concatenation approach is something that should be avoided in general.

Impact

Some submitted values could open the way to SQL injection or unexpected errors.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->

