### PR TITLE
Ensure non-admins can create dynamic content

### DIFF
--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -49,6 +49,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
         $repo = $this->em->getRepository(DynamicContent::class);
 
         $repo->setTranslator($this->translator);
+        $repo->setCurrentUser($this->userHelper->getUser());
 
         return $repo;
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description

This PR fixes an issue where non-admin users were unable to create dynamic content due to a problematic check of permissions from the current user when using custom roles.

The permission system was preventing non-admin users from accessing the dynamic content creation functionality even when they had the appropriate create permissions.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](mdc:https:/contribute.mautic.org/contributing-to-mautic/tester))
2. Create a role without admin privileges but with dynamic content create permissions
3. Create a user with this role
4. Log in as this user and try to create dynamic content
5. Verify that the user can successfully create dynamic content