### PR TITLE
Revert email template schedule options visibility changes

### DIFF
--- a/app/bundles/EmailBundle/Assets/js/email.js
+++ b/app/bundles/EmailBundle/Assets/js/email.js
@@ -236,11 +236,13 @@ Mautic.selectEmailType = function(emailType) {
         mQuery('#segmentTranslationParent').removeClass('hide');
         mQuery('#templateTranslationParent').addClass('hide');
         mQuery('.page-header h3').text(mauticLang.newListEmail);
+        mQuery('#scheduleOptions').removeClass('hide');
     } else {
         mQuery('#segmentTranslationParent').addClass('hide');
         mQuery('#templateTranslationParent').removeClass('hide');
         mQuery('#leadList').addClass('hide');
         mQuery('.page-header h3').text(mauticLang.newTemplateEmail);
+        mQuery('#scheduleOptions').addClass('hide');
     }
 
     mQuery('#emailform_emailType').val(emailType);

--- a/app/bundles/EmailBundle/Resources/views/Email/form.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/form.html.twig
@@ -201,14 +201,9 @@
                             'data-end': 'mautic.core.form.available_until_scheduled_end'
                         }
                     }) }}
-                    <div id="scheduleOptions">
-                        {% if emailType == 'template' %}
-                            {{ form_row(form.publishUp) }}
-                            {{ form_row(form.publishDown) }}
-                        {% else %}
-                            {{ form_row(form.publishUp, {'label': 'mautic.core.form.sending.start_at'}) }}
-                            {{ form_row(form.publishDown, {'label': 'mautic.core.form.sending.stop_at'}) }}
-                        {% endif %}
+                    <div id="scheduleOptions"{{ (('template' == emailType) ? ' class="hide"' : '') }}>
+                        {{ form_row(form.publishUp, {'label': 'mautic.core.form.sending.start_at'}) }}
+                        {{ form_row(form.publishDown, {'label': 'mautic.core.form.sending.stop_at'}) }}
                     </div>
 
                 {% endif %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | Reverts #15503

## Description

This PR reverts the changes made in PR #15503 that modified the email template schedule options visibility logic. **The original PR was accidentally merged before proper review and testing.**

**What this revert does:**
- Restores the original JavaScript logic in `email.js` for showing/hiding schedule options
- Restores the original template conditional visibility logic in `form.html.twig`
- Template emails now **hide** schedule options (original behavior)
- List emails now **show** schedule options (original behavior)

**Files reverted:**
- `app/bundles/EmailBundle/Assets/js/email.js` - Restored schedule options toggle logic
- `app/bundles/EmailBundle/Resources/views/Email/form.html.twig` - Restored conditional template structure

This revert brings back the original intended behavior where schedule options (publish up/down dates) are only available for list emails, not template emails.

**Note:** The changes in #15503 were accidentally merged before thorough testing and may have introduced unintended behavior changes that need to be reverted until proper analysis can be completed.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to the Email section in Mautic
3. Create a new email and select **"Template Email"** type
4. ✅ Verify that the **publish up/down date fields ARE HIDDEN** for template emails (reverted behavior)
5. Go back and create a new email, select **"List Email"** type 
6. ✅ Verify that the **publish up/down date fields ARE VISIBLE** for list emails (reverted behavior)
7. Test switching between different email types to verify conditional visibility works as originally intended
8. Ensure the form layout is clean and properly structured