### PR TITLE
Fix: Boolean field filters now properly handle NULL values in segments

### DIFF
--- a/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\EventListener;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\ORM\Query\Expr;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Event\SegmentOperatorQueryBuilderEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\OperatorOptions;
@@ -41,20 +42,20 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
         }
 
         // Get the parameter value - will be cast to boolean
-        $parameterValue  = $filter->getParameterValue();
+        $parameterValue  = InputHelper::boolean($filter->getParameterValue());
         $leadsTableAlias = $event->getLeadsTableAlias();
         $field           = $leadsTableAlias.'.'.$filter->getField();
         $expr            = $event->getQueryBuilder()->expr();
 
-        // Boolean = NO (0) means "not YES" (not 1) - includes 0 and NULL
-        if (false === $parameterValue || 0 === $parameterValue || '0' === $parameterValue) {
+        // Boolean = NO (false) means "not YES" (not 1) - includes 0 and NULL
+        if (false === $parameterValue) {
             $event->addExpression(
                 $expr->neq($field, $expr->literal('1'))
             );
             $event->stopPropagation();
         }
-        // Boolean = YES (1) means exactly 1
-        elseif (true === $parameterValue || 1 === $parameterValue || '1' === $parameterValue) {
+        // Boolean = YES (true) means exactly 1
+        elseif (true === $parameterValue) {
             $event->addExpression(
                 $expr->eq($field, $expr->literal('1'))
             );
@@ -120,16 +121,16 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
 
         // Special handling for boolean neq
         if ($filter->isColumnTypeBoolean() && 'neq' === $filter->getOperator()) {
-            $parameterValue = $filter->getParameterValue();
+            $parameterValue = InputHelper::boolean($filter->getParameterValue());
 
-            // Boolean != NO (0) means "YES" (exactly 1)
-            if (false === $parameterValue || 0 === $parameterValue || '0' === $parameterValue) {
+            // Boolean != NO (false) means "YES" (exactly 1)
+            if (false === $parameterValue) {
                 $event->addExpression(
                     $expr->eq($field, $expr->literal('1'))
                 );
             }
-            // Boolean != YES (1) means "not YES" (not 1) - includes 0 and NULL
-            elseif (true === $parameterValue || 1 === $parameterValue || '1' === $parameterValue) {
+            // Boolean != YES (true) means "not YES" (not 1) - includes 0 and NULL
+            elseif (true === $parameterValue) {
                 $event->addExpression(
                     $expr->neq($field, $expr->literal('1'))
                 );

--- a/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
@@ -47,10 +47,13 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
         $field           = $leadsTableAlias.'.'.$filter->getField();
         $expr            = $event->getQueryBuilder()->expr();
 
-        // Boolean = NO (false) means "not YES" (not 1) - includes 0 and NULL
+        // Boolean = NO (false) means "not YES" (0 or NULL)
         if (false === $parameterValue) {
             $event->addExpression(
-                $expr->neq($field, $expr->literal('1'))
+                $expr->or(
+                    $expr->eq($field, $expr->literal('0')),
+                    $expr->isNull($field)
+                )
             );
             $event->stopPropagation();
         }
@@ -129,10 +132,13 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
                     $expr->eq($field, $expr->literal('1'))
                 );
             }
-            // Boolean != YES (true) means "not YES" (not 1) - includes 0 and NULL
+            // Boolean != YES (true) means "not YES" (0 or NULL)
             elseif (true === $parameterValue) {
                 $event->addExpression(
-                    $expr->neq($field, $expr->literal('1'))
+                    $expr->or(
+                        $expr->eq($field, $expr->literal('0')),
+                        $expr->isNull($field)
+                    )
                 );
             }
         } else {

--- a/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
@@ -17,6 +17,7 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
     {
         return [
             LeadEvents::LIST_FILTERS_OPERATOR_QUERYBUILDER_ON_GENERATE => [
+                ['onBooleanEqualsOperator', 10], // Higher priority - runs first
                 ['onEmptyOperator', 0],
                 ['onNotEmptyOperator', 0],
                 ['onNegativeOperators', 0],
@@ -24,6 +25,41 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
                 ['onDefaultOperators', 0],
             ],
         ];
+    }
+
+    public function onBooleanEqualsOperator(SegmentOperatorQueryBuilderEvent $event): void
+    {
+        if (!$event->operatorIsOneOf('eq')) {
+            return;
+        }
+
+        $filter = $event->getFilter();
+
+        // Check if this is a boolean field
+        if (!$filter->isColumnTypeBoolean()) {
+            return;
+        }
+
+        // Get the parameter value - will be cast to boolean
+        $parameterValue  = $filter->getParameterValue();
+        $leadsTableAlias = $event->getLeadsTableAlias();
+        $field           = $leadsTableAlias.'.'.$filter->getField();
+        $expr            = $event->getQueryBuilder()->expr();
+
+        // Boolean = NO (0) means "not YES" (not 1) - includes 0 and NULL
+        if (false === $parameterValue || 0 === $parameterValue || '0' === $parameterValue) {
+            $event->addExpression(
+                $expr->neq($field, $expr->literal('1'))
+            );
+            $event->stopPropagation();
+        }
+        // Boolean = YES (1) means exactly 1
+        elseif (true === $parameterValue || 1 === $parameterValue || '1' === $parameterValue) {
+            $event->addExpression(
+                $expr->eq($field, $expr->literal('1'))
+            );
+            $event->stopPropagation();
+        }
     }
 
     public function onEmptyOperator(SegmentOperatorQueryBuilderEvent $event): void
@@ -78,16 +114,38 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
         }
 
         $leadsTableAlias = $event->getLeadsTableAlias();
+        $filter          = $event->getFilter();
+        $field           = $leadsTableAlias.'.'.$filter->getField();
+        $expr            = $event->getQueryBuilder()->expr();
 
-        $event->addExpression(
-            $event->getQueryBuilder()->expr()->or(
-                $event->getQueryBuilder()->expr()->isNull($leadsTableAlias.'.'.$event->getFilter()->getField()),
-                $event->getQueryBuilder()->expr()->{$event->getFilter()->getOperator()}(
-                    $leadsTableAlias.'.'.$event->getFilter()->getField(),
-                    $event->getParameterHolder()
+        // Special handling for boolean neq
+        if ($filter->isColumnTypeBoolean() && 'neq' === $filter->getOperator()) {
+            $parameterValue = $filter->getParameterValue();
+
+            // Boolean != NO (0) means "YES" (exactly 1)
+            if (false === $parameterValue || 0 === $parameterValue || '0' === $parameterValue) {
+                $event->addExpression(
+                    $expr->eq($field, $expr->literal('1'))
+                );
+            }
+            // Boolean != YES (1) means "not YES" (not 1) - includes 0 and NULL
+            elseif (true === $parameterValue || 1 === $parameterValue || '1' === $parameterValue) {
+                $event->addExpression(
+                    $expr->neq($field, $expr->literal('1'))
+                );
+            }
+        } else {
+            // For non-boolean fields, include NULL in neq operations
+            $event->addExpression(
+                $expr->or(
+                    $expr->isNull($field),
+                    $expr->{$filter->getOperator()}(
+                        $field,
+                        $event->getParameterHolder()
+                    )
                 )
-            )
-        );
+            );
+        }
 
         $event->stopPropagation();
     }

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -4,6 +4,7 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
 /**
@@ -75,23 +76,80 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
 
                 break;
             case 'neq':
-                $expression = $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField()),
-                    $queryBuilder->expr()->$filterOperator(
-                        $tableAlias.'.'.$filter->getField(),
-                        $filterParametersHolder
-                    )
-                );
+                // Special handling for boolean neq
+                if ($filter->isColumnTypeBoolean()) {
+                    // Boolean != NO (0) means "YES" (exactly 1)
+                    if (false === $filterParameters || 0 === $filterParameters || '0' === $filterParameters) {
+                        $expression = $queryBuilder->expr()->eq(
+                            $tableAlias.'.'.$filter->getField(),
+                            $queryBuilder->expr()->literal('1')
+                        );
+                    }
+                    // Boolean != YES (1) means "not YES" (not 1) - includes 0 and NULL
+                    elseif (true === $filterParameters || 1 === $filterParameters || '1' === $filterParameters) {
+                        $expression = $queryBuilder->expr()->neq(
+                            $tableAlias.'.'.$filter->getField(),
+                            $queryBuilder->expr()->literal('1')
+                        );
+                    }
+                } else {
+                    // For non-boolean fields, include NULL in neq operations
+                    $expression = $queryBuilder->expr()->or(
+                        $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField()),
+                        $queryBuilder->expr()->$filterOperator(
+                            $tableAlias.'.'.$filter->getField(),
+                            $filterParametersHolder
+                        )
+                    );
+                }
                 break;
             case 'startsWith':
             case 'endsWith':
             case 'gt':
-            case 'eq':
             case 'gte':
             case 'like':
             case 'lt':
             case 'lte':
             case 'in':
+            case OperatorOptions::INCLUDING_ANY:
+                $expression = $queryBuilder->expr()->in(
+                    $tableAlias.'.'.$filter->getField(),
+                    $filterParametersHolder
+                );
+                break;
+            case 'eq':
+                // Special handling for boolean eq
+                if ($filter->isColumnTypeBoolean()) {
+                    // Boolean = NO (0) means "not YES" (not 1) - includes 0 and NULL
+                    if (false === $filterParameters || 0 === $filterParameters || '0' === $filterParameters) {
+                        $expression = $queryBuilder->expr()->neq(
+                            $tableAlias.'.'.$filter->getField(),
+                            $queryBuilder->expr()->literal('1')
+                        );
+                    }
+                    // Boolean = YES (1) means exactly 1
+                    elseif (true === $filterParameters || 1 === $filterParameters || '1' === $filterParameters) {
+                        $expression = $queryBuilder->expr()->eq(
+                            $tableAlias.'.'.$filter->getField(),
+                            $queryBuilder->expr()->literal('1')
+                        );
+                    }
+                } else {
+                    $expression = $queryBuilder->expr()->$filterOperator(
+                        $tableAlias.'.'.$filter->getField(),
+                        $filterParametersHolder
+                    );
+                }
+                break;
+            case OperatorOptions::INCLUDING_ALL:
+                // Note: INCLUDING_ALL for complex relations may not be mathematically meaningful
+                // as it implies a single field value matches ALL provided values simultaneously
+                // This is likely a configuration error, but we'll treat it as INCLUDING_ANY
+                $expression = $queryBuilder->expr()->in(
+                    $tableAlias.'.'.$filter->getField(),
+                    $filterParametersHolder
+                );
+                break;
             case 'between':   // Used only for date with week combination (EQUAL [this week, next week, last week])
             case 'regexp':
             case 'notRegexp': // Different behaviour from 'notLike' because of BC (do not use condition for NULL). Could be changed in Mautic 3.

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
@@ -78,15 +79,17 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
             case 'neq':
                 // Special handling for boolean neq
                 if ($filter->isColumnTypeBoolean()) {
-                    // Boolean != NO (0) means "YES" (exactly 1)
-                    if (false === $filterParameters || 0 === $filterParameters || '0' === $filterParameters) {
+                    $boolValue = InputHelper::boolean($filterParameters);
+
+                    // Boolean != NO (false) means "YES" (exactly 1)
+                    if (false === $boolValue) {
                         $expression = $queryBuilder->expr()->eq(
                             $tableAlias.'.'.$filter->getField(),
                             $queryBuilder->expr()->literal('1')
                         );
                     }
-                    // Boolean != YES (1) means "not YES" (not 1) - includes 0 and NULL
-                    elseif (true === $filterParameters || 1 === $filterParameters || '1' === $filterParameters) {
+                    // Boolean != YES (true) means "not YES" (not 1) - includes 0 and NULL
+                    elseif (true === $boolValue) {
                         $expression = $queryBuilder->expr()->neq(
                             $tableAlias.'.'.$filter->getField(),
                             $queryBuilder->expr()->literal('1')
@@ -120,15 +123,17 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
             case 'eq':
                 // Special handling for boolean eq
                 if ($filter->isColumnTypeBoolean()) {
-                    // Boolean = NO (0) means "not YES" (not 1) - includes 0 and NULL
-                    if (false === $filterParameters || 0 === $filterParameters || '0' === $filterParameters) {
+                    $boolValue = InputHelper::boolean($filterParameters);
+
+                    // Boolean = NO (false) means "not YES" (not 1) - includes 0 and NULL
+                    if (false === $boolValue) {
                         $expression = $queryBuilder->expr()->neq(
                             $tableAlias.'.'.$filter->getField(),
                             $queryBuilder->expr()->literal('1')
                         );
                     }
-                    // Boolean = YES (1) means exactly 1
-                    elseif (true === $filterParameters || 1 === $filterParameters || '1' === $filterParameters) {
+                    // Boolean = YES (true) means exactly 1
+                    elseif (true === $boolValue) {
                         $expression = $queryBuilder->expr()->eq(
                             $tableAlias.'.'.$filter->getField(),
                             $queryBuilder->expr()->literal('1')

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -5,7 +5,6 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
-use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
 /**
@@ -117,12 +116,6 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
             case 'lt':
             case 'lte':
             case 'in':
-            case OperatorOptions::INCLUDING_ANY:
-                $expression = $queryBuilder->expr()->in(
-                    $tableAlias.'.'.$filter->getField(),
-                    $filterParametersHolder
-                );
-                break;
             case 'eq':
                 // Special handling for boolean eq
                 if ($filter->isColumnTypeBoolean()) {
@@ -137,6 +130,7 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
                             ),
                             $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField())
                         );
+                        break;
                     }
                     // Boolean = YES (true) means exactly 1
                     elseif (true === $boolValue) {
@@ -144,19 +138,11 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
                             $tableAlias.'.'.$filter->getField(),
                             $queryBuilder->expr()->literal('1')
                         );
+                        break;
                     }
-                } else {
-                    $expression = $queryBuilder->expr()->$filterOperator(
-                        $tableAlias.'.'.$filter->getField(),
-                        $filterParametersHolder
-                    );
                 }
-                break;
-            case OperatorOptions::INCLUDING_ALL:
-                // Note: INCLUDING_ALL for complex relations may not be mathematically meaningful
-                // as it implies a single field value matches ALL provided values simultaneously
-                // This is likely a configuration error, but we'll treat it as INCLUDING_ANY
-                $expression = $queryBuilder->expr()->in(
+                // For non-boolean fields or 'in' operator, use default expression
+                $expression = $queryBuilder->expr()->$filterOperator(
                     $tableAlias.'.'.$filter->getField(),
                     $filterParametersHolder
                 );

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -88,11 +88,14 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
                             $queryBuilder->expr()->literal('1')
                         );
                     }
-                    // Boolean != YES (true) means "not YES" (not 1) - includes 0 and NULL
+                    // Boolean != YES (true) means "not YES" (0 or NULL)
                     elseif (true === $boolValue) {
-                        $expression = $queryBuilder->expr()->neq(
-                            $tableAlias.'.'.$filter->getField(),
-                            $queryBuilder->expr()->literal('1')
+                        $expression = $queryBuilder->expr()->or(
+                            $queryBuilder->expr()->eq(
+                                $tableAlias.'.'.$filter->getField(),
+                                $queryBuilder->expr()->literal('0')
+                            ),
+                            $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField())
                         );
                     }
                 } else {
@@ -125,11 +128,14 @@ class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
                 if ($filter->isColumnTypeBoolean()) {
                     $boolValue = InputHelper::boolean($filterParameters);
 
-                    // Boolean = NO (false) means "not YES" (not 1) - includes 0 and NULL
+                    // Boolean = NO (false) means "not YES" (0 or NULL)
                     if (false === $boolValue) {
-                        $expression = $queryBuilder->expr()->neq(
-                            $tableAlias.'.'.$filter->getField(),
-                            $queryBuilder->expr()->literal('1')
+                        $expression = $queryBuilder->expr()->or(
+                            $queryBuilder->expr()->eq(
+                                $tableAlias.'.'.$filter->getField(),
+                                $queryBuilder->expr()->literal('0')
+                            ),
+                            $queryBuilder->expr()->isNull($tableAlias.'.'.$filter->getField())
                         );
                     }
                     // Boolean = YES (true) means exactly 1

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
@@ -564,4 +564,161 @@ final class SegmentOperatorQuerySubscriberTest extends TestCase
 
         $this->assertTrue($event->wasOperatorHandled());
     }
+
+    public function testOnBooleanEqualsOperatorIfNotEqOperator(): void
+    {
+        $event = new SegmentOperatorQueryBuilderEvent(
+            $this->queryBuilder,
+            $this->contactSegmentFilter,
+            'paramenter_holder_1'
+        );
+
+        $this->contactSegmentFilter->method('getOperator')
+            ->willReturn('neq');
+
+        $this->subscriber->onBooleanEqualsOperator($event);
+
+        $this->assertFalse($event->wasOperatorHandled());
+    }
+
+    public function testOnBooleanEqualsOperatorIfNotBooleanField(): void
+    {
+        $event = new SegmentOperatorQueryBuilderEvent(
+            $this->queryBuilder,
+            $this->contactSegmentFilter,
+            'paramenter_holder_1'
+        );
+
+        $this->contactSegmentFilter->method('getOperator')
+            ->willReturn('eq');
+
+        $this->contactSegmentFilter->method('isColumnTypeBoolean')
+            ->willReturn(false);
+
+        $this->subscriber->onBooleanEqualsOperator($event);
+
+        $this->assertFalse($event->wasOperatorHandled());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataBooleanEqualsOperator')]
+    public function testOnBooleanEqualsOperator(mixed $parameterValue, string $expectedOperator, string $expectedValue): void
+    {
+        $event = new SegmentOperatorQueryBuilderEvent(
+            $this->queryBuilder,
+            $this->contactSegmentFilter,
+            'paramenter_holder_1'
+        );
+
+        $this->contactSegmentFilter->method('getField')
+            ->willReturn('is_active');
+
+        $this->contactSegmentFilter->method('getOperator')
+            ->willReturn('eq');
+
+        $this->contactSegmentFilter->method('getParameterValue')
+            ->willReturn($parameterValue);
+
+        $this->contactSegmentFilter->method('isColumnTypeBoolean')
+            ->willReturn(true);
+
+        $this->contactSegmentFilter->method('getGlue')
+            ->willReturn(CompositeExpression::TYPE_AND);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('addLogic')
+            ->with(
+                $this->anything(),
+                CompositeExpression::TYPE_AND
+            );
+
+        $this->expressionBuilder->expects($this->once())
+            ->method($expectedOperator)
+            ->with('l.is_active', "'1'");
+
+        $this->expressionBuilder->expects($this->once())
+            ->method('literal')
+            ->with('1')
+            ->willReturn("'1'");
+
+        $this->subscriber->onBooleanEqualsOperator($event);
+
+        $this->assertTrue($event->wasOperatorHandled());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public static function dataBooleanEqualsOperator(): iterable
+    {
+        // Boolean = YES (true/1/'1') should generate: field = '1'
+        yield 'true value' => [true, 'eq', '1'];
+        yield '1 value' => [1, 'eq', '1'];
+        yield 'string 1 value' => ['1', 'eq', '1'];
+
+        // Boolean = NO (false/0/'0') should generate: field <> '1' (includes NULL and 0)
+        yield 'false value' => [false, 'neq', '1'];
+        yield '0 value' => [0, 'neq', '1'];
+        yield 'string 0 value' => ['0', 'neq', '1'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataBooleanNeqOperator')]
+    public function testOnNegativeOperatorsWithBooleanField(mixed $parameterValue, string $expectedOperator, string $expectedValue): void
+    {
+        $event = new SegmentOperatorQueryBuilderEvent(
+            $this->queryBuilder,
+            $this->contactSegmentFilter,
+            'paramenter_holder_1'
+        );
+
+        $this->contactSegmentFilter->method('getField')
+            ->willReturn('is_active');
+
+        $this->contactSegmentFilter->method('getOperator')
+            ->willReturn('neq');
+
+        $this->contactSegmentFilter->method('getParameterValue')
+            ->willReturn($parameterValue);
+
+        $this->contactSegmentFilter->method('isColumnTypeBoolean')
+            ->willReturn(true);
+
+        $this->contactSegmentFilter->method('getGlue')
+            ->willReturn(CompositeExpression::TYPE_AND);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('addLogic')
+            ->with(
+                $this->anything(),
+                CompositeExpression::TYPE_AND
+            );
+
+        $this->expressionBuilder->expects($this->once())
+            ->method($expectedOperator)
+            ->with('l.is_active', "'1'");
+
+        $this->expressionBuilder->expects($this->once())
+            ->method('literal')
+            ->with('1')
+            ->willReturn("'1'");
+
+        $this->subscriber->onNegativeOperators($event);
+
+        $this->assertTrue($event->wasOperatorHandled());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public static function dataBooleanNeqOperator(): iterable
+    {
+        // Boolean != YES (true/1/'1') should generate: field <> '1' (includes NULL and 0)
+        yield 'not true value' => [true, 'neq', '1'];
+        yield 'not 1 value' => [1, 'neq', '1'];
+        yield 'not string 1 value' => ['1', 'neq', '1'];
+
+        // Boolean != NO (false/0/'0') should generate: field = '1' (only exactly 1)
+        yield 'not false value' => [false, 'eq', '1'];
+        yield 'not 0 value' => [0, 'eq', '1'];
+        yield 'not string 0 value' => ['0', 'eq', '1'];
+    }
 }


### PR DESCRIPTION
## What's Fixed? 🐛

Boolean field filters in contact and company segments now correctly handle NULL values. Previously, filtering for "NO" wouldn't include NULL values, even though NULL logically means "not answered" or "not set".

## The Problem

When you filtered contacts by a boolean field:
- **Boolean = NO** would skip NULL values  
- Users expected NULL to mean "not answered" = "not YES"
- This caused incomplete segment results

## The Solution  

We now use simplified YES/NOT-YES logic:
- **Boolean = YES** → Only records with value 1
- **Boolean = NO** → All records that are NOT 1 (includes 0 and NULL)
- **Boolean != YES** → All records that are NOT 1 (includes 0 and NULL)
- **Boolean != NO** → Only records with value 1

**"NO" means "not 1"** ✅

## What Changed

✅ Fixed boolean field handling in segment filters
✅ Applied same logic to both contact and company fields  
✅ Code quality improvements using InputHelper::boolean()

## How to Test

1. Create a boolean custom field
2. Add test records with NULL, 0, and 1 values
3. Create segments and verify filter results:
   - **Field = YES** → shows only 1 values
   - **Field = NO** → shows 0 and NULL values
   - **Field != YES** → shows 0 and NULL values
   - **Field != NO** → shows only 1 values