### PR TITLE
DPMMA-2974 Fix Email chart stats for unsubscribed and bounced recipients

### DIFF
--- a/app/bundles/EmailBundle/Stats/Helper/BouncedHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/BouncedHelper.php
@@ -32,7 +32,7 @@ class BouncedHelper extends AbstractHelper
 
         $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = "email" AND t.lead_id = es.lead_id');
 
-        if (true === $options->canViewOthers()) {
+        if (!$options->canViewOthers()) {
             $this->limitQueryToCreator($q, 'es.email_id');
         }
         $this->addCompanyFilter($q, $options->getCompanyId());

--- a/app/bundles/EmailBundle/Stats/Helper/UnsubscribedHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/UnsubscribedHelper.php
@@ -32,7 +32,7 @@ class UnsubscribedHelper extends AbstractHelper
 
         $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = "email" AND t.lead_id = es.lead_id');
 
-        if (true === $options->canViewOthers()) {
+        if (!$options->canViewOthers()) {
             $this->limitQueryToCreator($q, 'es.email_id');
         }
         $this->addCompanyFilter($q, $options->getCompanyId());

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
@@ -54,6 +55,62 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($sentCount, 8);
         [$sentCount] = $this->emailModel->sendEmailToLists($email, [$segment], null, null, null, null, null, 3, 3);
         $this->assertEquals($sentCount, 8);
+    }
+
+    public function testGetEmailGeneralStats(): void
+    {
+        $contacts = $this->generateContacts(12);
+        $segment  = $this->createSegment();
+        $this->addContactsToSegment($contacts, $segment);
+        $email = $this->createEmail($segment);
+
+        // Send email to segment
+        [$sentCount] = $this->emailModel->sendEmailToLists($email, [$segment]);
+
+        // Emulate email reads
+        $statRepository = $this->em->getRepository(Stat::class);
+        $stats          = $statRepository->findBy([
+            'email' => $email,
+            'lead'  => $contacts,
+        ]);
+        for ($index = 0; $index < $readCount = 4; ++$index) {
+            $this->emulateEmailRead($stats[$index]);
+        }
+
+        // Emulate clicks
+        $this->emulateClick($contacts[0], $email, 1, 1);
+        $this->emulateClick($contacts[1], $email, 1, 1);
+
+        // Emulate unsubscribing and bounces
+        $this->createDnc('email', $contacts[3], DoNotContact::UNSUBSCRIBED, $email->getId());
+        $this->createDnc('email', $contacts[4], DoNotContact::BOUNCED, $email->getId());
+
+        // Emulate failed email
+        $this->emulateEmailFailed($stats[5]);
+
+        $this->em->flush();
+
+        $dateFrom        = new \DateTime('-7 days');
+        $dateTo          = new \DateTime();
+        $unit            = 'D';
+        $includeVariants = false;
+
+        $result = $this->emailModel->getEmailGeneralStats($email, $includeVariants, $unit, $dateFrom, $dateTo);
+
+        $this->assertIsArray($result);
+        $this->assertCount(6, $result['datasets']);
+        $this->assertEquals('Sent emails', $result['datasets'][0]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, $sentCount], $result['datasets'][0]['data']);
+        $this->assertEquals('Read emails', $result['datasets'][1]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, $readCount], $result['datasets'][1]['data']);
+        $this->assertEquals('Failed emails', $result['datasets'][2]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, 1], $result['datasets'][2]['data']);
+        $this->assertEquals('Clicked', $result['datasets'][3]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, 2], $result['datasets'][3]['data']);
+        $this->assertEquals('Unsubscribed', $result['datasets'][4]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, 1], $result['datasets'][4]['data']);
+        $this->assertEquals('Bounced', $result['datasets'][5]['label']);
+        $this->assertEquals([0, 0, 0, 0, 0, 0, 0, 1], $result['datasets'][5]['data']);
     }
 
     /**
@@ -238,6 +295,38 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         $pageHit->setSource('email');
         $pageHit->setSourceId($email->getId());
         $this->em->persist($pageHit);
+    }
+
+    private function emulateEmailRead(Stat $emailStat): void
+    {
+        $emailStat->setIsRead(true);
+        $emailStat->setDateRead(new \DateTime());
+        $emailStat->setOpenCount(1);
+        $email = $emailStat->getEmail();
+        $email->setReadCount($email->getReadCount() + 1);
+        $this->em->persist($emailStat);
+        $this->em->persist($email);
+    }
+
+    private function emulateEmailFailed(Stat $emailStat): void
+    {
+        $emailStat->setIsFailed(true);
+        $this->em->persist($emailStat);
+    }
+
+    private function createDnc(string $channel, Lead $contact, int $reason, int $channelId = null): DoNotContact
+    {
+        $dnc = new DoNotContact();
+        $dnc->setChannel($channel);
+        $dnc->setLead($contact);
+        $dnc->setReason($reason);
+        $dnc->setDateAdded(new \DateTime());
+        if ($channelId) {
+            $dnc->setChannelId($channelId);
+        }
+        $this->em->persist($dnc);
+
+        return $dnc;
     }
 
     /**


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
The unsubscribed and bounced stats in **triggered** Email chart are only visible to the Email owner. This PR fixes this issue.

<img width="1163" height="379" alt="image" src="https://github.com/user-attachments/assets/5173573e-2487-4346-b0ca-2608931ad95b" />





<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new triggered email.
3. Add one or more contacts and assign them to a segment.
4. Create a campaign and send the email to the segment you created.
5. As a contact, click the unsubscribe link in the email (use a private browser session).
6. Log in as the email owner and check the email stats.
7. Log in to Mautic as a different user.
8. Verify that the unsubscribed count is accurate.


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->