### PR TITLE
Fixing DateTo for Report API

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -380,4 +380,17 @@ class DateTimeHelper
             self::$defaultLocalTimezone = $parameterLoader->getParameterBag()->get('default_timezone') ?? date_default_timezone_get();
         }
     }
+
+    /**
+     * Ensures a date string has a time component. If no time is present, adds the specified default time.
+     */
+    public static function setTimeIfMissing(string $dateString, string $defaultTime = '00:00:00', string $timezone = 'UTC'): \DateTimeImmutable
+    {
+        // Check for time format with either space or T separator (ISO 8601)
+        if (!preg_match('/[T ]\d{2}:\d{2}(:\d{2})?/', $dateString)) {
+            $dateString .= ' '.$defaultTime;
+        }
+
+        return new \DateTimeImmutable($dateString, new \DateTimeZone($timezone));
+    }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
@@ -240,9 +240,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
     }
 
-    /**
-     * @dataProvider setTimeIfMissingDataProvider
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('setTimeIfMissingDataProvider')]
     public function testSetTimeIfMissing(string $input, string $defaultTime, string $timezone, string $expectedOutput, string $expectedTimezone): void
     {
         $result = DateTimeHelper::setTimeIfMissing($input, $defaultTime, $timezone);
@@ -255,7 +253,7 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @return \Generator<string, array{string, string, string, string, string}>
      */
-    public function setTimeIfMissingDataProvider(): \Generator
+    public static function setTimeIfMissingDataProvider(): \Generator
     {
         // [input, defaultTime, timezone, expectedOutput, expectedTimezone]
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
@@ -239,4 +239,85 @@ class DateTimeHelperTest extends \PHPUnit\Framework\TestCase
         // Assert that the original DateTime object remains unchanged
         $this->assertEquals($originalDate, $originalDateTime->format(DateTimeHelper::FORMAT_DB));
     }
