### PR TITLE
Fix company import override when 'Keep existing value' option is enabled

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1220,15 +1220,6 @@ class LeadModel extends FormModel
         $fields    = array_flip($fields);
         $fieldData = [];
 
-        // Extract company data and import separately
-        // Modifies the data array
-        $company                           = null;
-        [$companyFields, $companyData]     = $this->companyModel->extractCompanyDataFromImport($fields, $data);
-
-        if (!empty($companyData)) {
-            $company       = $this->companyModel->importCompany(array_flip($companyFields), $companyData);
-        }
-
         foreach ($fields as $leadField => $importField) {
             // Prevent overwriting existing data with empty data
             if (array_key_exists($importField, $data) && !is_null($data[$importField]) && '' != $data[$importField]) {
@@ -1255,6 +1246,27 @@ class LeadModel extends FormModel
 
         if (!$granted) {
             throw new \Exception($this->translator->trans('mautic.lead.import.error.unauthorized', ['%username%' => $this->userHelper->getUser()->getUsername()]));
+        }
+
+        // Extract company data and import separately
+        // Modifies the data array
+        $company                       = null;
+        [$companyFields, $companyData] = $this->companyModel->extractCompanyDataFromImport($fields, $data);
+
+        if (true === $skipIfExists && empty($lead->getCompany()) || false === $skipIfExists) {
+            if (!empty($companyData)) {
+                $company = $this->companyModel->importCompany(
+                    array_flip($companyFields),
+                    $companyData,
+                    null,
+                    true,
+                    $skipIfExists
+                );
+            }
+        }
+
+        foreach (array_keys($companyFields) as $companyField) { // Remove company fields from lead fields import data
+            unset($fieldData[$companyField]);
         }
 
         if (!empty($fields['dateAdded']) && !empty($data[$fields['dateAdded']])) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1253,16 +1253,14 @@ class LeadModel extends FormModel
         $company                       = null;
         [$companyFields, $companyData] = $this->companyModel->extractCompanyDataFromImport($fields, $data);
 
-        if (true === $skipIfExists && empty($lead->getCompany()) || false === $skipIfExists) {
-            if (!empty($companyData)) {
-                $company = $this->companyModel->importCompany(
-                    array_flip($companyFields),
-                    $companyData,
-                    null,
-                    true,
-                    $skipIfExists
-                );
-            }
+        if (!empty($companyData) && (true === $skipIfExists && empty($lead->getCompany()) || false === $skipIfExists)) {
+            $company = $this->companyModel->importCompany(
+                array_flip($companyFields),
+                $companyData,
+                null,
+                true,
+                $skipIfExists
+            );
         }
 
         foreach (array_keys($companyFields) as $companyField) { // Remove company fields from lead fields import data

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -2,12 +2,15 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class CompanyModelTest extends \PHPUnit\Framework\TestCase
@@ -195,6 +198,7 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedCompanyData, $companyData);
     }
 
+<<<<<<< HEAD
     private function setSecurity(CompanyModel $companyModel): void
     {
         $security = $this->createMock(CorePermissions::class);
@@ -207,5 +211,92 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
         $property   = $reflection->getProperty('security');
         $property->setAccessible(true);
         $property->setValue($companyModel, $security);
+=======
+    public function testImportCompanyWithUserReferenceFields(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        // Create repository mocks
+        $userRepo = $this->createMock(UserRepository::class);
+        $userRepo->method('findByIdentifier')->willReturn($user);
+
+        $companyLeadRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyLeadRepository::class);
+
+        $companyRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
+        $companyRepo->method('setDispatcher')->willReturnSelf();
+
+        // Setup entity manager with repositories
+        $entityManager = $this->createMock(\Doctrine\ORM\EntityManager::class);
+        $entityManager->method('getRepository')
+            ->will($this->returnValueMap([
+                [User::class, $userRepo],
+                [\Mautic\LeadBundle\Entity\CompanyLead::class, $companyLeadRepo],
+                [Company::class, $companyRepo],
+            ]));
+        $entityManager->method('getReference')->willReturn($user);
+
+        $userHelper = $this->createMock(UserHelper::class);
+        $userHelper->method('getUser')->willReturn($user);
+
+        $dispatcher = $this->createMock(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
+
+        // Create the CompanyModel with constructor injection
+        $companyModel = new class($entityManager, $this->leadFieldModel, $this->companyDeduper, $userHelper, $dispatcher) extends CompanyModel {
+            private $entity;
+
+            // Override constructor to accept only what we need
+            public function __construct($em, $leadFieldModel, $companyDeduper, $userHelper, $dispatcher)
+            {
+                $this->em             = $em;
+                $this->leadFieldModel = $leadFieldModel;
+                $this->companyDeduper = $companyDeduper;
+                $this->userHelper     = $userHelper;
+                $this->dispatcher     = $dispatcher;
+                $this->entity         = new Company();
+            }
+
+            // Override getRepository to return our mock directly
+            public function getRepository(): \Mautic\LeadBundle\Entity\CompanyRepository
+            {
+                return $this->em->getRepository(Company::class);
+            }
+
+            // Override fetchCompanyFields with test data
+            public function fetchCompanyFields()
+            {
+                return [
+                    [
+                        'alias'        => 'companyfield',
+                        'defaultValue' => '',
+                        'type'         => 'text',
+                    ],
+                ];
+            }
+
+            // Override getFieldData with test data
+            public function getFieldData($fields, $data): array
+            {
+                return ['companyfield' => 'xxx'];
+            }
+
+            // Add getter for the entity to verify in test
+            public function getEntity($id = null): ?Company
+            {
+                return $this->entity;
+            }
+        };
+
+        // Test with createdByUser
+        $company = $companyModel->importCompany(
+            ['createdByUser' => 'created_field', 'modifiedByUser' => 'modified_field'],
+            ['created_field' => 'admin', 'modified_field' => 'admin'],
+            1
+        );
+
+        $this->assertSame($user->getId(), $company->getCreatedBy());
+        $this->assertSame($user->getId(), $company->getModifiedBy());
+        $this->assertSame($user, $company->getOwner());
+>>>>>>> 5726ce20d9 (test: add test for get Repository and importCompany with notOverwrite option)
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;
 use Mautic\LeadBundle\Entity\Company;
@@ -198,20 +197,6 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedCompanyData, $companyData);
     }
 
-<<<<<<< HEAD
-    private function setSecurity(CompanyModel $companyModel): void
-    {
-        $security = $this->createMock(CorePermissions::class);
-        $security->method('hasEntityAccess')
-            ->willReturn(true);
-        $security->method('isGranted')
-            ->willReturn(true);
-
-        $reflection = new \ReflectionClass($companyModel);
-        $property   = $reflection->getProperty('security');
-        $property->setAccessible(true);
-        $property->setValue($companyModel, $security);
-=======
     public function testImportCompanyWithUserReferenceFields(): void
     {
         $user = $this->createMock(User::class);
@@ -297,6 +282,5 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($user->getId(), $company->getCreatedBy());
         $this->assertSame($user->getId(), $company->getModifiedBy());
         $this->assertSame($user, $company->getOwner());
->>>>>>> 5726ce20d9 (test: add test for get Repository and importCompany with notOverwrite option)
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -2,14 +2,11 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\UserBundle\Entity\User;
-use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class CompanyModelTest extends \PHPUnit\Framework\TestCase
@@ -194,106 +191,5 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($expectedCompanyFields, $companyFields);
         $this->assertSame($expectedCompanyData, $companyData);
-    }
-
-    public function testImportCompanyWithUserReferenceFields(): void
-    {
-        $user = $this->createMock(User::class);
-        $user->method('getId')->willReturn(1);
-
-        // Create repository mocks
-        $userRepo = $this->createMock(UserRepository::class);
-        $userRepo->method('findByIdentifier')->willReturn($user);
-
-        $companyLeadRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyLeadRepository::class);
-
-        $companyRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
-        $companyRepo->method('setDispatcher')->willReturnSelf();
-
-        // Setup entity manager with repositories
-        $entityManager = $this->createMock(\Doctrine\ORM\EntityManager::class);
-        $entityManager->method('getRepository')
-            ->will($this->returnValueMap([
-                [User::class, $userRepo],
-                [\Mautic\LeadBundle\Entity\CompanyLead::class, $companyLeadRepo],
-                [Company::class, $companyRepo],
-            ]));
-        $entityManager->method('getReference')->willReturn($user);
-
-        $userHelper = $this->createMock(UserHelper::class);
-        $userHelper->method('getUser')->willReturn($user);
-
-        $dispatcher = $this->createMock(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
-
-        // Create the CompanyModel with constructor injection
-        $companyModel = new class($entityManager, $this->leadFieldModel, $this->companyDeduper, $userHelper, $dispatcher) extends CompanyModel {
-            private Company $entity;
-
-            // Override constructor to accept only what we need
-            public function __construct(
-                \Doctrine\ORM\EntityManager $em,
-                FieldModel $leadFieldModel,
-                CompanyDeduper $companyDeduper,
-                UserHelper $userHelper,
-                \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher,
-            ) {
-                $this->em             = $em;
-                $this->leadFieldModel = $leadFieldModel;
-                $this->companyDeduper = $companyDeduper;
-                $this->userHelper     = $userHelper;
-                $this->dispatcher     = $dispatcher;
-                $this->entity         = new Company();
-            }
-
-            // Override getRepository to return our mock directly
-            public function getRepository(): \Mautic\LeadBundle\Entity\CompanyRepository
-            {
-                return $this->em->getRepository(Company::class);
-            }
-
-            // Override fetchCompanyFields with test data
-            /**
-             * @return array<int, array<string, mixed>>
-             */
-            public function fetchCompanyFields(): array
-            {
-                return [
-                    [
-                        'alias'        => 'companyfield',
-                        'defaultValue' => '',
-                        'type'         => 'text',
-                    ],
-                ];
-            }
-
-            // Override getFieldData with test data
-            /**
-             * @param array<string, mixed> $fields
-             * @param array<string, mixed> $data
-             *
-             * @return array<string, mixed>
-             */
-            public function getFieldData(array $fields, array $data): array
-            {
-                return ['companyfield' => 'xxx'];
-            }
-
-            // Add getter for the entity to verify in test
-            public function getEntity($id = null): ?Company
-            {
-                return $this->entity;
-            }
-        };
-
-        // Test with createdByUser
-        $company = $companyModel->importCompany(
-            ['createdByUser' => 'created_field', 'modifiedByUser' => 'modified_field'],
-            ['created_field' => 'admin', 'modified_field' => 'admin'],
-            1
-        );
-
-        $this->assertSame($user->getId(), $company->getCreatedBy());
-        $this->assertSame($user->getId(), $company->getModifiedBy());
-        $this->assertSame($user, $company->getOwner());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -2,14 +2,12 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
-use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\UserBundle\Entity\User;
-use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class CompanyModelTest extends \PHPUnit\Framework\TestCase
@@ -123,6 +121,7 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
             ]
         );
         $companyModel->method('getFieldData')->willReturn(['companyfield' => 'xxx']);
+        $this->setSecurity($companyModel);
 
         return $companyModel;
     }
@@ -196,104 +195,17 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expectedCompanyData, $companyData);
     }
 
