### PR TITLE
Update CustomFieldsApiControllerTrait.php

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -199,10 +199,11 @@ trait CustomFieldsApiControllerTrait
             );
         }
 
-        $overwriteWithBlank = !$isPostOrPatch;
-        if (isset($parameters['overwriteWithBlank']) && !empty($parameters['overwriteWithBlank'])) {
-            $overwriteWithBlank = true;
-            unset($parameters['overwriteWithBlank']);
+        $request = $this->requestStack->getCurrentRequest(); 
+
+        $overwriteWithBlank = $request->get('overwriteWithBlank', !$isPostOrPatch); // 
+        if (isset($parameters['overwriteWithBlank'])) {
+            unset($parameters['overwriteWithBlank']); //
         }
 
         $this->model->setFieldValues($entity, $parameters, $overwriteWithBlank);


### PR DESCRIPTION
Fix: Prevent overwriting empty fields in PUT when overwriteWithBlank is false

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

### Summary
This PR ensures that the overwriteWithBlank=false parameter works as documented in PUT /contacts/{id}/edit.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->

### Fixes
- Prevents fields from being blanked out when not present in the request payload and overwriteWithBlank is set to false.
---
### 📋 Steps to test this PR:

1. Create a contact with multiple fields filled
Use the Mautic UI or API to create a contact with several fields, e.g., firstname, lastname, email, company.

2. Send a PUT request with only one field and overwriteWithBlank=false

`PUT /api/contacts/{id}/edit?overwriteWithBlank=false`

Body:

```
{
  "email": "updated@example.com"
}

```

✅ Expected result: Only email is updated. All other fields (e.g., firstname, lastname) remain unchanged.

3. Send a PUT request with overwriteWithBlank=true

`PUT /api/contacts/{id}/edit?overwriteWithBlank=true`

Body:

```
{
  "email": "another@example.com"
}
```

✅ Expected result: email is updated, and all other fields not included in the payload are cleared (set to blank/default).

4. Try the same with PATCH

To confirm that PATCH still behaves as expected (does not blank fields by default), run:

`PATCH /api/contacts/{id}/edit`

Body:
```
{
  "email": "patch@example.com"
}
```
✅ Expected result: Only email is updated. All other fields remain untouched.