### PR TITLE
fix: Wrong encoded string value constants for ANSI SQL compatibility (7.x)

### DIFF
--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -84,7 +84,7 @@ class StatRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX.'email_stats', 's')
             ->leftJoin('s', MAUTIC_TABLE_PREFIX.'emails', 'e', 's.email_id = e.id')
             ->addSelect('e.name AS email_name')
-            ->leftJoin('s', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.source = "email" and ph.source_id = s.email_id and ph.lead_id = s.lead_id')
+            ->leftJoin('s', MAUTIC_TABLE_PREFIX.'page_hits', 'ph', 'ph.source = \'email\' and ph.source_id = s.email_id and ph.lead_id = s.lead_id')
             ->addSelect('COUNT(ph.id) AS link_hits');
 
         if (null !== $createdByUserId) {

--- a/app/bundles/EmailBundle/Stats/Helper/BouncedHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/BouncedHelper.php
@@ -30,7 +30,7 @@ class BouncedHelper extends AbstractHelper
 
         $this->limitQueryToEmailIds($q, $options->getEmailIds(), 'channel_id', 't');
 
-        $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = "email" AND t.lead_id = es.lead_id');
+        $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = \'email\' AND t.lead_id = es.lead_id');
 
         if (true === $options->canViewOthers()) {
             $this->limitQueryToCreator($q, 'es.email_id');

--- a/app/bundles/EmailBundle/Stats/Helper/UnsubscribedHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/UnsubscribedHelper.php
@@ -30,7 +30,7 @@ class UnsubscribedHelper extends AbstractHelper
 
         $this->limitQueryToEmailIds($q, $options->getEmailIds(), 'channel_id', 't');
 
-        $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = "email" AND t.lead_id = es.lead_id');
+        $q->join('t', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 't.channel_id = es.email_id AND t.channel = \'email\' AND t.lead_id = es.lead_id');
 
         if (true === $options->canViewOthers()) {
             $this->limitQueryToCreator($q, 'es.email_id');

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -69,7 +69,7 @@ class RedirectRepository extends CommonRepository
             ->addSelect('count(distinct ph.tracking_id) as unique_hits')
             ->from(MAUTIC_TABLE_PREFIX.'page_hits', 'ph')
             ->join('ph', MAUTIC_TABLE_PREFIX.'page_redirects', 'pr', 'pr.id = ph.redirect_id')
-            ->join('ph', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 'ph.source = "email" and ph.source_id = es.email_id and ph.lead_id = es.lead_id')
+            ->join('ph', MAUTIC_TABLE_PREFIX.'email_stats', 'es', 'ph.source = \'email\' and ph.source_id = es.email_id and ph.lead_id = es.lead_id')
             ->join('es', MAUTIC_TABLE_PREFIX.'emails', 'e', 'es.email_id = e.id')
             ->addSelect('e.id AS email_id')
             ->addSelect('e.name AS email_name');


### PR DESCRIPTION
## Description

This pull request standardizes the use of single quotes for string literals in SQL queries across multiple files to improve consistency and align with coding standards. The changes primarily affect SQL join conditions in the `EmailBundle` and `PageBundle`.

### Standardization of string literals in SQL queries:

* [`app/bundles/EmailBundle/Entity/StatRepository.php`](diffhunk://#diff-bff5279d93a64cd23a12d89c6426a7224f54527c9902d758455b6ee9be08c116L87-R87): Updated the `leftJoin` condition in `getSentEmailToContactData` to use single quotes for the `email` string literal.
* [`app/bundles/EmailBundle/Stats/Helper/BouncedHelper.php`](diffhunk://#diff-e6cc86d821b30acdfceac68ad673deb045238c3ccafda764c80593fa93f9f29cL33-R33): Changed the `join` condition in `generateStats` to use single quotes for the `email` string literal.
* [`app/bundles/EmailBundle/Stats/Helper/UnsubscribedHelper.php`](diffhunk://#diff-84d30885671bf318f52e937e75011c8a02846b744172c144e4f9c717aed1dcfcL33-R33): Updated the `join` condition in `generateStats` to use single quotes for the `email` string literal.
* [`app/bundles/PageBundle/Entity/RedirectRepository.php`](diffhunk://#diff-d4d2a1631f9b5d93ddee057ae7e476d9fb4afbf46ff10087ef123d425582af28L72-R72): Modified the `join` condition in `getMostHitEmailRedirects` to use single quotes for the `email` string literal.

This is the same fix as #15324, but for 7.x.