### PR TITLE
Move email statistics above date range in detail page

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -314,6 +314,48 @@
               {% set dateFrom = dateRangeForm.children['date_from'].vars['data'] %}
               {% set dateTo = dateRangeForm.children['date_to'].vars['data'] %}
 
+              <!-- some stats -->
+              <div class="pa-md">
+                  <div class="row">
+                      <div class="col-sm-12">
+                        {% if securityIsGranted('lead:leads:viewown') %}
+                            {{ include('@MauticCore/Modules/stat--icon.html.twig', {'stats': [
+                                {
+                                    'title': 'mautic.email.stat.sent',
+                                    'value': email.getSentCount(true),
+                                    'tooltip': 'mautic.email.stat.sent.tooltip',
+                                    'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_sent'|trans) ~ ':' ~ email.getId()}),
+                                    'icon': 'ri-mail-unread-line'
+                                },
+                                {
+                                    'title': 'mautic.email.stat.read',
+                                    'value': email.getReadCount(true),
+                                    'desc': email.getReadPercentage(true) ~ '%',
+                                    'tooltip': 'mautic.email.stat.read.tooltip',
+                                    'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_read'|trans) ~ ':' ~ email.getId()}),
+                                    'icon': 'ri-mail-open-line'
+                                },
+                                {
+                                    'title': 'mautic.email.stat.queued',
+                                    'value': email.getQueuedCount(),
+                                    'tooltip': 'mautic.email.stat.queued.tooltip',
+                                    'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_queued'|trans) ~ ':' ~ email.getId()}),
+                                    'icon': 'ri-mail-send-line'
+                                },
+                                {
+                                    'title': 'mautic.email.stat.pending',
+                                    'value': email.getPendingCount(),
+                                    'tooltip': 'mautic.email.stat.leadcount.tooltip',
+                                    'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_pending'|trans) ~ ':' ~ email.getId()}),
+                                    'icon': 'ri-more-fill'
+                                }
+                            ]}) }}
+                        {% endif %}
+                      </div>
+                  </div>
+              </div>
+              <!--/ stats -->
+
               <div class="stats-menu pl-md mt-lg">
                   <!-- tabs controls -->
                   <ul class="nav nav-tabs nav-tabs-contained">
@@ -339,39 +381,6 @@
 
               <div class="stats-menu__content tab-content pa-md mb-lg shd-sm">
                   <div class="tab-pane active bdr-w-0" id="stats-container">
-                    {% if securityIsGranted('lead:leads:viewown') %}
-                        {{ include('@MauticCore/Modules/stat--icon.html.twig', {'stats': [
-                            {
-                                'title': 'mautic.email.stat.sent',
-                                'value': email.getSentCount(true),
-                                'tooltip': 'mautic.email.stat.sent.tooltip',
-                                'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_sent'|trans) ~ ':' ~ email.getId()}),
-                                'icon': 'ri-mail-unread-line'
-                            },
-                            {
-                                'title': 'mautic.email.stat.read',
-                                'value': email.getReadCount(true),
-                                'desc': email.getReadPercentage(true) ~ '%',
-                                'tooltip': 'mautic.email.stat.read.tooltip',
-                                'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_read'|trans) ~ ':' ~ email.getId()}),
-                                'icon': 'ri-mail-open-line'
-                            },
-                            {
-                                'title': 'mautic.email.stat.queued',
-                                'value': email.getQueuedCount(),
-                                'tooltip': 'mautic.email.stat.queued.tooltip',
-                                'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_queued'|trans) ~ ':' ~ email.getId()}),
-                                'icon': 'ri-mail-send-line'
-                            },
-                            {
-                                'title': 'mautic.email.stat.pending',
-                                'value': email.getPendingCount(),
-                                'tooltip': 'mautic.email.stat.leadcount.tooltip',
-                                'link': path('mautic_contact_index', {'search': ('mautic.lead.lead.searchcommand.email_pending'|trans) ~ ':' ~ email.getId()}),
-                                'icon': 'ri-more-fill'
-                            }
-                        ]}) }}
-                    {% endif %}
                       <div id="emailGraphStats"
                            data-graph-url="{{ path('mautic_email_graph_stats', {'objectId' : email.id, 'isVariant' : isVariant, 'dateFrom' : dateFrom|date('Y-m-d'), 'dateTo' : dateTo|date('Y-m-d')}) }}"
                       >

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -315,7 +315,7 @@
               {% set dateTo = dateRangeForm.children['date_to'].vars['data'] %}
 
               <!-- some stats -->
-              <div class="pa-md">
+              <div class="pt-15 pl-15 pr-15">
                   <div class="row">
                       <div class="col-sm-12">
                         {% if securityIsGranted('lead:leads:viewown') %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | UI/UX improvement

## Description

This PR moves the email statistics section above the date range selector for two main reasons:

1. **Consistency** - We use the same layout pattern in assets and other detail pages
2. **Data clarity** - The statistics (sent, read, queued, pending) are not related to the selected date range, so they should be displayed separately from date-filtered charts

<img width="3635" height="1560" alt="image" src="https://github.com/user-attachments/assets/fd99d68f-1499-409d-ae5b-f7583d917589" />


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Navigate to any email detail page (Email → View any email)
4. Verify that email statistics appear above the chart tabs and date range selector
5. Compare with asset detail page to confirm consistent layout pattern