### PR TITLE
feat: add AuditLogSubscriber to log integration config changes with sensitive data sanitization

### DIFF
--- a/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
@@ -34,8 +34,8 @@ class AuditLogSubscriber implements EventSubscriberInterface
         $details = $this->sanitizeDetails($integration);
 
         $this->auditLogModel->writeToLog([
-            'bundle'    => 'integrations',
-            'object'    => 'integration',
+            'bundle'    => 'integration',
+            'object'    => $integration->getName(),
             'objectId'  => $integration->getId(),
             'action'    => 'update',
             'details'   => $details,

--- a/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
@@ -45,6 +45,8 @@ class AuditLogSubscriber implements EventSubscriberInterface
 
     /**
      * Sanitizes integration details to remove sensitive information before logging.
+     *
+     * @return array<string, mixed>
      */
     private function sanitizeDetails(Integration $integration): array
     {

--- a/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\IntegrationsBundle\EventListener;
+
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\IntegrationsBundle\Event\ConfigSaveEvent;
+use Mautic\IntegrationsBundle\IntegrationEvents;
+use Mautic\PluginBundle\Entity\Integration;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AuditLogSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            IntegrationEvents::INTEGRATION_CONFIG_AFTER_SAVE => 'onIntegrationConfigSave',
+        ];
+    }
+
+    public function onIntegrationConfigSave(ConfigSaveEvent $event): void
+    {
+        $integration = $event->getIntegrationConfiguration();
+
+        // Sanitize sensitive data
+        $details = $this->sanitizeDetails($integration);
+
+        $this->auditLogModel->writeToLog([
+            'bundle'    => 'integrations',
+            'object'    => 'integration',
+            'objectId'  => $integration->getId(),
+            'action'    => 'update',
+            'details'   => $details,
+            'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
+        ]);
+    }
+
+    /**
+     * Sanitizes integration details to remove sensitive information before logging.
+     */
+    private function sanitizeDetails(Integration $integration): array
+    {
+        $details = [
+            'name'            => $integration->getName(),
+            'isPublished'     => $integration->getIsPublished(),
+            'apiKeys'         => [],
+            'featureSettings' => [],
+        ];
+
+        // Get API keys but mask sensitive values
+        $apiKeys = $integration->getApiKeys();
+        if (is_array($apiKeys)) {
+            foreach ($apiKeys as $key => $value) {
+                // Don't log actual sensitive values, just note that they were changed
+                if (in_array(strtolower($key), ['token', 'secret', 'password', 'key', 'client_secret', 'client_id', 'refresh_token'])) {
+                    $details['apiKeys'][$key] = '[MASKED]';
+                } else {
+                    $details['apiKeys'][$key] = $value;
+                }
+            }
+        }
+
+        // Get feature settings but mask sensitive values
+        $featureSettings = $integration->getFeatureSettings();
+        if (is_array($featureSettings)) {
+            // Recursive function to mask sensitive data in nested arrays
+            $maskSensitiveData = function ($data) use (&$maskSensitiveData) {
+                if (!is_array($data)) {
+                    return $data;
+                }
+
+                $result = [];
+                foreach ($data as $key => $value) {
+                    if (is_array($value)) {
+                        $result[$key] = $maskSensitiveData($value);
+                    } else {
+                        // Mask values in keys that suggest they contain sensitive information
+                        if (preg_match('/(password|token|secret|key|credential|auth)/i', $key)) {
+                            $result[$key] = '[MASKED]';
+                        } else {
+                            $result[$key] = $value;
+                        }
+                    }
+                }
+
+                return $result;
+            };
+
+            $details['featureSettings'] = $maskSensitiveData($featureSettings);
+        }
+
+        return $details;
+    }
+}

--- a/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/AuditLogSubscriber.php
@@ -63,7 +63,7 @@ class AuditLogSubscriber implements EventSubscriberInterface
             foreach ($apiKeys as $key => $value) {
                 // Don't log actual sensitive values, just note that they were changed
                 if (in_array(strtolower($key), ['token', 'secret', 'password', 'key', 'client_secret', 'client_id', 'refresh_token'])) {
-                    $details['apiKeys'][$key] = '[MASKED]';
+                    $details['apiKeys'][$key] = '*****';
                 } else {
                     $details['apiKeys'][$key] = $value;
                 }


### PR DESCRIPTION
 < /dev/null |  Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description

This PR adds an AuditLogSubscriber to log integration configuration changes. It ensures sensitive data is properly sanitized before writing to the audit log.

The subscriber:
1. Captures integration configuration changes
2. Sanitizes sensitive data (tokens, passwords, secrets, etc.)
3. Logs the changes to the audit log

This is a security enhancement to improve auditing capabilities for integration configuration changes.

Example of audit log entry:
```sql
INSERT INTO `audit_log` (`id`, `user_id`, `user_name`, `bundle`, `object`, `object_id`, `action`, `details`, `date_added`, `ip_address`) VALUES (38, 4, 'Admin User', 'integration', 'GrapesJsBuilder', 25, 'update', 'a:4:{s:4:"name";s:15:"GrapesJsBuilder";s:11:"isPublished";i:0;s:7:"apiKeys";a:0:{}s:15:"featureSettings";a:0:{}}', '2025-05-21 06:58:43', '127.0.0.1');
```

## 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Configure or update any integration (e.g., Mailchimp, CRM integrations)
3. Check the audit log to verify the changes are logged without exposing sensitive data