### PR TITLE
Use lightweight Debian base image for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,27 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
-	"features": {
-	  "ghcr.io/ddev/ddev/install-ddev:latest": {}
-	},
-	"portsAttributes": {
-	  "3306": {
-		"label": "database"
-	  },
-	  "8027": {
-		"label": "mailpit"
-	  },
-	  "8036": {
-		"label": "phpmyadmin"
-	  },
-	  "80": {
-		"label": "mautic (http)"
-	  },
-	  "8443": {
-		"label": "mautic (https)"
-	  }
-	},
-	"postCreateCommand": "chmod +x .devcontainer/setup-project.sh && .devcontainer/setup-project.sh"
-  }
+    "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "version": "latest"
+        },
+        "ghcr.io/ddev/ddev/install-ddev:latest": {}
+    },
+    "portsAttributes": {
+        "80": {
+            "label": "Mautic (HTTP)"
+        },
+        "3306": {
+            "label": "Database"
+        },
+        "8027": {
+            "label": "Mailpit"
+        },
+        "8036": {
+            "label": "phpMyAdmin"
+        },
+        "8443": {
+            "label": "Mautic (HTTPS)"
+        }
+    },
+    "postCreateCommand": "chmod +x .devcontainer/setup-project.sh && .devcontainer/setup-project.sh"
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Replaced `mcr.microsoft.com/devcontainers/universal:2` with `mcr.microsoft.com/devcontainers/base:debian-12` to reduce image size and avoid `no space left on device` errors during Codespaces build.

debian-13 (trixie) is the latest, but using that image causes a new error, so we’ll stick with debian-12 (bookworm) instead.
```
#16 0.344 (!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
#16 0.344 (!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
#16 0.345 ERROR: Feature "Docker (Docker-in-Docker)" (ghcr.io/devcontainers/features/docker-in-docker) failed to install! Look at the documentation at ********/devcontainers/features/tree/main/src/docker-in-docker for help troubleshooting this error.
```

> The Debian 12 life cycle encompasses five years: the initial three years of full Debian support, until June 10th, 2026, and two years of Long Term Support (LTS), **until June 30th, 2028**. 

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a codespace on this PR.
<img width="481" height="206" alt="image" src="https://github.com/user-attachments/assets/82cb7d2a-57cc-45e8-914b-eaff80567ae5" />

3. It should successfully spin up a Mautic instance. Wait until the `Running postCreateCommand...` step finishes.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->