### PR TITLE
Do not hide options of the three dot list item menu on small mobile devices

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/list_actions.html.twig
@@ -41,7 +41,7 @@
             {% if templateButtons.edit is defined and templateButtons.edit is not empty %}
             {{ buttonAdd({
                 attr: editAttr|merge({
-                    class: 'hidden-xs btn btn-ghost btn-sm btn-nospin',
+                    class: 'btn btn-ghost btn-sm btn-nospin',
                     href: path(
                         actionRoute,
                         query|merge({objectAction: 'edit', objectId: id})
@@ -56,7 +56,7 @@
             {% if templateButtons.clone is defined and templateButtons.clone is not empty %}
             {{ buttonAdd({
                 attr: editAttr|merge({
-                    class: 'hidden-xs btn btn-ghost btn-sm btn-nospin',
+                    class: 'btn btn-ghost btn-sm btn-nospin',
                     href: path(
                         actionRoute,
                         query|merge({objectAction: 'clone', objectId: id})
@@ -86,7 +86,7 @@
             {% if templateButtons.export is defined and templateButtons.export is not empty %}
             {{ buttonAdd({
                 attr: {
-                    class: 'hidden-xs btn btn-ghost btn-sm btn-nospin',
+                    class: 'btn btn-ghost btn-sm btn-nospin',
                     href: path(
                         actionRoute,
                         query|merge({objectAction: 'export', objectId: id})


### PR DESCRIPTION
# Summary

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | n/a
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #15547

# Description

The options within the three-dot list item menu were hidden on small mobile devices (via the `hidden-xs` CSS class). This could be attributed to the transformation of list item actions from horizontal to vertical.

Please see the comparison 👇

| Before | After |
| - | - |
| <img width="1130" height="976" alt="Screenshot 2025-10-22 at 22 07 44" src="https://github.com/user-attachments/assets/2acc89a1-0aad-4f37-bb15-4bcdae57e36e" /> | <img width="1130" height="976" alt="Screenshot 2025-10-22 at 22 08 41" src="https://github.com/user-attachments/assets/8e77225d-bcb2-4895-9798-d3b8ab81a11f" /> |

Please see the video showing how I verified that 👇

https://github.com/user-attachments/assets/4bcd36d9-0c44-4668-930c-86c3be4b54b8

# 📋 Steps to test this PR:

1. Create a
    1. contact
    2. company
    3. segment
    4. etc.
5. Go to list view
6. Click on the three-dot for the previously created item
7. Make the window wider/thinner so the navbar appears/disappears (for example: by opening the Responsive mode in DevTools)