### PR TITLE
add firstSlotAttribute for channelfrequency

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -299,7 +299,8 @@ final class BuilderSubscriber implements EventSubscriberInterface
         return $this->renderTemplate(
             '@MauticCore/Slots/channelfrequency.html.twig',
             $params,
-            '<div class="pref-channelfrequency">{templateContent}</div>'
+            '<div class="pref-channelfrequency"%s>{templateContent}</div>',
+            static::firstSlotAttribute
         );
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | N/A <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR add `data-prefs-center-first="1"` attribute for channel frequency form for LP.

When using the LP as a preference center, the div element with the `data-prefs-center-first="1"` attribute is used as a marker, and the entire form is wrapped in a form tag to make it possible to unsubscribe from the LP. However, the channel frequency input field is not included in this.
Therefore, if the channel frequency input field is the first input field in the preference center, the field will not be enclosed in a form tag and the DNC flag cannot be set correctly. This PR resolves this issue.
<img width="288" alt="スクリーンショット 2025-05-27 17 33 13" src="https://github.com/user-attachments/assets/a820513c-2124-4251-822b-a81a2d5b5a00" />



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the config settings, click Email Settings, change Show contact preference settings and Show contact frequency preferences to yes.
3. Create a landing page, place the {channelfrequency} and {saveprefsbutton} tokens on the page, and set `Set as preference center page` to yes.
4. Create an email and set the landing page created in step 3 as the preference center page.
5. Send the email you created in step 4 to your contacts, and click a unsubscribe link.(using guest window)
6. uncheck the DNC checkbox, and submit.
7. Confirm your contact DNC added.


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->