### PR TITLE
Fixed issue with MySQL reserved keywords as column name

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1957,7 +1957,7 @@ class LeadModel extends FormModel
     {
         $columns = [];
         foreach ($aliases as $alias) {
-            $columns[] = sprintf('max(CHAR_LENGTH(%s)) %s', $alias, $alias);
+            $columns[] = sprintf('max(CHAR_LENGTH(`%s`)) `%s`', $alias, $alias);
         }
 
         $query = $this->em->getConnection()->createQueryBuilder();

--- a/app/bundles/LeadBundle/Tests/Field/Command/AnalyseCustomFieldCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Command/AnalyseCustomFieldCommandFunctionalTest.php
@@ -45,6 +45,13 @@ final class AnalyseCustomFieldCommandFunctionalTest extends MauticMysqlTestCase
                 'limit' => 255,
                 'value' => '',
             ],
+            'range' => [
+                'label' => 'Range',
+                'alias' => 'range',
+                'type'  => 'text',
+                'limit' => 64,
+                'value' => '',
+            ],
         ];
 
         foreach ($fields as $field) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

If the Custom field is created with name and alias as one of the [MySQL reserved keywords](https://dev.mysql.com/doc/refman/8.0/en/keywords.html)
`mautic:fields:analyse` command gives below error

```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'drop)) drop, max(CHAR_LENGTH(range)) range, max  
  (CHAR_LENGTH(rank)) rank FROM ...' at line 1 
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom field with name of reserved MySQL keyword.
3. As fields created with reserved keywords have autoappend txt to alias we need to manually change the alias of custom field without prefix and change column name of column with same.
4. Execute `mautic:fields:analyse` command.
5. You should see report getting generated correctly.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->