### PR TITLE
Increment version to 6.0.5

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,7 +14,7 @@ hooks:
 upload_dirs:
     - media/files
     - media/images
-#webimage_extra_packages: ["php${DDEV_PHP_VERSION}-imap"]
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-imap"]
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []

--- a/app/release_metadata.json
+++ b/app/release_metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.4",
+  "version": "6.0.5",
   "stability": "stable",
   "minimum_php_version": "8.1.0",
   "maximum_php_version": "8.3.99",
@@ -7,5 +7,5 @@
   "minimum_mariadb_version": "10.2.7",
   "show_php_version_warning_if_under": "8.1.0",
   "minimum_mautic_version": "5.0.0",
-  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.4"
+  "announcement_url": "https://github.com/mautic/mautic/releases/tag/6.0.5"
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Version increment for 6.0.5 release

## Description

This PR increments the version number from 6.0.4 to 6.0.5 in the release metadata file to prepare for the next release.

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Verify that `app/release_metadata.json` contains version "6.0.5"
3. Verify that the announcement URL points to the correct release tag