### PR TITLE
Fix admin menu with URL link

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Menu/admin.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Menu/admin.html.twig
@@ -11,7 +11,7 @@
                         {% set labelAttributes = child.getLabelAttributes() %}
                         {% set labelClasses = (labelAttributes.class is not defined) ? 'nav-item-name' : labelAttributes.class ~ ' nav-item-name' %}
 
-                        {% if child.hasChildren() and child.getDisplayChildren() %}
+                        {% if (child.hasChildren() and child.getDisplayChildren()) or child.getUri() %}
                             <div class="dropdown-header">
                                 {% if extras.iconClass is defined and extras.iconClass is not empty %}
                                     <i class="icon {{ extras.iconClass }}"></i>


### PR DESCRIPTION
|  Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | mautic/user-documentation#...
| Related developer documentation PR URL | mautic/developer-documentation-new#...
| Issue(s) addressed                     | Fixes https://github.com/Webmecanik/Automation_dev/issues/6012

<\!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

If a menu entry has a URI, we must keep it (for example portal and support admin menu)

<\!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<\!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->

### 📋 Steps to test this PR:

<\!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add to core bundle this subscriber, clear cache and check if there is first item in the admin menu
![image](https://github.com/user-attachments/assets/e1e903dd-5942-403a-b451-4bc6e668a2d9)


```
<?php

namespace Mautic\CoreBundle\EventListener;

use Mautic\CoreBundle\CoreEvents;
use Mautic\CoreBundle\Event\MenuEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

final class MenuSubscriber implements EventSubscriberInterface
{
    public function __construct()
    {
    }

    public static function getSubscribedEvents(): array
    {
        return [
            CoreEvents::BUILD_MENU => ['onBuildMenu', 999],
        ];
    }

    public function onBuildMenu(MenuEvent $event): void
    {
        if ('admin' !== $event->getType()) {
            return;
        }

        $event->addMenuItems(
            [
                'priority' => 10000,
                'items'    => [
                    'mautic.portal.menu.index' => [
                        'id'             => 'mautic_portal_index',
                        'uri'            => 'https://google.com',
                        'iconClass'      => 'ri-home-4-line',
                        'linkAttributes' => [
                            'target' => '_blank',
                            'data-toggle' => '',
                        ],
                    ],
                ],
            ]
        );
    }
}

```

<\!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->