### PR TITLE
Fix campaign source widget text overflow handling

### DIFF
--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -421,7 +421,8 @@
     padding: 0 4px;
 }
 
-/* Campaign source widget text overflow handling */
+
+/* Text overflow handling for campaign source widget */
 .list-campaign-source .campaign-event-name {
     max-width: 300px;
     overflow: hidden;

--- a/app/bundles/CampaignBundle/Assets/css/campaign.css
+++ b/app/bundles/CampaignBundle/Assets/css/campaign.css
@@ -420,3 +420,13 @@
 .campaign-event-stat-divider {
     padding: 0 4px;
 }
+
+/* Campaign source widget text overflow handling */
+.list-campaign-source .campaign-event-name {
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    vertical-align: middle;
+    white-space: nowrap;
+}

--- a/app/bundles/CampaignBundle/Resources/views/Source/_index.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Source/_index.html.twig
@@ -11,7 +11,7 @@
 {% endif %}
 <div class="campaign-event-content">
     <div class="h5 fw-b mb-5 campaign-source-title">{{'mautic.campaign.form.lead_source'|trans}}</div>
-    <div><span class="campaign-event-name ellipsis"><i class="mr-xs campaign-event-icon {% if 'lists' == sourceType %}ri-pie-chart-line{% else %}ri-survey-line{% endif %}"></i>{{ names|default(null) }}</span></div>
+    <div><span class="campaign-event-name ellipsis" title="{{ names|default(null) }}"><i class="mr-xs campaign-event-icon {% if 'lists' == sourceType %}ri-pie-chart-line{% else %}ri-survey-line{% endif %}"></i>{{ names|default(null) }}</span></div>
 </div>
 
 {% if update is not defined or update is empty %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #5962

## Description

This PR fixes text overflow issues in campaign source widgets by adding specific CSS rules to properly handle long names.

### Summary
- Fixed text overflow issues in campaign source widgets by adding specific CSS rules
- Added max-width constraint to prevent widget expansion
- Added title attribute for full text display on hover

### Problem
Campaign source widgets with long names were causing layout issues due to improper text overflow handling.

### Solution
- Added specific CSS rules for `.list-campaign-source .campaign-event-name` with:
  - `max-width: 300px` to constrain the width
  - `overflow: hidden` and `text-overflow: ellipsis` for proper truncation
  - `display: inline-block` and `vertical-align: middle` for proper alignment
- Added `title` attribute to the element to show full text on hover

Before:

![image](https://github.com/user-attachments/assets/d936dbe6-5bca-4c61-8e79-88fe79f0b841)

After

![image](https://github.com/user-attachments/assets/baea3f4b-a8ef-422e-b950-1ded65b69894)


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to a campaign with source widgets
3. Add sources with long names (e.g., segments or forms with lengthy titles)
4. Verify that:
   - [ ] Long names are truncated with ellipsis
   - [ ] Widget width is constrained and doesn't expand indefinitely
   - [ ] Full text appears on hover via tooltip
   - [ ] Layout remains consistent with other campaign elements