### PR TITLE
Add mautic/theme-multi-step to subtree splitter

### DIFF
--- a/.github/subtree-splitter-config.json
+++ b/.github/subtree-splitter-config.json
@@ -264,6 +264,11 @@
             "name": "theme-capture",
             "directory": "themes/capture",
             "target": "git@github.com:mautic/theme-capture.git"
+        },
+        {
+            "name": "theme-multi-step",
+            "directory": "themes/multi-step",
+            "target": "git@github.com:mautic/theme-multi-step.git"
         }
     ]
 }

--- a/.github/workflows/gitsplit/theme-multi-step.json
+++ b/.github/workflows/gitsplit/theme-multi-step.json
@@ -1,0 +1,9 @@
+{
+    "subtree-splits": [
+        {
+            "name": "theme-multi-step",
+            "directory": "themes/multi-step",
+            "target": "git@github.com:mautic/theme-multi-step.git"
+        }
+    ]
+}

--- a/.github/workflows/split-monorepo-in-multi-repo.yml
+++ b/.github/workflows/split-monorepo-in-multi-repo.yml
@@ -91,6 +91,7 @@ jobs:
                     - theme-blend
                     - theme-mono
                     - theme-capture
+                    - theme-multi-step
 
         name: Sync commits into mautic/${{ matrix.config }}
         steps:

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,8 @@
     "mautic/theme-capture": "self.version",
     "mautic/theme-chord": "self.version",
     "mautic/theme-formscape": "self.version",
-    "mautic/theme-reachout": "self.version"
+    "mautic/theme-reachout": "self.version",
+    "mautic/theme-multi-step": "self.version"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "baebcd4a10f9da07ef496a15614c5607",
+    "content-hash": "46b54265380e77f94cf03bd8a47fe4ce",
     "packages": [
         {
             "name": "api-platform/core",


### PR DESCRIPTION
## Description

This PR adds `mautic/theme-multi-step` to the subtree splitter to fix the `mautic/recommended-project` Composer installation error.

https://github.com/mautic/theme-multi-step

@RCheesley, please make sure that `mautic/theme-multi-step` is created in the Packagist registry.