-    public function testImportCompanyWithUserReferenceFields(): void
+    private function setSecurity(CompanyModel $companyModel): void
     {
-        $user = $this->createMock(User::class);
-        $user->method('getId')->willReturn(1);
+        $security = $this->createMock(CorePermissions::class);
+        $security->method('hasEntityAccess')
+            ->willReturn(true);
+        $security->method('isGranted')
+            ->willReturn(true);
 
-        // Create repository mocks
-        $userRepo = $this->createMock(UserRepository::class);
-        $userRepo->method('findByIdentifier')->willReturn($user);
-
-        $companyLeadRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyLeadRepository::class);
-
-        $companyRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
-        $companyRepo->method('setDispatcher')->willReturnSelf();
-
-        // Setup entity manager with repositories
-        $entityManager = $this->createMock(\Doctrine\ORM\EntityManager::class);
-        $entityManager->method('getRepository')
-            ->will($this->returnValueMap([
-                [User::class, $userRepo],
-                [\Mautic\LeadBundle\Entity\CompanyLead::class, $companyLeadRepo],
-                [Company::class, $companyRepo],
-            ]));
-        $entityManager->method('getReference')->willReturn($user);
-
-        $userHelper = $this->createMock(UserHelper::class);
-        $userHelper->method('getUser')->willReturn($user);
-
-        $dispatcher = $this->createMock(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
-
-        // Create the CompanyModel with constructor injection
-        $companyModel = new class($entityManager, $this->leadFieldModel, $this->companyDeduper, $userHelper, $dispatcher) extends CompanyModel {
-            private Company $entity;
-
-            // Override constructor to accept only what we need
-            public function __construct(
-                \Doctrine\ORM\EntityManager $em,
-                FieldModel $leadFieldModel,
-                CompanyDeduper $companyDeduper,
-                UserHelper $userHelper,
-                \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher,
-            ) {
-                $this->em             = $em;
-                $this->leadFieldModel = $leadFieldModel;
-                $this->companyDeduper = $companyDeduper;
-                $this->userHelper     = $userHelper;
-                $this->dispatcher     = $dispatcher;
-                $this->entity         = new Company();
-            }
-
-            // Override getRepository to return our mock directly
-            public function getRepository(): \Mautic\LeadBundle\Entity\CompanyRepository
-            {
-                return $this->em->getRepository(Company::class);
-            }
-
-            // Override fetchCompanyFields with test data
-            /**
-             * @return array<int, array<string, mixed>>
-             */
-            public function fetchCompanyFields(): array
-            {
-                return [
-                    [
-                        'alias'        => 'companyfield',
-                        'defaultValue' => '',
-                        'type'         => 'text',
-                    ],
-                ];
-            }
-
-            // Override getFieldData with test data
-            /**
-             * @param array<string, mixed> $fields
-             * @param array<string, mixed> $data
-             *
-             * @return array<string, mixed>
-             */
-            public function getFieldData(array $fields, array $data): array
-            {
-                return ['companyfield' => 'xxx'];
-            }
-
-            // Add getter for the entity to verify in test
-            public function getEntity($id = null): ?Company
-            {
-                return $this->entity;
-            }
-        };
-
-        // Test with createdByUser
-        $company = $companyModel->importCompany(
-            ['createdByUser' => 'created_field', 'modifiedByUser' => 'modified_field'],
-            ['created_field' => 'admin', 'modified_field' => 'admin'],
-            1
-        );
-
-        $this->assertSame($user->getId(), $company->getCreatedBy());
-        $this->assertSame($user->getId(), $company->getModifiedBy());
-        $this->assertSame($user, $company->getOwner());
+        $reflection = new \ReflectionClass($companyModel);
+        $property   = $reflection->getProperty('security');
+        $property->setAccessible(true);
+        $property->setValue($companyModel, $security);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -2,11 +2,14 @@
 
 namespace Mautic\LeadBundle\Tests\Model;
 
+use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\Session\Session;
 
 class CompanyModelTest extends \PHPUnit\Framework\TestCase
@@ -191,5 +194,106 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame($expectedCompanyFields, $companyFields);
         $this->assertSame($expectedCompanyData, $companyData);
+    }
+
+    public function testImportCompanyWithUserReferenceFields(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(1);
+
+        // Create repository mocks
+        $userRepo = $this->createMock(UserRepository::class);
+        $userRepo->method('findByIdentifier')->willReturn($user);
+
+        $companyLeadRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyLeadRepository::class);
+
+        $companyRepo = $this->createMock(\Mautic\LeadBundle\Entity\CompanyRepository::class);
+        $companyRepo->method('setDispatcher')->willReturnSelf();
+
+        // Setup entity manager with repositories
+        $entityManager = $this->createMock(\Doctrine\ORM\EntityManager::class);
+        $entityManager->method('getRepository')
+            ->will($this->returnValueMap([
+                [User::class, $userRepo],
+                [\Mautic\LeadBundle\Entity\CompanyLead::class, $companyLeadRepo],
+                [Company::class, $companyRepo],
+            ]));
+        $entityManager->method('getReference')->willReturn($user);
+
+        $userHelper = $this->createMock(UserHelper::class);
+        $userHelper->method('getUser')->willReturn($user);
+
+        $dispatcher = $this->createMock(\Symfony\Component\EventDispatcher\EventDispatcherInterface::class);
+
+        // Create the CompanyModel with constructor injection
+        $companyModel = new class($entityManager, $this->leadFieldModel, $this->companyDeduper, $userHelper, $dispatcher) extends CompanyModel {
+            private Company $entity;
+
+            // Override constructor to accept only what we need
+            public function __construct(
+                \Doctrine\ORM\EntityManager $em,
+                FieldModel $leadFieldModel,
+                CompanyDeduper $companyDeduper,
+                UserHelper $userHelper,
+                \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher,
+            ) {
+                $this->em             = $em;
+                $this->leadFieldModel = $leadFieldModel;
+                $this->companyDeduper = $companyDeduper;
+                $this->userHelper     = $userHelper;
+                $this->dispatcher     = $dispatcher;
+                $this->entity         = new Company();
+            }
+
+            // Override getRepository to return our mock directly
+            public function getRepository(): \Mautic\LeadBundle\Entity\CompanyRepository
+            {
+                return $this->em->getRepository(Company::class);
+            }
+
+            // Override fetchCompanyFields with test data
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            public function fetchCompanyFields(): array
+            {
+                return [
+                    [
+                        'alias'        => 'companyfield',
+                        'defaultValue' => '',
+                        'type'         => 'text',
+                    ],
+                ];
+            }
+
+            // Override getFieldData with test data
+            /**
+             * @param array<string, mixed> $fields
+             * @param array<string, mixed> $data
+             *
+             * @return array<string, mixed>
+             */
+            public function getFieldData(array $fields, array $data): array
+            {
+                return ['companyfield' => 'xxx'];
+            }
+
+            // Add getter for the entity to verify in test
+            public function getEntity($id = null): ?Company
+            {
+                return $this->entity;
+            }
+        };
+
+        // Test with createdByUser
+        $company = $companyModel->importCompany(
+            ['createdByUser' => 'created_field', 'modifiedByUser' => 'modified_field'],
+            ['created_field' => 'admin', 'modified_field' => 'admin'],
+            1
+        );
+
+        $this->assertSame($user->getId(), $company->getCreatedBy());
+        $this->assertSame($user->getId(), $company->getModifiedBy());
+        $this->assertSame($user, $company->getOwner());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -123,7 +123,6 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
             ]
         );
         $companyModel->method('getFieldData')->willReturn(['companyfield' => 'xxx']);
