### PR TITLE
fix: add missing padding to campaign preview for conditions and decisions

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/Event/_preview.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Event/_preview.html.twig
@@ -25,7 +25,7 @@ data-event-no-percent="{{ event['noPercent'] }}">
 
 <div class="campaign-event-type">
     {% if event['eventType'] == 'decision' %}
-    <div class="campaign-event-content fw-nowrap gap-xs ai-center fd-row d-flex fg-1">
+    <div class="campaign-event-content fw-nowrap gap-xs ai-center fd-row d-flex fg-1 pa-sm">
         <span class="h5 fw-b event-type-color">{{ 'mautic.campaign.when'|trans }}</span>
         <span>{{ ('mautic.campaign.'~event['type'])|trans }}</span>
         <span class="campaign-event-name label label-info ml-5 mr-5 ellipsis">
@@ -58,7 +58,7 @@ data-event-no-percent="{{ event['noPercent'] }}">
         </div>
 
     {% elseif event['eventType'] == 'condition' %}
-    <div class="campaign-event-content fw-nowrap gap-xs ai-center fd-row d-flex fg-1">
+    <div class="campaign-event-content fw-nowrap gap-xs ai-center fd-row d-flex fg-1 pa-sm">
         <span class="h5 fw-b event-type-color">{{ 'mautic.campaign.if'|trans }}</span>
         <span>{{ ('mautic.campaign.'~event['type'])|trans }}</span>
             <span class="campaign-event-name label label-warning ml-5 mr-5 ellipsis">


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- No related open issue found -->

## Description

This PR fixes a bug where campaign conditions and decisions had no padding on the campaign preview, causing them to look buggy and inconsistent with other event types.

---
### 📋 Steps to test this PR:

1. Open a campaign with conditions and decisions in the campaign details view.
2. Verify that the preview for these events now has proper padding and looks consistent with actions.

---

### Before

<img width="1283" height="707" alt="image" src="https://github.com/user-attachments/assets/13921b3e-f212-4dc2-938d-08b79c50f8b4" />


### After

<img width="1283" height="707" alt="image" src="https://github.com/user-attachments/assets/f1fcbb50-2b95-4b4e-9ac1-d4470e3b858f" />