+
+    /**
+     * @dataProvider setTimeIfMissingDataProvider
+     */
+    public function testSetTimeIfMissing(string $input, string $defaultTime, string $timezone, string $expectedOutput, string $expectedTimezone): void
+    {
+        $result = DateTimeHelper::setTimeIfMissing($input, $defaultTime, $timezone);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertEquals($expectedOutput, $result->format('Y-m-d H:i:s'));
+        $this->assertEquals($expectedTimezone, $result->getTimezone()->getName());
+    }
+
+    /**
+     * @return \Generator<string, array{string, string, string, string, string}>
+     */
+    public function setTimeIfMissingDataProvider(): \Generator
+    {
+        // [input, defaultTime, timezone, expectedOutput, expectedTimezone]
+
+        // Date only - should add default time
+        yield 'date only with default 00:00:00' => [
+            '2025-01-31', '00:00:00', 'UTC', '2025-01-31 00:00:00', 'UTC',
+        ];
+        yield 'date only with custom default time' => [
+            '2025-01-31', '23:59:59', 'UTC', '2025-01-31 23:59:59', 'UTC',
+        ];
+        yield 'date only with custom timezone' => [
+            '2025-01-31', '12:30:45', 'America/New_York', '2025-01-31 12:30:45', 'America/New_York',
+        ];
+
+        // Existing time with space separator - should preserve
+        yield 'datetime with space separator full' => [
+            '2025-01-31 14:30:45', '00:00:00', 'UTC', '2025-01-31 14:30:45', 'UTC',
+        ];
+        yield 'datetime with space separator HH:MM' => [
+            '2025-01-31 14:30', '00:00:00', 'UTC', '2025-01-31 14:30:00', 'UTC',
+        ];
+        yield 'datetime space separator ignores default' => [
+            '2025-01-31 09:15:30', '23:59:59', 'UTC', '2025-01-31 09:15:30', 'UTC',
+        ];
+        yield 'midnight time preserved' => [
+            '2025-01-31 00:00:00', '12:00:00', 'UTC', '2025-01-31 00:00:00', 'UTC',
+        ];
+        yield 'end of day time preserved' => [
+            '2025-01-31 23:59:59', '00:00:00', 'UTC', '2025-01-31 23:59:59', 'UTC',
+        ];
+
+        // Existing time with T separator (ISO 8601) - should preserve
+        yield 'ISO 8601 with T separator full' => [
+            '2025-01-31T14:30:45', '00:00:00', 'UTC', '2025-01-31 14:30:45', 'UTC',
+        ];
+        yield 'ISO 8601 with T separator HH:MM' => [
+            '2025-01-31T14:30', '00:00:00', 'UTC', '2025-01-31 14:30:00', 'UTC',
+        ];
+        yield 'ISO 8601 T separator ignores default' => [
+            '2025-01-31T09:15:30', '23:59:59', 'UTC', '2025-01-31 09:15:30', 'UTC',
+        ];
+        yield 'ISO 8601 with timezone offset' => [
+            '2025-01-31T14:30:45+02:00', '00:00:00', 'UTC', '2025-01-31 14:30:45', '+02:00',
+        ];
+
+        // Different date formats
+        yield 'December date' => [
+            '2025-12-31', '00:00:00', 'UTC', '2025-12-31 00:00:00', 'UTC',
+        ];
+        yield 'January date' => [
+            '2025-01-01', '00:00:00', 'UTC', '2025-01-01 00:00:00', 'UTC',
+        ];
+        yield 'Mid year date' => [
+            '2025-06-15', '00:00:00', 'UTC', '2025-06-15 00:00:00', 'UTC',
+        ];
+
+        // Different timezones
+        yield 'with Europe/London timezone' => [
+            '2025-01-31', '00:00:00', 'Europe/London', '2025-01-31 00:00:00', 'Europe/London',
+        ];
+        yield 'with America/New_York timezone' => [
+            '2025-01-31', '00:00:00', 'America/New_York', '2025-01-31 00:00:00', 'America/New_York',
+        ];
+    }
 }

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -8,7 +8,6 @@ use Mautic\ApiBundle\Helper\EntityResultHelper;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\AppVersion;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\ApiBundle\Controller\CommonApiController;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Exception\PermissionException;

