### PR TITLE
Fix issue #14955: Inject DeviceTrackingService in PublicController

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -18,7 +18,6 @@ use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
-use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
@@ -55,6 +54,7 @@ class PublicController extends AbstractFormController
         ThemeHelper $themeHelper,
         Tracking404Model $tracking404Model,
         RouterInterface $router,
+        DeviceTrackingServiceInterface $deviceTrackingService,
         $slug)
     {
         /** @var PageModel $model */
@@ -299,8 +299,6 @@ class PublicController extends AbstractFormController
 
             $response = new Response($content);
             if ($request->cookies->has('Blocked-Tracking')) {
-                /* @var DeviceTrackingService $deviceTrackingService */
-                $deviceTrackingService = $this->container->get('mautic.lead.service.device_tracking_service');
                 $deviceTrackingService->clearTrackingCookies();
             }
 

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -272,13 +272,14 @@ class PublicControllerTest extends MauticMysqlTestCase
 
         $this->request->attributes->set('ignore_mismatch', true);
 
-        $router               = $this->createMock(RouterInterface::class);
-        $doctrine             = $this->createMock(ManagerRegistry::class);
-        $userHelper           = $this->createMock(UserHelper::class);
-        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $translator           = $this->createMock(Translator::class);
-        $flashBag             = $this->createMock(FlashBag::class);
-        $themeHelper          = $this->createMock(ThemeHelper::class);
+        $router                = $this->createMock(RouterInterface::class);
+        $doctrine              = $this->createMock(ManagerRegistry::class);
+        $userHelper            = $this->createMock(UserHelper::class);
+        $coreParametersHelper  = $this->createMock(CoreParametersHelper::class);
+        $translator            = $this->createMock(Translator::class);
+        $flashBag              = $this->createMock(FlashBag::class);
+        $themeHelper           = $this->createMock(ThemeHelper::class);
+        $deviceTrackingService = $this->createMock(DeviceTrackingServiceInterface::class);
         $themeHelper->expects(self::never())
             ->method('checkForTwigTemplate');
         $requestStack         = new RequestStack();
@@ -305,6 +306,7 @@ class PublicControllerTest extends MauticMysqlTestCase
             $themeHelper,
             $this->createMock(Tracking404Model::class),
             $router,
+            $deviceTrackingService,
             '/page/a',
         );
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #14955

## Description

This PR resolves a 500 Internal Server Error when accessing landing page URLs with tracking query parameters. The error occurred because `device_tracking_service` was not available in the narrowed service container context of `PublicController`.

### ✅ What changed:
- Injected `DeviceTrackingServiceInterface` into the constructor of `PublicController`
- Removed the container call to fetch the service manually
- This aligns with Symfony best practices and ensures the service is always available

This change avoids a service not found exception and restores expected tracking behavior on landing pages.


---

### 📋 Steps to test this PR:

1. Open this PR in Gitpod or pull it locally for testing
2. Go to a landing page URL with tracking query parameters, e.g. `https://yourmautic.com/lp/test?mtm_campaign=test`
3. ✅ Page should load without a 500 error
4. ✅ Tracking should function normally (no PHP error in logs)
5. ✅ No regression in page rendering or cookie handling logic

