### PR TITLE
Exclude .devcontainer from update and full packages [5.2]

### DIFF
--- a/build/exclude_files.txt
+++ b/build/exclude_files.txt
@@ -1,6 +1,7 @@
 *.git*
 *.idea*
 .ddev/*
+.devcontainer/*
 .DS_Store
 .env.dist
 .github/*


### PR DESCRIPTION
Not needed because `.devcontainer` does not exist in the 5.2 branch.

## Description

This PR adds `.devcontainer` to the `exclude_files.txt` list so it is omitted from both full and update packages, as it contains development environment files that are not needed in release artifacts.

<img width="934" height="283" alt="image" src="https://github.com/user-attachments/assets/4d782af3-5b57-4cb2-a9de-1c959d3bc95e" />