### PR TITLE
Feature/segment last built display

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
@@ -55,7 +55,7 @@
             {% if hoursSinceLastBuilt >= segmentRebuildWarningThreshold %}
                 <label class="control-label" data-toggle="tooltip"
                        data-container="body" data-placement="top" title=""
-                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt}) }}">
+                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt | number_format(2)}) }}">
                     <i class="text-danger ri-error-warning-line fs-14"></i></label>
             {% endif %}
             {% if item.lastBuiltTime >= segmentBuildWarningThreshold %}

--- a/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
@@ -55,7 +55,7 @@
             {% if hoursSinceLastBuilt >= segmentRebuildWarningThreshold %}
                 <label class="control-label" data-toggle="tooltip"
                        data-container="body" data-placement="top" title=""
-                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt | number_format(2)}) }}">
+                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt}) }}">
                     <i class="text-danger ri-error-warning-line fs-14"></i></label>
             {% endif %}
             {% if item.lastBuiltTime >= segmentBuildWarningThreshold %}

--- a/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/List/_list_row.html.twig
@@ -55,7 +55,7 @@
             {% if hoursSinceLastBuilt >= segmentRebuildWarningThreshold %}
                 <label class="control-label" data-toggle="tooltip"
                        data-container="body" data-placement="top" title=""
-                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt}) }}">
+                       data-original-title="{{ 'mautic.lead.list.form.config.segment_rebuild_time.message'|trans({'%count%': hoursSinceLastBuilt  | number_format(2)}) }}">
                     <i class="text-danger ri-error-warning-line fs-14"></i></label>
             {% endif %}
             {% if item.lastBuiltTime >= segmentBuildWarningThreshold %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch) | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     |  #15478 

## Description

This pull request makes a minor UI consistency improvement to the segment rebuild time tooltip in `_list_row.html.twig`.

- **Purpose**: ensure the `hoursSinceLastBuilt` value shown in the tooltip is consistently formatted to **two decimal places** for better readability and uniformity across the UI.  
- **Scope**: single, low-risk template change; no public API or data model changes.  
- **Implementation summary**: the tooltip now formats `hoursSinceLastBuilt` with `number_format(2)` in the Twig template so values display like `1.23 hours` instead of `1.234567` or `1`.

> **File touched**: `_list_row.html.twig` — update is restricted to the tooltip formatting.

---

### 📋 Steps to test this PR

1. Checkout the PR branch locally (or open it in your preferred dev environment).  
2. Rebuild assets / clear caches as required by your local Mautic dev setup (e.g., clear Symfony/Twig cache and regenerate assets if needed).  
3. Open the Mautic UI and navigate to the **Segments** list (where segment rows are rendered).  
4. Identify a segment that has a non-zero `hoursSinceLastBuilt` (or create one / simulate one).  
5. Hover the segment rebuild/time warning tooltip (the element that previously displayed the raw hours value).  
6. Verify the tooltip displays the hours since last built with **two decimal places** (examples: `0.50 hours`, `12.34 hours`, `1.00 hours`).  
7. *(Optional)* Inspect `_list_row.html.twig` to confirm the formatting change is present (search for `hoursSinceLastBuilt` and verify `number_format(2)` is applied).

---

### Notes / Branch guidance

- **Category**: UI enhancement — submit against the **current major release branch (`a.x`)** — e.g., `7.x` if the current major release is `7`.  
- **Rationale**: no functional or BC-impacting changes; `a.x` is the correct branch for enhancements and UI changes.


# OUTPUT IMAGES:
## Earlier
<img width="433" height="235" alt="image" src="https://github.com/user-attachments/assets/9233ee75-178e-45d7-8b2e-c496eb60a979" />

## NOW:
<img width="523" height="178" alt="image" src="https://github.com/user-attachments/assets/0d4d8dee-38de-47a6-a6bf-bf0ea8af517b" />
