### PR TITLE
[UXUI-230] Fix form fields linked to custom fields showing translation strings instead of names

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Builder/_labels.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/_labels.html.twig
@@ -43,13 +43,14 @@
 
     {% if field.mappedObject is not empty and field.mappedField is not empty and mappedFields[field.mappedObject] is defined %}
     <!-- Mapped field -->
+    {% set fieldCollection = mappedFields[field.mappedObject] %}
     {% set objectLabel = field.mappedObject == 'company' ? 'mautic.company.company'|trans|lower : (field.mappedObject == 'contact' ? 'mautic.lead.contact'|trans|lower : field.mappedObject|lower) %}
 
     {% include '@MauticCore/Helper/_tag.html.twig' with {
         'tags': [{
             'color': 'green',
             'icon': field.mappedObject == 'company' ? 'ri-building-3-line' : (field.mappedObject == 'contact' ? 'ri-contacts-book-line' : 'ri-shape-line'),
-            'label': fieldCollection[field.mappedField] is defined ? fieldCollection[field.mappedField].name :
+            'label': fieldCollection.getFieldByKey(field.mappedField, false) is not empty ? fieldCollection.getFieldByKey(field.mappedField).name :
                     (field.mappedObject == 'contact' ? ('mautic.lead.field.' ~ field.mappedField) :
                     (field.mappedObject == 'company' ? ('mautic.lead.field.' ~ field.mappedField) : field.mappedField)),
             'attributes': {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description

This PR fixes a bug where form fields linked to custom fields were displaying translation strings instead of the actual field names in the form builder.

### Before:

<img width="600" height="379" alt="image" src="https://github.com/user-attachments/assets/fad914ea-36b0-4cf4-a6e0-cbde63ffb376" />


### After:

<img width="600" height="379" alt="image" src="https://github.com/user-attachments/assets/f678525a-e17f-467c-b8c6-ca55a56a1a8d" />



---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom field in Mautic (e.g., "Test Field")
3. Create a new form and add a field
4. Link the form field to the custom field you created

<img width="738" height="435" alt="image" src="https://github.com/user-attachments/assets/b72a08cb-f34f-4638-89ee-30bd8658d86f" />

5. Verify that the field name shows "Test Field" instead of a translation string