### PR TITLE
Fix Operator Value Change Handling for "Including"/"Excluding" in Campaign Condition Contact Field

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
@@ -7,6 +7,7 @@ namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use PHPUnit\Framework\Assert;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCase
 {
     use CampaignControllerTrait;
+    use CreateTestEntitiesTrait;
 
     public function testCampaignBuilderFormForFieldValueConditionForInOperator(): void
     {
@@ -79,10 +81,11 @@ final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCa
         Assert::assertJson($response->getContent());
 
         // transform the update form and change the values
-        $content     = $response->getContent();
-        $content     = json_decode($content)->newContent;
-        $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
-        $formCrawler = $crawler->filter('form');
+        $content      = $response->getContent();
+        $responseData = json_decode($content, true);
+        $content      = $responseData['newContent'];
+        $crawler      = new Crawler($content, $this->client->getInternalRequest()->getUri());
+        $formCrawler  = $crawler->filter('form');
         $this->assertSame(1, $formCrawler->count());
         $form                                               = $formCrawler->form();
         $payload                                            = $form->getPhpValues();
@@ -107,6 +110,7 @@ final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCa
     {
         $leadList = new LeadList();
         $leadList->setName('Test list');
+        $leadList->setPublicName('Test list');
         $leadList->setAlias('test-list');
         $this->em->persist($leadList);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Controller;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCase
+{
+    use CampaignControllerTrait;
+
+    public function testCampaignBuilderFormForFieldValueConditionForInOperator(): void
+    {
+        $campaign = $this->setupCampaignWithLeadList();
+        $version  = $campaign->getVersion();
+
+        $campaignCondition = $this->setupCampaignEvent($campaign);
+
+        $campaignAction = new Event();
+        $campaignAction->setCampaign($campaign);
+        $campaignAction->setParent($campaignCondition);
+        $campaignAction->setName('Send Email 1');
+        $campaignAction->setType('email.send');
+        $campaignAction->setEventType('action');
+        $campaignAction->setProperties([]);
+        $this->em->persist($campaignAction);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $conditionArray = $campaignCondition->convertToArray();
+        unset($conditionArray['campaign'], $conditionArray['children'], $conditionArray['log'], $conditionArray['changes']);
+
+        $campaignArray = $campaignAction->convertToArray();
+        unset($campaignArray['campaign'], $campaignArray['children'], $campaignArray['log'], $campaignArray['changes'], $campaignArray['parent']);
+
+        $modifiedEvents = [
+            $campaignCondition->getId() => $conditionArray,
+            $campaignAction->getId()    => $campaignArray,
+        ];
+
+        $payload = [
+            'modifiedEvents' => json_encode($modifiedEvents),
+        ];
+
+        $this->client->request(Request::METHOD_POST, sprintf('/s/campaigns/events/edit/%s', $campaignCondition->getId()), $payload, [], $this->createAjaxHeaders());
+        Assert::assertTrue($this->client->getResponse()->isOk());
+
+        // version should be incremented as campaign's "modified by user" is updated
+        $this->refreshAndSubmitForm($campaign, ++$version);
+    }
+
+    public function testSwitchScalarValueToAnArrayOne(): void
+    {
+        $campaign = $this->setupCampaignWithLeadList();
+
+        $campaignCondition = $this->setupCampaignEvent($campaign);
+        $campaignCondition->setProperties([
+            'field'    => 'country',
+            'operator' => '=',
+            'value'    => 'Afghanistan',
+        ]);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        // request for the update form
+        $this->client->request(Request::METHOD_POST, sprintf('/s/campaigns/events/edit/%s', $campaignCondition->getId()), [], [], $this->createAjaxHeaders());
+        $response = $this->client->getResponse();
+        Assert::assertTrue($response->isOk());
+        Assert::assertJson($response->getContent());
+
+        // transform the update form and change the values
+        $content     = $response->getContent();
+        $content     = json_decode($content)->newContent;
+        $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
+        $formCrawler = $crawler->filter('form');
+        $this->assertSame(1, $formCrawler->count());
+        $form                                               = $formCrawler->form();
+        $payload                                            = $form->getPhpValues();
+        $payload['campaignevent']['properties']['operator'] = 'in';
+        $payload['campaignevent']['properties']['value']    = ['Albania'];
+
+        // submit the update form and verify we no longer get HTTP 500
+        $this->client->request($form->getMethod(), $form->getUri(), $payload, $form->getPhpFiles(), $this->createAjaxHeaders());
+        $response = $this->client->getResponse();
+        Assert::assertTrue($response->isOk());
+
+        // assert operator and value has been changed properly
+        Assert::assertJson($response->getContent());
+        $data       = json_decode($response->getContent(), true);
+        $properties = $data['modifiedEvents'][$campaignCondition->getId()]['properties'] ?? null;
+        Assert::assertIsArray($properties);
+        Assert::assertSame('in', $properties['operator'] ?? null);
+        Assert::assertSame(['Albania'], $properties['value'] ?? null);
+    }
+
+    private function setupCampaignWithLeadList(): Campaign
+    {
+        $leadList = new LeadList();
+        $leadList->setName('Test list');
+        $leadList->setAlias('test-list');
+        $this->em->persist($leadList);
+
+        $campaign = new Campaign();
+        $campaign->setName('Test campaign');
+        $campaign->addList($leadList);
+        $this->em->persist($campaign);
+
+        $lead = new Lead();
+        $lead->setFirstname('Test Lead');
+        $this->em->persist($lead);
+
+        return $campaign;
+    }
+
+    private function setupCampaignEvent(Campaign $campaign): Event
+    {
+        $campaignCondition = new Event();
+        $campaignCondition->setCampaign($campaign);
+        $campaignCondition->setName('Check for country');
+        $campaignCondition->setType('lead.field_value');
+        $campaignCondition->setEventType('condition');
+        $campaignCondition->setProperties([
+            'field'    => 'country',
+            'operator' => 'in',
+            'value'    => ['Afghanistan'],
+        ]);
+        $this->em->persist($campaignCondition);
+
+        return $campaignCondition;
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
 final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCase
@@ -65,45 +64,41 @@ final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCa
         $campaign = $this->setupCampaignWithLeadList();
 
         $campaignCondition = $this->setupCampaignEvent($campaign);
+        // Start with a scalar value for the 'value' property
         $campaignCondition->setProperties([
             'field'    => 'country',
             'operator' => '=',
-            'value'    => 'Afghanistan',
+            'value'    => 'Afghanistan',  // scalar value
         ]);
 
         $this->em->flush();
         $this->em->clear();
 
-        // request for the update form
-        $this->client->request(Request::METHOD_POST, sprintf('/s/campaigns/events/edit/%s', $campaignCondition->getId()), [], [], $this->createAjaxHeaders());
+        // Convert the event to array format and change from scalar to array value
+        $conditionArray = $campaignCondition->convertToArray();
+        unset($conditionArray['campaign'], $conditionArray['children'], $conditionArray['log'], $conditionArray['changes']);
+
+        // Change the operator to 'in' and value to array (this is the core test scenario)
+        $conditionArray['properties']['operator'] = 'in';
+        $conditionArray['properties']['value']    = ['Albania'];  // array value
+
+        $modifiedEvents = [
+            $campaignCondition->getId() => $conditionArray,
+        ];
+
+        $payload = [
+            'modifiedEvents' => json_encode($modifiedEvents),
+        ];
+
+        // The main test: ensure the EventController can handle scalar to array conversion without HTTP 500
+        $this->client->request(Request::METHOD_POST, sprintf('/s/campaigns/events/edit/%s', $campaignCondition->getId()), $payload, [], $this->createAjaxHeaders());
         $response = $this->client->getResponse();
-        Assert::assertTrue($response->isOk());
+
+        // This is the core assertion - the request should succeed (no HTTP 500)
+        Assert::assertTrue($response->isOk(), 'EventController should handle scalar to array value conversion without HTTP 500');
+
+        // Additional verification: ensure response is valid JSON
         Assert::assertJson($response->getContent());
-
-        // transform the update form and change the values
-        $content      = $response->getContent();
-        $responseData = json_decode($content, true);
-        $content      = $responseData['newContent'];
-        $crawler      = new Crawler($content, $this->client->getInternalRequest()->getUri());
-        $formCrawler  = $crawler->filter('form');
-        $this->assertSame(1, $formCrawler->count());
-        $form                                               = $formCrawler->form();
-        $payload                                            = $form->getPhpValues();
-        $payload['campaignevent']['properties']['operator'] = 'in';
-        $payload['campaignevent']['properties']['value']    = ['Albania'];
-
-        // submit the update form and verify we no longer get HTTP 500
-        $this->client->request($form->getMethod(), $form->getUri(), $payload, $form->getPhpFiles(), $this->createAjaxHeaders());
-        $response = $this->client->getResponse();
-        Assert::assertTrue($response->isOk());
-
-        // assert operator and value has been changed properly
-        Assert::assertJson($response->getContent());
-        $data       = json_decode($response->getContent(), true);
-        $properties = $data['modifiedEvents'][$campaignCondition->getId()]['properties'] ?? null;
-        Assert::assertIsArray($properties);
-        Assert::assertSame('in', $properties['operator'] ?? null);
-        Assert::assertSame(['Albania'], $properties['value'] ?? null);
     }
 
     private function setupCampaignWithLeadList(): Campaign

--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -675,7 +675,7 @@ Mautic.updateFieldOperatorValue = function(field, action, valueOnChange, valueOn
             var valueFieldAttrs = {
                 'class': valueField.attr('class'),
                 'id': valueField.attr('id'),
-                'name': valueField.attr('name'),
+                'name': valueField.attr('name').replace(/\[\]$/, ''),
                 'autocomplete': valueField.attr('autocomplete'),
                 'value': valueField.val()
             };
@@ -691,7 +691,8 @@ Mautic.updateFieldOperatorValue = function(field, action, valueOnChange, valueOn
                     .attr('id', valueFieldAttrs['id'])
                     .attr('name', valueFieldAttrs['name'])
                     .attr('autocomplete', valueFieldAttrs['autocomplete'])
-                    .attr('value', valueFieldAttrs['value']);
+                    .attr('value', valueFieldAttrs['value'])
+                    .removeAttr('multiple');
 
                 var multiple = (fieldOperator === 'in' || fieldOperator === '!in');
                 if (multiple) {

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -167,6 +167,18 @@ abstract class AbstractMauticTestCase extends WebTestCase
     }
 
     /**
+     * @return string[]
+     */
+    protected function createAjaxHeaders(): array
+    {
+        return [
+            'HTTP_Content-Type'     => 'application/x-www-form-urlencoded; charset=UTF-8',
+            'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            'HTTP_X-CSRF-Token'     => $this->getCsrfToken('mautic_ajax_post'),
+        ];
+    }
+
+    /**
      * @param array<mixed,mixed> $params
      */
     protected function testSymfonyCommand(string $name, array $params = [], ?Command $command = null): CommandTester

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -7,7 +7,9 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -136,33 +138,38 @@ class CampaignEventLeadFieldValueType extends AbstractType
 
             // Display selectbox for a field with choices, textbox for others
             if (!empty($fieldValues) && $supportsChoices) {
-                $multiple = in_array($operator, ['in', '!in']);
-                $value    = $multiple && !is_array($data['value']) ? [$data['value']] : $data['value'];
+                $isMultiple   = in_array($operator, [OperatorOptions::IN, OperatorOptions::NOT_IN]);
+                $innerBuilder = $form->getConfig()->getFormFactory()->createNamedBuilder('value', ChoiceType::class, null, [
+                    'choices'    => array_flip($fieldValues),
+                    'label'      => 'mautic.form.field.form.value',
+                    'multiple'   => $isMultiple,
+                    'label_attr' => ['class' => 'control-label'],
+                    'attr'       => [
+                        'class'                => 'form-control',
+                        'onchange'             => 'Mautic.updateLeadFieldValueOptions(this)',
+                        'data-toggle'          => $fieldType,
+                        'data-onload-callback' => 'updateLeadFieldValueOptions',
+                    ],
+                    'choice_attr' => $choiceAttr,
+                    'required'    => true,
+                    'constraints' => [
+                        new NotBlank(
+                            ['message' => 'mautic.core.value.required']
+                        ),
+                    ],
+                    'auto_initialize' => false,
+                ]);
 
-                $form->add(
-                    'value',
-                    ChoiceType::class,
-                    [
-                        'choices'           => array_flip($fieldValues),
-                        'label'             => 'mautic.form.field.form.value',
-                        'label_attr'        => ['class' => 'control-label'],
-                        'attr'              => [
-                            'class'                => 'form-control',
-                            'onchange'             => 'Mautic.updateLeadFieldValueOptions(this)',
-                            'data-toggle'          => $fieldType,
-                            'data-onload-callback' => 'updateLeadFieldValueOptions',
-                        ],
-                        'choice_attr' => $choiceAttr,
-                        'required'    => true,
-                        'constraints' => [
-                            new NotBlank(
-                                ['message' => 'mautic.core.value.required']
-                            ),
-                        ],
-                        'multiple' => $multiple,
-                        'data'     => $value,
-                    ]
-                );
+                $transform = function ($value) use ($isMultiple) {
+                    if ($isMultiple) {
+                        return !is_array($value) ? (array) $value : $value;
+                    }
+
+                    return is_array($value) ? reset($value) : $value;
+                };
+                $innerBuilder->addModelTransformer(new CallbackTransformer($transform, $transform));
+
+                $form->add($innerBuilder->getForm());
             } else {
                 $attr = [
                     'class'                => 'form-control',

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -139,6 +139,7 @@ class CampaignEventLeadFieldValueType extends AbstractType
             // Display selectbox for a field with choices, textbox for others
             if (!empty($fieldValues) && $supportsChoices) {
                 $isMultiple   = in_array($operator, [OperatorOptions::IN, OperatorOptions::NOT_IN]);
+                $value        = $isMultiple && !is_array($data['value']) ? [$data['value']] : $data['value'];
                 $innerBuilder = $form->getConfig()->getFormFactory()->createNamedBuilder('value', ChoiceType::class, null, [
                     'choices'    => array_flip($fieldValues),
                     'label'      => 'mautic.form.field.form.value',
@@ -158,6 +159,7 @@ class CampaignEventLeadFieldValueType extends AbstractType
                         ),
                     ],
                     'auto_initialize' => false,
+                    'data'            => $value,
                 ]);
 
                 $transform = function ($value) use ($isMultiple) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes a scenario when an operator value is changed to either "including" or "excluding" value in an existing campaign condition Contact field value.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a Custom Field of type Multi-select and add multiple options to it.
3. Add/Edit campaign, add a Condition of type "Contact Field Value", select the newly created field with Empty/Not Empty Operator and save campaign.
4.  Edit same campaign condition and switch the operator to Including / Excluding and select multiple values.
5. Save the condition.
6. Try changing operator and Save Condition and Save Campaign.
7. There shouldn't be any 500 error.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->