### PR TITLE
[NOT-FOR-MERGE] Fix: Form label link with target="_blank" is removed by purify filter (M5 Backport)

### DIFF
--- a/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Twig\Extension;
+
+use Mautic\CoreBundle\Twig\Extension\PurifyExtension;
+use PHPUnit\Framework\TestCase;
+
+class PurifyExtensionTest extends TestCase
+{
+    private PurifyExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new PurifyExtension();
+    }
+
+    /**
+     * @dataProvider purifyHtmlDataProvider
+     */
+    public function testPurifyAllowTargetBlank(?string $input, string $expected): void
+    {
+        $result = $this->extension->purifyAllowTargetBlank($input);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return array<string, array{input: ?string, expected: string}>
+     */
+    public function purifyHtmlDataProvider(): array
+    {
+        return [
+            'null input' => [
+                'input'    => null,
+                'expected' => '',
+            ],
+            'empty string' => [
+                'input'    => '',
+                'expected' => '',
+            ],
+            'plain text' => [
+                'input'    => 'Hello World',
+                'expected' => 'Hello World',
+            ],
+            'basic html' => [
+                'input'    => '<p>Hello World</p>',
+                'expected' => '<p>Hello World</p>',
+            ],
+            'link with target blank' => [
+                'input'    => '<a href="https://example.com" target="_blank">Link</a>',
+                'expected' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
+            ],
+            'malicious html' => [
+                'input'    => '<script>alert("xss")</script><p>Hello</p>',
+                'expected' => '<p>Hello</p>',
+            ],
+            'mixed content' => [
+                'input'    => '<p>Hello</p><script>alert("xss")</script><a href="https://example.com" target="_blank">Link</a>',
+                'expected' => '<p>Hello</p><a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
+            ],
+            'invalid html' => [
+                'input'    => '<p>Unclosed paragraph<a>Unclosed link',
+                'expected' => '<p>Unclosed paragraph<a>Unclosed link</a></p>',
+            ],
+        ];
+    }
+}

--- a/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class PurifyExtension extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('purify_allow_target_blank', [$this, 'purifyAllowTargetBlank'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function purifyAllowTargetBlank(?string $html): string
+    {
+        $config = \HTMLPurifier_Config::createDefault();
+        $config->set('HTML.TargetBlank', true);
+        $purifier = new \HTMLPurifier($config);
+
+        return $purifier->purify($html);
+    }
+}

--- a/app/bundles/FormBundle/Resources/views/Field/freehtml.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/freehtml.html.twig
@@ -180,7 +180,7 @@
 {# end: field_helper #}
 
 <div {% for attrName, attrValue in containerAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
-  {% if field.showLabel %}<h3 {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify }}</h3>{% endif %}
+  {% if field.showLabel %}<h3 {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify_allow_target_blank }}</h3>{% endif %}
   <div {% for attrName, attrValue in inputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
     {% if inBuilder %}
       {{ showScriptTags(field.properties.text|default('')) }}

--- a/app/bundles/FormBundle/Resources/views/Field/freetext.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/freetext.html.twig
@@ -183,7 +183,7 @@
 {# end: field_helper #}
 
 <div {% for attrName, attrValue in containerAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
-  {% if field.showLabel %}<h3 {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify }}</h3>{% endif %}
+  {% if field.showLabel %}<h3 {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify_allow_target_blank }}</h3>{% endif %}
   <div {% for attrName, attrValue in inputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
     {{ field.properties.text|raw }}
   </div>

--- a/app/bundles/FormBundle/Resources/views/Field/group.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/group.html.twig
@@ -224,9 +224,9 @@
     {% set labelAttributes = labelAttributes|merge({
             'for': firstId,
     }) %}
-    <label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify }}</label>
+    <label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify_allow_target_blank }}</label>
   {% endif %}
