### PR TITLE
[UXUI-230] Fix form fields linked to custom fields showing translation strings instead of names

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Builder/_labels.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/_labels.html.twig
@@ -43,13 +43,15 @@
 
     {% if field.mappedObject is not empty and field.mappedField is not empty and mappedFields[field.mappedObject] is defined %}
     <!-- Mapped field -->
+    {# @var \Mautic\FormBundle\Collection\FieldCollection #}
+    {% set fieldCollection = mappedFields[field.mappedObject] %}
     {% set objectLabel = field.mappedObject == 'company' ? 'mautic.company.company'|trans|lower : (field.mappedObject == 'contact' ? 'mautic.lead.contact'|trans|lower : field.mappedObject|lower) %}
 
     {% include '@MauticCore/Helper/_tag.html.twig' with {
         'tags': [{
             'color': 'green',
             'icon': field.mappedObject == 'company' ? 'ri-building-3-line' : (field.mappedObject == 'contact' ? 'ri-contacts-book-line' : 'ri-shape-line'),
-            'label': fieldCollection[field.mappedField] is defined ? fieldCollection[field.mappedField].name :
+            'label': fieldCollection.getFieldByKey(field.mappedField, false) is not empty ? fieldCollection.getFieldByKey(field.mappedField).name :
                     (field.mappedObject == 'contact' ? ('mautic.lead.field.' ~ field.mappedField) :
                     (field.mappedObject == 'company' ? ('mautic.lead.field.' ~ field.mappedField) : field.mappedField)),
             'attributes': {

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -1327,4 +1327,132 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             ],
         ];
     }
+
+    public function testCustomFieldLabelDisplayInFormBuilder(): void
+    {
+        // Create a custom boolean field with a specific name
+        $this->client->request(Request::METHOD_POST, '/api/fields/contact/new', [
+            'label' => 'My Custom Boolean Field',
+            'alias' => 'custom_boolean_field',
+            'type'  => 'boolean',
+            'properties' => [
+                'yes' => 'Yes',
+                'no'  => 'No',
+            ],
+        ]);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $this->assertArrayHasKey('field', $response);
+        $contactCustomField = $response['field'];
+
+        // Create a form with the custom field mapped
+        $formPayload = [
+            'name'        => 'Custom Field Test Form',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'fields'      => [
+                [
+                    'label'        => 'Test Boolean Field',
+                    'type'         => 'boolean',
+                    'alias'        => 'test_boolean',
+                    'mappedField'  => 'custom_boolean_field',
+                    'mappedObject' => 'contact',
+                ],
+                [
+                    'label' => 'Submit',
+                    'type'  => 'button',
+                ],
+            ],
+            'postAction'  => 'return',
+        ];
+
+        // Create the form
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
+        $clientResponse = $this->client->getResponse();
+        $response       = json_decode($clientResponse->getContent(), true);
+        $formId         = $response['form']['id'];
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        // Test that the form builder displays the correct field label
+        // This tests the _labels.html.twig template functionality
+        $this->client->request(Request::METHOD_GET, "/s/forms/field/new?type=boolean&tmpl=field&formId={$formId}&inBuilder=1");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        // Get the form field configuration to verify the mapping
+        $this->client->request(Request::METHOD_GET, "/api/forms/{$formId}");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        
+        $formData = json_decode($clientResponse->getContent(), true);
+        $this->assertArrayHasKey('form', $formData);
+        $form = $formData['form'];
+        
+        // Find the boolean field and verify its mapping
+        $booleanField = null;
+        foreach ($form['fields'] as $field) {
+            if ($field['type'] === 'boolean') {
+                $booleanField = $field;
+                break;
+            }
+        }
+        
+        $this->assertNotNull($booleanField, 'Boolean field should exist in the form');
+        $this->assertEquals('custom_boolean_field', $booleanField['mappedField']);
+        $this->assertEquals('contact', $booleanField['mappedObject']);
+
+        // Submit the form to test the mapping works correctly
+        $crawler = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
+        $formCrawler = $crawler->filter('form[id=mauticform_customfieldtestform]');
+        $this->assertCount(1, $formCrawler);
+        $form = $formCrawler->form();
+
+        // Submit with a value
+        $form->setValues([
+            'mauticform[test_boolean]' => '1',
+        ]);
+
+        $this->client->submit($form);
+
+        // Verify the submission was successful
+        $this->client->request(Request::METHOD_GET, "/api/forms/{$formId}/submissions");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $submissionsData = json_decode($clientResponse->getContent(), true);
+        $this->assertArrayHasKey('submissions', $submissionsData);
+        $this->assertGreaterThan(0, count($submissionsData['submissions']));
+
+        $latestSubmission = $submissionsData['submissions'][0];
+        $this->assertArrayHasKey('results', $latestSubmission);
+        $this->assertArrayHasKey('test_boolean', $latestSubmission['results']);
+        $this->assertEquals('1', $latestSubmission['results']['test_boolean']);
+
+        // Verify the contact was created with the custom field value
+        $this->assertArrayHasKey('lead', $latestSubmission);
+        $submissionContact = $latestSubmission['lead'];
+
+        $this->client->request(Request::METHOD_GET, "/api/contacts/{$submissionContact['id']}");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        
+        $contactResponse = json_decode($clientResponse->getContent(), true);
+        $this->assertArrayHasKey('contact', $contactResponse);
+        $contact = $contactResponse['contact'];
+
+        // Verify the custom field is properly mapped in the contact
+        $this->assertArrayHasKey('custom_boolean_field', $contact['fields']['core']);
+        $customField = $contact['fields']['core']['custom_boolean_field'];
+        $this->assertEquals('1', $customField['value']);
+
+        // Cleanup
+        $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $this->client->request(Request::METHOD_DELETE, "/api/fields/contact/{$contactCustomField['id']}/delete");
+        $clientResponse = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+    }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description

This PR fixes a bug where form fields linked to custom fields were displaying translation strings instead of the actual field names in the form builder.

### Before:

<img width="600" height="379" alt="image" src="https://github.com/user-attachments/assets/fad914ea-36b0-4cf4-a6e0-cbde63ffb376" />


### After:

<img width="600" height="379" alt="image" src="https://github.com/user-attachments/assets/f678525a-e17f-467c-b8c6-ca55a56a1a8d" />



---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom field in Mautic (e.g., "Test Field")
3. Create a new form and add a field
4. Link the form field to the custom field you created

<img width="738" height="435" alt="image" src="https://github.com/user-attachments/assets/b72a08cb-f34f-4638-89ee-30bd8658d86f" />

5. Verify that the field name shows "Test Field" instead of a translation string