### PR TITLE
Upgrade composer/installers package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/mautic/mautic"
     },
   "require": {
-    "composer/installers": "^1.11",
+    "composer/installers": "^2.3",
     "mautic/core-lib": "^7.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aec371433c5f6bc4c6a813820fc4d543",
+    "content-hash": "baebcd4a10f9da07ef496a15614c5607",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -663,39 +663,37 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.12.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "1.6.* || ^2.0",
-                "composer/semver": "^1 || ^3",
-                "phpstan/phpstan": "^0.12.55",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.3"
+                "composer/composer": "^1.10.27 || ^2.7",
+                "composer/semver": "^1.7.2 || ^3.4.0",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-phpunit": "^1",
+                "symfony/phpunit-bridge": "^7.1.1",
+                "symfony/process": "^5 || ^6 || ^7"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
+                    "dev-main": "2.x-dev"
+                },
+                "plugin-modifies-install-path": true
             },
             "autoload": {
                 "psr-4": {
@@ -716,7 +714,6 @@
             "description": "A multi-framework Composer library installer",
             "homepage": "https://composer.github.io/installers/",
             "keywords": [
-                "Craft",
                 "Dolibarr",
                 "Eliasis",
                 "Hurad",
@@ -737,7 +734,6 @@
                 "Whmcs",
                 "WolfCMS",
                 "agl",
-                "aimeos",
                 "annotatecms",
                 "attogram",
                 "bitrix",
@@ -746,6 +742,7 @@
                 "cockpit",
                 "codeigniter",
                 "concrete5",
+                "concreteCMS",
                 "croogo",
                 "dokuwiki",
                 "drupal",
@@ -756,7 +753,6 @@
                 "grav",
                 "installer",
                 "itop",
-                "joomla",
                 "known",
                 "kohana",
                 "laravel",
@@ -765,6 +761,7 @@
                 "magento",
                 "majima",
                 "mako",
+                "matomo",
                 "mediawiki",
                 "miaoxing",
                 "modulework",
@@ -784,9 +781,7 @@
                 "silverstripe",
                 "sydes",
                 "sylius",
-                "symfony",
                 "tastyigniter",
-                "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
@@ -794,7 +789,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.12.0"
+                "source": "https://github.com/composer/installers/tree/v2.3.0"
             },
             "funding": [
                 {
@@ -810,7 +805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T08:19:44+00:00"
+            "time": "2024-06-24T20:46:46+00:00"
         },
         {
             "name": "composer/metadata-minifier",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR resolves the deprecations that occur when running Composer commands by upgrading the `composer/installers` package from v1.12 to v2.3.
Below are the deprecations shown in the output:
```
$ composer update composer/installers
PHP Deprecated:  Composer\Installers\Installer::__construct(): Implicitly marking parameter $filesystem as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/composer/installers/src/Composer/Installers/Installer.php on line 136
PHP Deprecated:  Composer\Installers\Installer::__construct(): Implicitly marking parameter $binaryInstaller as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/composer/installers/src/Composer/Installers/Installer.php on line 136
PHP Deprecated:  Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $package as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php on line 22
PHP Deprecated:  Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $composer as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php on line 22
PHP Deprecated:  Composer\Installers\BaseInstaller::__construct(): Implicitly marking parameter $io as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/composer/installers/src/Composer/Installers/BaseInstaller.php on line 22
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading composer/installers (v1.12.0 => v2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading composer/installers (v2.3.0)
  - Upgrading composer/installers (v1.12.0 => v2.3.0): Extracting archive
```

<img width="1329" height="353" alt="image" src="https://github.com/user-attachments/assets/9e00ecf3-08b9-4775-9f02-b2f9c50d9f70" />

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Check that all automated tests pass (CI green)
2. Check that the `Run E2E tests` job in `e2e-tests` does not contain the deprecations.
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->