### PR TITLE
Fixing custom field search containing a colon

### DIFF
--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -520,14 +520,6 @@ class FieldModel extends FormModel
     }
 
     /**
-     * @return LeadField[]|array<int,mixed>|iterable<LeadField>|\Doctrine\ORM\Internal\Hydration\IterableResult<LeadField>|Paginator<LeadField>|SimplePaginator<LeadField>
-     */
-    public function getEntities(array $args = [])
-    {
-        return $this->getRepository()->getEntities($args);
-    }
-
-    /**
      * @return array
      */
     public function getLeadFields()

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
-use Mautic\CoreBundle\Doctrine\Paginator\SimplePaginator;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\UserHelper;

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -171,6 +171,15 @@ class FieldFunctionalTest extends MauticMysqlTestCase
         );
     }
 
+    public function testFieldsSearchByIds(): void
+    {
+        $urlEncodedSearch = urlencode('ids:2,3');
+        $this->client->request(Request::METHOD_GET, "/s/contacts/fields?search={$urlEncodedSearch}");
+        $this->assertResponseIsSuccessful();
+        Assert::assertStringContainsString('First Name', $this->client->getResponse()->getContent());
+        Assert::assertStringContainsString('Last Name', $this->client->getResponse()->getContent());
+    }
+
     /**
      * @param array<string, mixed> $parameters
      */


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [n]
| Deprecations?                          | [n]
| BC breaks? (use the c.x branch)        | [n]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

This PR is fixing custom field search if it contains a colon. This is the error:
```
Uncaught exception 'Error' with message 'Call to a member function trans() on null' in app/bundles/CoreBundle/Entity/CommonRepository.php:1736
in Mautic\CoreBundle\Entity\CommonRepository::isSupportedSearchCommand called at app/bundles/CoreBundle/Entity/CommonRepository.php (1764)
in Mautic\CoreBundle\Entity\CommonRepository::parseSearchFilters called at app/bundles/CoreBundle/Entity/CommonRepository.php (993)
in Mautic\CoreBundle\Entity\CommonRepository::addAdvancedSearchWhereClause called at app/bundles/CoreBundle/Entity/CommonRepository.php (1540)
in Mautic\CoreBundle\Entity\CommonRepository::buildWhereClause called at app/bundles/CoreBundle/Entity/CommonRepository.php (1250)
in Mautic\CoreBundle\Entity\CommonRepository::buildClauses called at app/bundles/CoreBundle/Entity/CommonRepository.php (339)
in Mautic\CoreBundle\Entity\CommonRepository::getEntities called at app/bundles/LeadBundle/Model/FieldModel.php (536)
in Mautic\LeadBundle\Model\FieldModel::getEntities called at app/bundles/LeadBundle/Controller/FieldController.php (64)
```

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to custom fields
3. Search for example for `ids:1`

#### Other areas of Mautic that may be affected by the change:
1. Just custom field search.

#### List deprecations along with the new alternative:
1. The removed method is present in the parent class and it also sets the translator there so I removed it so the parent method takes care of fixing the bug.

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The functional test ensures that searching by IDs works as it returned 500 error before. It also asserts that it finds the right custom fields.
