### PR TITLE
Optimize slow campaign execution query

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -339,6 +339,7 @@ class CampaignRepository extends CommonRepository
                         $sq->expr()->in('e.event_id', $pendingEvents)
                     )
                 );
+            $this->updateQueryFromContactLimiter('e', $sq, $limiter, true);
 
             $q->andWhere(
                 sprintf('NOT EXISTS (%s)', $sq->getSQL())

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryFunctionalTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Entity;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Entity\Result\CountResult;
+use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+class CampaignRepositoryFunctionalTest extends MauticMysqlTestCase
+{
+    private CampaignRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = self::getContainer()->get('mautic.campaign.repository.campaign');
+    }
+
+    public function testGetCountsForPendingContactsWithEmptyData(): void
+    {
+        $result = $this->repository->getCountsForPendingContacts(
+            1,
+            [1, 2, 3],
+            new ContactLimiter(100, null, null, null, [1, 2, 3])
+        );
+
+        Assert::assertEquals(
+            new CountResult(0, 0, 0),
+            $result,
+            'There should not be any match as there are no campaign/lead records.'
+        );
+    }
+
+    public function testGetCountsForPendingContactsWithoutEventLogs(): void
+    {
+        $campaign   = $this->createCampaign();
+        $eventOne   = $this->createEvent($campaign);
+        $eventTwo   = $this->createEvent($campaign);
+        $eventThree = $this->createEvent($campaign);
+        $leadOne    = $this->createLead($campaign);
+        $leadTwo    = $this->createLead($campaign);
+        $leadThree  = $this->createLead($campaign);
+        $this->em->flush();
+
+        $result = $this->repository->getCountsForPendingContacts(
+            $campaign->getId(),
+            [$eventOne->getId(), $eventTwo->getId(), $eventThree->getId()],
+            new ContactLimiter(100, null, null, null, [$leadOne->getId(), $leadTwo->getId(), $leadThree->getId()])
+        );
+
+        Assert::assertEquals(
+            new CountResult(3, $leadOne->getId(), $leadThree->getId()),
+            $result,
+            'All three leads should match as none of them have any event logs.'
+        );
+    }
+
+    public function testGetCountsForPendingContactsWithEventLogs(): void
+    {
+        $campaign   = $this->createCampaign();
+        $logOne     = $this->createEventLog($campaign);
+        $leadOne    = $logOne->getLead();
+        $eventOne   = $logOne->getEvent();
+        $logTwo     = $this->createEventLog($campaign);
+        $leadTwo    = $logTwo->getLead();
+        $eventTwo   = $logTwo->getEvent();
+        $leadThree  = $this->createLead($campaign);
+        $eventThree = $this->createEvent($campaign);
+        $this->em->flush();
+
+        $result = $this->repository->getCountsForPendingContacts(
+            $campaign->getId(),
+            [$eventOne->getId(), $eventTwo->getId(), $eventThree->getId()],
+            new ContactLimiter(100, null, null, null, [$leadOne->getId(), $leadTwo->getId(), $leadThree->getId()])
+        );
+
+        Assert::assertEquals(
+            new CountResult(1, $leadThree->getId(), $leadThree->getId()),
+            $result,
+            'Only lead three should match as it is the only one who does not have any event log.'
+        );
+    }
+
+    public function testGetCountsForPendingContactsWithEventLogsWithNonMatchingRotations(): void
+    {
+        $campaign   = $this->createCampaign();
+        $logOne     = $this->createEventLog($campaign);
+        $leadOne    = $logOne->getLead();
+        $eventOne   = $logOne->getEvent();
+        $logTwo     = $this->createEventLog($campaign, $campaignLeadTwo);
+        $leadTwo    = $logTwo->getLead();
+        $eventTwo   = $logTwo->getEvent();
+        $logThree   = $this->createEventLog($campaign);
+        $leadThree  = $logThree->getLead();
+        $eventThree = $logThree->getEvent();
+        $campaignLeadTwo->setRotation($logTwo->getRotation() + 1);
+        $this->em->flush();
+
+        $result = $this->repository->getCountsForPendingContacts(
+            $campaign->getId(),
+            [$eventOne->getId(), $eventTwo->getId(), $eventThree->getId()],
+            new ContactLimiter(100, null, null, null, [$leadOne->getId(), $leadTwo->getId(), $leadThree->getId()])
+        );
+
+        Assert::assertEquals(
+            new CountResult(1, $leadTwo->getId(), $leadTwo->getId()),
+            $result,
+            'Only lead two should match as it is the only one who has a non-matching rotation.'
+        );
+    }
+
+    private function createLead(Campaign $campaign, ?CampaignLead &$campaignLead = null): Lead // @phpstan-ignore parameterByRef.unusedType
+    {
+        $lead = new Lead();
+        $this->em->persist($lead);
+
+        $campaignLead = new CampaignLead();
+        $campaignLead->setCampaign($campaign);
+        $campaignLead->setLead($lead);
+        $campaignLead->setDateAdded(new \DateTime());
+        $this->em->persist($campaignLead);
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test campaign');
+        $campaign->setIsPublished(true);
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+
+    private function createEvent(Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setName('Test event');
+        $event->setCampaign($campaign);
+        $event->setType('lead.changepoints');
+        $event->setEventType(Event::TYPE_ACTION);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createEventLog(Campaign $campaign, ?CampaignLead &$campaignLead = null): LeadEventLog
+    {
+        $event        = $this->createEvent($campaign);
+        $lead         = $this->createLead($campaign, $campaignLead);
+        $leadEventLog = new LeadEventLog();
+        $leadEventLog->setLead($lead);
+        $leadEventLog->setEvent($event);
+        $leadEventLog->setTriggerDate(new \DateTime());
+        $this->em->persist($leadEventLog);
+
+        return $leadEventLog;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR optimizes performance of query that counts number of contacts that there are campaign events to be executed for.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Create a campaign with a few contacts and a few events.
2. Make sure that all appropriate events are executed for all the contacts.
3. Also make sure that events are executed appropriately when contacts restart the campaign or when there are `Jump to Event` events.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->