### PR TITLE
Bump version to 6.0.3

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.2",
+  "version": "6.0.3",
   "stability": "stable",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "5.0.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.2"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.3"
 }


### PR DESCRIPTION
## Summary
- Bump version from 6.0.2 to 6.0.3 in release_metadata.json
- Update announcement URL to point to 6.0.3 release tag
