### PR TITLE
Fix Device tracking service not found error

### DIFF
--- a/.github/prompts/write-test.prompt.md
+++ b/.github/prompts/write-test.prompt.md
@@ -21,6 +21,7 @@ Good practices:
 - Make all new classes final by default. Including tests.
 - Provide property, param and return types. If not possible to use native types you can always specify the types in the docblock. Mautic uses PHPSTAN so be sure to add types so the PHPSTAN won't fail.
 - Use `$this->assertResponseIsSuccessful();` to assert successful requests.
+- Use PHPUNIT's data providers to test multiple scenarios in a single test method.
 
 Suggestions for AI:
 - Do not modify the production code unless requested. Always just modify the test code.

--- a/.github/prompts/write-test.prompt.md
+++ b/.github/prompts/write-test.prompt.md
@@ -1,0 +1,31 @@
+---
+mode: 'agent'
+tools: ['testFailure', 'usages']
+description: 'Generate a functional test for highlighted code'
+---
+Generate a new or update an existing functional test for the highlighted code. The test should cover the following aspects:
+
+A good test should be:
+- **Isolated**: It should not depend on other tests or external systems.
+- **Fast**: It should run quickly to allow for rapid feedback during development.
+- **Deterministic**: It should produce the same result every time it runs, regardless of the environment.
+- **Readable**: It should be easy to understand and maintain.
+- **Descriptive**: It should clearly indicate what it is testing and why.
+- **Comprehensive**: It should cover a wide range of scenarios, including edge cases.
+- **Independent**: It should not rely on the state of the application or database, ensuring that it can run in any order without affecting other tests.
+- **Behavior-focused**: It should test output for specific input rather than internal implementation, except when verifying performance-critical operations like expensive method calls.
+
+Good practices:
+- Never mock objects that have no PHP service dependencies like event or entity classes. Use the real object instead.
+- The best way to write a functional test is to use the actual endpoint. Either call a route or a command. The next best thing is to call a subscriber via EventDispatcher. If that is still too broad call a service.
+- Make all new classes final by default. Including tests.
+- Provide property, param and return types. If not possible to use native types you can always specify the types in the docblock. Mautic uses PHPSTAN so be sure to add types so the PHPSTAN won't fail.
+- Use `$this->assertResponseIsSuccessful();` to assert successful requests.
+
+Suggestions for AI:
+- Do not modify the production code unless requested. Always just modify the test code.
+- Make the simplest test possible. The human will suggest improvements if needed.
+
+You can take an inspiration of existing functional tests. They all extend the `MysqlFunctionalTestCase` class and are located in the `app/bundles/*Bundle/Tests` or `plugins/*Bundle/Tests` directory. The tests are written in PHPUNIT. You can read the version in the `composer.json` file.
+
+To execute a test you have to run it in DDEV. Example: `ddev exec composer test app/bundles/ExampleBundle/tests/ExampleTest.php`.

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -18,7 +18,6 @@ use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
-use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
@@ -55,6 +54,7 @@ class PublicController extends AbstractFormController
         ThemeHelper $themeHelper,
         Tracking404Model $tracking404Model,
         RouterInterface $router,
