### PR TITLE
Projects unified in API endpoints

### DIFF
--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -9,6 +9,7 @@ use FOS\RestBundle\Controller\AbstractFOSRestController;
 use FOS\RestBundle\View\View;
 use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
 use Mautic\ApiBundle\ApiEvents;
+use Mautic\ApiBundle\Event\ApiInitializeEvent;
 use Mautic\ApiBundle\Event\ApiSerializationContextEvent;
 use Mautic\ApiBundle\Helper\BatchIdToEntityHelper;
 use Mautic\ApiBundle\Helper\EntityResultHelper;
@@ -149,6 +150,16 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
         if (null !== $this->model && !$this->permissionBase && method_exists($this->model, 'getPermissionBase')) {
             $this->permissionBase = $this->model->getPermissionBase();
         }
+
+        $event = new ApiInitializeEvent(
+            (string) $this->entityClass,
+            $this->serializerGroups,
+            $this->exclusionStrategies,
+        );
+        $this->dispatcher->dispatch($event);
+
+        $this->serializerGroups    = $event->getSerializerGroups();
+        $this->exclusionStrategies = $event->getExclusionStrategies();
     }
 
     /**

--- a/app/bundles/ApiBundle/Event/ApiInitializeEvent.php
+++ b/app/bundles/ApiBundle/Event/ApiInitializeEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ApiBundle\Event;
+
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ApiInitializeEvent extends Event
+{
+    /**
+     * @param string[]                     $serializerGroups
+     * @param ExclusionStrategyInterface[] $exclusionStrategies
+     */
+    public function __construct(
+        private string $entityClass,
+        private array $serializerGroups,
+        private array $exclusionStrategies,
+    ) {
+    }
+
+    public function getEntityClass(): string
+    {
+        return $this->entityClass;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSerializerGroups(): array
+    {
+        return $this->serializerGroups;
+    }
+
+    public function addSerializerGroup(string $serializerGroup): void
+    {
+        $this->serializerGroups[] = $serializerGroup;
+    }
+
+    /**
+     * @return ExclusionStrategyInterface[]
+     */
+    public function getExclusionStrategies(): array
+    {
+        return $this->exclusionStrategies;
+    }
+
+    public function addExclusionStrategy(ExclusionStrategyInterface $exclusionStrategy): void
+    {
+        $this->exclusionStrategies[] = $exclusionStrategy;
+    }
+}

--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -50,7 +50,7 @@ class AssetApiController extends CommonApiController
         $this->entityClass      = Asset::class;
         $this->entityNameOne    = 'asset';
         $this->entityNameMulti  = 'assets';
-        $this->serializerGroups = ['assetDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['assetDetails', 'categoryList', 'publishDetails'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -74,7 +74,6 @@ class CampaignApiController extends CommonApiController
             'publishDetails',
             'leadListList',
             'formList',
-            'projectList',
         ];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -49,7 +49,7 @@ class MessageApiController extends CommonApiController
         $this->entityClass      = Message::class;
         $this->entityNameOne    = 'message';
         $this->entityNameMulti  = 'messages';
