### PR TITLE
Fix email graph ignored read failed

### DIFF
--- a/app/bundles/ConfigBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigType.php
@@ -4,7 +4,6 @@ namespace Mautic\ConfigBundle\Form\Type;
 
 use Mautic\ConfigBundle\Form\Helper\RestrictionHelper;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
-use Mautic\CoreBundle\Loader\ParameterLoader;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -24,16 +23,17 @@ class ConfigType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $parameterLoader = new ParameterLoader();
-        $parameters      = $parameterLoader->getLocalParameterBag();
-
-        // fix for https://github.com/mautic/mautic/issues/8854
-        if (!$parameters->has('api_oauth2_access_token_lifetime')) {
-            $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'] /= 60;
+        // TODO very dirty quick fix for https://github.com/mautic/mautic/issues/8854
+        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'])
+            && 3600 === $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime']
+        ) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'] = 60;
         }
 
-        if (!$parameters->has('api_oauth2_refresh_token_lifetime')) {
-            $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'] /= 60 * 60 * 24;
+        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'])
+            && 1_209_600 === $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime']
+        ) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'] = 14;
         }
 
         foreach ($options['data'] as $config) {

--- a/app/bundles/ConfigBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigType.php
@@ -4,6 +4,7 @@ namespace Mautic\ConfigBundle\Form\Type;
 
 use Mautic\ConfigBundle\Form\Helper\RestrictionHelper;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
+use Mautic\CoreBundle\Loader\ParameterLoader;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -23,17 +24,16 @@ class ConfigType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        // TODO very dirty quick fix for https://github.com/mautic/mautic/issues/8854
-        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'])
-            && 3600 === $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime']
-        ) {
-            $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'] = 60;
+        $parameterLoader = new ParameterLoader();
+        $parameters      = $parameterLoader->getLocalParameterBag();
+
+        // fix for https://github.com/mautic/mautic/issues/8854
+        if (!$parameters->has('api_oauth2_access_token_lifetime')) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_access_token_lifetime'] /= 60;
         }
 
-        if (isset($options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'])
-            && 1_209_600 === $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime']
-        ) {
-            $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'] = 14;
+        if (!$parameters->has('api_oauth2_refresh_token_lifetime')) {
+            $options['data']['apiconfig']['parameters']['api_oauth2_refresh_token_lifetime'] /= 60 * 60 * 24;
         }
 
         foreach ($options['data'] as $config) {

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -524,6 +524,7 @@ class ReportSubscriber implements EventSubscriberInterface
                     break;
 
                 case 'mautic.email.graph.pie.ignored.read.failed':
+                    $queryBuilder->resetQueryPart('groupBy');
                     $counts = $this->statRepository->getIgnoredReadFailed($queryBuilder);
                     $chart  = new PieChart();
                     $chart->setDataset($options['translator']->trans('mautic.email.read.emails'), $counts['read']);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | N/A <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Currently, in the email report, "Ignored / Read / Failed emails" does not provide accurate information because it **always reflects only the information of the email_stats1 record.**
<img width="403" height="276" alt="スクリーンショット 2025-07-11 12 08 22" src="https://github.com/user-attachments/assets/5ccf0ae5-3dc1-4129-b80c-d72a3d5211cd" />
The query executed in StatRepository's getIgnoredReadFailed is as follows:
```
SELECT count(es.id) as sent, count(CASE WHEN es.is_read THEN 1 ELSE null END) as "read", count(CASE WHEN es.is_failed THEN 1 ELSE null END) as failed FROM email_stats es LEFT JOIN emails e ON e.id = es.email_id WHERE (es.date_sent IS NULL OR (es.date_sent BETWEEN :dateFrom AND :dateTo)) AND (e.is_published = :i0ceispublished) GROUP BY es.id;
```
The query itself is not a big problem. However, the problem is that because of the "GROUP BY es.id;" statement, there is only one piece of email_stats information per row, but **getIgnoredReadFailed only uses that one row of data.**
As a result, **the pie chart always only provides information for one email.**

<img width="411" height="287" alt="スクリーンショット 2025-07-11 12 10 47" src="https://github.com/user-attachments/assets/42f7ab41-726d-4b31-8f09-2c34effbe9e5" />

This PR solves the problem by removing the group by statement from the query, allowing getIgnoredReadFailed to execute the desired query.




<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the reports screen and check the "Ignored / Read / Failed emails" pie chart.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->