### PR TITLE
Fix refetchEntity call timing after Lead instance check

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -331,10 +331,12 @@ trait LeadDetailsTrait
             }
 
             $lead = $model->getEntity($contact['lead_id']);
-            $model->getRepository()->refetchEntity($lead);
+
             if (!$lead instanceof Lead) {
                 continue;
             }
+
+            $model->getRepository()->refetchEntity($lead);
             $engagementsData = $this->getStatsCount($lead);
 
             $engagements = array_map(fn ($a, $b) => $a + $b, $engagementsData['engagements']['byUnit'], $engagements);

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -335,7 +335,6 @@ trait LeadDetailsTrait
             if (!$lead instanceof Lead) {
                 continue;
             }
-
             $model->getRepository()->refetchEntity($lead);
             $engagementsData = $this->getStatsCount($lead);
 


### PR DESCRIPTION
 |  Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

This PR fixes a potential issue where `refetchEntity` was being called on a null value when the lead is not found. The fix moves the `refetchEntity` call after the null check to ensure it's only called on valid Lead instances.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to a page that uses the LeadDetailsTrait
3. Ensure the code handles cases where a lead might not be found without throwing errors
4. Verify that when a lead is found, the refetchEntity is properly called