-        $this->serializerGroups = ['messageDetails', 'messageChannelList', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['messageDetails', 'messageChannelList', 'categoryList', 'publishDetails'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
@@ -31,7 +31,7 @@ class DynamicContentApiController extends CommonApiController
         $this->entityClass      = DynamicContent::class;
         $this->entityNameOne    = 'dynamicContent';
         $this->entityNameMulti  = 'dynamicContents';
-        $this->serializerGroups = ['dwcDetails', 'categoryList', 'projectList'];
+        $this->serializerGroups = ['dwcDetails', 'categoryList'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -61,7 +61,6 @@ class EmailApiController extends CommonApiController
             'assetList',
             'formList',
             'leadListList',
-            'projectList',
         ];
         $this->dataInputMasks   = [
             'customHtml'     => 'html',

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -55,7 +55,7 @@ class FormApiController extends CommonApiController
         $this->entityClass      = Form::class;
         $this->entityNameOne    = 'form';
         $this->entityNameMulti  = 'forms';
-        $this->serializerGroups = ['formDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['formDetails', 'categoryList', 'publishDetails'];
 
         $this->dataInputMasks  = [
             'text'    => 'html',

--- a/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -44,7 +44,6 @@ class CompanyApiController extends CommonApiController
         $this->entityNameOne      = 'company';
         $this->entityNameMulti    = 'companies';
         $this->serializerGroups[] = 'companyDetails';
-        $this->serializerGroups[] = 'projectList';
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -49,7 +49,6 @@ class ListApiController extends CommonApiController
             'publishDetails',
             'ipAddress',
             'categoryList',
-            'projectList',
         ];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);

--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -38,7 +38,7 @@ class PageApiController extends CommonApiController
         $this->entityClass      = Page::class;
         $this->entityNameOne    = 'page';
         $this->entityNameMulti  = 'pages';
-        $this->serializerGroups = ['pageDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['pageDetails', 'categoryList', 'publishDetails'];
         $this->dataInputMasks   = ['customHtml' => 'html'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);

--- a/app/bundles/PointBundle/Controller/Api/PointApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/PointApiController.php
@@ -50,7 +50,7 @@ class PointApiController extends CommonApiController
         $this->entityClass      = Point::class;
         $this->entityNameOne    = 'point';
         $this->entityNameMulti  = 'points';
-        $this->serializerGroups = ['pointDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['pointDetails', 'categoryList', 'publishDetails'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -50,7 +50,7 @@ class TriggerApiController extends CommonApiController
         $this->entityClass      = Trigger::class;
         $this->entityNameOne    = 'trigger';
         $this->entityNameMulti  = 'triggers';
-        $this->serializerGroups = ['triggerDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['triggerDetails', 'categoryList', 'publishDetails'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/app/bundles/ProjectBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ProjectBundle/EventListener/ApiSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ProjectBundle\EventListener;
+
+use Mautic\ApiBundle\Event\ApiInitializeEvent;
+use Mautic\ApiBundle\Serializer\Exclusion\FieldInclusionStrategy;
+use Mautic\AssetBundle\Entity\Asset;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\ChannelBundle\Entity\Message;
+use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PointBundle\Entity\Point;
+use Mautic\PointBundle\Entity\Trigger;
+use Mautic\SmsBundle\Entity\Sms;
+use Mautic\StageBundle\Entity\Stage;
+use MauticPlugin\MauticFocusBundle\Entity\Focus;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class ApiSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ApiInitializeEvent::class=> ['onApiInitializeEvent', 0],
+        ];
+    }
+
+    public function onApiInitializeEvent(ApiInitializeEvent $event): void
+    {
+        if (!in_array($event->getEntityClass(), [
+            Asset::class,
+            Campaign::class,
+            Message::class,
+            DynamicContent::class,
+            Email::class,
+            Form::class,
+            Company::class,
+            LeadList::class,
+            Page::class,
+            Point::class,
+            Trigger::class,
+            Sms::class,
+            Stage::class,
+            Focus::class,
+        ])) {
+            return;
+        }
+
+        $event->addSerializerGroup('projectList');
+        $event->addExclusionStrategy(new FieldInclusionStrategy(['id', 'name'], 1, 'projects'));
+    }
+}

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -49,7 +49,6 @@ class SmsApiController extends CommonApiController
             'categoryList',
             'publishDetails',
             'leadListList',
-            'projectList',
         ];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);

--- a/app/bundles/StageBundle/Controller/Api/StageApiController.php
+++ b/app/bundles/StageBundle/Controller/Api/StageApiController.php
@@ -36,7 +36,7 @@ class StageApiController extends CommonApiController
         $this->entityClass      = Stage::class;
         $this->entityNameOne    = 'stage';
         $this->entityNameMulti  = 'stages';
-        $this->serializerGroups = ['stageDetails', 'categoryList', 'publishDetails', 'projectList'];
+        $this->serializerGroups = ['stageDetails', 'categoryList', 'publishDetails'];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }

--- a/plugins/MauticFocusBundle/Controller/Api/FocusApiController.php
+++ b/plugins/MauticFocusBundle/Controller/Api/FocusApiController.php
@@ -46,7 +46,6 @@ class FocusApiController extends CommonApiController
             'focusDetails',
             'categoryList',
             'publishDetails',
-            'projectList',
         ];
 
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PRs addresses discrepancies among API endpoints that return references to projects. See the below examples.

The endpoint `/api/dynamiccontents/` returns references to projects like:
```json
"projects": [
    {
        "id": 7,
        "name": "A new project 1"
    },
    {
        "id": 8,
        "name": "A new project 2"
    }
]
```
while the endpoint `/api/campaigns/` returns:
```json
"projects": [
    {
        "createdByUser": "Admin User",
        "modifiedByUser": "Admin User",
        "id": 7,
        "name": "A new project 1"
    },
    {
        "createdByUser": "Admin User",
        "modifiedByUser": "Admin User",
        "id": 8,
        "name": "A new project 2"
    }
]
```
This PR makes sure that all such API endpoints return only `id` and `name` for connected `projects` (as shown in the `/api/dynamiccontents/` example).


---
### 📋 Steps to test this PR:

1. Make sure that all the below API endpoints return only `id` and `name` for connected `projects`.
   1. `/api/assets`
   2. `/api/campaigns`
   3. `/api/messages`
   4. `/api/dynamiccontents`
   5. `/api/emails`
   6. `/api/forms`
   7. `/api/companies`
   8. `/api/segments`
   9. `/api/pages`
   10. `/api/points`
   11. `/api/points/triggers`
   12. `/api/smses`
   13. `/api/stages`
   14. `/api/focus`