-  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify }}</span>{% endif %}
+  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify_allow_target_blank }}</span>{% endif %}
 
   {% for listValue, listLabel in list|default([]) %}
     {% set id = field.alias ~ '_' ~ inputAlphanum(inputTransliterate(listValue)) ~ loop.index0 %}
@@ -250,7 +250,7 @@
             'id': 'mauticform_' ~ containerType ~ '_label_' ~ id,
             'for': 'mauticform_' ~ containerType ~ '_' ~ type ~ '_' ~ id,
     }) %}
-    <label {% for attrName, attrValue in optionLabelAttr %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ listLabel|purify }}</label>
+    <label {% for attrName, attrValue in optionLabelAttr %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ listLabel|purify_allow_target_blank }}</label>
 
     {% if wrapDiv %}</div>{% endif %}
   {% endfor %}

--- a/app/bundles/FormBundle/Resources/views/Field/select.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/select.html.twig
@@ -227,8 +227,8 @@
 {%- endmacro -%}
 
 <div {% for attrName, attrValue in containerAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
-  {% if field.showLabel -%}<label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify }}</label>{% endif %}
-  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify }}</span>{% endif %}
+  {% if field.showLabel -%}<label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify_allow_target_blank }}</label>{% endif %}
+  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify_allow_target_blank }}</span>{% endif %}
 
   <select {% for attrName, attrValue in inputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
     {# (!empty($properties['placeholder']) || empty($field['defaultValue']) && empty($properties['multiple'])) #}

--- a/app/bundles/FormBundle/Resources/views/Field/text.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/text.html.twig
@@ -136,9 +136,9 @@
 {# end: field_helper #}
 
 <div {% for attrName, attrValue in containerAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>
-  {% if field.showLabel %}<label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify }}</label>{% endif %}
+  {% if field.showLabel %}<label {% for attrName, attrValue in labelAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.label|purify_allow_target_blank }}</label>{% endif %}
 
-  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify }}</span>{% endif %}
+  {% if field.helpMessage is not empty %}<span class="mauticform-helpmessage">{{ field.helpMessage|purify_allow_target_blank }}</span>{% endif %}
 
   {% if 'textarea' == field.type %}
     <textarea {% for attrName, attrValue in inputAttributes %}{{ attrName }}="{% if attrValue is iterable %}{{ attrValue|join(' ') }}{% else %}{{ attrValue }}{% endif %}"{% endfor %}>{{ field.defaultValue }}</textarea>

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -110,4 +110,178 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('Contact', $crawler->filter('select[id="formfield_mappedObject"]')->filter('option[selected]')->text());
         $this->assertSame('Primary company', $crawler->filter('select[id="formfield_mappedField"]')->filter('option[selected]')->text());
     }
