### PR TITLE
Fix form edit error with no group "adjust contact's point" action

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Action/points.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Action/points.html.twig
@@ -17,8 +17,12 @@
         {% set operatorKey = 'mautic.lead.lead.submitaction.operator_' ~ action.properties.operator %}
         {% set operatorLabel = operatorKey|trans %}
 
-        {% set pointGroup = getEntity('Mautic\\PointBundle\\Entity\\Group', action.properties.group) %}
-        {% set groupName = pointGroup ? pointGroup.name : '' %}
+        {% if action.properties.group is defined %}
+            {% set pointGroup = getEntity('Mautic\\PointBundle\\Entity\\Group', action.properties.group) %}
+            {% set groupName = pointGroup ? pointGroup.name : '' %}
+        {% else %}
+            {% set groupName = '' %}
+        {% endif %}
 
         {% set label = 'mautic.form.field.points.operation'|trans({
             '%operator%': operatorLabel,


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | mautic/user-documentation#...
| Related developer documentation PR URL | mautic/developer-documentation-new#... 
| Issue(s) addressed                     | Fixes #15434

## Description

The "adjust contact's point" action may not have group. If it doesn't have any group, edit form view raises an error like the following:

    [2025-08-29T02:42:22.370669+00:00] mautic.CRITICAL: Uncaught PHP
    Exception Twig\Error\RuntimeError: "Key "group" for
    sequence/mapping with keys "operator, points" does not exist in
    "@MauticLead/Action/points.html.twig" at line 20." at
    /var/www/mautic/docroot/app/bundles/LeadBundle/Resources/views/Action/points.html.twig
    line 20 {"exception":"[object] (Twig\\Error\\RuntimeError(code:
    0): Key \"group\" for sequence/mapping with keys \"operator,
    points\" does not exist in \"@MauticLead/Action/points.html.twig\"
    at line 20. at
    /var/www/mautic/docroot/app/bundles/LeadBundle/Resources/views/Action/points.html.twig:20)"}
    {"hostname":"storage","pid":2455565}

### 📋 Steps to test this PR:

1. Create an old Mautic (< 6) but I'm not sure whether this is required
2. Create a form with the "adjust contact's point" action without "Point group"
3. Upgrade to Mautic 6.0
4. Edit the created form
