### PR TITLE
Fix point trigger hover styling for dark themes

### DIFF
--- a/app/bundles/PointBundle/Assets/css/point.css
+++ b/app/bundles/PointBundle/Assets/css/point.css
@@ -10,8 +10,9 @@
 #triggerEvents .trigger-event-row {
     padding: 20px;
     margin-bottom: 0 !important;
-    border: 1px solid #ecf0f1;
+    border: 1px solid var(--border-subtle);
     position: relative;
+    transition: var(--transition-all-productive);
 }
 
 #triggerEvents .trigger-event-row .event-label {
@@ -26,11 +27,11 @@
 }
 
 #triggerEvents .trigger-event-row:hover {
-    background-color: #ecf0f1;
+    background-color: var(--layer-hover);
 }
 
 #triggerEvents .trigger-event-row.bg-danger:hover {
-    background-color: #f2d4d2;
+    background-color: var(--support-error-inverse);
 }
 
 #triggerEvents .form-buttons {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | ✔️ |
| New feature/enhancement? | ❌ |
| Deprecations? | ❌ |
| BC breaks? | ❌ |
| Automated tests included? | ❌ |
| Issue(s) addressed | Fixes #15245 |

## Description

Fixes white text on white background issue when hovering over point trigger actions in dark themes.

- Uses CSS variables for better theme compatibility
- Replaces hardcoded styles with --layer-hover variable

### 📋 Steps to test this PR:

1. Switch to dark solarised theme in user preferences
2. Navigate to Points → Manage Point Triggers 
3. Hover over trigger event rows
4. Verify text remains readable