### PR TITLE
Replace improper executeQuery usage with executeStatement for data modification queries

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -625,7 +625,7 @@ SQL;
         $conn          = $this->getEntityManager()->getConnection();
         $deleteEntries = true;
         while ($deleteEntries) {
-            $deleteEntries = $conn->executeQuery($sql, [$campaignId], [Types::INTEGER])->rowCount();
+            $deleteEntries = $conn->executeStatement($sql, [$campaignId], [Types::INTEGER]);
         }
     }
 
@@ -639,7 +639,7 @@ SQL;
         $conn          = $this->getEntityManager()->getConnection();
         $deleteEntries = true;
         while ($deleteEntries) {
-            $deleteEntries = $conn->executeQuery($sql, [$eventIds], [ArrayParameterType::INTEGER])->rowCount();
+            $deleteEntries = $conn->executeStatement($sql, [$eventIds], [ArrayParameterType::INTEGER]);
         }
     }
 

--- a/app/bundles/CampaignBundle/Entity/SummaryRepository.php
+++ b/app/bundles/CampaignBundle/Entity/SummaryRepository.php
@@ -138,7 +138,7 @@ class SummaryRepository extends CommonRepository
             ' triggered_count = s.triggered_count_i, '.
             ' log_counts_processed = s.log_counts_processed_i;';
 
-            $this->getEntityManager()->getConnection()->executeQuery($sql);
+            $this->getEntityManager()->getConnection()->executeStatement($sql);
         }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -21,11 +21,11 @@ class LeadEventLogRepositoryTest extends MauticMysqlTestCase
 
         $insertStatement = $connection->prepare('INSERT INTO `'.MAUTIC_TABLE_PREFIX.'campaign_lead_event_log` (`event_id`, `lead_id`, `rotation`, `is_scheduled`, `system_triggered`) VALUES (?, ?, ?, ?, ?);');
 
-        $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0;');
+        $connection->executeStatement('SET FOREIGN_KEY_CHECKS=0;');
         foreach ($this->getLeadCampaignEventData($eventId) as $row) {
-            $insertStatement->executeQuery($row);
+            $insertStatement->executeStatement($row);
         }
-        $connection->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
+        $connection->executeStatement('SET FOREIGN_KEY_CHECKS=1;');
 
         Assert::assertCount(3, $leadEventLogRepository->findAll());
 

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -261,6 +261,6 @@ class AuditLogRepository extends CommonRepository
         $sql        = "UPDATE {$table_name} SET ip_address = '*.*.*.*' WHERE ip_address != '*.*.*.*'";
         $conn       = $this->getEntityManager()->getConnection();
 
-        return $conn->executeQuery($sql)->rowCount();
+        return $conn->executeStatement($sql);
     }
 }

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -114,6 +114,6 @@ SQL;
         $sql               = "UPDATE {$table_name} SET ip_address = '*.*.*.*', ip_details = 'N;' WHERE ip_address != '*.*.*.*'";
         $conn              = $this->getEntityManager()->getConnection();
 
-        return $conn->executeQuery($sql)->rowCount();
+        return $conn->executeStatement($sql);
     }
 }

--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -60,7 +60,7 @@ class MigrationCommandSubscriber implements EventSubscriberInterface
             $output->writeln("<info>++</info> adding generated column <comment>{$generatedColumn->getColumnName()}</comment>");
             $output->writeln("<comment>-></comment> {$generatedColumn->getAlterTableSql()}");
 
-            $this->connection->executeQuery($generatedColumn->getAlterTableSql());
+            $this->connection->executeStatement($generatedColumn->getAlterTableSql());
 
             $duration = (string) $stopwatch->stop($generatedColumn->getColumnName());
             $output->writeln("<info>++</info> generated column added ({$duration})");

--- a/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
@@ -54,7 +54,7 @@ class OptimisticLockSubscriber implements EventSubscriber
                 return "{$name} = :{$name}";
             }, $metadata->getIdentifierFieldNames())))
             ->setParameters($entityManager->getUnitOfWork()->getEntityIdentifier($object))
-            ->executeQuery();
+            ->executeStatement();
 
         $newVersion = (int) $connection->executeQuery('SELECT @newVersion')->fetchOne();
         $object->setVersion($newVersion);

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -145,7 +145,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
         $connection = $this->connection;
 
         foreach ($tables as $table) {
-            $connection->executeQuery(sprintf('ALTER TABLE `%s%s` AUTO_INCREMENT=1', $prefix, $table));
+            $connection->executeStatement(sprintf('ALTER TABLE `%s%s` AUTO_INCREMENT=1', $prefix, $table));
         }
     }
 
@@ -160,7 +160,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
         $prefix = MAUTIC_TABLE_PREFIX;
 
         foreach ($tables as $table) {
-            $this->connection->executeQuery("SET FOREIGN_KEY_CHECKS = 0; TRUNCATE TABLE `{$prefix}{$table}`; SET FOREIGN_KEY_CHECKS = 1;");
+            $this->connection->executeStatement("SET FOREIGN_KEY_CHECKS = 0; TRUNCATE TABLE `{$prefix}{$table}`; SET FOREIGN_KEY_CHECKS = 1;");
         }
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
@@ -154,7 +154,7 @@ class MigrationCommandSubscriberTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['id' => new \stdClass()]);
 
         $this->connection->expects($this->once())
