### PR TITLE
Increment version to 5.2.8

### DIFF
--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "4.4.10",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.2.7"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/5.2.8"
 }

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.2.7",
+  "version": "5.2.8",
   "stability": "stable",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | 🔴
| New feature/enhancement? (use the a.x branch)      | 🔴
| Deprecations?                          | 🔴
| BC breaks? (use the c.x branch)        | 🔴
| Automated tests included?              | 🟢
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Version increment for 5.2.8 release

## Description

This PR increments the version number from 5.2.7 to 5.2.8 in the release metadata file to prepare for the next minor release.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Verify that `app/release_metadata.json` contains version "5.2.8"
3. Confirm no other files were modified unintentionally