### PR TITLE
Use a version-specific name when using DDEV

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,6 @@
 type: php
 docroot: ""
+name: mautic7
 php_version: "8.4"
 webserver_type: apache-fpm
 database:


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

## Description

When testing and working with multiple version of Mautic, DDEV can get quite challenging because it will only allow you to run one instance with the default name of 'mautic.ddev.site'.

If you do a lot of PR testing you will need to have multiple versions locally for testing, because there's often database migrations, new packages etc which make it very difficult to only run one instance. When you pull down a PR to test, you need to have the relevant Mautic base instance into which you pull that PR otherwise you land up with a bunch of errors and problems. The alternative is blowing away the instance each time which is not at all efficient.

I'm suggesting that in the DDEV configuration file, we add a parameter for 'name', which will allow us to have this version separation in the instance naming by default, making it easier and smoother for testers. I've used this locally myself for years, just manually modifying the configuration file, and when I was explaining it to someone in Prague I figured it might make sense for us to just have it like this by default.

I don't think this should impact the Codespaces integration, or the Gitpod integration, but it should make things a bit smoother for people working locally with more than one release.

If folks are OK with this I will also make a PR for the earlier versions, using the same syntax (e.g. mautic5, mautic6).

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Spin up DDEV (GitPod/Codespaces does this for you) - you might need to use the `ddev restart` command if you're already using it.
3. Check that Mautic loads OK and uses mautic7.ddev.site as the instance name