### PR TITLE
[NOT-FOR-MERGE] MTC 8537 Prevent disabling campaigns when failing

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\CampaignEvents;
-use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Event\CampaignEvent;
 use Mautic\CampaignBundle\Event\FailedEvent;
@@ -12,9 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CampaignEventSubscriber implements EventSubscriberInterface
 {
-    private float $disableCampaignThreshold = 0.1;
-
-    public function __construct(private EventRepository $eventRepository, private NotificationHelper $notificationHelper, private CampaignRepository $campaignRepository)
+    public function __construct(private EventRepository $eventRepository, private NotificationHelper $notificationHelper)
     {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -58,17 +58,6 @@ class CampaignEventSubscriber implements EventSubscriberInterface
     {
         $log           = $event->getLog();
         $failedEvent   = $log->getEvent();
-        $campaign      = $failedEvent->getCampaign();
-        $failedCount   = $this->eventRepository->incrementFailedCount($failedEvent);
-        $contactCount  = $campaign->getLeads()->count();
-        $failedPercent = $contactCount ? ($failedCount / $contactCount) : 1;
-
         $this->notificationHelper->notifyOfFailure($log->getLead(), $failedEvent);
-
-        if ($failedPercent >= $this->disableCampaignThreshold && $campaign->isPublished()) {
-            $this->notificationHelper->notifyOfUnpublish($failedEvent);
-            $campaign->setIsPublished(false);
-            $this->campaignRepository->saveEntity($campaign);
-        }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -2,9 +2,7 @@
 
 namespace Mautic\CampaignBundle\Tests\EventListener;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
@@ -31,17 +29,11 @@ class CampaignEventSubscriberTest extends TestCase
      */
     private $notificationHelper;
 
-    /**
-     * @var CampaignRepository|MockObject
-     */
-    private $campaignRepository;
-
     public function setUp(): void
     {
         $this->eventRepo          = $this->createMock(EventRepository::class);
         $this->notificationHelper = $this->createMock(NotificationHelper::class);
-        $this->campaignRepository = $this->createMock(CampaignRepository::class);
-        $this->fixture            = new CampaignEventSubscriber($this->eventRepo, $this->notificationHelper, $this->campaignRepository);
+        $this->fixture            = new CampaignEventSubscriber($this->eventRepo, $this->notificationHelper);
     }
 
     public function testEventFailedCountsGetResetOnCampaignPublish(): void
@@ -86,15 +78,8 @@ class CampaignEventSubscriberTest extends TestCase
     public function testFailedEventGeneratesANotification(): void
     {
         $mockLead     = $this->createMock(Lead::class);
-        $mockCampaign = $this->createMock(Campaign::class);
-        $mockCampaign->expects($this->once())
-            ->method('getLeads')
-            ->willReturn(new ArrayCollection(range(0, 99)));
 
         $mockEvent = $this->createMock(Event::class);
-        $mockEvent->expects($this->once())
-            ->method('getCampaign')
-            ->willReturn($mockCampaign);
 
         $mockEventLog = $this->createMock(LeadEventLog::class);
         $mockEventLog->expects($this->once())
@@ -105,70 +90,11 @@ class CampaignEventSubscriberTest extends TestCase
             ->method('getLead')
             ->willReturn($mockLead);
 
-        // Set failed count to 5% of getLeads()->count()
-        $this->eventRepo->expects($this->once())
-            ->method('incrementFailedCount')
-            ->with($mockEvent)
-            ->willReturn(5);
-
         $this->notificationHelper->expects($this->once())
             ->method('notifyOfFailure')
             ->with($mockLead, $mockEvent);
 
         $failedEvent = new FailedEvent($this->createMock(AbstractEventAccessor::class), $mockEventLog);
-
-        $this->fixture->onEventFailed($failedEvent);
-    }
-
-    public function testFailedCountOverDisableCampaignThresholdDisablesTheCampaign(): void
-    {
-        $mockLead     = $this->createMock(Lead::class);
-        $mockCampaign = $this->createMock(Campaign::class);
-        $mockCampaign->expects($this->once())
-            ->method('isPublished')
-            ->willReturn(true);
-
-        $mockCampaign->expects($this->once())
-            ->method('getLeads')
-            ->willReturn(new ArrayCollection(range(0, 99)));
-
-        $mockEvent = $this->createMock(Event::class);
-        $mockEvent->expects($this->once())
-            ->method('getCampaign')
-            ->willReturn($mockCampaign);
-
-        $mockEventLog = $this->createMock(LeadEventLog::class);
-        $mockEventLog->expects($this->once())
-            ->method('getEvent')
-            ->willReturn($mockEvent);
-
-        $mockEventLog->expects($this->once())
-            ->method('getLead')
-            ->willReturn($mockLead);
-
-        // Set failed count to 10% of getLeads()->count()
-        $this->eventRepo->expects($this->once())
-            ->method('incrementFailedCount')
-            ->with($mockEvent)
-            ->willReturn(10);
-
-        $this->notificationHelper->expects($this->once())
-            ->method('notifyOfFailure')
-            ->with($mockLead, $mockEvent);
-
-        $this->notificationHelper->expects($this->once())
-            ->method('notifyOfUnpublish')
-            ->with($mockEvent);
-
-        $failedEvent = new FailedEvent($this->createMock(AbstractEventAccessor::class), $mockEventLog);
-
-        $this->campaignRepository->expects($this->once())
-            ->method('saveEntity')
-            ->with($mockCampaign);
-
-        $mockCampaign->expects($this->once())
-            ->method('setIsPublished')
-            ->with(false);
 
         $this->fixture->onEventFailed($failedEvent);
     }


### PR DESCRIPTION
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
In M5 the feature was introduced, that campaigns fail if a certain percentage of campaign events fail. This is not configurable and can lead to some unexpected behaviours. Thus, we should disable it,



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Mess up your smtp settings
3. Create a campaign with send email action, add a lead to the campaign and trigger it
4. Campaign should still be published

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->