+
+    /**
+     * @param array<string, mixed>|null $additionalValues
+     *
+     * @dataProvider provideFieldTypesData
+     */
+    public function testFieldWithLinkInLabel(
+        string $fieldType,
+        string $label,
+        string $expectedHtmlFragment,
+        string $helpMessage = '',
+        ?array $additionalValues = null,
+    ): void {
+        $this->client->request(
+            Request::METHOD_GET,
+            sprintf('/s/forms/field/new?type=%s&tmpl=field&formId=temporary_form_hash&inBuilder=1', $fieldType),
+            [],
+            [],
+            $this->createAjaxHeaders()
+        );
+        $this->assertResponseIsSuccessful();
+        $content     = $this->client->getResponse()->getContent();
+        $content     = json_decode($content)->newContent;
+        $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
+        $formCrawler = $crawler->filter('form[name=formfield]');
+        Assert::assertCount(1, $formCrawler, $this->client->getResponse()->getContent());
+        $form = $formCrawler->form();
+        $form->setValues(
+            [
+                'formfield[formId]'       => 'temporary_form_hash',
+                'formfield[label]'        => $label,
+                'formfield[helpMessage]'  => $helpMessage,
+            ]
+        );
+
+        $values = $form->getPhpValues();
+        if ($additionalValues) {
+            $values = array_merge_recursive($values, $additionalValues);
+        }
+
+        $this->client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles(), $this->createAjaxHeaders());
+        $this->assertResponseIsSuccessful();
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertStringContainsString($expectedHtmlFragment, $response['fieldHtml']);
+    }
+
+    /**
+     * @return array<string, array{
+     *     fieldType: string,
+     *     label: string,
+     *     expectedHtmlFragment: string,
+     *     additionalValues: array<string, mixed>|null
+     * }>
+     */
+    public function provideFieldTypesData(): array
+    {
+        return [
+            'email field with link in label' => [
+                'fieldType'            => 'email',
+                'label'                => 'Email <a href="https://example.com" target="_blank">link</a>',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => '',
+                'additionalValues'     => null,
+            ],
+            'email field with link in helpMessage' => [
+                'fieldType'            => 'email',
+                'label'                => 'Email',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => 'Find more info at <a href="https://example.com" target="_blank">link</a>',
+                'additionalValues'     => null,
+            ],
+            'checkbox group field with link in label' => [
+                'fieldType'            => 'checkboxgrp',
+                'label'                => 'Checkbox Group <a href="https://example.com" target="_blank">link</a>',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => '',
+                'additionalValues'     => [
+                    'formfield' => [
+                        'properties' => [
+                            'optionlist' => [
+                                'list' => [
+                                    [
+                                        'label' => 'option1',
+                                        'value' => 'option1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'checkbox group field with link in helpMessage' => [
+                'fieldType'            => 'checkboxgrp',
+                'label'                => 'Checkbox Group',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => 'Find <a href="https://example.com" target="_blank">link</a>',
+                'additionalValues'     => [
+                    'formfield' => [
+                        'properties' => [
+                            'optionlist' => [
+                                'list' => [
+                                    [
+                                        'label' => 'option1',
+                                        'value' => 'option1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'checkbox group field with link in option label' => [
+                'fieldType'            => 'checkboxgrp',
+                'label'                => 'Checkbox Group',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">terms and conditions</a>',
+                'helpMessage'          => '',
+                'additionalValues'     => [
+                    'formfield' => [
+                        'properties' => [
+                            'optionlist' => [
+                                'list' => [
+                                    [
+                                        'label' => 'I agree with the <a href="https://example.com" target="_blank">terms and conditions</a>.',
+                                        'value' => '1',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'select field with link in label' => [
+                'fieldType'            => 'select',
+                'label'                => 'Select',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => 'Get <a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'additionalValues'     => [
+                    'formfield' => [
+                        'properties' => [
+                            'list' => [
+                                'list' => [
+                                    [
+                                        'label' => 'abc',
+                                        'value' => 'abc',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'select field with link in helpMessage' => [
+                'fieldType'            => 'select',
+                'label'                => 'Select <a href="https://example.com" target="_blank">link</a>',
+                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+                'helpMessage'          => '',
+                'additionalValues'     => [
+                    'formfield' => [
+                        'properties' => [
+                            'list' => [
+                                'list' => [
+                                    [
+                                        'label' => 'abc',
+                                        'value' => 'abc',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
⚠️ **This PR is provided for use as a patch** and is not intended for merging into this Mautic release, as that release is no longer maintained.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This is a backport of #15298 for M5.

When a form field label includes a link with the attribute target="_blank", e.g.
```
I agree with the <a href="https://example.com" target="_blank">terms and conditions</a>.
```
the attribute is removed by the purify twig filter due to security concerns.

This PR includes new `purify_allow_target_blank` to handle this cases:
- Field label
- Field help message
- Group field (e.g. checkbox, radio) option label


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new standalone Form
3. Add a new field, for example the Checkbox group
4. Use the link in label with `target="_blank"` attribute, e.g. `I agree with the <a href="https://example.com" target="_blank">terms and conditions</a>.`
5. Save the form
6. Create a Landing Page and include this form using token:`{form=ID}`
7. Visit the LP and verify if the link opens in the new tab