--- a/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
+++ b/app/bundles/ReportBundle/Controller/Api/ReportApiController.php
@@ -8,6 +8,8 @@ use Mautic\ApiBundle\Helper\EntityResultHelper;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\AppVersion;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\ApiBundle\Controller\CommonApiController;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Exception\PermissionException;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -103,11 +105,11 @@ class ReportApiController extends CommonApiController
         $options = ['paginate'=> false, 'ignoreGraphData' => true];
 
         if ($request->query->has('dateFrom')) {
-            $options['dateFrom'] = new \DateTimeImmutable($request->query->get('dateFrom'), new \DateTimeZone('UTC'));
+            $options['dateFrom'] = DateTimeHelper::setTimeIfMissing($request->query->get('dateFrom'), '00:00:00');
         }
 
         if ($request->query->has('dateTo')) {
-            $options['dateTo']   = new \DateTimeImmutable($request->query->get('dateTo'), new \DateTimeZone('UTC'));
+            $options['dateTo'] = DateTimeHelper::setTimeIfMissing($request->query->get('dateTo'), '23:59:59');
         }
 
         if ($request->query->has('page')) {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -448,11 +448,14 @@ class ReportModel extends FormModel implements GlobalSearchInterface
         // Clone dateFrom/dateTo because they handled separately in charts
         $chartDateFrom = isset($options['dateFrom']) ? clone $options['dateFrom'] : (new \DateTime('-30 days'));
         $chartDateTo   = isset($options['dateTo']) ? clone $options['dateTo'] : (new \DateTime());
+        $debugData     = [];
 
-        $debugData = [];
+        // UI doesn't set time so reset it to midnight. API can set time so do not reset it. Using DateTimeImmutable to distinguish.
+        $resetTime = !(isset($options['dateFrom']) && $options['dateFrom'] instanceof \DateTimeImmutable);
 
-        if (isset($options['dateFrom'])) {
-            // Fix date ranges if applicable
+        if ($resetTime && isset($options['dateFrom'])) {
+            $now = new \DateTime();
+
             if (!isset($options['dateTo'])) {
                 $options['dateTo'] = new \DateTime();
             }

--- a/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
+++ b/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ReportBundle\Tests\Functional\Api;
+
+use DateTime;
+use DateTimeZone;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\Submission;
+use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReportApiDateHandlingTest extends MauticMysqlTestCase
+{
+    private Report $report;
+    private Form $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create test entities
+        $this->report = new Report();
+        $this->report->setName('Date Handling Test Report');
+        $this->report->setSource('form.submissions');
+        $this->report->setColumns(['fs.date_submitted', 'fs.id']);
+        $this->report->setSettings([]);
+
+        $this->form = new Form();
+        $this->form->setName('Test Form for Date Handling');
+        $this->form->setAlias('date_test_form');
+
+        $this->em->persist($this->report);
+        $this->em->persist($this->form);
+        $this->em->flush();
+    }
+
+    public function testApiReportWithDateFromAndDateToParameters(): void
+    {
+        // Arrange: Create submissions at specific times
+        $yesterday   = new DateTime('2025-08-16 06:30:00', new DateTimeZone('UTC')); // Yesterday
+        $targetTime1 = new DateTime('2025-08-15 06:30:00', new DateTimeZone('UTC')); // Within range
+        $targetTime2 = new DateTime('2025-08-15 07:00:00', new DateTimeZone('UTC')); // Within range
+        $beforeTime  = new DateTime('2025-08-15 06:00:00', new DateTimeZone('UTC'));  // Before range
+        $afterTime   = new DateTime('2025-08-15 08:00:00', new DateTimeZone('UTC'));   // After range
+        $tomorrow    = new DateTime('2025-08-16 08:00:00', new DateTimeZone('UTC'));   // After range
+
+        $submission0 = $this->createSubmission($yesterday);
+        $submission1 = $this->createSubmission($targetTime1);
+        $submission2 = $this->createSubmission($targetTime2);
+        $submission3 = $this->createSubmission($beforeTime);
+        $submission4 = $this->createSubmission($afterTime);
+        $submission5 = $this->createSubmission($tomorrow);
+
+        $this->em->persist($submission0);
+        $this->em->persist($submission1);
+        $this->em->persist($submission2);
+        $this->em->persist($submission3);
+        $this->em->persist($submission4);
+        $this->em->persist($submission5);
+        $this->em->flush();
+
+        // Act: Make API request with dateFrom and dateTo parameters
+        $this->client->request(
+            Request::METHOD_GET,
+            "/api/reports/{$this->report->getId()}?dateFrom=2025-08-15T06:14:10&dateTo=2025-08-15T07:13:23"
+        );
+
+        // Assert: Verify response
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+
+        $responseData = json_decode($response->getContent(), true);
+
+        // Verify report structure
+        Assert::assertArrayHasKey('report', $responseData);
+        Assert::assertArrayHasKey('data', $responseData);
+        Assert::assertArrayHasKey('totalResults', $responseData);
+        Assert::assertArrayHasKey('dateFrom', $responseData);
+        Assert::assertArrayHasKey('dateTo', $responseData);
+
+        // The key assertion: verify that only submissions within the time range are included
+        // Given the dateFrom=2025-08-15T06:14:10 and dateTo=2025-08-15T07:13:23
+        // Only submission1 (06:30:00) and submission2 (07:00:00) should be included
+        Assert::assertEquals(2, $responseData['totalResults'], 'Should return exactly 2 submissions within the date range');
+        Assert::assertCount(2, $responseData['data'], 'Data array should contain exactly 2 records');
+
+        // Now test that UI still show records for the whole day.
+        $crawler = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$this->report->getId()}");
+
+        $this->assertResponseIsSuccessful();
+
+        $buttonCrawler = $crawler->selectButton('Save');
+        $form          = $buttonCrawler->form();
+
+        $form->setValues([
+            'daterange[date_from]' => '2025-08-15',
+            'daterange[date_to]'   => '2025-08-15',
+        ]);
+
+        $crawler = $this->client->submit($form);
+        $this->assertResponseIsSuccessful();
+        // last row is for totals. So 4+1
+        $this->assertCount(5, $crawler->filter('#reportTable tbody tr'), $crawler->html());
+    }
+
+    public function testApiReportWithTimezoneConversion(): void
+    {
+        // Arrange: Create submission at specific UTC time
+        $utcTime    = new DateTime('2025-08-15 14:30:00', new DateTimeZone('UTC'));
+        $submission = $this->createSubmission($utcTime);
+        $this->em->persist($submission);
+        $this->em->flush();
+
+        // Act: Make API request with timezone-aware parameters
+        // Using New York timezone (UTC-4 in August): 10:00 NY = 14:00 UTC, 16:00 NY = 20:00 UTC
+        $this->client->request(
+            Request::METHOD_GET,
+            "/api/reports/{$this->report->getId()}?dateFrom=2025-08-15T10:00:00-04:00&dateTo=2025-08-15T16:00:00-04:00"
+        );
+
+        // Assert: Verify response includes the submission
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+
+        $responseData = json_decode($response->getContent(), true);
+
+        // The submission at 14:30 UTC should be included in the range 10:00-16:00 NY time (14:00-20:00 UTC)
+        Assert::assertEquals(1, $responseData['totalResults'], 'Should include submission within timezone-converted range');
+    }
+
+    public function testApiReportWithoutTime(): void
+    {
+        $this->em->persist($this->createSubmission(new DateTime('2025-08-14 23:59:59', new DateTimeZone('UTC'))));
+        $this->em->persist($this->createSubmission(new DateTime('2025-08-15 14:30:00', new DateTimeZone('UTC'))));
+        $this->em->persist($this->createSubmission(new DateTime('2025-08-16 00:00:00', new DateTimeZone('UTC'))));
+        $this->em->flush();
+
+        $this->client->request(
+            Request::METHOD_GET,
+            "/api/reports/{$this->report->getId()}?dateFrom=2025-08-15&dateTo=2025-08-15"
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+
+        $responseData = json_decode($response->getContent(), true);
+
+        // 1 submission should be included in the results as we consider dateFrom time as 00:00:00 and dateTo time as 23:59:59 UTC if not set.
+        Assert::assertEquals(1, $responseData['totalResults'], 'Should include submission within timezone-converted range');
+    }
+
+    private function createSubmission(DateTime $dateSubmitted): Submission
+    {
+        $submission = new Submission();
+        $submission->setForm($this->form);
+        $submission->setDateSubmitted($dateSubmitted);
+        $submission->setReferer('');
+
+        return $submission;
+    }
+}

--- a/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
+++ b/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\ReportBundle\Tests\Functional\Api;
 
-use DateTime;
-use DateTimeZone;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
@@ -41,12 +39,12 @@ final class ReportApiDateHandlingTest extends MauticMysqlTestCase
     public function testApiReportWithDateFromAndDateToParameters(): void
     {
         // Arrange: Create submissions at specific times
-        $yesterday   = new DateTime('2025-08-16 06:30:00', new DateTimeZone('UTC')); // Yesterday
-        $targetTime1 = new DateTime('2025-08-15 06:30:00', new DateTimeZone('UTC')); // Within range
-        $targetTime2 = new DateTime('2025-08-15 07:00:00', new DateTimeZone('UTC')); // Within range
-        $beforeTime  = new DateTime('2025-08-15 06:00:00', new DateTimeZone('UTC'));  // Before range
-        $afterTime   = new DateTime('2025-08-15 08:00:00', new DateTimeZone('UTC'));   // After range
-        $tomorrow    = new DateTime('2025-08-16 08:00:00', new DateTimeZone('UTC'));   // After range
+        $yesterday   = new \DateTime('2025-08-16 06:30:00', new \DateTimeZone('UTC')); // Yesterday
+        $targetTime1 = new \DateTime('2025-08-15 06:30:00', new \DateTimeZone('UTC')); // Within range
+        $targetTime2 = new \DateTime('2025-08-15 07:00:00', new \DateTimeZone('UTC')); // Within range
+        $beforeTime  = new \DateTime('2025-08-15 06:00:00', new \DateTimeZone('UTC'));  // Before range
+        $afterTime   = new \DateTime('2025-08-15 08:00:00', new \DateTimeZone('UTC'));   // After range
+        $tomorrow    = new \DateTime('2025-08-16 08:00:00', new \DateTimeZone('UTC'));   // After range
 
         $submission0 = $this->createSubmission($yesterday);
         $submission1 = $this->createSubmission($targetTime1);
@@ -110,7 +108,7 @@ final class ReportApiDateHandlingTest extends MauticMysqlTestCase
     public function testApiReportWithTimezoneConversion(): void
     {
         // Arrange: Create submission at specific UTC time
-        $utcTime    = new DateTime('2025-08-15 14:30:00', new DateTimeZone('UTC'));
+        $utcTime    = new \DateTime('2025-08-15 14:30:00', new \DateTimeZone('UTC'));
         $submission = $this->createSubmission($utcTime);
         $this->em->persist($submission);
         $this->em->flush();
@@ -134,9 +132,9 @@ final class ReportApiDateHandlingTest extends MauticMysqlTestCase
 
     public function testApiReportWithoutTime(): void
     {
-        $this->em->persist($this->createSubmission(new DateTime('2025-08-14 23:59:59', new DateTimeZone('UTC'))));
-        $this->em->persist($this->createSubmission(new DateTime('2025-08-15 14:30:00', new DateTimeZone('UTC'))));
-        $this->em->persist($this->createSubmission(new DateTime('2025-08-16 00:00:00', new DateTimeZone('UTC'))));
+        $this->em->persist($this->createSubmission(new \DateTime('2025-08-14 23:59:59', new \DateTimeZone('UTC'))));
+        $this->em->persist($this->createSubmission(new \DateTime('2025-08-15 14:30:00', new \DateTimeZone('UTC'))));
+        $this->em->persist($this->createSubmission(new \DateTime('2025-08-16 00:00:00', new \DateTimeZone('UTC'))));
         $this->em->flush();
 
         $this->client->request(
@@ -153,7 +151,7 @@ final class ReportApiDateHandlingTest extends MauticMysqlTestCase
         Assert::assertEquals(1, $responseData['totalResults'], 'Should include submission within timezone-converted range');
     }
 
-    private function createSubmission(DateTime $dateSubmitted): Submission
+    private function createSubmission(\DateTime $dateSubmitted): Submission
     {
         $submission = new Submission();
         $submission->setForm($this->form);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes /

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When making an API request to get report records for certain time range doesn't work because the DateTo time is reset to `23:59:59`. This is done because users cannot set time in the UI. But they can in the API. So we shouldn't reset the time for API calls.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a form and make some form submissions.
3. Create a report based on the form submissions source
4. Make API request like `curl --location 'https://yourmautic.com/api/reports/1?dateFrom=2025-08-15T06:14:10&dateTo=2025-08-15T07:13:23'  --header 'Content-Type: application/json' --header 'Authorization: Bearer <TOKEN_DUMMY>'` (Update the domain, date ranges and token for your use case)
5. Set the date range so it would find some of the form submissions you made but not all.
6. See that API will show all submissions for the dateTo date up till midnight instead of the time you've set.

#### Other areas of Mautic that may be affected by the change:
1. Just reports but it can affect both UI and API but also export, backend export command and widget.

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1.The functional tests ensures that the API can set time and it returns only the records for that date/time range. At the same time it tests that UI still shows all records up till midnight.
