### PR TITLE
Fix memory issues when sending large email batches

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -392,6 +392,7 @@ class MailHelper
             try {
                 if (!$this->skip) {
                     $this->mailer->send($this->message);
+                    $this->message->clearMetadata();
                 }
                 $this->skip = false;
             } catch (TransportExceptionInterface $exception) {

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -1216,12 +1216,14 @@ class MailHelperTest extends TestCase
         $mailer->message->addMetadata($contact['email'], ['test' => 'metadata']);
 
         // Verify metadata exists before sending
-        $this->assertNotEmpty($mailer->message->getMetadata(), 'Metadata should exist before sending');
+        $metadataBeforeSend = $mailer->message->getMetadata();
+        $this->assertCount(1, $metadataBeforeSend, 'Metadata should exist before sending');
 
         // Send the email
         $mailer->send();
 
         // Verify metadata is cleared after sending
-        $this->assertEmpty($mailer->message->getMetadata(), 'Metadata should be cleared after sending to prevent memory leaks');
+        $metadataAfterSend = $mailer->message->getMetadata();
+        $this->assertCount(0, $metadataAfterSend, 'Metadata should be cleared after sending to prevent memory leaks');
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -1192,4 +1192,36 @@ class MailHelperTest extends TestCase
         $this->assertEquals($email, $to[0]->getAddress());
         $this->assertEquals('', $to[0]->getName()); // Name should be empty due to length limit
     }
+
+    public function testClearMetadataAfterSend(): void
+    {
+        $this->coreParametersHelper->method('get')->will($this->returnValueMap($this->defaultParams));
+
+        $transport     = new BatchTransport();
+        $symfonyMailer = new Mailer($transport);
+        $mailer        = new MailHelper($this->mockFactory, $symfonyMailer, $this->fromEmailHelper, $this->coreParametersHelper, $this->mailbox, $this->logger, $this->mailHashHelper, $this->router);
+
+        $email = new Email();
+        $email->setSubject('Test Subject');
+        $email->setCustomHtml('Test content');
+        $mailer->setEmail($email);
+
+        // Add metadata to the message by setting lead and body
+        $contact = $this->contacts[0];
+        $mailer->addTo($contact['email']);
+        $mailer->setLead($contact);
+        $mailer->setBody('Test email body with {firstname} token');
+
+        // Manually add metadata to verify clearing functionality
+        $mailer->message->addMetadata($contact['email'], ['test' => 'metadata']);
+
+        // Verify metadata exists before sending
+        $this->assertNotEmpty($mailer->message->getMetadata(), 'Metadata should exist before sending');
+
+        // Send the email
+        $mailer->send();
+
+        // Verify metadata is cleared after sending
+        $this->assertEmpty($mailer->message->getMetadata(), 'Metadata should be cleared after sending to prevent memory leaks');
+    }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🟢
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🔴
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Memory leak in email sending

## Description

This PR fixes a memory leak issue in email sending functionality by clearing Swift_Message metadata after each email is sent. When sending multiple emails in batch operations, the message metadata accumulates in memory, potentially causing performance issues and memory exhaustion.

The fix adds a single line `$this->message->clearMetadata();` after successful email sending in the MailHelper class to ensure proper memory cleanup.

This is real issue: 

![image](https://github.com/user-attachments/assets/3abe2af5-2cb5-48ad-8129-d244555fd827)



---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Send broadcast email
3. Monitor with xdebug  increase metadata size each send, see image above