### PR TITLE
Fix: Prevent form unpublishing on API update

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -505,15 +505,13 @@ class CommonApiController extends FetchCommonApiController
 
         $form->submit($submitParams, 'PATCH' !== $method);
 
-        // continuing only in edit action
-        if ('edit' === $action) {
+        // continuing only in edit action and if the entity has isPublished property
+        if ('edit' === $action && null !== $publishedStatus) {
             // if the entity has isPublished property in parameters then using that else using original
-            if (null !== $publishedStatus) {
-                if (isset($parameters['isPublished'])) {
-                    $publishedStatus = $parameters['isPublished'];
-                } else {
-                    $entity->setIsPublished($publishedStatus);
-                }
+            if (isset($parameters['isPublished'])) {
+                $publishedStatus = $parameters['isPublished'];
+            } else {
+                $entity->setIsPublished($publishedStatus);
             }
         }
 

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -495,9 +495,22 @@ class CommonApiController extends FetchCommonApiController
             unset($submitParams['category']);
         }
 
+        // saving the previous published status
+        $publishedStatus = $entity->getIsPublished();
+
         $this->prepareParametersFromRequest($form, $submitParams, $entity, $this->dataInputMasks);
 
         $form->submit($submitParams, 'PATCH' !== $method);
+
+        // if it is an edit action, we need to restore the original published status
+        if ('edit' === $action) {
+            // if isPublished is set in request then we will use that, else we will use saved one
+            if (isset($parameters['isPublished'])) {
+                $publishedStatus = $parameters['isPublished'];
+            } else {
+                $entity->setIsPublished($publishedStatus);
+            }
+        }
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->setCategory($entity, $categoryId);

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -495,20 +495,25 @@ class CommonApiController extends FetchCommonApiController
             unset($submitParams['category']);
         }
 
-        // saving the previous published status
-        $publishedStatus = $entity->getIsPublished();
+        // if the entity has isPublished property then saving the previous published status
+        $publishedStatus = null;
+        if (property_exists($entity, 'isPublished')) {
+            $publishedStatus = $entity->getIsPublished();
+        }
 
         $this->prepareParametersFromRequest($form, $submitParams, $entity, $this->dataInputMasks);
 
         $form->submit($submitParams, 'PATCH' !== $method);
 
-        // if it is an edit action, we need to restore the original published status
+        // continuing only in edit action
         if ('edit' === $action) {
-            // if isPublished is set in request then we will use that, else we will use saved one
-            if (isset($parameters['isPublished'])) {
-                $publishedStatus = $parameters['isPublished'];
-            } else {
-                $entity->setIsPublished($publishedStatus);
+            // if the entity has isPublished property in parameters then using that else using original
+            if (null !== $publishedStatus) {
+                if (isset($parameters['isPublished'])) {
+                    $publishedStatus = $parameters['isPublished'];
+                } else {
+                    $entity->setIsPublished($publishedStatus);
+                }
             }
         }
 


### PR DESCRIPTION
**This pull request resolves issue [#15330](https://github.com/mautic/mautic/issues/15330).**

**Description of the problem:**
When updating a form via the API using a PUT request, the isPublished status is incorrectly reset to false if the isPublished key is not explicitly included in the request body. This leads to the unintended unpublishing of forms.

**Root Cause:**
The issue stems from the Symfony Form submit() method, which nullifies any fields that are not part of the submitted data. Since a PUT request replaces the entire resource, omitting the isPublished boolean caused it to be set to null, which then defaulted to false upon saving the entity.

**Changes Made:**
To fix this, the original isPublished status of the form is now preserved before the form submission is processed and then re-applied afterward. This ensures that the published status is only changed when explicitly specified in the API request and is no longer reset by default.

Steps to test the change:

1. Create a published form.
2. In the request body, update another field like the name, but do not include the isPublished key.
3. Verify that the form's name is updated and that it remains published.
4. Send another PUT request that explicitly includes "isPublished": false.
5. Verify that the form is now unpublished.