-            ->method('executeQuery');
+            ->method('executeStatement');
 
         $this->subscriber->addGeneratedColumns($this->event);
     }

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -507,7 +507,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
 
         if ($this->connection->createSchemaManager()->tablesExist("{$tablePrefix}form_results_1_submission")) {
-            $this->connection->executeQuery("DROP TABLE {$tablePrefix}form_results_1_submission");
+            $this->connection->executeStatement("DROP TABLE {$tablePrefix}form_results_1_submission");
         }
     }
 

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -160,7 +160,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
 
         if ($this->connection->createSchemaManager()->tablesExist("{$tablePrefix}form_results_1_test_form")) {
-            $this->connection->executeQuery("DROP TABLE {$tablePrefix}form_results_1_test_form");
+            $this->connection->executeStatement("DROP TABLE {$tablePrefix}form_results_1_test_form");
         }
     }
 }

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -164,7 +164,7 @@ class SchemaHelper
         // Execute drop queries
         foreach ($sql as $q) {
             try {
-                $this->db->executeQuery($q);
+                $this->db->executeStatement($q);
             } catch (\Exception $exception) {
                 $this->db->close();
 

--- a/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
@@ -101,7 +101,7 @@ class InstallSchemaTest extends TestCase
         if (!empty($sql)) {
             foreach ($sql as $q) {
                 try {
-                    $this->connection->executeQuery($q);
+                    $this->connection->executeStatement($q);
                 } catch (\Exception $exception) {
                     $exceptions[] = $exception->getMessage();
                 }

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -217,7 +217,7 @@ class CompanyLeadRepository extends CommonRepository
         $conn = $this->getEntityManager()->getConnection();
         do {
             $sql = 'DELETE FROM '.MAUTIC_TABLE_PREFIX.'companies_leads WHERE is_primary = 0 LIMIT '.self::DELETE_BATCH_SIZE;
-            $row = $conn->executeQuery($sql)->rowCount();
+            $row = $conn->executeStatement($sql);
         } while ($row);
     }
 

--- a/app/bundles/PluginBundle/Bundle/PluginDatabase.php
+++ b/app/bundles/PluginBundle/Bundle/PluginDatabase.php
@@ -47,12 +47,12 @@ class PluginDatabase
             // Check if the query is a DDL statement
             if (self::isDDLStatement($q)) {
                 // Execute DDL statements outside of a transaction
-                $connection->executeQuery($q);
+                $connection->executeStatement($q);
             } else {
                 // For non-DDL statements, use transactions
                 try {
                     $connection->beginTransaction();
-                    $connection->executeQuery($q);
+                    $connection->executeStatement($q);
                     $connection->commit();
                 } catch (\Exception $e) {
                     // Rollback only for non-DDL statements
@@ -92,7 +92,7 @@ class PluginDatabase
         $db->beginTransaction();
         try {
             foreach ($dropQueries as $q) {
-                $db->executeQuery($q);
+                $db->executeStatement($q);
             }
 
             $db->commit();

--- a/app/bundles/WebhookBundle/Entity/LogRepository.php
+++ b/app/bundles/WebhookBundle/Entity/LogRepository.php
@@ -50,7 +50,7 @@ class LogRepository extends CommonRepository
 
         if ($id) {
             $sql = "DELETE FROM {$table_name} WHERE webhook_id = (?) and id <= (?) LIMIT ".self::LOG_DELETE_BATCH_SIZE;
-            while ($rows = $conn->executeQuery($sql, [$webHookId, $id], [ParameterType::INTEGER, ParameterType::INTEGER])->rowCount()) {
+            while ($rows = $conn->executeStatement($sql, [$webHookId, $id], [ParameterType::INTEGER, ParameterType::INTEGER])) {
                 $deletedLogs += $rows;
             }
         }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14230

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR addresses an issue where the executeQuery method was used for data modification (write) operations in the codebase. According to Doctrine DBAL documentation, executeQuery should only be used for data retrieval, while executeStatement must be used for any operation that modifies data (e.g., INSERT, UPDATE, DELETE, DDL). Using executeQuery for writes can cause replication issues in primary-replica setups, potentially leading to data inconsistencies and errors such as duplicate keys.

**What was changed:**  
- Replaced all instances of `executeQuery` used for data modification with `executeStatement`.
- Ensured that all write operations now use the correct method, preventing accidental writes to replica databases.

---
### 📋 Steps to test this PR:

**1. Test with replication enabled:**  
- Set up a primary-replica database configuration by adding a replica database host to your `local.php` config using the `db_host_ro` key.
- Perform actions in Mautic that trigger data modification (e.g., run a campaign, anonymize IP addresses, remove event logs):
- Create and run a campaign 
- Generate the campaign summary - `ddev exec php bin/console mautic:campaign:summarize`
- Delete the campaign 
- Delete unused IP addresses - `ddev exec php bin/console mautic:unusedip:delete`
- Anonymize all IP adderesses - `ddev exec php bin/console  mautic:anonymize:ip`
- Verify that all data modification queries are executed on the primary database and not the replica.
- Check for the absence of replication errors (such as duplicate key errors) in your database logs.
- Confirm that data remains consistent between the primary and replica databases.

**2. Test without replication (single database):**  
- Use a standard single-database setup without configuring a replica in `local.php`.
- Perform actions in Mautic that trigger data modification (e.g., run a campaign, anonymize IP addresses, remove event logs):
- Create and run a campaign 
- Generate the campaign summary - `ddev exec php bin/console mautic:campaign:summarize`
- Delete the campaign 
- Delete unused IP addresses - `ddev exec php bin/console mautic:unusedip:delete`
- Anonymize all IP adderesses - `ddev exec php bin/console  mautic:anonymize:ip`
- Ensure that all affected features work as expected and that there are no errors or regressions in functionality.
- Confirm that data is correctly updated in the database.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->