### PR TITLE
Campaign subscriber to work with empty date filters

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -383,7 +383,7 @@ class LeadFieldRepository extends CommonRepository
         $q->select('l.id')
             ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
             ->where(
-                $q->expr()->andX(
+                $q->expr()->and(
                     $q->expr()->eq('l.id', ':lead'),
                     ('empty' === $operatorExpr) ?
                         $q->expr()->isNull($property)

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -392,7 +392,7 @@ class LeadFieldRepository extends CommonRepository
                 )
             )
             ->setParameter('lead', $lead, \PDO::PARAM_INT);
-        $result = $q->execute()->fetch();
+        $result = $q->executeQuery()->fetchAssociative();
 
         return !empty($result['id']);
     }

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -374,6 +374,30 @@ class LeadFieldRepository extends CommonRepository
     }
 
     /**
+     * Compare a form result value with empty value for defined lead.
+     */
+    public function compareEmptyDateValue(int $lead, string $field, string $operatorExpr): bool
+    {
+        $q        = $this->_em->getConnection()->createQueryBuilder();
+        $property = $this->getPropertyByField($field, $q);
+        $q->select('l.id')
+            ->from(MAUTIC_TABLE_PREFIX.'leads', 'l')
+            ->where(
+                $q->expr()->andX(
+                    $q->expr()->eq('l.id', ':lead'),
+                    ('empty' === $operatorExpr) ?
+                        $q->expr()->isNull($property)
+                        :
+                        $q->expr()->isNotNull($property)
+                )
+            )
+            ->setParameter('lead', $lead, \PDO::PARAM_INT);
+        $result = $q->execute()->fetch();
+
+        return !empty($result['id']);
+    }
+
+    /**
      * Compare a form result value with defined date value for defined lead.
      *
      * @param int    $lead  ID

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -526,9 +526,9 @@ class CampaignSubscriber implements EventSubscriberInterface
             } else {
                 $operators = OperatorOptions::getFilterExpressionFunctions();
                 $field     = $event->getConfig()['field'];
-                $value     = $event->getConfig()['value'];
+                $value     = $event->getConfig()['value'] ?? '';
                 $operator  = $event->getConfig()['operator'];
-                $fields    = $lead->getFields(true);
+                $fields    = $this->getFields($lead);
 
                 $fieldType  = '';
                 $fieldValue = $value;
@@ -538,7 +538,6 @@ class CampaignSubscriber implements EventSubscriberInterface
                 }
 
                 // Preventing date/datetime fields to fail on empty/notEmpty
-                // check.
                 if (in_array($fieldType, ['date', 'datetime']) && in_array($operator, ['empty', '!empty'])) {
                     $result     = $this->leadFieldModel->getRepository()->compareEmptyDateValue(
                         $lead->getId(),

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -362,7 +362,9 @@ final class LeadFieldRepositoryTest extends TestCase
         $query->method('setMaxResults')->willReturnSelf();
 
         return $query;
-    public function dataGetEmptyOperators(): iterable
+    }
+
+    public static function dataGetEmptyOperators(): iterable
     {
         yield ['empty', ['id' => 123],  true];
         yield ['!empty', ['id' => 123],  true];
@@ -380,8 +382,8 @@ final class LeadFieldRepositoryTest extends TestCase
         $value            = '';
         $builderAlias     = $this->createMock(QueryBuilder::class);
         $builderCompare   = $this->createMock(QueryBuilder::class);
-        $statementAlias   = $this->createMock(Statement::class);
-        $statementCompare = $this->createMock(Statement::class);
+        $statementAlias   = $this->createMock(Result::class);
+        $statementCompare = $this->createMock(Result::class);
         $exprCompare      = $this->createMock(ExpressionBuilder::class);
 
         $this->entityManager->method('getConnection')->willReturn($this->connection);
@@ -390,7 +392,7 @@ final class LeadFieldRepositoryTest extends TestCase
 
         $this->connection->expects($this->exactly(2))
             ->method('createQueryBuilder')
-            ->will($this->onConsecutiveCalls($builderCompare, $builderAlias));
+            ->willReturnOnConsecutiveCalls($builderCompare, $builderAlias);
 
         $builderAlias->expects($this->once())
             ->method('select')
@@ -417,12 +419,12 @@ final class LeadFieldRepositoryTest extends TestCase
             ->willReturnSelf();
 
         $builderAlias->expects($this->once())
-            ->method('execute')
+            ->method('executeQuery')
             ->willReturn($statementAlias);
 
         // No company column found. Therefore it's a contact field.
         $statementAlias->expects($this->once())
-            ->method('fetchAll')
+            ->method('fetchAllAssociative')
             ->willReturn([]);
 
         $exprCompare->expects($this->once())
@@ -458,12 +460,12 @@ final class LeadFieldRepositoryTest extends TestCase
             ->willReturnSelf();
 
         $builderCompare->expects($this->once())
-            ->method('execute')
+            ->method('executeQuery')
             ->willReturn($statementCompare);
 
         // No contact ID was found by the value so the result should be false.
         $statementCompare->expects($this->once())
-            ->method('fetch')
+            ->method('fetchAssociative')
             ->willReturn($returnValue);
 
         $this->assertSame($expected, $this->repository->compareEmptyDateValue($contactId, $fieldAlias, $operator));

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\QueryBuilder as OrmQueryBuilder;
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -364,6 +365,9 @@ final class LeadFieldRepositoryTest extends TestCase
         return $query;
     }
 
+    /**
+     * @return iterable<array{0: string, 1: array<string, int>|array<empty>, 2: bool}>
+     */
     public static function dataGetEmptyOperators(): iterable
     {
         yield ['empty', ['id' => 123],  true];
@@ -373,8 +377,9 @@ final class LeadFieldRepositoryTest extends TestCase
     }
 
     /**
-     * @dataProvider dataGetEmptyOperators
+     * @param array<string, int>|array<empty> $returnValue
      */
