### PR TITLE
Revert: Form preview URL panel (PR #15098)

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Form/details.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Form/details.html.twig
@@ -126,7 +126,6 @@
 
 {% block content %}
 {% set showActions = activeFormActions|length %}
-{% set previewUrl = url('mautic_form_action', {'objectAction': 'preview', 'objectId': activeForm.id}) %}
 <!-- start: box layout -->
 <div class="box-layout">
     <!-- left section -->
@@ -336,44 +335,6 @@
             }) }}
         </div>
         <!--/ form HTML -->
-
-        <!-- preview URL -->
-        <div class="panel shd-none bdr-rds-0 bdr-w-0 mt-sm mb-0">
-            <div class="panel-heading">
-                <div class="panel-title">{{ 'mautic.form.form.preview'|trans }}</div>
-            </div>
-            <div class="panel-body pt-xs">
-                <div class="row">
-                    <div class="form-group col-xs-12">
-                        <div class="input-group">
-                            <input type="text" class="form-control" readonly 
-                                   aria-label="{{ 'mautic.page.preview.url'|trans }}"
-                                   value="{{ previewUrl|escape }}"
-                                   onclick="this.setSelectionRange(0, this.value.length);"
-                                   onfocus="this.setSelectionRange(0, this.value.length);"/>
-                            <span class="input-group-btn">
-                                {% include '@MauticCore/Helper/button.html.twig' with {
-                                    buttons: [
-                                        {
-                                            label: 'mautic.core.open_link',
-                                            variant: 'ghost',
-                                            size: 'md',
-                                            icon_only: true,
-                                            icon: 'ri-external-link-line',
-                                            attributes: {
-                                                'type': 'button'
-                                            },
-                                            onclick: 'window.open("' ~ previewUrl|e('js') ~ '", "_blank");'
-                                        }
-                                    ]
-                                } %}
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!--/ preview URL -->
 
         <hr class="hr-w-2" style="width:50%">
 

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -657,30 +657,6 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($project->getId(), $savedForm->getProjects()->first()->getId());
     }
 
-    public function testFormDetailsViewWithPreviewPanel(): void
-    {
-        // Create a form
-        $form = $this->createForm('Test Form Details', 'test_form_details');
-        $this->em->persist($form);
-        $this->em->flush();
-
-        // Request the form details view
-        $crawler = $this->client->request('GET', sprintf('/s/forms/view/%d', $form->getId()));
-        $this->assertResponseIsSuccessful();
-
-        // Check if preview panel exists
-        $previewPanel = $crawler->filter('div.panel.shd-none.bdr-rds-0.bdr-w-0.mt-sm.mb-0');
-
-        if ($previewPanel->count() > 0) {
-            // If preview panel exists, verify its structure
-            $panelHeading = $previewPanel->filter('.panel-heading .panel-title:contains("Preview")');
-            $this->assertCount(1, $panelHeading, 'Preview panel should have correct heading structure');
-
-            $panelBody = $previewPanel->filter('.panel-body.pt-xs');
-            $this->assertCount(1, $panelBody, 'Preview panel should have correct body structure');
-        }
-    }
-
     private function createForm(string $name, string $alias): Form
     {
         $form = new Form();


### PR DESCRIPTION
## Summary
This PR reverts the form preview URL panel feature that was added in PR #15098.

## Changes Reverted
- ❌ **Preview URL panel** - Removed from form details sidebar  
- ❌ **previewUrl Twig variable** - Removed from template
- ❌ **Test method** - Removed testFormDetailsViewWithPreviewPanel
- ✅ **Original layout** - Restored original form details page

## Reason for Revert
[Add reason here - e.g., unexpected issues, design changes, etc.]

## Testing
- [x] Form details page loads without preview URL panel
- [x] No broken functionality  
- [x] Tests pass without preview panel test

## Files Changed
- `app/bundles/FormBundle/Resources/views/Form/details.html.twig`
- `app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php`

This cleanly reverts all preview URL functionality while preserving other unrelated changes.