### PR TITLE
Update klapaudius/oauth-server-bundle and klapaudius/oauth2-php packages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4946,16 +4946,16 @@
         },
         {
             "name": "klapaudius/oauth-server-bundle",
-            "version": "5.1.1",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klapaudius/FOSOAuthServerBundle.git",
-                "reference": "42f1a0e791726655de741671622faec6c5a19bed"
+                "reference": "0b112e6c28b4c2824124568db6a198e6f07af04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/42f1a0e791726655de741671622faec6c5a19bed",
-                "reference": "42f1a0e791726655de741671622faec6c5a19bed",
+                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/0b112e6c28b4c2824124568db6a198e6f07af04a",
+                "reference": "0b112e6c28b4c2824124568db6a198e6f07af04a",
                 "shasum": ""
             },
             "require": {
@@ -4971,11 +4971,11 @@
             "require-dev": {
                 "doctrine/mongodb-odm": "~2.0",
                 "doctrine/orm": "~2.2",
+                "ext-mongodb": "*",
                 "friendsofphp/php-cs-fixer": "^3.0",
-                "phing/phing": "~2.4",
                 "php-mock/php-mock-phpunit": "~1.0|~2.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "~9.0",
+                "phpunit/phpunit": "~11.0",
                 "symfony/class-loader": "^2.0",
                 "symfony/console": "~7.0",
                 "symfony/phpunit-bridge": "~7.0",
@@ -5029,27 +5029,27 @@
             ],
             "support": {
                 "issues": "https://github.com/klapaudius/FOSOAuthServerBundle/issues",
-                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/5.1.1"
+                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/5.1.2"
             },
-            "time": "2024-12-20T15:10:53+00:00"
+            "time": "2025-04-26T21:23:17+00:00"
         },
         {
             "name": "klapaudius/oauth2-php",
-            "version": "1.6.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klapaudius/oauth2-php.git",
-                "reference": "3a1137e31f3c6c8a935ffce11363a173e1037845"
+                "reference": "99b159388a002da2ca8f791b97eed4ff68e32d54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klapaudius/oauth2-php/zipball/3a1137e31f3c6c8a935ffce11363a173e1037845",
-                "reference": "3a1137e31f3c6c8a935ffce11363a173e1037845",
+                "url": "https://api.github.com/repos/klapaudius/oauth2-php/zipball/99b159388a002da2ca8f791b97eed4ff68e32d54",
+                "reference": "99b159388a002da2ca8f791b97eed4ff68e32d54",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0.8 || ^7.1.3 || ^7.2.5 || ^8.0.0 || ^8.2.0",
-                "symfony/http-foundation": "~3.0|~4.0|~5.0|~6.0|~7.0"
+                "php": "^7.1.3 || ^7.2.5 || ^8.0.0 || ^8.2.0",
+                "symfony/http-foundation": "~5.0|~6.0|~7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.0 || ^6.0 || ^8.0 || ^9.0.0 || ^10.0.0"
@@ -5093,9 +5093,9 @@
                 "oauth2"
             ],
             "support": {
-                "source": "https://github.com/klapaudius/oauth2-php/tree/1.6.0"
+                "source": "https://github.com/klapaudius/oauth2-php/tree/1.8.0"
             },
-            "time": "2024-01-11T22:06:13+00:00"
+            "time": "2024-12-20T16:40:40+00:00"
         },
         {
             "name": "knplabs/gaufrette",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Ran `composer update klapaudius/oauth-server-bundle klapaudius/oauth2-php` to bring the following packages up to date:
```
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading klapaudius/oauth-server-bundle (5.1.1 => 5.1.2)
  - Upgrading klapaudius/oauth2-php (1.6.0 => 1.8.0)
```

The update to `oauth2-php` [v1.8.0](https://github.com/klapaudius/oauth2-php/releases/tag/1.8.0) fixes [PHP 8.4 deprecation notices seen in the tests](https://github.com/mautic/mautic/actions/runs/16364412103/job/46238369092):
```
PHP Deprecated:  OAuth2\OAuth2::getBearerToken(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/OAuth2.php on line 491
PHP Deprecated:  OAuth2\OAuth2::grantAccessToken(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/OAuth2.php on line 684
PHP Deprecated:  OAuth2\OAuth2::getAuthorizeParams(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/OAuth2.php on line 1017
PHP Deprecated:  OAuth2\OAuth2::finishClientAuthorization(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/OAuth2.php on line 1129
PHP Deprecated:  OAuth2\IOAuth2::getBearerToken(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/IOAuth2.php on line 88
PHP Deprecated:  OAuth2\IOAuth2::grantAccessToken(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/IOAuth2.php on line 108
PHP Deprecated:  OAuth2\IOAuth2::finishClientAuthorization(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /home/runner/work/mautic/mautic/vendor/klapaudius/oauth2-php/lib/IOAuth2.php on line 128
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Check that all automated tests pass (CI green)
2. Check that PHPUnit tests (PHP 8.4) runs without deprecation notices related to OAuth2 in CI logs

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->