### PR TITLE
Use request time to determine Hit time

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -414,7 +414,8 @@ class PageModel extends FormModel
         }
 
         $hit = new Hit();
-        $hit->setDateHit(new \DateTime());
+        // Ensure we use the actual request time
+        $hit->setDateHit(\DateTime::createFromFormat('U', $request->server->get('REQUEST_TIME', time())));
         $hit->setIpAddress($this->ipLookupHelper->getIpAddress());
 
         // Set info from request


### PR DESCRIPTION
I don't think 5.2 is still supported, I mostly just need somewhere to store the patch that's not my personal repo.

Anyway, this one uses the request's REQUEST_TIME instead of the current timestamp.