### PR TITLE
Matching the DEC regions filter even if it's numerical

### DIFF
--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -3,6 +3,8 @@
 namespace Mautic\EmailBundle\EventListener;
 
 use Mautic\LeadBundle\Entity\LeadListRepository;
+use Mautic\LeadBundle\Exception\OperatorsNotFoundException;
+use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 
 trait MatchFilterForLeadTrait
@@ -95,6 +97,30 @@ trait MatchFilterForLeadTrait
                 case 'number':
                     $leadVal   = (float) $leadVal;
                     $filterVal = (float) $filterVal;
+                    break;
+                case 'region':
+                    $regionChoices = FormFieldHelper::getRegionChoices();
+                    $regions       = [];
+                    $currentIndex  = is_array($filterVal) ? 1 : 0; // The index starts at 0 for single value, 1 for array
+
+                    foreach ($regionChoices as $countryRegions) {
+                        foreach ($countryRegions as $region) {
+                            $regions[$currentIndex] = $region;
+                            ++$currentIndex;
+                        }
+                    }
+
+                    if (is_numeric($filterVal) && isset($regions[$filterVal])) {
+                        $filterVal = $regions[$filterVal];
+                    }
+
+                    if (is_array($filterVal)) {
+                        foreach ($filterVal as $key => $value) {
+                            if (is_numeric($value) && isset($regions[$value])) {
+                                $filterVal[$key] = $regions[$value];
+                            }
+                        }
+                    }
                     break;
                 case 'select':
                     if (!is_array($filterVal)) {

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -3,7 +3,6 @@
 namespace Mautic\EmailBundle\EventListener;
 
 use Mautic\LeadBundle\Entity\LeadListRepository;
-use Mautic\LeadBundle\Exception\OperatorsNotFoundException;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -45,10 +45,9 @@ class MatchFilterForLeadTraitTest extends TestCase
     }
 
     /**
-     * @dataProvider regionFilterDataProvider
-     *
      * @param string|array<int, string> $filter
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('regionFilterDataProvider')]
     public function testMatchFilterForLeadWithRegionFilter(string|array $filter, string $operator, bool $expected): void
     {
         $this->assertSame(
@@ -75,7 +74,7 @@ class MatchFilterForLeadTraitTest extends TestCase
     /**
      * @return iterable<string, array{filter: string|string[], operator: string, expected: bool}>
      */
-    public function regionFilterDataProvider(): iterable
+    public static function regionFilterDataProvider(): iterable
     {
         yield 'Region equals by state name is the same' => [
             'filter'   => 'California',

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -37,6 +37,93 @@ class MatchFilterForLeadTraitTest extends TestCase
     protected function setUp(): void
     {
         $this->matchFilterForLeadTrait = new MatchFilterForLeadTraitTestable();
+
+        // Set required environment variable for FormFieldHelper
+        if (!isset($_ENV['MAUTIC_UPLOAD_DIR'])) {
+            $_ENV['MAUTIC_UPLOAD_DIR'] = '/tmp';
+        }
+    }
+
+    /**
+     * @dataProvider regionFilterDataProvider
+     *
+     * @param string|array<int, string> $filter
+     */
+    public function testMatchFilterForLeadWithRegionFilter(string|array $filter, string $operator, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            $this->matchFilterForLeadTrait->match(
+                [
+                    [
+                        'glue'     => 'and',
+                        'type'     => 'region',
+                        'object'   => 'lead',
+                        'field'    => 'region',
+                        'operator' => $operator,
+                        'filter'   => $filter,
+                    ],
+                ],
+                [
+                    'id'     => 123,
+                    'region' => 'California',
+                ]
+            )
+        );
+    }
+
+    /**
+     * @return iterable<string, array{filter: string|string[], operator: string, expected: bool}>
+     */
+    public function regionFilterDataProvider(): iterable
+    {
+        yield 'Region equals by state name is the same' => [
+            'filter'   => 'California',
+            'operator' => '=',
+            'expected' => true,
+        ];
+
+        yield 'Region equals by state ID is the same' => [
+            'filter'   => '4', // index starts at 0 for single select
+            'operator' => '=',
+            'expected' => true,
+        ];
+
+        yield 'Region equals by state name is NOT the same' => [
+            'filter'   => 'Texas',
+            'operator' => '=',
+            'expected' => false,
+        ];
+
+        yield 'Region equals by state ID is NOT the same' => [
+            'filter'   => '555',
+            'operator' => '=',
+            'expected' => false,
+        ];
+
+        yield 'Region including by state name is the same' => [
+            'filter'   => ['California'],
+            'operator' => 'in',
+            'expected' => true,
+        ];
+
+        yield 'Region including by state ID is the same' => [
+            'filter'   => ['5'], // index starts at 1 for muli-select
+            'operator' => 'in',
+            'expected' => true,
+        ];
+
+        yield 'Region including by state name is NOT the same' => [
+            'filter'   => ['Texas'],
+            'operator' => 'in',
+            'expected' => false,
+        ];
+
+        yield 'Region including by state ID is NOT the same' => [
+            'filter'   => ['555'],
+            'operator' => 'in',
+            'expected' => false,
+        ];
     }
 
     public function testDWCContactStartWidth(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

In a special case the region/state field value is stored as a integer index of the region instead of the region name.

This PR makes sure that the state will be matched even though the numerical index is provided, not the actual state name. It still keeps working the same for the state names as before.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new email
3. Add a new Bee row to it
4. Add a new DEC to the row
5. Use filter `state = California`
6. Save the row to the saved rows collection
7. Save the email
8. Create a contact with the state of California
9. Back to your email and preview it for that new contact
10. You should see that the DEC is showing the content for Californians.
11. Edit the saved row. Do not change any values, save
12. Preview the email again as that same contact - the default content is shown even though nothing was changed.
13. Test also other field types and operators with the flow above to catch all problems.