### PR TITLE
Dispatch event on manual winner action

### DIFF
--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -19,6 +19,7 @@ use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailEditSubmitEvent;
+use Mautic\EmailBundle\Event\ManualWinnerEvent;
 use Mautic\EmailBundle\Form\Type\BatchSendType;
 use Mautic\EmailBundle\Form\Type\ExampleSendType;
 use Mautic\EmailBundle\Helper\EmailConfig;
@@ -1228,7 +1229,12 @@ class EmailController extends FormController
                 return $this->isLocked($postActionVars, $entity, 'email');
             }
 
+            // setting parent here, as the parent will be removed by the code below.
+            $parent = $entity->getVariantParent() ?? $entity;
+
             $model->convertVariant($entity);
+
+            $this->dispatcher->dispatch(new ManualWinnerEvent($parent));
 
             $flashes[] = [
                 'type'    => 'notice',

--- a/app/bundles/EmailBundle/Event/ManualWinnerEvent.php
+++ b/app/bundles/EmailBundle/Event/ManualWinnerEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Event;
+
+use Mautic\EmailBundle\Entity\Email;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ManualWinnerEvent extends Event
+{
+    public function __construct(private Email $email)
+    {
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -99,7 +99,10 @@ class EmailControllerTest extends TestCase
 
     private RequestStack $requestStack;
 
-    private EventDispatcherInterface $dispatcher;
+    /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    private MockObject $dispatcher;
 
     protected function setUp(): void
     {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Controller\EmailController;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Event\ManualWinnerEvent;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Helper\FakeContactHelper;
@@ -98,6 +99,8 @@ class EmailControllerTest extends TestCase
 
     private RequestStack $requestStack;
 
+    private EventDispatcherInterface $dispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -110,17 +113,17 @@ class EmailControllerTest extends TestCase
         $this->formMock      = $this->createMock(Form::class);
         $this->twigMock      = $this->createMock(Environment::class);
 
-        $this->formFactoryMock      = $this->createMock(FormFactory::class);
-        $formFieldHelper            = $this->createMock(FormFieldHelper::class);
-        $doctrine                   = $this->createMock(ManagerRegistry::class);
-        $this->modelFactoryMock     = $this->createMock(ModelFactory::class);
-        $helperUserMock             = $this->createMock(UserHelper::class);
-        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
-        $dispatcher                 = $this->createMock(EventDispatcherInterface::class);
-        $this->translatorMock       = $this->createMock(Translator::class);
-        $this->flashBagMock         = $this->createMock(FlashBag::class);
-        $this->requestStack         = new RequestStack();
-        $this->corePermissionsMock  = $this->createMock(CorePermissions::class);
+        $this->formFactoryMock            = $this->createMock(FormFactory::class);
+        $formFieldHelper                  = $this->createMock(FormFieldHelper::class);
+        $doctrine                         = $this->createMock(ManagerRegistry::class);
+        $this->modelFactoryMock           = $this->createMock(ModelFactory::class);
+        $helperUserMock                   = $this->createMock(UserHelper::class);
+        $coreParametersHelper             = $this->createMock(CoreParametersHelper::class);
+        $this->dispatcher                 = $this->createMock(EventDispatcherInterface::class);
+        $this->translatorMock             = $this->createMock(Translator::class);
+        $this->flashBagMock               = $this->createMock(FlashBag::class);
+        $this->requestStack               = new RequestStack();
+        $this->corePermissionsMock        = $this->createMock(CorePermissions::class);
 
         $helperUserMock->method('getUser')
             ->willReturn(new User(false));
@@ -132,7 +135,7 @@ class EmailControllerTest extends TestCase
             $this->modelFactoryMock,
             $helperUserMock,
             $coreParametersHelper,
-            $dispatcher,
+            $this->dispatcher,
             $this->translatorMock,
             $this->flashBagMock,
             $this->requestStack,
@@ -270,5 +273,51 @@ class EmailControllerTest extends TestCase
         $request = new Request();
         $this->requestStack->push($request);
         $this->controller->sendExampleAction($request, 1, $this->corePermissionsMock, $this->modelMock, $this->createMock(LeadModel::class), $this->createMock(FakeContactHelper::class));
+    }
+
+    public function testWinnerActionForDispatchManualWinnerEvent(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects(self::once())
+            ->method('getSession')
+            ->willReturn($this->sessionMock);
+
+        $this->routerMock->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturn('/test-url');
+        $this->containerMock->expects($this->exactly(2))
+            ->method('get')
+            ->with('router')
+            ->willReturn($this->routerMock);
+
+        $this->corePermissionsMock->expects($this->once())
+            ->method('hasEntityAccess')
+            ->with('email:emails:editown', 'email:emails:editother', null)
+            ->willReturn(true);
+
+        $request->expects(self::once())
+            ->method('getMethod')
+            ->willReturn(Request::METHOD_POST);
+
+        $this->modelFactoryMock->expects($this->once())
+            ->method('getModel')
+            ->with('email')
+            ->willReturn($this->modelMock);
+
+        $this->emailMock->expects($this->once())
+            ->method('getVariantParent')
+            ->willReturn($this->emailMock);
+
+        $this->modelMock->expects($this->once())
+            ->method('getEntity')
+            ->with(5)
+            ->willReturn($this->emailMock);
+
+        $this->dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(new ManualWinnerEvent($this->emailMock));
+
+        $this->requestStack->push($request);
+        $this->controller->winnerAction($request, 5);
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Adding the capability to dispatch an event when a winner is chosen manually.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create A/B test email
3. While choosing A/B test winner variant the ManualWinnerEvent should be dispatch.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->