### PR TITLE
Make campaign execution atomic to avoid duplicate execution

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -209,26 +209,6 @@ return [
                     'mautic.helper.core_parameters',
                 ],
             ],
-            'mautic.campaign.scheduler'               => [
-                'class'     => Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler::class,
-                'arguments' => [
-                    'monolog.logger.mautic',
-                    'mautic.campaign.event_logger',
-                    'mautic.campaign.scheduler.interval',
-                    'mautic.campaign.scheduler.datetime',
-                    'mautic.campaign.scheduler.optimized',
-                    'mautic.campaign.event_collector',
-                    'event_dispatcher',
-                    'mautic.helper.core_parameters',
-                ],
-            ],
-            'mautic.campaign.executioner.action' => [
-                'class'     => Mautic\CampaignBundle\Executioner\Event\ActionExecutioner::class,
-                'arguments' => [
-                    'mautic.campaign.dispatcher.action',
-                    'mautic.campaign.event_logger',
-                ],
-            ],
             'mautic.campaign.executioner.condition' => [
                 'class'     => Mautic\CampaignBundle\Executioner\Event\ConditionExecutioner::class,
                 'arguments' => [

--- a/app/bundles/CampaignBundle/Config/services.php
+++ b/app/bundles/CampaignBundle/Config/services.php
@@ -39,6 +39,8 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.campaign.scheduler.optimized', Mautic\CampaignBundle\Executioner\Scheduler\Mode\Optimized::class);
     $services->alias('mautic.campaign.event_logger', Mautic\CampaignBundle\Executioner\Logger\EventLogger::class);
     $services->alias('mautic.campaign.executioner.kickoff', Mautic\CampaignBundle\Executioner\KickoffExecutioner::class);
+    $services->alias('mautic.campaign.scheduler', Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler::class);
+    $services->alias('mautic.campaign.executioner.action', Mautic\CampaignBundle\Executioner\Event\ActionExecutioner::class);
     $services->set(Mautic\CampaignBundle\Executioner\ScheduledExecutioner::class)->tag('kernel.reset', ['method' => 'reset']);
 
     if ('test' === ($_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'] ?? 'prod')) {

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -6,10 +6,14 @@ use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Entity\OptimisticLockInterface;
+use Mautic\CoreBundle\Entity\OptimisticLockTrait;
 use Mautic\LeadBundle\Entity\Lead as LeadEntity;
 
-class LeadEventLog implements ChannelInterface
+class LeadEventLog implements ChannelInterface, OptimisticLockInterface
 {
+    use OptimisticLockTrait;
+
     public const TABLE_NAME = 'campaign_lead_event_log';
 
     /**
@@ -168,6 +172,8 @@ class LeadEventLog implements ChannelInterface
             ->fetchExtraLazy()
             ->cascadeAll()
             ->build();
+
+        self::addVersionField($builder);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php
@@ -3,6 +3,7 @@
 namespace Mautic\CampaignBundle\Executioner\Event;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
@@ -11,6 +12,9 @@ use Mautic\CampaignBundle\Executioner\Dispatcher\ActionDispatcher;
 use Mautic\CampaignBundle\Executioner\Exception\CannotProcessEventException;
 use Mautic\CampaignBundle\Executioner\Logger\EventLogger;
 use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
+use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class ActionExecutioner implements EventInterface
 {
@@ -19,6 +23,9 @@ class ActionExecutioner implements EventInterface
     public function __construct(
         private ActionDispatcher $dispatcher,
         private EventLogger $eventLogger,
+        private OptimisticLockServiceInterface $optimisticLockService,
+        #[Autowire(service: 'monolog.logger.mautic')]
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -42,6 +49,8 @@ class ActionExecutioner implements EventInterface
             throw new CannotProcessEventException('Cannot process event ID '.$event->getId().' as an action.');
         }
 
+        $this->lockLogs($logs);
+
         // Execute to process the batch of contacts
         $pendingEvent = $this->dispatcher->dispatchEvent($config, $event, $logs);
 
@@ -49,5 +58,21 @@ class ActionExecutioner implements EventInterface
         $failed = $this->eventLogger->extractContactsFromLogs($pendingEvent->getFailures());
 
         return new EvaluatedContacts($passed, $failed);
+    }
+
+    /**
+     * @param Collection<LeadEventLog> $logs
+     */
+    private function lockLogs(Collection $logs): void
+    {
+        foreach ($logs as $key => $log) {
+            if (!$this->optimisticLockService->acquireLock($log)) {
+                $logs->remove($key);
+                $this->logger->error(message: sprintf(
+                    'Campaign event log ID "%s" was skipped as it had been executed already.',
+                    $log->getId(),
+                ));
+            }
+        }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Executioner;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\CampaignBundle\Executioner\EventExecutioner;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Traits\LoggerTrait;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\LeadEvents;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class EventExecutionerLockTest extends MauticMysqlTestCase
+{
+    use LoggerTrait {
+        setUp as loggerTraitSetup;
+    }
+
+    private const ADD_POINTS = 10;
+    private EventExecutioner $eventExecutioner;
+    private EventDispatcherInterface $eventDispatcher;
+
+    protected function setUp(): void // @phpstan-ignore phpunit.callParent
+    {
+        $this->loggerTraitSetup();
+
+        $this->eventExecutioner = self::getContainer()->get('mautic.campaign.event_executioner');
+        $this->eventDispatcher  = self::getContainer()->get('event_dispatcher');
+    }
+
+    public function testLogsAreSkippedWhenAlreadyExecuted(): void
+    {
+        $event    = $this->createEvent($this->createCampaign());
+        $contact  = $this->createContact();
+        $this->em->flush();
+
+        Assert::assertSame(0, $contact->getPoints());
+
+        $contacts = new ArrayCollection([$contact->getId() => $contact]);
+        $this->eventExecutioner->executeForContacts($event, $contacts);
+        Assert::assertSame(self::ADD_POINTS, $contact->getPoints(), 'Points should be added.');
+
+        $logs = $this->em->getRepository(LeadEventLog::class)->findAll();
+        Assert::assertCount(1, $logs);
+
+        $log = reset($logs);
+        \assert($log instanceof LeadEventLog);
+        Assert::assertSame(2, $log->getVersion(), 'Version should be incremented.');
+
+        $this->eventExecutioner->executeLogs($event, new ArrayCollection($logs));
+        Assert::assertSame(self::ADD_POINTS, $contact->getPoints(),  // @phpstan-ignore argument.unresolvableType
+            'Points should not be added as the log has been executed already.');
+        Assert::assertTrue($this->testHandler->hasErrorThatContains(sprintf(
+            'Campaign event log ID "%s" was skipped as it had been executed already.',
+            $log->getId(),
+        )), 'There should be an error log regarding the skipped log.');
+    }
+
+    public function testFailedLogsCanBeReExecuted(): void
+    {
+        $event    = $this->createEvent($this->createCampaign());
+        $contact  = $this->createContact();
+        $this->em->flush();
+
+        Assert::assertSame(0, $contact->getPoints());
+
+        $listener = $this->makeEventExecutionFail();
+        $contacts = new ArrayCollection([$contact->getId() => $contact]);
+        $this->eventExecutioner->executeForContacts($event, $contacts);
+        Assert::assertSame(0, $contact->getPoints(),
+            'Points should not be added as the execution failed.');
+
+        $logs = $this->em->getRepository(LeadEventLog::class)->findAll();
+        Assert::assertCount(1, $logs);
+
+        $log = reset($logs);
+        \assert($log instanceof LeadEventLog);
+        Assert::assertSame(1, $log->getVersion(), 'Version should be reset when execution failed.');
+
+        $this->makeEventExecutionPass($listener);
+        $this->eventExecutioner->executeLogs($event, new ArrayCollection($logs));
+        Assert::assertSame(self::ADD_POINTS, $contact->getPoints(),
+            'Points should be added as the log\'s version has been reset when execution failed.');
+        Assert::assertFalse($this->testHandler->hasWarningThatContains(sprintf(
+            'Campaign event log ID "%s" was skipped as it had been executed already.',
+            $log->getId(),
+        )), 'There should not be any warning log regarding skipped logs.');
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test Campaign');
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+
+    private function createEvent(Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setCampaign($campaign);
+        $event->setName('Add points');
+        $event->setType('lead.changepoints');
+        $event->setEventType('action');
+        $event->setProperties(['points' => self::ADD_POINTS]);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createContact(): Lead
+    {
+        $contact = new Lead();
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function makeEventExecutionFail(): callable
+    {
+        $listener = function (CampaignExecutionEvent $event) { // @phpstan-ignore parameter.deprecatedClass
+            $event->setResult(false);
+            $event->stopPropagation();
+        };
+        $this->eventDispatcher->addListener(LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION, $listener, 9999); // @phpstan-ignore classConstant.deprecated
+
+        return $listener;
+    }
+
+    private function makeEventExecutionPass(callable $listener): void
+    {
+        $this->eventDispatcher->removeListener(LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION, $listener); // @phpstan-ignore classConstant.deprecated
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -17,6 +17,7 @@ use Mautic\CampaignBundle\Executioner\Scheduler\Mode\DateTime;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Optimized;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Services\PeakInteractionTimer;
 use PHPUnit\Framework\Assert;
@@ -84,7 +85,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             $this->optimizedScheduler,
             $this->eventCollector,
             $this->dispatcher,
-            $this->coreParamtersHelper
+            $this->coreParamtersHelper,
+            $this->createMock(OptimisticLockServiceInterface::class),
         );
     }
 
@@ -385,7 +387,8 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             $this->optimizedScheduler,
             $this->eventCollector,
             $this->dispatcher,
-            $coreParamtersHelper
+            $coreParamtersHelper,
+            $this->createMock(OptimisticLockServiceInterface::class),
         );
 
         $scheduler->rescheduleFailures(new ArrayCollection([$logWithRescheduleInterval, $logWithNoRescheduleInterval]));

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -843,8 +843,13 @@ class CommonRepository extends ServiceEntityRepository
         $set        = [];
         $update     = [];
         $hasId      = $metadata->containsForeignIdentifier;
+        $fieldNames = $metadata->getFieldNames();
 
-        foreach ($metadata->getFieldNames() as $fieldName) {
+        if ($entity instanceof OptimisticLockInterface) {
+            $fieldNames = array_diff($fieldNames, [$entity->getVersionField()]);
+        }
+
+        foreach ($fieldNames as $fieldName) {
             $value = $metadata->getFieldValue($entity, $fieldName);
             if ($metadata->isIdentifier($fieldName)) {
                 if ($value) {

--- a/app/bundles/CoreBundle/Entity/OptimisticLockInterface.php
+++ b/app/bundles/CoreBundle/Entity/OptimisticLockInterface.php
@@ -9,6 +9,8 @@ namespace Mautic\CoreBundle\Entity;
  */
 interface OptimisticLockInterface
 {
+    public const INITIAL_VERSION = 1;
+
     /**
      * Returns the current version of the entity.
      */

--- a/app/bundles/CoreBundle/Entity/OptimisticLockTrait.php
+++ b/app/bundles/CoreBundle/Entity/OptimisticLockTrait.php
@@ -12,8 +12,10 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
  */
 trait OptimisticLockTrait
 {
-    private int $version = 1;
-    private ?int $currentVersion;
+    private int $version = OptimisticLockInterface::INITIAL_VERSION;
+
+    private ?int $currentVersion = null;
+
     private bool $incrementVersion = false;
 
     public function getVersion(): int
@@ -46,7 +48,7 @@ trait OptimisticLockTrait
     {
         $builder->createField('version', Types::INTEGER)
             ->columnName('version')
-            ->option('default', 1)
+            ->option('default', OptimisticLockInterface::INITIAL_VERSION)
             ->option('unsigned', true)
             ->build();
     }

--- a/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\EventListener;
 
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Mautic\CoreBundle\Entity\OptimisticLockInterface;
-use Mautic\CoreBundle\Entity\OptimisticLockTrait;
+use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
 
 #[AsDoctrineListener(Events::postUpdate)]
 class OptimisticLockSubscriber
 {
+    public function __construct(private OptimisticLockServiceInterface $optimisticLockService)
+    {
+    }
+
     /**
      * If the object implements OptimisticLockInterface and is marked for incrementing the version, object's version column/field is incremented.
      */
@@ -25,32 +28,6 @@ class OptimisticLockSubscriber
             return;
         }
 
-        $entityManager = $args->getObjectManager();
-
-        if (!$entityManager instanceof EntityManagerInterface) {
-            return;
-        }
-
-        $className     = $object::class;
-        $metadata      = $entityManager->getClassMetadata($className);
-        $versionField  = $object->getVersionField();
-        $versionColumn = $metadata->fieldNames[$versionField] ?? null;
-
-        if (null === $versionColumn) {
-            throw new \LogicException(sprintf('Field "%s::$%s" is not mapped. Did you forget to do so? See "%s::addVersionField()"', $className, $versionField, OptimisticLockTrait::class));
-        }
-
-        $connection = $entityManager->getConnection();
-        $connection->createQueryBuilder()
-            ->update($metadata->table['name'])
-            ->set($versionColumn, "(@newVersion := {$versionColumn} + 1)")
-            ->where(implode(' AND ', array_map(function (string $name): string {
-                return "{$name} = :{$name}";
-            }, $metadata->getIdentifierFieldNames())))
-            ->setParameters($entityManager->getUnitOfWork()->getEntityIdentifier($object))
-            ->executeStatement();
-
-        $newVersion = (int) $connection->executeQuery('SELECT @newVersion')->fetchOne();
-        $object->setVersion($newVersion);
+        $this->optimisticLockService->incrementVersion($object);
     }
 }

--- a/app/bundles/CoreBundle/Service/OptimisticLockService.php
+++ b/app/bundles/CoreBundle/Service/OptimisticLockService.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Service;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CoreBundle\Entity\OptimisticLockInterface;
+use Mautic\CoreBundle\Entity\OptimisticLockTrait;
+
+final class OptimisticLockService implements OptimisticLockServiceInterface
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function incrementVersion(OptimisticLockInterface $entity): void
+    {
+        $this->buildUpdateQuery($entity, $versionColumn)
+            ->set($versionColumn, "(@newVersion := {$versionColumn} + 1)")
+            ->executeStatement();
+
+        $newVersion = (int) $this->entityManager->getConnection()
+            ->executeQuery('SELECT @newVersion')
+            ->fetchOne();
+
+        $entity->setVersion($newVersion);
+    }
+
+    public function resetVersion(OptimisticLockInterface $entity): void
+    {
+        $this->buildUpdateQuery($entity, $versionColumn)
+            ->set($versionColumn, (string) OptimisticLockInterface::INITIAL_VERSION)
+            ->executeStatement();
+
+        $entity->setVersion(OptimisticLockInterface::INITIAL_VERSION);
+    }
+
+    public function acquireLock(OptimisticLockInterface $entity, int $expectedVersion = OptimisticLockInterface::INITIAL_VERSION): bool
+    {
+        $this->incrementVersion($entity);
+
+        return ++$expectedVersion === $entity->getVersion();
+    }
+
+    private function buildUpdateQuery(OptimisticLockInterface $entity, ?string &$versionColumn = null): QueryBuilder // @phpstan-ignore parameterByRef.unusedType
+    {
+        $className     = get_class($entity);
+        $metadata      = $this->entityManager->getClassMetadata($className);
+        $versionField  = $entity->getVersionField();
+        $versionColumn = $metadata->fieldNames[$versionField] ?? null;
+
+        if (null === $versionColumn) {
+            throw new \LogicException(sprintf('Field "%s::$%s" is not mapped. Did you forget to do so? See "%s::addVersionField()"', $className, $versionField, OptimisticLockTrait::class));
+        }
+
+        if (!$identifierValues = $metadata->getIdentifierValues($entity)) {
+            throw new \LogicException('Entity must have ID for incrementing its version field.');
+        }
+
+        return $this->entityManager->getConnection()
+            ->createQueryBuilder()
+            ->update($metadata->table['name'])
+            ->where(implode(' AND ', array_map(
+                fn (string $name) => "{$name} = :{$name}",
+                $metadata->getIdentifierFieldNames(),
+            )))
+            ->setParameters($identifierValues);
+    }
+}

--- a/app/bundles/CoreBundle/Service/OptimisticLockService.php
+++ b/app/bundles/CoreBundle/Service/OptimisticLockService.php
@@ -46,7 +46,7 @@ final class OptimisticLockService implements OptimisticLockServiceInterface
 
     private function buildUpdateQuery(OptimisticLockInterface $entity, ?string &$versionColumn = null): QueryBuilder // @phpstan-ignore parameterByRef.unusedType
     {
-        $className     = get_class($entity);
+        $className     = $entity::class;
         $metadata      = $this->entityManager->getClassMetadata($className);
         $versionField  = $entity->getVersionField();
         $versionColumn = $metadata->fieldNames[$versionField] ?? null;

--- a/app/bundles/CoreBundle/Service/OptimisticLockServiceInterface.php
+++ b/app/bundles/CoreBundle/Service/OptimisticLockServiceInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Service;
+
+use Mautic\CoreBundle\Entity\OptimisticLockInterface;
+
+interface OptimisticLockServiceInterface
+{
+    public function incrementVersion(OptimisticLockInterface $entity): void;
+
+    public function resetVersion(OptimisticLockInterface $entity): void;
+
+    public function acquireLock(OptimisticLockInterface $entity, int $expectedVersion = OptimisticLockInterface::INITIAL_VERSION): bool;
+}

--- a/app/bundles/CoreBundle/Tests/Traits/LoggerTrait.php
+++ b/app/bundles/CoreBundle/Tests/Traits/LoggerTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Traits;
+
+use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+
+trait LoggerTrait
+{
+    /**
+     * @var ?HandlerInterface[]
+     */
+    private ?array $originalHandlers = null;
+    private Logger $logger;
+    private TestHandler $testHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger           = self::getContainer()->get('monolog.logger.mautic');
+        $this->originalHandlers = $this->logger->getHandlers();
+        $this->logger->setHandlers([$this->testHandler = new TestHandler()]);
+    }
+
+    protected function beforeTearDown(): void
+    {
+        $this->testHandler->clear();
+
+        if (null !== $this->originalHandlers) {
+            $this->logger->setHandlers($this->originalHandlers);
+        }
+    }
+}

--- a/app/migrations/Version20250806085552.php
+++ b/app/migrations/Version20250806085552.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+use Mautic\CoreBundle\Entity\OptimisticLockInterface;
+
+final class Version20250806085552 extends PreUpAssertionMigration
+{
+    protected const TABLE_NAME = LeadEventLog::TABLE_NAME;
+
+    protected function preUpAssertions(): void
+    {
+        $this->skipAssertion(
+            fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName())->hasColumn('version'),
+            "Table {$this->getPrefixedTableName()} already has 'version' column"
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable($this->getPrefixedTableName());
+        $table->addColumn('version', Types::INTEGER)
+            ->setUnsigned(true)
+            ->setDefault(OptimisticLockInterface::INITIAL_VERSION);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable($this->getPrefixedTableName());
+        $table->dropColumn('version');
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR makes sure that no campaign event log is executed more than once even if there are multiple processes executing the same campaign event log at the same moment. This was implemented using an optimistic lock.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Testing this PR is tricky as you need to make sure that a given campaign event log is executed by at least two processes at the same time. To do so, you can follow the below steps in your local environment.
    1. Create a campaign containing a few contacts with a scheduled event `Adjust contact points` with a delay of a minute.
    2. Run `php bin/console mautic:campaigns:update` to update campaign membership.
    3. Enable Xdebug and set a breakpoint on [this line](https://github.com/mautic/mautic/blob/207662954f946484e25006df146b80653dd14195/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php#L52)
    4. Wait a minute (the delay set in the step `1.1`).
    5. Run the following command `php bin/console mautic:campaigns:trigger` to trigger the campaign's events.
    6. While keeping the above command paused on [that line](https://github.com/mautic/mautic/blob/207662954f946484e25006df146b80653dd14195/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php#L52), run the same command in a new terminal tab as follows `php bin/console mautic:campaigns:trigger --bypass-locking`.
    7. Wait until the second command is also paused on [that line](https://github.com/mautic/mautic/blob/207662954f946484e25006df146b80653dd14195/app/bundles/CampaignBundle/Executioner/Event/ActionExecutioner.php#L52).
    8. Unpause the first command.
    9. You should see the output of the first command like.
    ```
    3 total events(s) to be processed in batches of 1OO contacts
     3/3 [============================] 100%
    3 total events were executed
    0 total events were scheduled
    ```
    10. Now unpause the second command.
    11. You should see output like.
    ```
    3 total events(s) to be processed in batches of 100 contacts
     3/3 [============================] 100%12:40:29 ERROR     [mautic] Campaign event log ID "432" was skipped as it had been executed already. ["instance" => "unknown","hostname" => "mautic-cloud-web","pid" => 12061]
    12:40:29 ERROR     [mautic] Campaign event log ID "433" was skipped as it had been executed already. ["instance" => "unknown","hostname" => "mautic-cloud-web","pid" => 12061]
    12:40:29 ERROR     [mautic] Campaign event log ID "434" was skipped as it had been executed already. ["instance" => "unknown","hostname" => "mautic-cloud-web","pid" => 12061]

    3 total events were executed
    0 total events were scheduled
    ```
    12. Check that the points were added to each contact only once.
2. Apart from the above steps, make sure that campaign actions are executed as expected.
