### PR TITLE
Fix: Tag removal and navigation conflicts on Contact page

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Helper/_tag.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/_tag.html.twig
@@ -5,7 +5,7 @@
     {% set attributes = tag.attributes|default({}) %}
     {% set icon_only = tag.icon_only|default(false) %}
     {% set size = tag.size|default('md') %}
-    {% set onclick = tag.onclick|default('') %}
+    {% set dismissible_onclick = tag.dismissible_onclick|default('') %}
 
     {# ID generation #}
     {% if attributes.id is defined %}
@@ -59,7 +59,7 @@
                 <span aria-hidden="true" {% if label_tooltip %} title="{{ label_tooltip }}" data-toggle="tooltip" tooltip-placement="top"{% endif %}>
                     {{ truncated_label }}
                 </span>
-                <button type="button" class="label-close" onclick="{{ onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-toggle="tooltip" tooltip-placement="top">
+                <button type="button" class="label-close" onclick="{{ dismissible_onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-toggle="tooltip" tooltip-placement="top">
                     <i class="ri-close-line" aria-hidden="true" focusable="false"></i>
                 </button>
 

--- a/app/bundles/CoreBundle/Resources/views/Helper/_tag.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/_tag.html.twig
@@ -5,6 +5,7 @@
     {% set attributes = tag.attributes|default({}) %}
     {% set icon_only = tag.icon_only|default(false) %}
     {% set size = tag.size|default('md') %}
+    {% set onclick = tag.onclick|default('') %}
 
     {# ID generation #}
     {% if attributes.id is defined %}
@@ -58,7 +59,7 @@
                 <span aria-hidden="true" {% if label_tooltip %} title="{{ label_tooltip }}" data-toggle="tooltip" tooltip-placement="top"{% endif %}>
                     {{ truncated_label }}
                 </span>
-                <button type="button" class="label-close" onclick="{{ attributes.onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-toggle="tooltip" tooltip-placement="top">
+                <button type="button" class="label-close" onclick="{{ onclick|default('') }}" aria-label="{{ 'mautic.core.dismiss'|trans }}" title="{{ 'mautic.core.dismiss'|trans }}" data-toggle="tooltip" tooltip-placement="top">
                     <i class="ri-close-line" aria-hidden="true" focusable="false"></i>
                 </button>
 

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1280,7 +1280,11 @@ Mautic.removeBounceStatus = function (el, dncId, channel) {
     });
 };
 
-Mautic.removeTagFromLead = function (el, leadId, tagId) {
+Mautic.removeTagFromLead = function (el, leadId, tagId, event) {
+    if (event) {
+        event.stopPropagation();
+        event.preventDefault();
+    }
     mQuery(el).removeClass('ri-close-line').addClass('ri-loader-3-line ri-spin');
 
     Mautic.ajaxActionRequest('lead:removeTagFromLead', {'leadId': leadId, 'tagId': tagId}, function() {

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1285,7 +1285,7 @@ Mautic.removeTagFromLead = function (el, leadId, tagId, event) {
         event.stopPropagation();
         event.preventDefault();
     }
-    mQuery(el).removeClass('ri-close-line').addClass('ri-loader-3-line ri-spin');
+    mQuery(el).find('i').removeClass('ri-close-line').addClass('ri-loader-3-line ri-spin');
 
     Mautic.ajaxActionRequest('lead:removeTagFromLead', {'leadId': leadId, 'tagId': tagId}, function() {
         mQuery('#tagLabel' + tagId).fadeOut(300, function() { mQuery(this).remove(); });

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -554,7 +554,7 @@
                                     },
                                     'color': 'blue',
                                     'type': 'dismissible',
-                                    'onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ', event);'
+                                    'dismissible_onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ', event);'
                                 }]} %}
                             </div>
                         {% endfor %}
@@ -586,10 +586,10 @@
                                 'attributes': {
                                     'href': path('mautic_tagmanager_action', {'objectAction': 'view', 'objectId': tag.id}),
                                     'data-toggle': 'ajax',
-                                    'onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ');'
                                 },
                                 'color': 'blue',
-                                'type': 'dismissible'
+                                'type': 'dismissible',
+                                'dismissible_onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ', event);'
                             }]} %}
                         </div>
                     {% endfor %}
@@ -605,10 +605,10 @@
                                 'attributes': {
                                     'href': path('mautic_tagmanager_action', {'objectAction': 'view', 'objectId': tag.id}),
                                     'data-toggle': 'ajax',
-                                    'onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ');'
                                 },
                                 'color': 'blue',
-                                'type': 'dismissible'
+                                'type': 'dismissible',
+                                'dismissible_onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ', event);'
                             }]} %}
                         </div>
                     {% endfor %}

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -551,10 +551,10 @@
                                     'attributes': {
                                         'href': path('mautic_tagmanager_action', {'objectAction': 'view', 'objectId': tag.id}),
                                         'data-toggle': 'ajax',
-                                        'onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ');'
                                     },
                                     'color': 'blue',
                                     'type': 'dismissible',
+                                    'onclick': 'Mautic.removeTagFromLead(this, ' ~ lead.id ~ ', ' ~ tag.id ~ ', event);'
                                 }]} %}
                             </div>
                         {% endfor %}


### PR DESCRIPTION
## Problem

Tag interactions on Contact pages have conflicting behaviors:
- Clicking a tag text removes the tag instead of viewing it
- Clicking the X button redirects to tag view page instead of just removing the tag

## Solution

Separate tag navigation from tag removal actions using `dismissible_onclick` attribute:
- Tag text now only navigates to tag view page
- X button now only removes the tag without page redirect

## Steps to Reproduce

### Before Fix:
1. Go to any Contact with tags
2. Click on tag text → **BUG**: Tag gets removed + redirects to tag page
3. Click the X button on a tag → **BUG**: Tag gets removed + redirects to tag page

### After Fix:
1. Go to any Contact with tags  
2. Click on tag text → ✅ Only redirects to tag view page
3. Click the X button → ✅ Only removes the tag (no redirect)

## Technical Changes

- **Template**: Use `dismissible_onclick` instead of `onclick` in `_tag.html.twig`
- **JavaScript**: Fix icon targeting and event handling in `removeTagFromLead()`
- **Structure**: Move dismissible actions outside of `attributes` object for better organization

Fixes #15311