-        $this->setSecurity($companyModel);
 
         return $companyModel;
     }
@@ -228,11 +227,16 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
 
         // Create the CompanyModel with constructor injection
         $companyModel = new class($entityManager, $this->leadFieldModel, $this->companyDeduper, $userHelper, $dispatcher) extends CompanyModel {
-            private $entity;
+            private Company $entity;
 
             // Override constructor to accept only what we need
-            public function __construct($em, $leadFieldModel, $companyDeduper, $userHelper, $dispatcher)
-            {
+            public function __construct(
+                \Doctrine\ORM\EntityManager $em,
+                FieldModel $leadFieldModel,
+                CompanyDeduper $companyDeduper,
+                UserHelper $userHelper,
+                \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher,
+            ) {
                 $this->em             = $em;
                 $this->leadFieldModel = $leadFieldModel;
                 $this->companyDeduper = $companyDeduper;
@@ -248,7 +252,10 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
             }
 
             // Override fetchCompanyFields with test data
-            public function fetchCompanyFields()
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            public function fetchCompanyFields(): array
             {
                 return [
                     [
@@ -260,7 +267,13 @@ class CompanyModelTest extends \PHPUnit\Framework\TestCase
             }
 
             // Override getFieldData with test data
-            public function getFieldData($fields, $data): array
+            /**
+             * @param array<string, mixed> $fields
+             * @param array<string, mixed> $data
+             *
+             * @return array<string, mixed>
+             */
+            public function getFieldData(array $fields, array $data): array
             {
                 return ['companyfield' => 'xxx'];
             }

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -758,6 +758,67 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
         $this->leadModel->modifyCompanies($lead, $companies);
     }
 
+    public function testImportLeadWithCompanyDataAndSkipIfExists(): void
+    {
+        $lead = new Lead();
+        $lead->setId(1);
+
+        $mockUserModel = $this->getMockBuilder(UserHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockUserModel->method('getUser')
+            ->willReturn(new User());
+
+        $mockEmailValidator = $this->getMockBuilder(EmailValidator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockLeadModel = $this->getMockBuilder(LeadModelStub::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['saveEntity', 'checkForDuplicateContact'])
+            ->getMock();
+
+        $mockLeadModel->setUserHelper($mockUserModel);
+
+        $this->setProperty($mockLeadModel, LeadModel::class, 'emailValidator', $mockEmailValidator);
+
+        $mockCompanyModel = $this->getMockBuilder(CompanyModel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['extractCompanyDataFromImport', 'importCompany'])
+            ->getMock();
+
+        // Set up expectations for extractCompanyDataFromImport
+        $companyFields = ['company' => 'company', 'companyemail' => 'companyemail'];
+        $companyData   = ['company' => 'Acme Inc', 'companyemail' => 'info@acme.com'];
+        $mockCompanyModel->expects($this->once())
+            ->method('extractCompanyDataFromImport')
+            ->willReturn([$companyFields, $companyData]);
+
+        // Set up expectation for importCompany with skipIfExists=true
+        $mockCompanyModel->expects($this->once())
+            ->method('importCompany')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                true,
+                $this->anything()
+            );
+
+        $this->setProperty($mockLeadModel, LeadModel::class, 'companyModel', $mockCompanyModel);
+        $this->setProperty($mockLeadModel, LeadModel::class, 'leadFields', [['alias' => 'email', 'type' => 'email', 'defaultValue' => '']]);
+
+        $mockLeadModel->expects($this->once())
+            ->method('checkForDuplicateContact')
+            ->willReturn($lead);
+
+        $fields = ['email' => 'email', 'company' => 'company', 'companyemail' => 'companyemail'];
+        $data   = ['email' => 'john@doe.com', 'company' => 'Acme Inc', 'companyemail' => 'info@acme.com'];
+
+        $mockLeadModel->import($fields, $data, null, null, null, true);
+    }
+
     private function getLead(int $id): Lead
     {
         return new class($id) extends Lead {

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -780,6 +780,7 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
             ->getMock();
 
         $mockLeadModel->setUserHelper($mockUserModel);
+        $this->setSecurity($mockLeadModel);
 
         $this->setProperty($mockLeadModel, LeadModel::class, 'emailValidator', $mockEmailValidator);
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️

## Description

**This PR updates and replaces #14737 for the 6.x branch.**

M6 version of https://github.com/mautic/mautic/pull/10719.

On contact import, if you import linked company and you enable Keep value if already exists company was overwritten even If you do not expect it. This PR fixed it.

This is a cherry-pick and rebase of the changes from the 5.2 branch (#14737) onto the 6.x branch, ensuring compatibility with the current codebase structure.

---
### 📋 Steps to test this PR:
- Create a contact with company Mautic
- Import a file for this contact with company Mautic2, like
```csv
email,company
test@test.com,Mautic2
```
- Contact should be assigned to company Mautic2
- Then import file for contact with company Mautic3 but enabled Don't overwrite value if already exists. CSV could look like
```csv
email,company
test@test.com,Mautic3 
```
- Contact should not be assigned to company Mautic3

🤖 Generated with [Claude Code](https://claude.ai/code)