### PR TITLE
fix(point triggers): ensure event delete/apply/clone works and icons use remix only

### DIFF
--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -350,7 +350,7 @@ class TriggerController extends FormController
 
                 if ($valid = $this->isFormValid($form)) {
                     // make sure that at least one field is selected
-                    if (empty($addEvents)) {
+                    if (empty($events)) {
                         // set the error
                         $form->addError(new FormError(
                             $this->translator->trans('mautic.core.value.required', [], 'validators')
@@ -368,6 +368,9 @@ class TriggerController extends FormController
                             \assert($triggerEventModel instanceof TriggerEventModel);
                             $triggerEventModel->deleteEntities($deletedEvents);
                         }
+
+                        $session->set('mautic.point.'.$objectId.'.triggerevents.modified', $events);
+                        $session->set('mautic.point.'.$objectId.'.triggerevents.deleted', []);
 
                         $this->addFlashMessage('mautic.core.notice.updated', [
                             '%name%'      => $entity->getName(),
@@ -400,8 +403,8 @@ class TriggerController extends FormController
                     ])
                 );
             } elseif ($form->get('buttons')->get('apply')->isClicked()) {
-                // rebuild everything to include new ids
-                $cleanSlate = true;
+                // do not clear session, just reload view with updated session
+                $cleanSlate = false;
             }
         } else {
             $cleanSlate = true;

--- a/app/bundles/PointBundle/Resources/views/Event/actions.html.twig
+++ b/app/bundles/PointBundle/Resources/views/Event/actions.html.twig
@@ -14,7 +14,7 @@
         <i class="ri-edit-line"></i>
     </a>
     <a data-menu-link="mautic_point_index" data-toggle="ajax" data-ignore-formexit="true" data-method="POST" data-hide-loadingbar="true" href="{{ path(route, {'objectAction': action, 'objectId': id, 'triggerId': sessionId}) }}"  class="btn {{ btnClass }} btn-xs">
-        <i class="fa {{ iconClass }}"></i>
+        <i class="{{ iconClass }}"></i>
     </a>
     <i class="ri-fw ri-more-2-line reorder-handle"></i>
 </div>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | mautic/user-documentation#...
| Related developer documentation PR URL | mautic/developer-documentation-new#...
| Issue(s) addressed                     | Fixes #14694

## Description

This PR fixes several issues with point trigger event management:
- Deleted events now disappear immediately after clicking Apply (no reload needed)
- Cloned triggers keep their events after the first apply/save
- Only Remix icon classes are used for event action buttons
- Always defines triggerEvents and deletedEvents for view rendering
- Fixes UI/UX bugs with event deletion and cloning in point triggers

---
### 📋 Steps to test this PR:

1. Create a point trigger and add multiple events
2. Delete an event and click Apply: it should disappear immediately
3. Clone a trigger and Apply: events should remain
4. No more 500 errors on apply

---