+        DeviceTrackingServiceInterface $deviceTrackingService,
         $slug)
     {
         /** @var PageModel $model */
@@ -299,8 +299,6 @@ class PublicController extends AbstractFormController
 
             $response = new Response($content);
             if ($request->cookies->has('Blocked-Tracking')) {
-                /* @var DeviceTrackingService $deviceTrackingService */
-                $deviceTrackingService = $this->container->get('mautic.lead.service.device_tracking_service');
                 $deviceTrackingService->clearTrackingCookies();
             }
 

--- a/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DeviceTrackingServiceClearCookiesTest extends MauticMysqlTestCase
+{
+    /**
+     * @return array<string, array{bool}>
+     */
+    public function blockedTrackingCookieDataProvider(): array
+    {
+        return [
+            'with blocked tracking cookie' => [true],
+            'without blocked tracking cookie' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider blockedTrackingCookieDataProvider
+     */
+    public function testClearTrackingCookiesBehavior(bool $shouldClearCookies): void
+    {
+        $this->logoutUser();
+
+        $page = new Page();
+        $page->setIsPublished(true);
+        $page->setTitle('Test Page for Clear Tracking Cookies');
+        $page->setAlias('test-clear-cookies');
+        $page->setCustomHtml('<html><body><h1>Test Page</h1></body></html>');
+        $this->em->persist($page);
+        $this->em->flush();
+
+        if ($shouldClearCookies) {
+            $this->client->getCookieJar()->set(new \Symfony\Component\BrowserKit\Cookie('Blocked-Tracking', '1'));
+        }
+        
+        $this->client->request(Request::METHOD_GET, '/test-clear-cookies');
+        $this->assertResponseIsSuccessful();
+        
+        $deviceIdCookieCleared = false;
+        $mtcIdCookieCleared    = false;
+        
+        foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
+            // Check if tracking cookies are being deleted (empty value + past expiration)
+            $cookieIsDeleted = $cookie->getValue() === '' && $cookie->getExpiresTime() < time();
+
+            if ($cookie->getName() === 'mautic_device_id' && $cookieIsDeleted) {
+                $deviceIdCookieCleared = true;
+            }
+
+            if ($cookie->getName() === 'mtc_id' && $cookieIsDeleted) {
+                $mtcIdCookieCleared = true;
+            }
+        }
+
+        Assert::assertSame($shouldClearCookies, $deviceIdCookieCleared);
+        Assert::assertSame($shouldClearCookies, $mtcIdCookieCleared);
+    }
+}

--- a/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
@@ -17,7 +17,7 @@ final class DeviceTrackingServiceClearCookiesTest extends MauticMysqlTestCase
     public function blockedTrackingCookieDataProvider(): array
     {
         return [
-            'with blocked tracking cookie' => [true],
+            'with blocked tracking cookie'    => [true],
             'without blocked tracking cookie' => [false],
         ];
     }
@@ -40,22 +40,22 @@ final class DeviceTrackingServiceClearCookiesTest extends MauticMysqlTestCase
         if ($shouldClearCookies) {
             $this->client->getCookieJar()->set(new \Symfony\Component\BrowserKit\Cookie('Blocked-Tracking', '1'));
         }
-        
+
         $this->client->request(Request::METHOD_GET, '/test-clear-cookies');
         $this->assertResponseIsSuccessful();
-        
+
         $deviceIdCookieCleared = false;
         $mtcIdCookieCleared    = false;
-        
+
         foreach ($this->client->getResponse()->headers->getCookies() as $cookie) {
             // Check if tracking cookies are being deleted (empty value + past expiration)
-            $cookieIsDeleted = $cookie->getValue() === '' && $cookie->getExpiresTime() < time();
+            $cookieIsDeleted = '' === $cookie->getValue() && $cookie->getExpiresTime() < time();
 
-            if ($cookie->getName() === 'mautic_device_id' && $cookieIsDeleted) {
+            if ('mautic_device_id' === $cookie->getName() && $cookieIsDeleted) {
                 $deviceIdCookieCleared = true;
             }
 
-            if ($cookie->getName() === 'mtc_id' && $cookieIsDeleted) {
+            if ('mtc_id' === $cookie->getName() && $cookieIsDeleted) {
                 $mtcIdCookieCleared = true;
             }
         }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -305,6 +305,7 @@ class PublicControllerTest extends MauticMysqlTestCase
             $themeHelper,
             $this->createMock(Tracking404Model::class),
             $router,
+            $this->createMock(DeviceTrackingServiceInterface::class),
             '/page/a',
         );
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/14955

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes https://github.com/mautic/mautic/issues/14955 which occurs when the browser sets the `Blocked-Tracking` cookie when visiting a Mautic landing page.

This is a PoC for the write-test prompt template:

https://github.com/user-attachments/assets/9f690975-f75f-4cff-bb48-0c18f800ea36



### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a landing page.
3. Open the landing page in an incognito window.
4. It creates the tracking cookies.
5. Here is how to set the cookie that triggered the error before:

#### Google Chrome:

1. **Open Developer Tools:**
   - Press `Ctrl + Shift + I` (Windows/Linux) or `Cmd + Option + I` (Mac) to open DevTools.
   - Go to the **Application** tab.

2. **Set the Cookie:**
   - Under **Storage**, click **Cookies** and select your domain.
   - Right-click the cookies table, select **Add Cookie**.
   - Enter `Blocked-Tracking` as the **Name** and `true` as the **Value**.

3. **Refresh the Page:**
   - Reload the page to apply the cookie.

#### Firefox:

1. **Open Developer Tools:**
   - Press `Ctrl + Shift + I` (Windows/Linux) or `Cmd + Option + I` (Mac) to open DevTools.
   - Go to the **Storage** tab.

2. **Set the Cookie:**
   - Expand **Cookies** and select your domain.
   - Right-click the cookies area, choose **Add Item**.
   - Enter `Blocked-Tracking` for **Name** and `true` for **Value**.

3. **Refresh the Page:**
   - Reload the page to ensure the cookie is active.

These steps help you manually set the `Blocked-Tracking` cookie using Chrome or Firefox's developer tools.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->