### PR TITLE
Fix tweets broken template

### DIFF
--- a/plugins/MauticSocialBundle/Resources/views/Tweet/_list.html.twig
+++ b/plugins/MauticSocialBundle/Resources/views/Tweet/_list.html.twig
@@ -31,8 +31,8 @@
                         {{ include('@MauticCore/Helper/list_actions.html.twig', {
                                 'item': item,
                                 'templateButtons': {
-                                    'edit': securityIsGranted('mauticSocial:tweet:edit'),
-                                    'delete': securityIsGranted('mauticSocial:tweet:delete'),
+                                    'edit': securityIsGranted('mauticSocial:tweets:edit'),
+                                    'delete': securityIsGranted('mauticSocial:tweets:delete'),
                                 },
                                 'routeBase': 'mautic_tweet',
                                 'langVar': 'mautic.integration.Twitter',

--- a/plugins/MauticSocialBundle/Resources/views/Tweet/list.html.twig
+++ b/plugins/MauticSocialBundle/Resources/views/Tweet/list.html.twig
@@ -14,7 +14,7 @@
         'action': currentRoute,
         'page_actions': {
             'templateButtons': {
-                'new': securityIsGranted('mauticSocial:tweet:create'),
+                'new': securityIsGranted('mauticSocial:tweets:create'),
             },
             'routeBase': 'mautic_tweet',
             'langVar': 'tweet',
@@ -23,7 +23,7 @@
           'langVar': 'mautic.social.tweets',
           'routeBase': 'mautic_tweet',
           'templateButtons': {
-              'delete': securityIsGranted('mauticSocial:tweet:delete'),
+              'delete': securityIsGranted('mauticSocial:tweets:delete'),
           },
       },
     }) }}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A 
| Issue(s) addressed                     | N/A

## Description

Fixed incorrect permission strings in Tweet template files. The templates were using `mauticSocial:tweet:*` permissions but should have been using `mauticSocial:tweets:*` (plural) to match the actual permission system.

This bug was preventing users from accessing the tweets list interface, even when they had the proper permissions.

---
### 📋 Steps to test this PR:

**First, enable the plugin:**
1. Open Plugins
2. Find X (Twitter)
3. Fill required fields with "XXX" (or literally anything else) and activate

**Then:**
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
4. Navigate to Channels > Tweets in the Mautic interface
5. Verify that users with proper permissions can see:
   - The "New" button to create tweets
   - Edit and Delete action buttons for existing tweets
6. Test with different user roles to ensure permissions are properly enforced
7. Verify that users without proper permissions do not see these buttons

---