### PR TITLE
Fix AuthorizeController method signature mismatches and lock klapaudius/oauth-server-bundle to 5.1.3

### DIFF
--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler;
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -24,11 +25,13 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\ApiBundle\\Entity\\oAuth2\\', '../Entity/oAuth2/*Repository.php');
 
+    $services->alias(AuthorizeFormHandler::class, 'fos_oauth_server.authorize.form.handler.default');
+
     $services->get(Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::class)
         ->arg('$authorizeForm', service('fos_oauth_server.authorize.form'))
-        ->arg('$authorizeFormHandler', service('fos_oauth_server.authorize.form.handler.default'))
         ->arg('$oAuth2Server', service('fos_oauth_server.server'))
-        ->arg('$clientManager', service('fos_oauth_server.client_manager.default'));
+        ->arg('$clientManager', service('fos_oauth_server.client_manager.default'))
+        ->tag('controller.service_arguments');
 
     $services->alias('mautic.api.model.client', Mautic\ApiBundle\Model\ClientModel::class);
 };

--- a/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
@@ -28,20 +28,16 @@ class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeCon
     public function __construct(
         RequestStack $requestStack,
         Form $authorizeForm,
-        AuthorizeFormHandler $authorizeFormHandler,
         OAuth2 $oAuth2Server,
         TokenStorageInterface $tokenStorage,
         UrlGeneratorInterface $router,
         ClientManagerInterface $clientManager,
         EventDispatcherInterface $eventDispatcher,
-        private Environment $twig,
     ) {
         parent::__construct(
             $requestStack,
             $authorizeForm,
-            $authorizeFormHandler,
             $oAuth2Server,
-            $twig,
             $tokenStorage,
             $router,
             $clientManager,
@@ -58,9 +54,9 @@ class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeCon
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    protected function renderAuthorize(array $data): Response
+    protected function renderAuthorize(array $data, Environment $twig): Response
     {
-        $response = $this->twig->render(
+        $response = $twig->render(
             '@MauticApi/Authorize/oAuth2/authorize.html.twig',
             $data
         );
@@ -68,13 +64,13 @@ class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeCon
         return new Response($response);
     }
 
-    public function authorizeAction(Request $request): Response
+    public function authorizeAction(Request $request, AuthorizeFormHandler $formHandler, Environment $twig): Response
     {
         // The parent bundle does not care about token being empty.
         if (null === $this->tokenStorage->getToken()) {
             throw new AccessDeniedException('This user does not have access to this section. No token.');
         }
 
-        return parent::authorizeAction($request);
+        return parent::authorizeAction($request, $formHandler, $twig);
     }
 }

--- a/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+++ b/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
@@ -40,9 +40,10 @@ class PreAuthorizationEventListener
 
     public function onPostAuthorizationProcess(OAuthEvent $event): void
     {
-        if ($event->isAuthorizedClient() && null !== $client = $event->getClient()) {
-            if ($client instanceof Client) {
-                $user = $this->getUser($event);
+        $client = $event->getClient();
+
+        if ($event->isAuthorizedClient() && $client instanceof Client) {
+            if ($user = $this->getUser($event)) {
                 $client->addUser($user);
                 $this->em->persist($client);
                 $this->em->flush();

--- a/app/composer.json
+++ b/app/composer.json
@@ -54,7 +54,7 @@
     "jms/serializer-bundle": "^5.4",
     "joomla/filter": "~1.4.4",
     "kamermans/guzzle-oauth2-subscriber": "^1.0",
-    "klapaudius/oauth-server-bundle": "^5.0.0",
+    "klapaudius/oauth-server-bundle": "5.1.3",
     "knplabs/gaufrette": "~0.9.0",
     "knplabs/knp-menu-bundle": "^3.0",
     "matomo/device-detector": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -5168,16 +5168,16 @@
         },
         {
             "name": "klapaudius/oauth-server-bundle",
-            "version": "5.1.2",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klapaudius/FOSOAuthServerBundle.git",
-                "reference": "0b112e6c28b4c2824124568db6a198e6f07af04a"
+                "reference": "c67a39afd881b4a36adf6df74c2873b9a3ceb0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/0b112e6c28b4c2824124568db6a198e6f07af04a",
-                "reference": "0b112e6c28b4c2824124568db6a198e6f07af04a",
+                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/c67a39afd881b4a36adf6df74c2873b9a3ceb0b7",
+                "reference": "c67a39afd881b4a36adf6df74c2873b9a3ceb0b7",
                 "shasum": ""
             },
             "require": {
@@ -5251,9 +5251,15 @@
             ],
             "support": {
                 "issues": "https://github.com/klapaudius/FOSOAuthServerBundle/issues",
-                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/5.1.2"
+                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/5.1.3"
             },
-            "time": "2025-04-26T21:23:17+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/klapaudius",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-28T11:39:01+00:00"
         },
         {
             "name": "klapaudius/oauth2-php",
@@ -6123,7 +6129,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "abdfd426667df2bfcd0af523f7d370ae72b7d494"
+                "reference": "0d3182dcdfd44755e8775aa3950b72ac31cc5279"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6162,7 +6168,7 @@
                 "jms/serializer-bundle": "^5.4",
                 "joomla/filter": "~1.4.4",
                 "kamermans/guzzle-oauth2-subscriber": "^1.0",
-                "klapaudius/oauth-server-bundle": "^5.0.0",
+                "klapaudius/oauth-server-bundle": "5.1.3",
                 "knplabs/gaufrette": "~0.9.0",
                 "knplabs/knp-menu-bundle": "^3.0",
                 "matomo/device-detector": "^4.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

`klapaudius/oauth-server-bundle` v5.1.3 (released on 28th August) introduced a breaking change. The error appears in the GitHub test `composer install`, during installation of `mautic/recommended-project:7.0.0-alpha`, and also in Docker image builds that rely on `mautic/recommended-project`.

The problem only affects Composer installations that resolves to 5.1.3 instead of the 5.1.2 listed in composer.lock.

The dependency is now locked to 5.1.3 to ensure stable Composer installations and avoid unexpected issues if future releases introduce breaking changes.

```
> bin/console mautic:assets:generate && bin/console assets:install --symlink --relative ./
PHP Fatal error:  Declaration of Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request): Symfony\Component\HttpFoundation\Response must be compatible with FOS\OAuthServerBundle\Controller\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request, FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler $formHandler, Twig\Environment $twig): Symfony\Component\HttpFoundation\Response in /var/www/html/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php on line 71

Fatal error: Declaration of Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request): Symfony\Component\HttpFoundation\Response must be compatible with FOS\OAuthServerBundle\Controller\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request, FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler $formHandler, Twig\Environment $twig): Symfony\Component\HttpFoundation\Response in /var/www/html/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php on line 71
Symfony\Component\ErrorHandler\Error\FatalError^ {#5014
  #message: "Compile Error: Declaration of Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request): Symfony\Component\HttpFoundation\Response must be compatible with FOS\OAuthServerBundle\Controller\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request, FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler $formHandler, Twig\Environment $twig): Symfony\Component\HttpFoundation\Response"
  #code: 0
  #file: "./app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php"
  #line: 71
  -error: array:4 [
    "type" => 64
    "message" => "Declaration of Mautic\ApiBundle\Controller\oAuth2\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request): Symfony\Component\HttpFoundation\Response must be compatible with FOS\OAuthServerBundle\Controller\AuthorizeController::authorizeAction(Symfony\Component\HttpFoundation\Request $request, FOS\OAuthServerBundle\Form\Handler\AuthorizeFormHandler $formHandler, Twig\Environment $twig): Symfony\Component\HttpFoundation\Response"
    "file" => "/var/www/html/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php"
    "line" => 71
  ]
}
Script bin/console mautic:assets:generate && bin/console assets:install --symlink --relative ./ handling the generate-assets event returned with error code 255
Script @generate-assets was called via post-update-cmd
```

https://github.com/klapaudius/FOSOAuthServerBundle/blob/5.1.2/Controller/AuthorizeController.php
https://github.com/klapaudius/FOSOAuthServerBundle/blob/5.1.3/Controller/AuthorizeController.php

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->