### PR TITLE
Bump Node version to 18 which is required by Octokit

### DIFF
--- a/.github/workflows/bounties.yml
+++ b/.github/workflows/bounties.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The bounties workflow uses Octokit, which requires Node.js 18 or higher, as it includes a native fetch API. Currently, it is failing with the following error:
```
Error: fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}).
```
This PR bumps the Node version from 16 to 18, which should resolve the issue.