### PR TITLE
[uli] Create one time admin login link via command line

### DIFF
--- a/app/migrations/Version20250925120000.php
+++ b/app/migrations/Version20250925120000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20250925120000 extends AbstractMauticMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE `' . $this->prefix . 'plugin_uli_unique_logins` (
+            `id` int(11) NOT NULL AUTO_INCREMENT,
+            `hash` varchar(64) NOT NULL,
+            `user_id` int(11) NOT NULL,
+            `ttl` datetime NOT NULL,
+            `date_created` datetime NOT NULL,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `UNIQ_ULI_HASH` (`hash`),
+            KEY `IDX_ULI_TTL` (`ttl`),
+            KEY `IDX_ULI_USER` (`user_id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS `' . $this->prefix . 'plugin_uli_unique_logins`');
+    }
+}

--- a/plugins/MauticUliBundle/Command/GenerateUniqueLoginCommand.php
+++ b/plugins/MauticUliBundle/Command/GenerateUniqueLoginCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace MauticPlugin\MauticUliBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\UserBundle\Entity\UserRepository;
+use MauticPlugin\MauticUliBundle\Entity\UniqueLogin;
+use MauticPlugin\MauticUliBundle\Entity\UniqueLoginRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+#[AsCommand(
+    name: 'mautic:uli',
+    description: 'Generate a unique login link for a user'
+)]
+class GenerateUniqueLoginCommand extends Command
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UrlGeneratorInterface $urlGenerator,
+        private LoggerInterface $logger,
+        private string $siteUrl = ''
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('mautic:uli')
+            ->setDescription('Generate a unique login link for a user')
+            ->addArgument(
+                'user_id',
+                InputArgument::REQUIRED,
+                'The numeric user ID to generate a login link for'
+            )
+            ->setHelp('This command generates a one-time login link for a specified user ID that expires in 24 hours.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $userId = (int) $input->getArgument('user_id');
+
+        if ($userId <= 0) {
+            $output->writeln('<error>User ID must be a positive integer.</error>');
+            return Command::FAILURE;
+        }
+
+        // Check if user exists
+        /** @var UserRepository $userRepository */
+        $userRepository = $this->entityManager->getRepository(\Mautic\UserBundle\Entity\User::class);
+        $user = $userRepository->find($userId);
+
+        if (!$user) {
+            $output->writeln("<error>User with ID {$userId} not found.</error>");
+            return Command::FAILURE;
+        }
+
+
+        try {
+            // Generate secure hash
+            $hash = bin2hex(random_bytes(32));
+
+            // Create ULI entry
+            $uniqueLogin = new UniqueLogin();
+            $uniqueLogin->setHash($hash)
+                ->setUserId($userId)
+                ->setTtl((new \DateTime())->add(new \DateInterval('P1D'))) // 24 hours from now
+                ->setDateCreated(new \DateTime());
+
+            $this->entityManager->persist($uniqueLogin);
+            $this->entityManager->flush();
+
+            // Generate URL
+            $this->urlGenerator->getContext()->setScheme('https'); // Ensure HTTPS
+            $url = $this->urlGenerator->generate('mautic_uli_login', ['hash' => $hash], UrlGeneratorInterface::ABSOLUTE_URL);
+
+            $output->writeln('<info>Unique login link generated successfully!</info>');
+            $output->writeln('<info>User:</info> ' . $user->getName() . ' (' . $user->getUsername() . ')');
+            $output->writeln('<info>Expires:</info> ' . $uniqueLogin->getTtl()->format('Y-m-d H:i:s T'));
+            $output->writeln('<info>URL:</info> ' . $url);
+
+            // Log the generation
+            $this->logger->info('ULI generated', [
+                'user_id' => $userId,
+                'username' => $user->getUsername(),
+                'hash' => $hash,
+                'ttl' => $uniqueLogin->getTtl()->format('Y-m-d H:i:s T')
+            ]);
+
+            return Command::SUCCESS;
+
+        } catch (\Exception $e) {
+            $output->writeln('<error>Failed to generate unique login link: ' . $e->getMessage() . '</error>');
+            $this->logger->error('ULI generation failed', [
+                'user_id' => $userId,
+                'error' => $e->getMessage()
+            ]);
+            return Command::FAILURE;
+        }
+    }
+}

--- a/plugins/MauticUliBundle/Config/config.php
+++ b/plugins/MauticUliBundle/Config/config.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name'        => 'Unique Login Links (ULI)',
+    'description' => 'Generate secure one-time login links for users via command line',
+    'version'     => '1.0.0',
+    'author'      => 'Mautic Community',
+
+    'routes' => [
+        'main'   => [],
+        'public' => [
+            'mautic_uli_login' => [
+                'path'       => '/unique_login',
+                'controller' => 'MauticPlugin\MauticUliBundle\Controller\UniqueLoginController::loginAction',
+            ],
+        ],
+        'api'    => [],
+    ],
+
+    'menu' => [],
+
+    'services' => [
+        'commands' => [
+            'mautic.uli.command.generate_unique_login' => [
+                'class'     => MauticPlugin\MauticUliBundle\Command\GenerateUniqueLoginCommand::class,
+                'arguments' => [
+                    'doctrine.orm.entity_manager',
+                    'router',
+                    'monolog.logger.mautic',
+                    '%mautic.site_url%',
+                ],
+                'tag' => 'console.command',
+            ],
+        ],
+        'other' => [
+            'mautic.uli.repository.unique_login' => [
+                'class'     => 'Doctrine\ORM\EntityRepository',
+                'factory'   => ['@doctrine.orm.entity_manager', 'getRepository'],
+                'arguments' => ['MauticPlugin\MauticUliBundle\Entity\UniqueLogin'],
+            ],
+        ],
+    ],
+
+    'parameters' => [
+        'uli_token_lifetime' => 24, // hours
+    ],
+];

--- a/plugins/MauticUliBundle/Controller/UniqueLoginController.php
+++ b/plugins/MauticUliBundle/Controller/UniqueLoginController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace MauticPlugin\MauticUliBundle\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CoreBundle\Controller\CommonController;
+use Mautic\CoreBundle\Service\FlashBag;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserRepository;
+use MauticPlugin\MauticUliBundle\Entity\UniqueLoginRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class UniqueLoginController extends CommonController
+{
+    public function loginAction(
+        Request $request,
+        AuthorizationCheckerInterface $authChecker,
+        EntityManagerInterface $entityManager,
+        EventDispatcherInterface $eventDispatcher,
+        LoggerInterface $logger
+    ): Response
+    {
+        // Check if user is already authenticated
+        if ($authChecker->isGranted('IS_AUTHENTICATED_FULLY') || $authChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            $this->addFlashMessage('mautic.user.user.notice.alreadyloggedin', [], FlashBag::LEVEL_WARNING);
+            return $this->redirectToRoute('mautic_dashboard_index');
+        }
+
+        $hash = $request->query->get('hash');
+
+        if (!$hash) {
+            $this->addFlashMessage('mautic.uli.error.missing_hash', [], FlashBag::LEVEL_ERROR);
+            return $this->renderAccessDenied();
+        }
+
+        try {
+            /** @var UniqueLoginRepository $uliRepository */
+            $uliRepository = $entityManager->getRepository(\MauticPlugin\MauticUliBundle\Entity\UniqueLogin::class);
+
+            // Find valid unique login by hash
+            $uniqueLogin = $uliRepository->findValidByHash($hash);
+
+            if (!$uniqueLogin) {
+                $logger->warning('ULI access denied: invalid or expired hash', [
+                    'hash' => $hash,
+                    'ip' => $request->getClientIp()
+                ]);
+                $this->addFlashMessage('mautic.uli.error.invalid_expired', [], FlashBag::LEVEL_ERROR);
+                return $this->renderAccessDenied();
+            }
+
+            // Get user
+            /** @var UserRepository $userRepository */
+            $userRepository = $entityManager->getRepository(User::class);
+            $user = $userRepository->find($uniqueLogin->getUserId());
+
+            if (!$user) {
+                $logger->error('ULI access denied: user not found', [
+                    'user_id' => $uniqueLogin->getUserId(),
+                    'hash' => $hash
+                ]);
+                $this->addFlashMessage('mautic.uli.error.user_not_found', [], FlashBag::LEVEL_ERROR);
+                return $this->renderAccessDenied();
+            }
+
+
+            // Create authentication token
+            $token = new UsernamePasswordToken($user, 'main', $user->getRoles());
+
+            // Set the token to the security context
+            $this->container->get('security.token_storage')->setToken($token);
+
+            // Fire the login event
+            $event = new InteractiveLoginEvent($request, $token);
+            $eventDispatcher->dispatch($event, 'security.interactive_login');
+
+            // Delete the used hash
+            $uliRepository->deleteByHash($hash);
+
+            // Log successful login
+            $logger->info('ULI successful login', [
+                'user_id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'ip' => $request->getClientIp(),
+                'hash' => $hash
+            ]);
+
+            $this->addFlashMessage('mautic.uli.success.logged_in', ['%username%' => $user->getUsername()]);
+
+            // Redirect to dashboard
+            return $this->redirectToRoute('mautic_dashboard_index');
+
+        } catch (\Exception $e) {
+            $logger->error('ULI login error', [
+                'hash' => $hash,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            $this->addFlashMessage('mautic.uli.error.system_error', [], FlashBag::LEVEL_ERROR);
+            return $this->renderAccessDenied();
+        }
+    }
+
+    private function renderAccessDenied(): Response
+    {
+        return $this->redirectToRoute('login');
+    }
+}

--- a/plugins/MauticUliBundle/Entity/UniqueLogin.php
+++ b/plugins/MauticUliBundle/Entity/UniqueLogin.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace MauticPlugin\MauticUliBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class UniqueLogin
+{
+    public const TABLE_NAME = 'plugin_uli_unique_logins';
+
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * @var int
+     */
+    private $userId;
+
+    /**
+     * @var \DateTime
+     */
+    private $ttl;
+
+    /**
+     * @var \DateTime
+     */
+    private $dateCreated;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(UniqueLoginRepository::class)
+            ->addIndex(['hash'], 'uli_hash_search')
+            ->addIndex(['ttl'], 'uli_ttl_search')
+            ->addIndex(['user_id'], 'uli_user_search');
+
+        $builder->addId();
+
+        $builder->createField('hash', 'string')
+            ->columnName('hash')
+            ->length(64)
+            ->unique()
+            ->build();
+
+        $builder->createField('userId', 'integer')
+            ->columnName('user_id')
+            ->build();
+
+        $builder->createField('ttl', 'datetime')
+            ->columnName('ttl')
+            ->build();
+
+        $builder->createField('dateCreated', 'datetime')
+            ->columnName('date_created')
+            ->build();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getHash(): ?string
+    {
+        return $this->hash;
+    }
+
+    public function setHash(string $hash): self
+    {
+        $this->hash = $hash;
+        return $this;
+    }
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(int $userId): self
+    {
+        $this->userId = $userId;
+        return $this;
+    }
+
+    public function getTtl(): ?\DateTime
+    {
+        return $this->ttl;
+    }
+
+    public function setTtl(\DateTime $ttl): self
+    {
+        $this->ttl = $ttl;
+        return $this;
+    }
+
+    public function getDateCreated(): ?\DateTime
+    {
+        return $this->dateCreated;
+    }
+
+    public function setDateCreated(\DateTime $dateCreated): self
+    {
+        $this->dateCreated = $dateCreated;
+        return $this;
+    }
+
+    public function isValid(): bool
+    {
+        return $this->ttl >= new \DateTime();
+    }
+}

--- a/plugins/MauticUliBundle/Entity/UniqueLoginRepository.php
+++ b/plugins/MauticUliBundle/Entity/UniqueLoginRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MauticPlugin\MauticUliBundle\Entity;
+
+use Mautic\CoreBundle\Entity\CommonRepository;
+
+class UniqueLoginRepository extends CommonRepository
+{
+    public function findByHash(string $hash): ?UniqueLogin
+    {
+        return $this->findOneBy(['hash' => $hash]);
+    }
+
+    public function findValidByHash(string $hash): ?UniqueLogin
+    {
+        $qb = $this->createQueryBuilder('uli');
+
+        return $qb
+            ->where('uli.hash = :hash')
+            ->andWhere('uli.ttl >= :now')
+            ->setParameter('hash', $hash)
+            ->setParameter('now', new \DateTime())
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function deleteExpiredTokens(): int
+    {
+        $qb = $this->createQueryBuilder('uli');
+
+        return $qb
+            ->delete()
+            ->where('uli.ttl < :now')
+            ->setParameter('now', new \DateTime())
+            ->getQuery()
+            ->execute();
+    }
+
+    public function deleteByHash(string $hash): int
+    {
+        $qb = $this->createQueryBuilder('uli');
+
+        return $qb
+            ->delete()
+            ->where('uli.hash = :hash')
+            ->setParameter('hash', $hash)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/plugins/MauticUliBundle/MauticUliBundle.php
+++ b/plugins/MauticUliBundle/MauticUliBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticUliBundle;
+
+use Mautic\IntegrationsBundle\Bundle\AbstractPluginBundle;
+
+class MauticUliBundle extends AbstractPluginBundle
+{
+}

--- a/plugins/MauticUliBundle/README.md
+++ b/plugins/MauticUliBundle/README.md
@@ -1,0 +1,65 @@
+# Mautic Unique Login Links (ULI) Plugin
+
+This plugin provides the ability to generate secure one-time login links for Mautic users via console command.
+
+## Features
+
+- Generate secure one-time login links via CLI command
+- Links expire automatically after 24 hours
+- Used links are automatically deleted
+- Comprehensive logging for security auditing
+- Access denied page for invalid/expired links
+
+## Usage
+
+### Generate a unique login link
+
+```bash
+php bin/console mautic:uli {user_id}
+```
+
+Example:
+```bash
+php bin/console mautic:uli 1
+```
+
+This will generate a URL like:
+```
+https://yourmautic.com/s/unique_login?hash=abc123...
+```
+
+### Access the login link
+
+Users can access the generated URL in their browser to be automatically logged in. The link:
+- Expires after 24 hours
+- Is automatically deleted after use
+- Logs all access attempts (successful and failed)
+
+## Database Schema
+
+The plugin creates a table `plugin_uli_unique_logins` with the following structure:
+
+- `id` - Primary key
+- `hash` - Unique 64-character hash
+- `user_id` - Foreign key to users table
+- `ttl` - Time-to-live (expiration datetime)
+- `date_created` - Creation timestamp
+
+## Security Features
+
+- Cryptographically secure random hash generation
+- Automatic cleanup of expired tokens
+- Comprehensive logging of all login attempts
+- User account status validation
+- Protection against replay attacks (one-time use)
+
+## Installation
+
+1. Copy the plugin to `plugins/MauticUliBundle/`
+2. Run database migrations: `php bin/console doctrine:migrations:migrate`
+3. Clear cache: `php bin/console cache:clear`
+
+## Configuration
+
+The plugin supports the following configuration parameters:
+- `uli_token_lifetime` - Token lifetime in hours (default: 24)

--- a/plugins/MauticUliBundle/Translations/en_US.ini
+++ b/plugins/MauticUliBundle/Translations/en_US.ini
@@ -1,0 +1,7 @@
+mautic.uli.error.missing_hash="Missing authentication hash parameter"
+mautic.uli.error.invalid_expired="Invalid or expired login link"
+mautic.uli.error.user_not_found="User not found"
+mautic.uli.error.user_disabled="User account is disabled"
+mautic.uli.error.system_error="System error occurred during login"
+mautic.uli.success.logged_in="Successfully logged in as %username%"
+mautic.user.user.notice.alreadyloggedin="You are already logged in"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌ ??
| Automated tests included?              | ❌  (I dont know how to do this)
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | No issue exists for this (that I know)


## Description
This feature makes it possible for admins to log in using a one time login url generated by via the console. 

````➜  mauticorangepoc git:(feature/ai) ✗ php bin/console mautic:uli  1
Unique login link generated successfully!
User: Frederik Wouters (admin)
Expires: 2025-09-26 07:57:14 UTC
URL: https://localhost/unique_login?hash=438311c5a91af91f135636d8e628701bc3055c1e7d312b6358e30f13a2656ed8
````
Using the URL you will be logged in as this user.

---
### 📋 Steps to test this PR:

0. Run the migrations (it adds the table for hashes for one time login links).
1. run the command php bin/console mautic:uli  1 (where 1 is the id of the user you want to log in).
2. Use the url that is generated to log the user in one time. 
3. Try the url again and see that it will not work anymore.  

I'm aware it needs test, but I have no clue how to write them