+    #[DataProvider('dataGetEmptyOperators')]
     public function testCompareEmptyDateValueForContactField(string $operator, array $returnValue, bool $expected): void
     {
         $contactId        = 12;

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -8,8 +8,10 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Model\FieldModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
+use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\EventListener\CampaignSubscriber;
 use PHPUnit\Framework\Assert;
 
@@ -82,5 +84,98 @@ class CampaignSubscriberTest extends MauticMysqlTestCase
         $result                 = $this->campaignSubscriber->onCampaignTriggerCondition($campaignExecutionEvent);
         Assert::assertInstanceOf(CampaignExecutionEvent::class, $result); // @phpstan-ignore classConstant.deprecatedClass
         Assert::assertTrue($result->getResult());
+    }
+
+    public function dataEventProperties(): iterable
+    {
+        yield [
+            ['type' => 'datetime', 'alias' => 'date_field'],
+            ['field' => 'date_field', 'operator' => 'empty'],
+            true,
+        ];
+        yield [
+            ['type' => 'datetime', 'alias' => 'date_field_another'],
+            ['field' => 'date_field_another', 'operator' => '!empty'],
+            false,
+        ];
+        yield [
+            ['type' => 'text', 'alias' => 'test_text_field'],
+            ['field' => 'firstname', 'operator' => 'empty'],
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider dataEventProperties
+     */
+    public function testOnCampaignTriggerConditionReturnsCorrectResultsForLeadFieldContext(array $field, array $properties, bool $expected): void
+    {
+        $this->makeField($field);
+        $lead = $this->createTestLead($field);
+
+        // Create a campaign.
+        $campaign = new Campaign();
+        $campaign->setName('My campaign');
+        $campaign->setIsPublished(true);
+        $this->em->persist($campaign);
+
+        // Create an event for campaign.
+        $entityEvent = new Event();
+        $entityEvent->setCampaign($campaign);
+        $entityEvent->setName('Test Condition');
+        $entityEvent->setEventType('condition');
+        $entityEvent->setType('lead.field_value');
+        $entityEvent->setProperties($properties);
+
+        $this->em->persist($entityEvent);
+        $this->em->flush();
+
+        $eventProperties = [
+            'lead'            => $lead,
+            'event'           => $entityEvent,
+            'eventDetails'    => [],
+            'systemTriggered' => false,
+            'eventSettings'   => [],
+        ];
+
+        $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false);
+        $result                 = $this->campaignSubscriber->onCampaignTriggerCondition($campaignExecutionEvent);
+        $this->assertInstanceOf(CampaignExecutionEvent::class, $result);
+        $this->assertSame($expected, $result->getResult());
+    }
+
+    private function makeField(array $fieldDetails): void
+    {
+        // Create a field and add it to the lead object.
+        $field = new LeadField();
+        $field->setLabel($fieldDetails['alias']);
+        $field->setType($fieldDetails['type']);
+        $field->setObject('lead');
+        $field->setGroup('core');
+        $field->setAlias($fieldDetails['alias']);
+
+        /** @var FieldModel $fieldModel */
+        $fieldModel = $this->container->get('mautic.lead.model.field');
+        $fieldModel->saveEntity($field);
+    }
+
+    private function createTestLead(array $fieldDetails): Lead
+    {
+        // Create a contact
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $lead->setFields([
+            'core' => [
+                $fieldDetails['alias'] => [
+                    'value' => '',
+                    'type'  => $fieldDetails['type'],
+                ],
+            ],
+        ]);
+
+        $this->em->persist($lead);
+        $this->em->flush();
+
+        return $lead;
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️<!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom datetime field with for contacts.
3. Add a condition to a campaign for a Contact Field Value
1.1 Select the newly created fields
1.1 Choose either empty/!empty operator
4. Save the campaign
5. Trigger the campaign
6. Condition should be evaluated correctly.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->