### PR TITLE
Update PHP CS Fixer to version 3.84.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "codeception/module-asserts": "^3.0",
     "codeception/module-db": "^3.1",
     "codeception/module-webdriver": "^4.0",
-    "friendsofphp/php-cs-fixer": "^3.14",
+    "friendsofphp/php-cs-fixer": "^3.84.0",
     "http-interop/http-factory-guzzle": "^1.0",
     "liip/functional-test-bundle": "^4.3",
     "liip/test-fixtures-bundle": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb230cb47c9539e4bf6097862bf6253c",
+    "content-hash": "914dc5e954c5c4e14d623fc59e86955d",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

This PR updates the PHP CS Fixer package from version `^3.14` to `^3.84.0` in the `composer.json` file. This is a maintenance update to keep the code style fixer up to date with the latest version.

The changes include:
- Updated `friendsofphp/php-cs-fixer` from `^3.14` to `^3.84.0` in `composer.json`
- Updated `composer.lock` with the new package version

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `composer install` to ensure the new version is installed
3. Run `bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run` to verify the CS fixer works with the new version
4. Verify that no new CS violations are introduced by the version update

---