### PR TITLE
Limiting score value for company to be in a range

### DIFF
--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -137,15 +137,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
         self::addProjectsField($builder, 'company_projects_xref', 'company_id');
     }
 
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
-        $metadata->addPropertyConstraint('score', new Assert\Range([
-            'min' => 0,
-            'max' => 2147483647,
-        ]));
-    }
-
     /**
      * Prepares the metadata for API usage.
      */
@@ -181,6 +172,15 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
             ->build();
 
         self::addProjectsInLoadApiMetadata($metadata, 'company');
+    }
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
+        $metadata->addPropertyConstraint('score', new Assert\Range([
+            'min' => 0,
+            'max' => 2147483647,
+        ]));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Form\Validator\Constraints\UniqueCustomField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Mautic\UserBundle\Entity\User;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Company extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface
@@ -136,6 +137,15 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
         self::addProjectsField($builder, 'company_projects_xref', 'company_id');
     }
 
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
+        $metadata->addPropertyConstraint('score', new Assert\Range([
+            'min' => 0,
+            'max' => 2147483647,
+        ]));
+    }
+
     /**
      * Prepares the metadata for API usage.
      */
@@ -171,11 +181,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
             ->build();
 
         self::addProjectsInLoadApiMetadata($metadata, 'company');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
@@ -1,10 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Persistence\Mapping\MappingException;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
+use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpFoundation\Request;
 
-class CompanyTest extends \PHPUnit\Framework\TestCase
+class CompanyTest extends MauticMysqlTestCase
 {
     public function testChangingPropertiesHydratesFieldChanges(): void
     {
@@ -16,5 +24,61 @@ class CompanyTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(empty($changes['fields']['email']));
 
         $this->assertEquals($email, $changes['fields']['email'][1]);
+    }
+
+    /**
+     * @throws MappingException
+     */
+    public function testScoreValidationOnCompanyCreate(): void
+    {
+        $crawler       = $this->client->request(Request::METHOD_GET, '/s/companies/new');
+        $buttonCrawler = $crawler->selectButton('Save & Close');
+        $form          = $buttonCrawler->form();
+        $form['company[score]']->setValue((string) -3);
+        $this->testCompanyData($form);
+
+        $form['company[score]']->setValue((string) 2147483648);
+        $this->testCompanyData($form);
+    }
+
+    /**
+     * @throws MappingException
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function testMinScoreValidationOnCompanyEdit(): void
+    {
+        $company = new Company();
+        $company->setScore(-1);
+
+        $this->em->persist($company);
+        $this->em->flush();
+
+        $companyId = $company->getId();
+
+        $crawler       = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$companyId);
+        $buttonCrawler = $crawler->selectButton('Save & Close');
+        $form          = $buttonCrawler->form();
+        $form['company[score]']->setValue((string) -3);
+        $this->testCompanyData($form);
+
+        $form['company[score]']->setValue((string) 2147483648);
+        $this->testCompanyData($form);
+    }
+
+    /**
+     * @throws MappingException
+     */
+    private function testCompanyData(Form $form): void
+    {
+        $errorMessage = 'This value should be between 0 and 2147483647.';
+
+        $this->client->submit($form);
+        $this->assertTrue($this->client->getResponse()->isOk());
+
+        $this->em->clear();
+
+        $response = $this->client->getResponse()->getContent();
+        $this->assertStringContainsString($errorMessage, (string) $response);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Bug fix for score field in company where if we try to save long int value like `92147483647` it gives below 500 error.

> 500 Internal Server Error - An exception occurred while executing a query: SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'score' at row 1 

So, added validation that checks score must be between 0 and 2147483647 (Max value of int of 32bits that can be stored in mysql db).

## Changes
 - Added `Assert\Range` validation constraint to Company entity score property 
 - Prevent negative scores and integer overflow for company scoring system                                                                                     
 - Added tests for score validation on both company creation and editing                                                                                                     
 - Tests verify proper error handling for out-of-range values (-3 and 2147483648)

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create or edit company with any score value greater than 2147483647 or less than 0 should give you an error and should be saving company for any value in range.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->