### PR TITLE
Fix/empty date from and date to

### DIFF
--- a/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
@@ -85,8 +85,12 @@ class SegmentLogReportSubscriber implements EventSubscriberInterface
                 $qb->expr()->isNotNull('log_removed.date_added')
             )
         );
-        $qb->setParameter('dateFrom', $event->getOptions()['dateFrom']->format('Y-m-d H:i:s'));
-        $qb->setParameter('dateTo', $event->getOptions()['dateTo']->format('Y-m-d H:i:s'));
+
+        $dateFrom = $event->getOptions()['dateFrom'] ?? (new \DateTime('-30 days'));
+        $dateTo   = $event->getOptions()['dateTo'] ?? (new \DateTime());
+
+        $qb->setParameter('dateFrom', $dateFrom->format('Y-m-d H:i:s'));
+        $qb->setParameter('dateTo', $dateTo->format('Y-m-d H:i:s'));
 
         if (!$event->hasGroupBy()) {
             $qb->groupBy('l.id,log_added.object_id');

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\LeadBundle\EventListener\SegmentLogReportSubscriber;
+use Mautic\ReportBundle\Entity\Report;
+
+class SegmentLogReportSubscriberFunctionalTest extends MauticMysqlTestCase
+{
+    use CreateTestEntitiesTrait;
+
+    public function testOnReportGenerate(): void
+    {
+        $contactJohn = $this->createLead('John', 'Doe', 'john@doe.corp');
+        $contactJane = $this->createLead('Jane', 'Alien', 'jane@alien.corp');
+        $contactBob  = $this->createLead('Bob', 'Alien', 'bob@alien.corp');
+
+        $segment = $this->createSegment('Segment A', []);
+        $this->em->flush();
+
+        $logJohn = $this->createLeadEventLogEntry($contactJohn, 'lead', 'segment', 'added', $segment->getId());
+        $logJohn->setDateAdded(new \DateTime('-1 day'));
+
+        $logJane = $this->createLeadEventLogEntry($contactJane, 'lead', 'segment', 'added', $segment->getId());
+        $logJane->setDateAdded(new \DateTime('-3 hours'));
+
+        $logBob  = $this->createLeadEventLogEntry($contactBob, 'lead', 'segment', 'added', $segment->getId());
+        $logBob->setDateAdded(new \DateTime('-1 day'));
+
+        $logBobRemoved = $this->createLeadEventLogEntry($contactBob, 'lead', 'segment', 'removed', $segment->getId());
+        $logBobRemoved->setDateAdded(new \DateTime('-4 hours'));
+
+        $report = $this->createReport();
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->request('GET', 'api/reports/'.$report->getId());
+        $clientResponse = $this->client->getResponse();
+        $this->assertResponseStatusCodeSame(200, $clientResponse->getContent());
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $this->assertSame(3, $response['totalResults']);
+        $this->assertCount(3, $response['data']);
+
+        $data = $response['data'];
+
+        $this->assertSame('john@doe.corp', $data[0]['email']);
+        $this->assertNotEmpty($data[0]['date_added1']);
+        $this->assertEmpty($data[0]['date_added2']);
+
+        $this->assertSame('jane@alien.corp', $data[1]['email']);
+        $this->assertNotEmpty($data[1]['date_added1']);
+        $this->assertEmpty($data[1]['date_added2']);
+
+        $this->assertSame('bob@alien.corp', $data[2]['email']);
+        $this->assertNotEmpty($data[2]['date_added1']);
+        $this->assertNotEmpty($data[2]['date_added2']);
+    }
+
+    private function createReport(): Report
+    {
+        $report = new Report();
+        $report->setName('Segment Log Report');
+        $report->setSource(SegmentLogReportSubscriber::SEGMENT_LOG);
+        $report->setColumns(['l.id', 'l.email', 'l.firstname', 'l.lastname', 'log_added.object_id', 'log_added.date_added', 'log_removed.date_added']);
+
+        $this->em->persist($report);
+
+        return $report;
+    }
+}

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
@@ -68,6 +68,7 @@ class SegmentLogReportSubscriberFunctionalTest extends MauticMysqlTestCase
         $report->setName('Segment Log Report');
         $report->setSource(SegmentLogReportSubscriber::SEGMENT_LOG);
         $report->setColumns(['l.id', 'l.email', 'l.firstname', 'l.lastname', 'log_added.object_id', 'log_added.date_added', 'log_removed.date_added']);
+        $report->setGroupBy(['l.id', 'log_added.object_id', 'log_added.date_added', 'log_removed.date_added']);
 
         $this->em->persist($report);
 


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

This PR fixes an issue where accessing a report using the "Contact's segments activity log" data source via the API without specifying dateFrom and dateTo options caused a server error (500).

### Problem
When the report is fetched via the API (e.g. /api/reports/{id}), and no dateFrom/dateTo parameters are passed in the request, Mautic throws an error due to undefined keys.

### Solution

The event listener now sets default date values when missing:

- `dateFrom`: 30 days ago
- `dateTo`: current datetime

This ensures reports can be safely queried even when the time range isn't explicitly provided.



---
### 📋 Steps to test this PR:


1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new report: 
    1. Data source: `Contact’s segments activity log`
    2. Add relevant columns: Email, First name, Last name, log dates, etc.
3. Save the report.
4. Call the report using the API endpoint:
```
curl --location --request GET 'https://mautic.ddev.site/api/reports/{id}' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic <credentials>' 
```
(Replace {id} with the report ID)
5. Expected: You receive a 200 OK response and report data.
6. Previously: This would return a 500 Internal Server Error.
