### PR TITLE
Bump codecov-action version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
I’ve read through https://github.com/codecov/codecov-action/issues/1580, and it looks like someone reported that v5 resolves the error we’re encountering. We should update codecov-action to v5 and see if it fixes the issue.
Whenever @dependabot updates a dependency, one of the tests fails with the following error (example: https://github.com/mautic/mautic/pull/14961):
https://github.com/mautic/mautic/actions/runs/14759617327/job/41436799454
```
> Upload coverage report
Run codecov/codecov-action@v4
eventName: pull_request
baseRef: mautic:7.x | headRef: mautic:dependabot/npm_and_yarn/plugins/GrapesJsBuilderBundle/base-x-3.0.[1](https://github.com/mautic/mautic/actions/runs/14759617327/job/41436799454#step:11:1)1
==> linux OS detected
https://cli.codecov.io/latest/linux/codecov.SHA256SUM
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 806BB28AED779869: public key "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Wed Apr  9 03:02:55 2025 UTC
gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 2703 4E7F DB85 0E0B BC2C  62FF 806B B28A ED77 9869
==> Uploader SHASUM verified (0f7aadde579ebde[14](https://github.com/mautic/mautic/actions/runs/14759617327/job/41436799454#step:11:15)43ad2f977beada703f562997fdda603f213faf2a8559868  codecov)
==> Running version latest
Could not pull latest version information: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
==> Running git config --global --add safe.directory /home/runner/work/mautic/mautic
/usr/bin/git config --global --add safe.directory /home/runner/work/mautic/mautic
==> Running command '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit --git-service github -C ea8f9f7d2b93b75294794cf32ae19e5d53888aff -Z
info - 2025-04-30 [16](https://github.com/mautic/mautic/actions/runs/14759617327/job/41436799454#step:11:17):48:04,485 -- ci service found: github-actions
warning - 2025-04-30 16:48:04,513 -- Branch `dependabot/npm_and_yarn/plugins/GrapesJsBuilderBundle/base-x-3.0.11` is protected but no token was provided
warning - 2025-04-30 16:48:04,513 -- For information on Codecov upload tokens, see https://docs.codecov.com/docs/codecov-tokens
info - 2025-04-30 16:48:04,816 -- Process Commit creating complete
error - 2025-04-30 16:48:04,8[17](https://github.com/mautic/mautic/actions/runs/14759617327/job/41436799454#step:11:18) -- Commit creating failed: {"message":"Token required because branch is protected"}
Error: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```