### PR TITLE
Add email name and subject maxlength validation

### DIFF
--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -17,3 +17,4 @@ mautic.core.invalid_file_type="Invalid file type {{ type }}. Use a file that mat
 mautic.core.invalid_file_encoding="The file is not encoded correctly into UTF-8."
 mautic.core.not.allowed.file.extension="%extension% is not an allowed file extension"
 mautic.core.regex.invalid="The regex syntax is invalid."
+mautic.email.name.length="Email name cannot be longer than 190 characters."

--- a/app/bundles/CoreBundle/Translations/en_US/validators.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/validators.ini
@@ -17,4 +17,3 @@ mautic.core.invalid_file_type="Invalid file type {{ type }}. Use a file that mat
 mautic.core.invalid_file_encoding="The file is not encoded correctly into UTF-8."
 mautic.core.not.allowed.file.extension="%extension% is not an allowed file extension"
 mautic.core.regex.invalid="The regex syntax is invalid."
-mautic.email.name.length="Email name cannot be longer than 190 characters."

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -61,6 +61,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     use DynamicContentEntityTrait;
     use UuidTrait;
 
+    public const MAX_NAME_SUBJECT_LENGTH = 190;
+
     /**
      * @var int
      *
@@ -446,7 +448,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
             'name',
             new Length(
                 [
-                    'max'        => 190,
+                    'max'        => self::MAX_NAME_SUBJECT_LENGTH,
                     'maxMessage' => 'mautic.email.name.length',
                 ]
             )
@@ -465,7 +467,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
             'subject',
             new Length(
                 [
-                    'max'        => 190,
+                    'max'        => self::MAX_NAME_SUBJECT_LENGTH,
                     'maxMessage' => 'mautic.email.subject.length',
                 ]
             )

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -443,6 +443,16 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         );
 
         $metadata->addPropertyConstraint(
+            'name',
+            new Length(
+                [
+                    'max'        => 190,
+                    'maxMessage' => 'mautic.email.name.length',
+                ]
+            )
+        );
+
+        $metadata->addPropertyConstraint(
             'subject',
             new NotBlank(
                 [

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -559,29 +559,44 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * Test that valid length email name and subject are accepted.
+     * Test email name length validation (190 character limit).
      */
