### PR TITLE
feat: add ignoreDnc option to email send lead API endpoint

### DIFF
--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -158,12 +158,12 @@ class EmailApiController extends CommonApiController
             return $lead;
         }
 
-        $post       = $request->request->all();
-        $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
-        $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
+        $post             = $request->request->all();
+        $tokens           = (!empty($post['tokens'])) ? $post['tokens'] : [];
+        $assetsIds        = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
         $defaultIgnoreDnc = !$entity->isSegmentEmail();
-        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : $defaultIgnoreDnc;
-        $response   = ['success' => false];
+        $ignoreDnc        = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : $defaultIgnoreDnc;
+        $response         = ['success' => false];
 
         $cleanTokens = [];
 

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -161,6 +161,7 @@ class EmailApiController extends CommonApiController
         $post       = $request->request->all();
         $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
         $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
+        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : false;
         $response   = ['success' => false];
 
         $cleanTokens = [];
@@ -188,7 +189,7 @@ class EmailApiController extends CommonApiController
                 'tokens'            => $cleanTokens,
                 'assetAttachments'  => $assetsIds,
                 'return_errors'     => true,
-                'ignoreDNC'         => true,
+                'ignoreDNC'         => $ignoreDnc,
                 'email_type'        => MailHelper::EMAIL_TYPE_TRANSACTIONAL,
             ]
         );

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -161,7 +161,8 @@ class EmailApiController extends CommonApiController
         $post       = $request->request->all();
         $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
         $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
-        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : true;
+        $defaultIgnoreDnc = !$entity->isSegment();
+        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : $defaultIgnoreDnc;
         $response   = ['success' => false];
 
         $cleanTokens = [];

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -161,7 +161,7 @@ class EmailApiController extends CommonApiController
         $post       = $request->request->all();
         $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
         $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
-        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : false;
+        $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : true;
         $response   = ['success' => false];
 
         $cleanTokens = [];

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -161,7 +161,7 @@ class EmailApiController extends CommonApiController
         $post       = $request->request->all();
         $tokens     = (!empty($post['tokens'])) ? $post['tokens'] : [];
         $assetsIds  = (!empty($post['assetAttachments'])) ? $post['assetAttachments'] : [];
