### PR TITLE
Exclude .devcontainer from update and full packages [6.0]

### DIFF
--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -1,6 +1,7 @@
 *.git*
 *.idea*
 .ddev/*
+.devcontainer/*
 .DS_Store
 .env.dist
 .github/*


### PR DESCRIPTION
## Description

This PR adds `.devcontainer` to the `exclude_files.txt` list so it is omitted from both full and update packages, as it contains development environment files that are not needed in release artifacts.

<img width="934" height="283" alt="image" src="https://github.com/user-attachments/assets/4d782af3-5b57-4cb2-a9de-1c959d3bc95e" />

Related PR for the 7.x branch: https://github.com/mautic/mautic/pull/15373