-    public function testValidEmailNameAndSubjectLength(): void
+    public function testEmailNameLengthValidation(): void
     {
-        $validName    = str_repeat('c', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
-        $validSubject = str_repeat('d', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
+        $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
         $this->assertTrue($this->client->getResponse()->isOk());
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue($validName);
-        $form['emailform[subject]']->setValue($validSubject);
+        $form['emailform[name]']->setValue($longName);
+        $form['emailform[subject]']->setValue('Valid Subject');
         $form['emailform[emailType]']->setValue('template');
 
         $this->client->submit($form);
 
-        // Should redirect on successful save (no validation errors)
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isRedirection() || $response->isOk());
+        $this->assertStringContainsString('mautic.email.name.length', $response->getContent());
+    }
 
-        // Should not contain validation error messages
-        $this->assertStringNotContainsString('mautic.email.name.length', $response->getContent());
-        $this->assertStringNotContainsString('mautic.email.subject.length', $response->getContent());
+    /**
+     * Test email subject length validation (190 character limit).
+     */
+    public function testEmailSubjectLengthValidation(): void
+    {
+        $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $form = $crawler->selectButton('emailform[buttons][save]')->form();
+        $form['emailform[name]']->setValue('Valid Name');
+        $form['emailform[subject]']->setValue($longSubject);
+        $form['emailform[emailType]']->setValue('template');
+
+        $this->client->submit($form);
+
+        $response = $this->client->getResponse();
+        $this->assertStringContainsString('mautic.email.subject.length', $response->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -559,44 +559,29 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * Test email name length validation (190 character limit).
+     * Test that valid length email name and subject are accepted.
      */
-    public function testEmailNameLengthValidation(): void
+    public function testValidEmailNameAndSubjectLength(): void
     {
-        $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
+        $validName    = str_repeat('c', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
+        $validSubject = str_repeat('d', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
         $this->assertTrue($this->client->getResponse()->isOk());
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue($longName);
-        $form['emailform[subject]']->setValue('Valid Subject');
+        $form['emailform[name]']->setValue($validName);
+        $form['emailform[subject]']->setValue($validSubject);
         $form['emailform[emailType]']->setValue('template');
 
         $this->client->submit($form);
 
+        // Should redirect on successful save (no validation errors)
         $response = $this->client->getResponse();
-        $this->assertStringContainsString('Email name maximum length is 190 characters', $response->getContent());
-    }
+        $this->assertTrue($response->isRedirection() || $response->isOk());
 
-    /**
-     * Test email subject length validation (190 character limit).
-     */
-    public function testEmailSubjectLengthValidation(): void
-    {
-        $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
-
-        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
-
-        $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue('Valid Name');
-        $form['emailform[subject]']->setValue($longSubject);
-        $form['emailform[emailType]']->setValue('template');
-
-        $this->client->submit($form);
-
-        $response = $this->client->getResponse();
-        $this->assertStringContainsString('Email subject maximum length is 190 characters', $response->getContent());
+        // Should not contain validation error messages
+        $this->assertStringNotContainsString('mautic.email.name.length', $response->getContent());
+        $this->assertStringNotContainsString('mautic.email.subject.length', $response->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -576,7 +576,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $response = $this->client->getResponse();
-        $this->assertStringContainsString('mautic.email.name.length', $response->getContent());
+        $this->assertStringContainsString('Email name maximum length is 190 characters', $response->getContent());
     }
 
     /**
@@ -597,6 +597,6 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $response = $this->client->getResponse();
-        $this->assertStringContainsString('mautic.email.subject.length', $response->getContent());
+        $this->assertStringContainsString('Email subject maximum length is 190 characters', $response->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -559,29 +559,44 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * Test that valid length email name and subject are accepted.
+     * Test email name length validation (190 character limit).
      */
-    public function testValidEmailNameAndSubjectLength(): void
+    public function testEmailNameLengthValidation(): void
     {
-        $validName    = str_repeat('c', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
-        $validSubject = str_repeat('d', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
+        $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
         $this->assertTrue($this->client->getResponse()->isOk());
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue($validName);
-        $form['emailform[subject]']->setValue($validSubject);
+        $form['emailform[name]']->setValue($longName);
+        $form['emailform[subject]']->setValue('Valid Subject');
         $form['emailform[emailType]']->setValue('template');
 
         $this->client->submit($form);
 
-        // Should redirect on successful save (no validation errors)
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isRedirection() || $response->isOk());
+        $this->assertStringContainsString('Email name maximum length is 190 characters', $response->getContent());
+    }
 
-        // Should not contain validation error messages
-        $this->assertStringNotContainsString('mautic.email.name.length', $response->getContent());
-        $this->assertStringNotContainsString('mautic.email.subject.length', $response->getContent());
+    /**
+     * Test email subject length validation (190 character limit).
+     */
+    public function testEmailSubjectLengthValidation(): void
+    {
+        $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $form = $crawler->selectButton('emailform[buttons][save]')->form();
+        $form['emailform[name]']->setValue('Valid Name');
+        $form['emailform[subject]']->setValue($longSubject);
+        $form['emailform[emailType]']->setValue('template');
+
+        $this->client->submit($form);
+
+        $response = $this->client->getResponse();
+        $this->assertStringContainsString('Email subject maximum length is 190 characters', $response->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -559,48 +559,6 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * Test email name length validation (190 character limit).
-     */
-    public function testEmailNameLengthValidation(): void
-    {
-        $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
-
-        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
-
-        $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue($longName);
-        $form['emailform[subject]']->setValue('Valid Subject');
-        $form['emailform[emailType]']->setValue('template');
-
-        $this->client->submit($form);
-
-        $response = $this->client->getResponse();
-        $this->assertStringContainsString('mautic.email.name.length', $response->getContent());
-    }
-
-    /**
-     * Test email subject length validation (190 character limit).
-     */
-    public function testEmailSubjectLengthValidation(): void
-    {
-        $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
-
-        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
-
-        $form = $crawler->selectButton('emailform[buttons][save]')->form();
-        $form['emailform[name]']->setValue('Valid Name');
-        $form['emailform[subject]']->setValue($longSubject);
-        $form['emailform[emailType]']->setValue('template');
-
-        $this->client->submit($form);
-
-        $response = $this->client->getResponse();
-        $this->assertStringContainsString('mautic.email.subject.length', $response->getContent());
-    }
-
-    /**
      * Test that valid length email name and subject are accepted.
      */
     public function testValidEmailNameAndSubjectLength(): void

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -557,4 +557,73 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($email->getSubject(), $response['subject']);
         $this->assertNotEmpty($response['body']);
     }
+
+    /**
+     * Test email name length validation (190 character limit).
+     */
+    public function testEmailNameLengthValidation(): void
+    {
+        $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $form = $crawler->selectButton('emailform[buttons][save]')->form();
+        $form['emailform[name]']->setValue($longName);
+        $form['emailform[subject]']->setValue('Valid Subject');
+        $form['emailform[emailType]']->setValue('template');
+
+        $this->client->submit($form);
+
+        $response = $this->client->getResponse();
+        $this->assertStringContainsString('mautic.email.name.length', $response->getContent());
+    }
+
+    /**
+     * Test email subject length validation (190 character limit).
+     */
+    public function testEmailSubjectLengthValidation(): void
+    {
+        $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $form = $crawler->selectButton('emailform[buttons][save]')->form();
+        $form['emailform[name]']->setValue('Valid Name');
+        $form['emailform[subject]']->setValue($longSubject);
+        $form['emailform[emailType]']->setValue('template');
+
+        $this->client->submit($form);
+
+        $response = $this->client->getResponse();
+        $this->assertStringContainsString('mautic.email.subject.length', $response->getContent());
+    }
+
+    /**
+     * Test that valid length email name and subject are accepted.
+     */
+    public function testValidEmailNameAndSubjectLength(): void
+    {
+        $validName    = str_repeat('c', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
+        $validSubject = str_repeat('d', Email::MAX_NAME_SUBJECT_LENGTH); // Exactly 190 characters
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $form = $crawler->selectButton('emailform[buttons][save]')->form();
+        $form['emailform[name]']->setValue($validName);
+        $form['emailform[subject]']->setValue($validSubject);
+        $form['emailform[emailType]']->setValue('template');
+
+        $this->client->submit($form);
+
+        // Should redirect on successful save (no validation errors)
+        $response = $this->client->getResponse();
+        $this->assertTrue($response->isRedirection() || $response->isOk());
+
+        // Should not contain validation error messages
+        $this->assertStringNotContainsString('mautic.email.name.length', $response->getContent());
+        $this->assertStringNotContainsString('mautic.email.subject.length', $response->getContent());
+    }
 }

--- a/app/bundles/EmailBundle/Translations/en_US/validators.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/validators.ini
@@ -9,3 +9,4 @@ mautic.email.dsn.invalid_dsn="Invalid DSN. Please make sure you entered all the 
 mautic.email.dsn.unsupported_scheme="Unsupported scheme."
 mautic.email.preheader_text.length="Preheader Text maximum length is 130 characters."
 mautic.email.subject.length="Email subject maximum length is 190 characters."
+mautic.email.name.length="Email name maximum length is 190 characters."

--- a/app/bundles/EmailBundle/Translations/en_US/validators.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/validators.ini
@@ -9,4 +9,3 @@ mautic.email.dsn.invalid_dsn="Invalid DSN. Please make sure you entered all the 
 mautic.email.dsn.unsupported_scheme="Unsupported scheme."
 mautic.email.preheader_text.length="Preheader Text maximum length is 130 characters."
 mautic.email.subject.length="Email subject maximum length is 190 characters."
-mautic.email.name.length="Email name maximum length is 190 characters."


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✅
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Enhancement - add validation for email name and subject fields

## Description

This PR adds 190 character length validation for email name field to match the existing subject field validation. This prevents users from creating emails with excessively long names that could cause issues in the database or UI.

**Key Changes:**
- Added `Length` constraint for email name field with 190 character maximum
- Added validator message `mautic.email.name.length` for the name length constraint
- Subject field already had the 190 character limit validation


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Go to Channels → Emails
3. Create a new email or edit an existing one
4. Try to enter a name longer than 190 characters in the "Internal Name" field
5. Try to enter a subject longer than 190 characters in the "Subject" field
6. Save the email
7. Verify that validation errors are displayed for both fields when they exceed 190 characters
8. Verify that emails can be saved successfully when both fields are 190 characters or less

**Expected Result:** Error messages should appear for both name and subject fields when they exceed 190 characters, preventing the email from being saved.