-        $defaultIgnoreDnc = !$entity->isSegment();
+        $defaultIgnoreDnc = !$entity->isSegmentEmail();
         $ignoreDnc  = isset($post['ignoreDnc']) ? (bool) $post['ignoreDnc'] : $defaultIgnoreDnc;
         $response   = ['success' => false];
 

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -1205,6 +1205,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     }
 
     /**
+     * Check if this is a segment email (list email type).
+     */
+    public function isSegmentEmail(): bool
+    {
+        return 'list' === $this->emailType;
+    }
+
+    /**
      * Add asset.
      *
      * @return Email

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
+use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
@@ -647,6 +648,128 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             [
                 'name' => 'Updated Child Email',
             ],
+        ];
+    }
+
+    /**
+     * Test sending email to DNC contact with ignoreDnc parameter.
+     */
+    #[DataProvider('ignoreDncDataProvider')]
+    public function testSendEmailToDNCLeadWithIgnoreDnc(bool $isSegmentEmail, ?bool $ignoreDncParam, bool $expectedSuccess, string $testDescription): void
+    {
+        // Create a segment if needed
+        $segment = null;
+        if ($isSegmentEmail) {
+            $segment = new LeadList();
+            $segment->setName('Test Segment');
+            $segment->setPublicName('Test Segment');
+            $segment->setAlias('test-segment');
+            $this->em->persist($segment);
+        }
+
+        // Create email
+        $email = new Email();
+        $email->setName('Test Email');
+        $email->setSubject('Test Subject');
+        $email->setCustomHtml('<h1>Test</h1>');
+        $email->setFromAddress('from@test.com');
+        $email->setFromName('Test');
+        $email->setIsPublished(true);
+        if ($segment) {
+            $email->addList($segment);
+            $email->setEmailType('list');
+        } else {
+            $email->setEmailType('template');
+        }
+        $this->em->persist($email);
+
+        // Create contact
+        $contact = new Lead();
+        $contact->setEmail('john@doe.email');
+        $this->em->persist($contact);
+
+        // Create DNC entry
+        $contactDNC = new DoNotContact();
+        $contactDNC->setLead($contact);
+        $contactDNC->setReason(DoNotContact::UNSUBSCRIBED);
+        $contactDNC->setChannel('email');
+        $contactDNC->setDateAdded(new \DateTime());
+        $this->em->persist($contactDNC);
+
+        $this->em->flush();
+
+        // Prepare request payload
+        $payload = [];
+        if (null !== $ignoreDncParam) {
+            $payload['ignoreDnc'] = $ignoreDncParam;
+        }
+
+        // Send email via API
+        $this->client->request('POST', "/api/emails/{$email->getId()}/contact/{$contact->getId()}/send", $payload);
+        $response     = $this->client->getResponse();
+        $responseData = json_decode($response->getContent(), true);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), $testDescription.': '.$response->getContent());
+        $this->assertSame($expectedSuccess, $responseData['success'], $testDescription);
+
+        // Verify stat was created only if email was sent successfully
+        $stat = $this->em->getRepository(Stat::class)->findOneBy([
+            'email' => $email->getId(),
+            'lead'  => $contact->getId(),
+        ]);
+
+        if ($expectedSuccess) {
+            $this->assertNotNull($stat, $testDescription.': Stat should be created when email is sent');
+        } else {
+            $this->assertNull($stat, $testDescription.': Stat should NOT be created when email is not sent');
+        }
+    }
+
+    /**
+     * @return iterable<string, array{isSegmentEmail: bool, ignoreDncParam: bool|null, expectedSuccess: bool, testDescription: string}>
+     */
+    public static function ignoreDncDataProvider(): iterable
+    {
+        yield 'Segment email without ignoreDnc parameter - should NOT send (default false)' => [
+            'isSegmentEmail'   => true,
+            'ignoreDncParam'   => null,
+            'expectedSuccess'  => false,
+            'testDescription'  => 'Segment email defaults to ignoreDnc=false',
+        ];
+
+        yield 'Segment email with ignoreDnc=true - should send' => [
+            'isSegmentEmail'   => true,
+            'ignoreDncParam'   => true,
+            'expectedSuccess'  => true,
+            'testDescription'  => 'Segment email with ignoreDnc=true overrides DNC',
+        ];
+
+        yield 'Segment email with ignoreDnc=false - should NOT send' => [
+            'isSegmentEmail'   => true,
+            'ignoreDncParam'   => false,
+            'expectedSuccess'  => false,
+            'testDescription'  => 'Segment email with ignoreDnc=false respects DNC',
+        ];
+
+        yield 'Non-segment email without ignoreDnc parameter - should send (default true for backward compatibility)' => [
+            'isSegmentEmail'   => false,
+            'ignoreDncParam'   => null,
+            'expectedSuccess'  => true,
+            'testDescription'  => 'Non-segment email defaults to ignoreDnc=true',
+        ];
+
+        yield 'Non-segment email with ignoreDnc=true - should send' => [
+            'isSegmentEmail'   => false,
+            'ignoreDncParam'   => true,
+            'expectedSuccess'  => true,
+            'testDescription'  => 'Non-segment email with ignoreDnc=true overrides DNC',
+        ];
+
+        yield 'Non-segment email with ignoreDnc=false - should NOT send' => [
+            'isSegmentEmail'   => false,
+            'ignoreDncParam'   => false,
+            'expectedSuccess'  => false,
+            'testDescription'  => 'Non-segment email with ignoreDnc=false respects DNC',
         ];
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #6965

## Description

Adds optional `ignoreDnc` parameter to `/api/emails/{id}/contact/{leadId}/send` endpoint.

### Background

This addresses a **backward compatibility issue** introduced during the migration from Mautic 4 to Mautic 5+:

- **Before (Mautic 4)**: API endpoint sent emails **without checking DNC status**
- **After (Mautic 5+)**: API endpoint started **respecting DNC status** by default
- **Issue**: Existing API integrations that relied on sending emails to DNC contacts stopped working after the upgrade

This PR restores backward compatibility while providing better control over DNC handling.

### Solution

**Default behavior:**
- **Segment emails**: `ignoreDnc = false` (respects DNC status - safer default for marketing emails)
- **Non-segment emails**: `ignoreDnc = true` (ignores DNC - maintains backward compatibility with Mautic 4 behavior)

**API Usage:**
```json
POST /api/emails/123/contact/456/send
{
  "ignoreDnc": false
}
```

To restore the **exact Mautic 4 behavior** in your existing API code, explicitly set `"ignoreDnc": true` in your API requests.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Mark a contact as DNC
3. **Segment email**: Send via API without parameter - should NOT send (respects DNC)
4. **Non-segment email**: Send via API without parameter - should send (backward compatible)
5. Both types: Send with `"ignoreDnc": true` - should send
6. Both types: Send with `"ignoreDnc": false` - should NOT send
7. Run the automated tests: `bin/phpunit --filter testSendEmailToDNCLeadWithIgnoreDnc`

---