### PR TITLE
Fix mb_convert_encoding() error in Mailbox.php 6.x (#15282)

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -1054,7 +1054,10 @@ class Mailbox
         if ($string && $fromEncoding != $toEncoding) {
             $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
             if (!$convertedString && extension_loaded('mbstring')) {
-                $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
+                $listOfEncodings = mb_list_encodings();
+                if (in_array($fromEncoding, $listOfEncodings)) {
+                    $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
+                }
             }
         }
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -4,6 +4,7 @@ namespace Mautic\EmailBundle\Tests\MonitoredEmail;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 
 class MailboxTest extends \PHPUnit\Framework\TestCase
 {
@@ -26,7 +27,7 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
 
         $this->assertEquals($expected, $mailbox->getMailboxSettings());
     }
@@ -69,7 +70,7 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
             ->method('getSystemPath')
             ->will($this->returnValue(__DIR__.'/../../../../cache/'));
 
-        $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
 
         $settings = $mailbox->getMailboxSettings('EmailBundle', 'bounces');
 
@@ -116,7 +117,7 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
             ->method('getSystemPath')
             ->will($this->returnValue(__DIR__.'/../../../../cache/'));
 
-        $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
 
         $settings = $mailbox->getMailboxSettings('EmailBundle', 'bounces');
 
@@ -151,7 +152,7 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+        new Mailbox($parametersHelper, $pathsHelper);
 
         // Test $this->settings['use_attachments'] == true
         // dir creation is not failing
@@ -182,6 +183,117 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
             ->with('tmp', true)
             ->will($this->returnValue(__DIR__.'/../../../../cache/tmp'));
 
-        new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+        new Mailbox($parametersHelper, $pathsHelper);
+    }
+
+    public function testEncodingConversionWithValidEncoding(): void
+    {
+        $string       = 'some UTF8 text with öüóőúéáűíä and ÖÜÓŐÚÉÁŰÍßÄŁ';
+        $fromEncoding = 'UTF-8';
+        $toEncoding   = 'ISO-8859-1';
+
+        // Mock dependencies
+        $parametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
+
+        $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+
+        $this->assertNotSame($string, $result, 'Converted string should differ from the original string.');
+    }
+
+    public function testEncodingConversionWithInvalidEncoding(): void
+    {
+        $string       = 'some text with non-ascii chars öüóőúéáűíä and ÖÜÓŐÚÉÁŰÍßÄŁ';
+        $fromEncoding = 'INVALID-ENC';
+        $toEncoding   = 'ISO-8859-1';
+
+        // Mock dependencies
+        $parametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
+
+        $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+
+        $this->assertSame($string, $result, 'Conversion with invalid encodings should return the original string.');
+    }
+
+    public function testEncodingConversionFallback(): void
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('Test skipped as the mbstring extension is not installed.');
+        }
+
+        $string       = 'some UTF-8 text with non-ascii chars öüóőúéáűíä and ÖÜÓŐÚÉÁŰÍßÄŁ';
+        $fromEncoding = 'UTF-8';
+        $toEncoding   = 'ISO-8859-1';
+
+        // Mock dependencies
+        $parametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
+
+        $listEncodings = mb_list_encodings();
+        if (in_array($fromEncoding, $listEncodings)) {
+            $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+            $this->assertNotSame($string, $result, 'Converted string should differ from the original string if conversion succeeds.');
+        } else {
+            $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+            $this->assertSame($string, $result, 'Conversion with invalid encodings should return the original string.');
+        }
+    }
+
+    public function testEncodingConversionFallbackWithInvalidEncoding(): void
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('Test skipped as the mbstring extension is not installed.');
+        }
+
+        $string       = 'some text with non-ascii chars öüóőúéáűíä and ÖÜÓŐÚÉÁŰÍßÄŁ';
+        $fromEncoding = 'INVALID-ENC';
+        $toEncoding   = 'ISO-8859-1';
+
+        // Mock dependencies
+        $parametersHelper = $this->getMockBuilder(CoreParametersHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pathsHelper = $this->getMockBuilder(PathsHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mailbox = new Mailbox($parametersHelper, $pathsHelper);
+
+        $listEncodings = mb_list_encodings();
+        if (in_array($fromEncoding, $listEncodings)) {
+            $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+            $this->assertNotSame($string, $result, 'Converted string should differ from the original string if conversion succeeds.');
+        } else {
+            $result = $this->invokeConvertStringEncoding($mailbox, $string, $fromEncoding, $toEncoding);
+            $this->assertSame($string, $result, 'Conversion with invalid encodings should return the original string.');
+        }
+    }
+
+    private function invokeConvertStringEncoding(Mailbox $mailbox, string $string, string $fromEncoding, string $toEncoding): string
+    {
+        $reflection = new \ReflectionClass($mailbox);
+        $method     = $reflection->getMethod('convertStringEncoding');
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($mailbox, [$string, $fromEncoding, $toEncoding]);
     }
 }


### PR DESCRIPTION
Original implementation by @trianity in #14478, re-submitted due to inactivity and to address the issue in the 6.x branch.

Referenced and adapted the solution proposed in #14478 to fix mb_convert_encoding() error in Mailbox.php (#15282).

- Handled unsupported encodings by checking mb_list_encodings() before attempting conversion.
- Ensured the method returns the original string if the fromEncoding is not supported.

Credit to @trianity for the original investigation and code changes.


<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the 6.x branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #15282 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The handle unsupported encoding we need add one more check with mb_list_encodings(), that will return as an array the supported encodings in the PHP instance. And if the $fromEncoding value is not on the list, the encoding will be untouched.

See: https://github.com/mautic/mautic/issues/14468

The error occurred while running console command mautic:email:fetch when the monitored email box contained unsupported text encoding in the email text.

The issue prevents the console command mautic:email:fetch from running, so it is considered a critical error.

According the manual page of mb_convert_encoding() this is an old issue with the function, and the @ operator is not enough the handle.

The original function in MailBox.php about line 1051, that fails:

```
protected function convertStringEncoding($string, $fromEncoding, $toEncoding)
    {
        $convertedString = null;
        if ($string && $fromEncoding != $toEncoding) {
            $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
            if (!$convertedString && extension_loaded('mbstring')) {
                $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
            }
        }

        return $convertedString ?: $string;
    }
```

The handle unsupported encoding we need add one more check with mb_list_encodings(), that will return as an array the supported encodings in the PHP instance. And the $fromEncoding is not on the list, it will be untouched.

```
protected function convertStringEncoding($string, $fromEncoding, $toEncoding)
    {
        $convertedString = null;
        if ($string && $fromEncoding != $toEncoding) {
            $convertedString = @iconv($fromEncoding, $toEncoding.'//IGNORE', $string);
            if (!$convertedString && extension_loaded('mbstring')) {
                $listOfEncodings = mb_list_encodings();
                if (in_array($fromEncoding, $listOfEncodings)) {
                    $convertedString = @mb_convert_encoding($string, $toEncoding, $fromEncoding);
                }
            }
        }

        return $convertedString ?: $string;
    }
```

The suggested solution will handle the bug fully.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->