### PR TITLE
Added campaign_lead_event_log.date_queued column

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -103,6 +104,8 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
      */
     private $rescheduleInterval;
 
+    private ?\DateTime $dateQueued = null;
+
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
@@ -171,6 +174,11 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
             ->mappedBy('log')
             ->fetchExtraLazy()
             ->cascadeAll()
+            ->build();
+
+        $builder->createField('dateQueued', Types::DATETIME_MUTABLE)
+            ->columnName('date_queued')
+            ->nullable()
             ->build();
 
         self::addVersionField($builder);
@@ -542,5 +550,17 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
     public function getRescheduleInterval(): ?\DateInterval
     {
         return $this->rescheduleInterval;
+    }
+
+    public function getDateQueued(): ?\DateTime
+    {
+        return $this->dateQueued;
+    }
+
+    public function setDateQueued(?\DateTime $dateQueued): LeadEventLog
+    {
+        $this->dateQueued = $dateQueued;
+
+        return $this;
     }
 }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -677,4 +677,23 @@ SQL;
 
         return $deletedRecordCount;
     }
+
+    /**
+     * @param string[] $ids
+     */
+    public function markEventLogsQueued(array $ids): void
+    {
+        if (!$ids) {
+            return;
+        }
+
+        $this->getEntityManager()
+            ->getConnection()
+            ->createQueryBuilder()
+            ->update($this->getTableName())
+            ->set('date_queued', 'NOW()')
+            ->where('id IN (:ids)')
+            ->setParameter('ids', $ids, ArrayParameterType::STRING)
+            ->executeStatement();
+    }
 }

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -73,8 +73,7 @@ class LeadEventLogRepositoryTest extends MauticMysqlTestCase
     private function createCampaign(): Campaign
     {
         $campaign = new Campaign();
-        $campaign->setName('Test campaign');
-        $campaign->setIsPublished(true);
+        $campaign->setName('Campaign');
         $this->em->persist($campaign);
 
         return $campaign;
@@ -83,10 +82,10 @@ class LeadEventLogRepositoryTest extends MauticMysqlTestCase
     private function createEvent(Campaign $campaign): Event
     {
         $event = new Event();
-        $event->setName('Test event');
+        $event->setName('Event');
         $event->setCampaign($campaign);
-        $event->setType('lead.changepoints');
-        $event->setEventType(Event::TYPE_ACTION);
+        $event->setType('page.devicehit');
+        $event->setEventType(Event::TYPE_DECISION);
         $this->em->persist($event);
 
         return $event;

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -4,42 +4,105 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Tests\Functional\Entity;
 
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 
 class LeadEventLogRepositoryTest extends MauticMysqlTestCase
 {
-    public function testThatRemoveEventLogsMethodRemovesLogs(): void
+    private LeadEventLogRepository $repository;
+
+    protected function setUp(): void
     {
-        $eventId    = random_int(200, 2000);
-        $connection = $this->em->getConnection();
+        parent::setUp();
 
-        $leadEventLogRepository = $this->em->getRepository(LeadEventLog::class);
-        \assert($leadEventLogRepository instanceof LeadEventLogRepository);
-
-        $insertStatement = $connection->prepare('INSERT INTO `'.MAUTIC_TABLE_PREFIX.'campaign_lead_event_log` (`event_id`, `lead_id`, `rotation`, `is_scheduled`, `system_triggered`) VALUES (?, ?, ?, ?, ?);');
-
-        $connection->executeStatement('SET FOREIGN_KEY_CHECKS=0;');
-        foreach ($this->getLeadCampaignEventData($eventId) as $row) {
-            $insertStatement->executeStatement($row);
-        }
-        $connection->executeStatement('SET FOREIGN_KEY_CHECKS=1;');
-
-        Assert::assertCount(3, $leadEventLogRepository->findAll());
-
-        $leadEventLogRepository->removeEventLogs([(string) $eventId]);
-
-        Assert::assertCount(0, $leadEventLogRepository->findAll());
+        $this->repository = $this->em->getRepository(LeadEventLog::class);
     }
 
-    private function getLeadCampaignEventData(int $eventId): array
+    public function testThatRemoveEventLogsMethodRemovesLogs(): void
     {
-        return [
-            [$eventId, 100, 200, 1, 1],
-            [$eventId, 101, 201, 1, 1],
-            [$eventId, 102, 202, 1, 1],
-        ];
+        $campaign = $this->createCampaign();
+        $event    = $this->createEvent($campaign);
+        $this->createEventLog($campaign, $event);
+        $this->createEventLog($campaign, $event);
+        $this->createEventLog($campaign, $event);
+        $this->em->flush();
+
+        Assert::assertCount(3, $this->repository->findAll());
+        $this->repository->removeEventLogs([(string) $event->getId()]);
+        Assert::assertCount(0, $this->repository->findAll());
+    }
+
+    public function testMarkEventLogsQueued(): void
+    {
+        $campaign = $this->createCampaign();
+        $event    = $this->createEvent($campaign);
+        $log1     = $this->createEventLog($campaign, $event);
+        $log2     = $this->createEventLog($campaign, $event);
+        $log3     = $this->createEventLog($campaign, $event);
+        $this->em->flush();
+
+        Assert::assertCount(3, $this->repository->findAll());
+        Assert::assertEmpty($log1->getDateQueued());
+        Assert::assertEmpty($log2->getDateQueued());
+        Assert::assertEmpty($log3->getDateQueued());
+
+        $this->repository->markEventLogsQueued([(string) $log1->getId(), (string) $log3->getId()]);
+        $this->em->refresh($log1);
+        $this->em->refresh($log2);
+        $this->em->refresh($log3);
+
+        Assert::assertNotEmpty($log1->getDateQueued());
+        Assert::assertEmpty($log2->getDateQueued());
+        Assert::assertNotEmpty($log3->getDateQueued());
+    }
+
+    private function createLead(): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createCampaign(): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test campaign');
+        $campaign->setIsPublished(true);
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+
+    private function createEvent(Campaign $campaign): Event
+    {
+        $event = new Event();
+        $event->setName('Test event');
+        $event->setCampaign($campaign);
+        $event->setType('lead.changepoints');
+        $event->setEventType(Event::TYPE_ACTION);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createEventLog(Campaign $campaign, ?Event $event = null): LeadEventLog
+    {
+        $event        = $event ?: $this->createEvent($campaign);
+        $lead         = $this->createLead();
+        $leadEventLog = new LeadEventLog();
+        $leadEventLog->setLead($lead);
+        $leadEventLog->setEvent($event);
+        $leadEventLog->setTriggerDate(new \DateTime());
+        $leadEventLog->setIsScheduled(true);
+        $this->em->persist($leadEventLog);
+
+        return $leadEventLog;
     }
 }

--- a/app/migrations/Version20250923114835.php
+++ b/app/migrations/Version20250923114835.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+
+final class Version20250923114835 extends PreUpAssertionMigration
+{
+    protected const TABLE_NAME = 'campaign_lead_event_log';
+
+    protected function preUpAssertions(): void
+    {
+        $this->skipAssertion(
+            fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName())->hasColumn('date_queued'),
+            "Table {$this->getPrefixedTableName()} already has 'date_queued' column"
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable($this->getPrefixedTableName());
+        $table->addColumn('date_queued', Types::DATETIME_MUTABLE)->setNotnull(false);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable($this->getPrefixedTableName());
+        $table->dropColumn('date_queued');
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR just adds a new column `date_queued` to `campaign_lead_event_log` table plus `\Mautic\CampaignBundle\Entity\LeadEventLogRepository::markEventLogsQueued()` method. We use the column and the method in our environment together with a queueing mechanism.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. There is nothing to test. The newly added column and method are tested by a functional test.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->