### PR TITLE
Predis 3

### DIFF
--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -91,7 +91,7 @@ class PRedisConnectionHelper
         $replication = $inputOptions['replication'] ?? null;
 
         if ('sentinel' === $replication) {
-            $inputOptions['aggregate'] = fn () => fn ($sentinels, $options): SentinelReplication => new SentinelReplication(
+            $inputOptions['aggregate'] = fn ($sentinels, $options): SentinelReplication => new SentinelReplication(
                 $options->service,
                 $sentinels,
                 $options->connections,

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -107,8 +107,8 @@ class PRedisConnectionHelper
         // Convert single-endpoint array to string to avoid Predis 3 aggregate connection error
         // This is to maintain compatibility with Predis 3 which expects a string for single endpoint
         // or an array of endpoints for multiple connections.
-        if (1 === count($endpoints) && is_string($endpoints[0])) {
-            $endpoints = $endpoints[0];
+        if (1 === count($endpoints) && is_string(reset($endpoints))) {
+            $endpoints = reset($endpoints);
         }
 
         $client  = new Client($endpoints, $inputOptions);

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -9,10 +9,9 @@ use Mautic\CoreBundle\Predis\Replication\MasterOnlyStrategy;
 use Mautic\CoreBundle\Predis\Replication\StrategyConfig;
 use Predis\Client;
 use Predis\Cluster\ClusterStrategy;
-use Predis\Connection\Aggregate\PredisCluster;
-use Predis\Connection\Aggregate\RedisCluster;
-use Predis\Connection\Aggregate\SentinelReplication;
-use Predis\Profile\RedisProfile;
+use Predis\Connection\Cluster\PredisCluster;
+use Predis\Connection\Cluster\RedisCluster;
+use Predis\Connection\Replication\SentinelReplication;
 
 /**
  * Helper functions for simpler operations with arrays.
@@ -100,13 +99,12 @@ class PRedisConnectionHelper
             );
         }
 
-        $client  = new Client($endpoints, $inputOptions);
-        $profile = $client->getProfile();
-        \assert($profile instanceof RedisProfile);
+        $inputOptions['commands'] = array_merge(
+            $inputOptions['commands'] ?? [],
+            [Unlink::ID => Unlink::class]
+        );
 
-        if (!$profile->getCommandClass(Unlink::ID)) {
-            $profile->defineCommand(Unlink::ID, Unlink::class);
-        }
+        $client  = new Client($endpoints, $inputOptions);
 
         $connection = $client->getConnection();
 

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -104,6 +104,13 @@ class PRedisConnectionHelper
             [Unlink::ID => Unlink::class]
         );
 
+        // Convert single-endpoint array to string to avoid Predis 3 aggregate connection error
+        // This is to maintain compatibility with Predis 3 which expects a string for single endpoint
+        // or an array of endpoints for multiple connections.
+        if (1 === count($endpoints) && is_string($endpoints[0])) {
+            $endpoints = $endpoints[0];
+        }
+
         $client  = new Client($endpoints, $inputOptions);
 
         $connection = $client->getConnection();

--- a/app/bundles/CoreBundle/Predis/Command/Unlink.php
+++ b/app/bundles/CoreBundle/Predis/Command/Unlink.php
@@ -17,13 +17,11 @@ class Unlink extends Command implements PrefixableCommandInterface
     }
 
     /**
-     * @param mixed[] $arguments
-     *
-     * @return mixed[]
+     * @param list<string> $arguments
      */
-    protected function filterArguments(array $arguments): array
+    public function setArguments(array $arguments): void
     {
-        return self::normalizeArguments($arguments);
+        parent::setArguments(self::normalizeArguments($arguments));
     }
 
     public function prefixKeys($prefix): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -11,10 +11,9 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Predis\Cluster\ClusterStrategy;
 use Predis\Command\Processor\KeyPrefixProcessor;
-use Predis\Connection\Aggregate\PredisCluster;
-use Predis\Connection\Aggregate\RedisCluster;
-use Predis\Connection\Aggregate\SentinelReplication;
-use Predis\Profile\RedisProfile;
+use Predis\Connection\Cluster\PredisCluster;
+use Predis\Connection\Cluster\RedisCluster;
+use Predis\Connection\Replication\SentinelReplication;
 
 class PRedisConnectionHelperTest extends TestCase
 {
@@ -78,9 +77,8 @@ class PRedisConnectionHelperTest extends TestCase
         Assert::assertSame($prefix, $options->prefix->getPrefix());
         Assert::assertNull($options->aggregate);
 
-        $profile = $client->getProfile();
-        \assert($profile instanceof RedisProfile);
-        Assert::assertTrue($profile->supportsCommand(Unlink::ID));
+        $commandFactory = $client->getCommandFactory();
+        Assert::assertTrue($commandFactory->supports(Unlink::ID));
 
         $connection = $client->getConnection();
 

--- a/app/composer.json
+++ b/app/composer.json
@@ -62,7 +62,7 @@
     "oneup/uploader-bundle": "^5.0",
     "php-http/guzzle7-adapter": "^1.0",
     "phpoffice/phpspreadsheet": "^4.2.0",
-    "predis/predis": "^1.1",
+    "predis/predis": "^3.0",
     "ramsey/uuid": "^4.7",
     "simshaun/recurr": "^5.0",
     "symfony/asset": "^7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -5911,7 +5911,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "e5397a3bf1dede4d317b1578eede16a58f7ab60e"
+                "reference": "5f1d5056095f34fd9e0d211d090ba09f15e1e2e0"
             },
             "require": {
                 "aws/aws-sdk-php": "~3.0",
@@ -5958,7 +5958,7 @@
                 "php": "~8.2",
                 "php-http/guzzle7-adapter": "^1.0",
                 "phpoffice/phpspreadsheet": "^4.2.0",
-                "predis/predis": "^1.1",
+                "predis/predis": "^3.0",
                 "ramsey/uuid": "^4.7",
                 "simshaun/recurr": "^5.0",
                 "symfony/asset": "^7.3",
@@ -6879,27 +6879,30 @@
         },
         {
             "name": "predis/predis",
-            "version": "v1.1.10",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/predis/predis.git",
-                "reference": "a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e"
+                "reference": "34fb0a7da0330df1bab4280fcac4afdeeccc3edf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/predis/predis/zipball/a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e",
-                "reference": "a2fb02d738bedadcffdbb07efa3a5e7bd57f8d6e",
+                "url": "https://api.github.com/repos/predis/predis/zipball/34fb0a7da0330df1bab4280fcac4afdeeccc3edf",
+                "reference": "34fb0a7da0330df1bab4280fcac4afdeeccc3edf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpcov": "^6.0 || ^8.0",
+                "phpunit/phpunit": "^8.0 || ~9.4.4"
             },
             "suggest": {
-                "ext-curl": "Allows access to Webdis when paired with phpiredis",
-                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+                "ext-relay": "Faster connection with in-memory caching (>=0.6.2)"
             },
             "type": "library",
             "autoload": {
@@ -6913,18 +6916,12 @@
             ],
             "authors": [
                 {
-                    "name": "Daniele Alessandri",
-                    "email": "suppakilla@gmail.com",
-                    "homepage": "http://clorophilla.net",
-                    "role": "Creator & Maintainer"
-                },
-                {
                     "name": "Till Krüss",
                     "homepage": "https://till.im",
                     "role": "Maintainer"
                 }
             ],
-            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "description": "A flexible and feature-complete Redis/Valkey client for PHP.",
             "homepage": "http://github.com/predis/predis",
             "keywords": [
                 "nosql",
@@ -6933,7 +6930,7 @@
             ],
             "support": {
                 "issues": "https://github.com/predis/predis/issues",
-                "source": "https://github.com/predis/predis/tree/v1.1.10"
+                "source": "https://github.com/predis/predis/tree/v3.0.1"
             },
             "funding": [
                 {
@@ -6941,7 +6938,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-05T17:46:08+00:00"
+            "time": "2025-05-16T18:30:32+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR resolves several PHP 8.4 deprecations by upgrading `predis/predis` from `v1.1.10` to `v3.0.1`, along with code changes required by breaking changes in Predis v3.

Below is the list of PHP 8.4 deprecations that were reported:
```
2 tests triggered 7 PHP deprecations:

1) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Client.php:429
Predis\Client::createPipeline(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

2) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Client.php:472
Predis\Client::createTransaction(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

3) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Client.php:504
Predis\Client::createPubSub(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

4) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Connection/Aggregate/PredisCluster.php:37
Predis\Connection\Aggregate\PredisCluster::__construct(): Implicitly marking parameter $strategy as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

5) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Cluster/PredisStrategy.php:29
Predis\Cluster\PredisStrategy::__construct(): Implicitly marking parameter $distributor as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

6) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Profile/RedisProfile.php:124
Predis\Profile\RedisProfile::setProcessor(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithoutSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:71

7) /home/runner/work/mautic/mautic/vendor/predis/predis/src/Connection/Aggregate/SentinelReplication.php:110
Predis\Connection\Aggregate\SentinelReplication::__construct(): Implicitly marking parameter $strategy as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* Mautic\CoreBundle\Tests\Unit\Helper\PRedisConnectionHelperTest::testCreateClientWithSentinel
  /home/runner/work/mautic/mautic/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php:95
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Check that all automated tests pass (CI green)

Testing this PR requires knowledge of Redis.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->