### PR TITLE
- Preserve selected company when contact has more than 100 companies …

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/CompanyListType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyListType.php
@@ -3,7 +3,11 @@
 namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\EntityLookupType;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -13,6 +17,33 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class CompanyListType extends AbstractType
 {
     public const DEFAULT_LIMIT = 100;
+
+    public function __construct(
+        private CompanyRepository $companyRepository,
+    ) {
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $data = $form->getData();
+
+        if ($data) {
+            $selectedIds     = is_array($data) ? $data : [$data];
+            $existingChoices = array_column($view->vars['choices'], 'value');
+            $missingIds      = array_diff($selectedIds, $existingChoices);
+
+            if ($missingIds) {
+                $missingCompanies = $this->companyRepository->findBy(['id' => $missingIds]);
+                foreach ($missingCompanies as $company) {
+                    $view->vars['choices'][] = new ChoiceView(
+                        $company->getId(),
+                        (string) $company->getId(),
+                        $company->getName()
+                    );
+                }
+            }
+        }
+    }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -27,7 +58,6 @@ class CompanyListType extends AbstractType
                 'model_lookup_method' => 'getLookupResults',
                 'lookup_arguments'    => fn (Options $options): array => [
                     'type'      => 'lead.company',
-                    'limit'     => self::DEFAULT_LIMIT,
                 ] + ((isset($options['model_lookup_method']) && ('getSimpleLookupResults' === $options['model_lookup_method'])) ? ['exclude' => $options['main_entity']] : []),
                 'multiple'            => true,
                 'main_entity'         => null,

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -856,6 +856,38 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         // Assert that the number of available options is 100 (or your expected limit)
         Assert::assertEquals(100, $availableOptions, 'The number of available company options should be limited to 100');
+
+        // Create a company that will not be visible initially on the list
+        $lastCompany = new Company();
+        $lastCompany->setName('XYZTestCompany');
+        $this->em->persist($lastCompany);
+        $this->em->flush();
+
+        $contact = new Lead();
+        $contact->setFirstname('John');
+        $contact->setLastname('Doe');
+        $contact->setEmail('john.doe@example.com');
+        $contact->setCompany($lastCompany);
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $companyLead = new CompanyLead();
+        $companyLead->setLead($contact);
+        $companyLead->setCompany($lastCompany);
+        $companyLead->setDateAdded(new \DateTime());
+        $companyLead->setPrimary(true);
+        $this->em->persist($companyLead);
+        $this->em->flush();
+
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/contacts/edit/'.$contact->getId());
+        $pageContent = $crawler->html();
+
+        // Assure that the last company is present in the contact edit view
+        Assert::assertStringContainsString(
+            $lastCompany->getName(),
+            $pageContent,
+            'The hidden company should appear in the contact edit view.'
+        );
     }
 
     public function testNonExitingContactIsRedirected(): void


### PR DESCRIPTION
Fix based on other PR against mautic 6(https://github.com/mautic/mautic/pull/15232/). 
This one is against mautic 5.2 

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add over 100 companies or use this import file: [generated-contacts.csv](https://github.com/user-attachments/files/21163393/generated-contacts.csv)
3. Create a contact and assign it to a company that does not appear in the initial company selection list (e.g., Visionary Corp).
4. Edit the contact and confirm that the assigned company is displayed.
5. Save the contact and verify that the company remains associated and visible.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->