### PR TITLE
Fix development environment database connection issues

### DIFF
--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -180,7 +180,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function applySqlFromFile($file): void
     {
         $connectionParams = $this->connection->getParams();
-        $command = 'mysql -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" < "${:db_backup_file}"';
+        $command          = 'mysql -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" < "${:db_backup_file}"';
 
         $envVars = [
             'db_host'        => $connectionParams['host'],
@@ -280,7 +280,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function dumpToFile(string $sqlDumpFile): void
     {
         $connectionParams = $this->connection->getParams();
-        $command = 'mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" > "${:db_backup_file}"';
+        $command          = 'mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" > "${:db_backup_file}"';
 
         $envVars = [
             'db_host'        => $connectionParams['host'],

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -180,19 +180,19 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function applySqlFromFile($file): void
     {
         $connectionParams = $this->connection->getParams();
-        $command          = 'mysql -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" < "${:db_backup_file}"';
-
-        $envVars = [
-            'db_host'        => $connectionParams['host'],
-            'db_port'        => $connectionParams['port'],
-            'db_user'        => $connectionParams['user'],
-            'db_password'    => $connectionParams['password'],
-            'db_name'        => $connectionParams['dbname'],
-            'db_backup_file' => $file,
-        ];
+        $password = $connectionParams['password'] ? '-p' . escapeshellarg($connectionParams['password']) : '';
+        $command = sprintf(
+            'mysql -h%s -P%s -u%s %s %s < %s',
+            escapeshellarg($connectionParams['host']),
+            escapeshellarg($connectionParams['port']),
+            escapeshellarg($connectionParams['user']),
+            $password,
+            escapeshellarg($connectionParams['dbname']),
+            escapeshellarg($file)
+        );
 
         $process = Process::fromShellCommandline($command);
-        $process->run(null, $envVars);
+        $process->run();
 
         // executes after the command finishes
         if (!$process->isSuccessful()) {
@@ -280,19 +280,19 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function dumpToFile(string $sqlDumpFile): void
     {
         $connectionParams = $this->connection->getParams();
-        $command          = 'mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" > "${:db_backup_file}"';
-
-        $envVars = [
-            'db_host'        => $connectionParams['host'],
-            'db_port'        => $connectionParams['port'],
-            'db_user'        => $connectionParams['user'],
-            'db_password'    => $connectionParams['password'],
-            'db_name'        => $connectionParams['dbname'],
-            'db_backup_file' => $sqlDumpFile,
-        ];
+        $password = $connectionParams['password'] ? '-p' . escapeshellarg($connectionParams['password']) : '';
+        $command = sprintf(
+            'mysqldump --opt -h%s -P%s -u%s %s %s > %s',
+            escapeshellarg($connectionParams['host']),
+            escapeshellarg($connectionParams['port']),
+            escapeshellarg($connectionParams['user']),
+            $password,
+            escapeshellarg($connectionParams['dbname']),
+            escapeshellarg($sqlDumpFile)
+        );
 
         $process = Process::fromShellCommandline($command);
-        $process->run(null, $envVars);
+        $process->run();
 
         // executes after the command finishes
         if (!$process->isSuccessful()) {

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -179,14 +179,15 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      */
     private function applySqlFromFile($file): void
     {
-        $connection = $this->connection;
-        $command    = 'mysql -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" "${:db_name}" < "${:db_backup_file}"';
-        $envVars    = [
-            'MYSQL_PWD'      => $this->connection->getParams()['password'],
-            'db_host'        => $this->connection->getParams()['host'],
-            'db_port'        => $this->connection->getParams()['port'],
-            'db_user'        => $this->connection->getParams()['user'],
-            'db_name'        => $this->connection->getParams()['dbname'],
+        $connectionParams = $this->connection->getParams();
+        $command = 'mysql -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" < "${:db_backup_file}"';
+
+        $envVars = [
+            'db_host'        => $connectionParams['host'],
+            'db_port'        => $connectionParams['port'],
+            'db_user'        => $connectionParams['user'],
+            'db_password'    => $connectionParams['password'],
+            'db_name'        => $connectionParams['dbname'],
             'db_backup_file' => $file,
         ];
 
@@ -278,14 +279,15 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      */
     private function dumpToFile(string $sqlDumpFile): void
     {
-        $connection = $this->connection;
-        $command    = 'mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" "${:db_name}" > "${:db_backup_file}"';
-        $envVars    = [
-            'MYSQL_PWD'      => $this->connection->getParams()['password'],
-            'db_host'        => $this->connection->getParams()['host'],
-            'db_port'        => $this->connection->getParams()['port'],
-            'db_user'        => $this->connection->getParams()['user'],
-            'db_name'        => $this->connection->getParams()['dbname'],
+        $connectionParams = $this->connection->getParams();
+        $command = 'mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" -p"${:db_password}" "${:db_name}" > "${:db_backup_file}"';
+
+        $envVars = [
+            'db_host'        => $connectionParams['host'],
+            'db_port'        => $connectionParams['port'],
+            'db_user'        => $connectionParams['user'],
+            'db_password'    => $connectionParams['password'],
+            'db_name'        => $connectionParams['dbname'],
             'db_backup_file' => $sqlDumpFile,
         ];
 

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -180,11 +180,11 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function applySqlFromFile($file): void
     {
         $connectionParams = $this->connection->getParams();
-        $password = $connectionParams['password'] ? '-p' . escapeshellarg($connectionParams['password']) : '';
-        $command = sprintf(
+        $password         = $connectionParams['password'] ? '-p'.escapeshellarg($connectionParams['password']) : '';
+        $command          = sprintf(
             'mysql -h%s -P%s -u%s %s %s < %s',
             escapeshellarg($connectionParams['host']),
-            escapeshellarg($connectionParams['port']),
+            escapeshellarg((string) $connectionParams['port']),
             escapeshellarg($connectionParams['user']),
             $password,
             escapeshellarg($connectionParams['dbname']),
@@ -280,11 +280,11 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function dumpToFile(string $sqlDumpFile): void
     {
         $connectionParams = $this->connection->getParams();
-        $password = $connectionParams['password'] ? '-p' . escapeshellarg($connectionParams['password']) : '';
-        $command = sprintf(
+        $password         = $connectionParams['password'] ? '-p'.escapeshellarg($connectionParams['password']) : '';
+        $command          = sprintf(
             'mysqldump --opt -h%s -P%s -u%s %s %s > %s',
             escapeshellarg($connectionParams['host']),
-            escapeshellarg($connectionParams['port']),
+            escapeshellarg((string) $connectionParams['port']),
             escapeshellarg($connectionParams['user']),
             $password,
             escapeshellarg($connectionParams['dbname']),


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Seems like with the most recent ddev version, functional tests are not working properly when trying to access the database. The following error will show up:
`Exception: mysqldump --opt -h"${:db_host}" -P"${:db_port}" -u"${:db_user}" "${:db_name}" > "${:db_backup_file}" failed with status code 2 and last line of "mysqldump: Got error: 1045: "Access denied for user 'db'@'...' (using password: YES)" when trying to connect`

Seems like the problem is occurs due to the MYSQL_PWD variable which isn't accepted anymore. I solved the problem by changing the variable to db_host. 


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run an existing functions test (e.g. `composer test -- --filter testManipulatorSetOnCampaignTriggerAction`)
3. See that it will run without an error


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->