### PR TITLE
Fix/view report button outside widget

### DIFF
--- a/app/bundles/DashboardBundle/Assets/css/dashboard.css
+++ b/app/bundles/DashboardBundle/Assets/css/dashboard.css
@@ -166,3 +166,8 @@ body:has(.s-dashboard) {
     line-height: 250px;
     font-size: 24px;
 }
+.report-footer{
+    position: absolute;
+    bottom: 10px;
+    right: 12px;
+}

--- a/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
+++ b/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
@@ -1,4 +1,4 @@
-<div class="tile" style="height: {{ widget.height|default('310') - 10 }}px;">
+<div class="tile" style="height: {{ widget.height|default('350') + 20 }}px;">
     <div class="card-header d-flex jc-space-between ai-center">
         <h4 class="fw-sb">{{ widget.name|purify }}</h4>
         {% if widget.id %}

--- a/app/bundles/ReportBundle/Resources/views/SubscribedEvents/Dashboard/widget.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/SubscribedEvents/Dashboard/widget.html.twig
@@ -17,7 +17,7 @@
         {% set dateFrom = dateToFullConcat(dateFrom.date, dateFrom.timezone) %}
         {% set dateTo = dateToFullConcat(dateTo.date, dateTo.timezone) %}
     {% endif %}
-    <div class="pull-right mr-md mb-md">
+    <div class="pull-right mr-md mb-md report-footer">
         <a href="{{ path('mautic_report_action', {'objectId': reportId, 'objectAction': 'view', 'daterange': {'date_to': dateTo, 'date_from': dateFrom}}) }}">
             <span class="label label-success">{{ 'mautic.report.dashboard.widgets.full_report'|trans }}</span>
         </a>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #14843 

## Description

This PR fixes a UI bug where a button was rendering outside its intended widget container. The following changes were made:

1. Moved the button inside the correct widget container.
2. Added a new CSS class to the existing widget for improved styling control.
3. Modified the height of the main body to accommodate the new layout properly.

These changes aim to improve layout consistency and user interface alignment.

---

### 📋 Steps to test this PR:

Step 1: Open Dashbord
Step 2: Click Add widget
Step 3: Set Type field on Report Graph
Step 4: Set Chose a graph field on All Emails Emails send


---