### PR TITLE
Fix an error when saving a Custom Field of type Select Multiple Choices

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
@@ -159,13 +159,13 @@ class ColumnSchemaHelper
      * @throws SchemaException
      * @throws \OutOfRangeException
      */
-    public function updateColumnLength(string $column, int $length): ColumnSchemaHelper
+    public function updateColumnLength(string $column, ?int $length): ColumnSchemaHelper
     {
         if (empty($column)) {
             throw new SchemaException('The column name is should not be empty/missing.');
         }
 
-        if ($length < 1 || $length > LeadField::MAX_VARCHAR_LENGTH) {
+        if (null !== $length && ($length < 1 || $length > LeadField::MAX_VARCHAR_LENGTH)) {
             throw new \OutOfRangeException('Column length should be between 1 and 191.');
         }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
 {
@@ -25,22 +26,28 @@ class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
         $this->schemaHelper = $this->getContainer()->get('mautic.schema.helper.column');
     }
 
-    public function testUpdateColumnSchemaLengthSuccessfully(): void
+    #[DataProvider('provideColumnLength')]
+    public function testUpdateColumnSchemaLengthSuccessfully(?int $length): void
     {
-        $newLength = 100;
-        $this->schemaHelper->updateColumnLength($this->field->getAlias(), $newLength);
+        $this->schemaHelper->updateColumnLength($this->field->getAlias(), $length);
 
         $column = $this->schemaHelper->getColumns()[$this->field->getAlias()];
         \assert($column instanceof Column);
 
-        $this->assertEquals($newLength, $column->getLength(), 'Column length updated.');
+        $this->assertEquals($length, $column->getLength(), 'Column length updated.');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateColumnExceptionCheck')]
-    public function testUpdateColumnLengthThrowsException(string $column, int $len, string $message): void
+    #[DataProvider('dataUpdateColumnExceptionCheck')]
+    public function testUpdateColumnLengthThrowsException(string $column, ?int $len, string $message): void
     {
         $this->expectExceptionMessageMatches($message);
         $this->schemaHelper->updateColumnLength($column, $len);
+    }
+
+    public static function provideColumnLength(): \Generator
+    {
+        yield 'null' => [null];
+        yield '100' => [100];
     }
 
     /**
@@ -50,7 +57,11 @@ class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
     {
         // name, length, exception msg.
         yield 'Column name missing.' => ['', 10, '/The column name is should not be empty\/missing./'];
+        yield 'Column name missing, when length is unknown' => ['', null, '/The column name is should not be empty\/missing./'];
+
         yield 'Column name does not exist.' => ['does_not_exists', 10, '/There is no column with name "does_not_exists" on table/'];
+        yield 'Column name does not exist, when length is unknown' => ['does_not_exists', null, '/There is no column with name "does_not_exists" on table/'];
+
         yield 'Out of range, when length is 0.' => ['custom_field_test', 0, '/Column length should be between 1 and 191./'];
         yield 'Out of range, when length greater than 191.' => ['custom_field_test', 195, '/Column length should be between 1 and 191./'];
     }

--- a/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Field\Exception\CustomFieldLimitException;
 use Mautic\LeadBundle\Field\LeadFieldSaver;
 use Mautic\LeadBundle\Field\SchemaDefinition;
 use Monolog\Logger;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -514,7 +515,8 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
         $customFieldColumn->updateLeadColumn($leadField);
     }
 
-    public function testUpdateLeadColumnNow(): void
+    #[DataProvider('provideColumnLength')]
+    public function testUpdateLeadColumnNow(?int $length): void
     {
         $columnSchemaHelper    = $this->createMock(ColumnSchemaHelper::class);
         $schemaDefinition      = $this->createMock(SchemaDefinition::class);
@@ -530,6 +532,7 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
         $leadField->setId(42);
         $leadField->setObject('lead');
         $leadField->setAlias('IamAlias');
+        $leadField->setCharLengthLimit($length);
 
         $fieldColumnDispatcher->expects($this->once())
             ->method('dispatchPreUpdateColumnEvent')
@@ -542,13 +545,14 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
 
         $columnSchemaHelper->expects($this->once())
             ->method('updateColumnLength')
-            ->with('IamAlias', 64)
+            ->with('IamAlias', $length)
             ->willReturn($columnSchemaHelper);
 
         $customFieldColumn->updateLeadColumn($leadField);
     }
 
-    public function testProcessUpdateLeadColumnLength(): void
+    #[DataProvider('provideColumnLength')]
+    public function testProcessUpdateLeadColumnLength(?int $length): void
     {
         $columnSchemaHelper    = $this->createMock(ColumnSchemaHelper::class);
         $schemaDefinition      = $this->createMock(SchemaDefinition::class);
@@ -564,6 +568,7 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
         $leadField->setId(42);
         $leadField->setObject('lead');
         $leadField->setAlias('IamAlias');
+        $leadField->setCharLengthLimit($length);
 
         $columnSchemaHelper->expects($this->once())
             ->method('setName')
@@ -572,12 +577,18 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
 
         $columnSchemaHelper->expects($this->once())
             ->method('updateColumnLength')
-            ->with('IamAlias', 64)
+            ->with('IamAlias', $length)
             ->willReturn($columnSchemaHelper);
 
         $columnSchemaHelper->expects($this->once())
             ->method('executeChanges');
 
         $customFieldColumn->processUpdateLeadColumnLength($leadField);
+    }
+
+    public static function provideColumnLength(): \Generator
+    {
+        yield 'null' => [null];
+        yield '100' => [100];
     }
 }


### PR DESCRIPTION
# Summary

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #15589

# Description

It looks like the `charLengthLimit` property for a Custom Field of type `Select: Multiple Choices` is `null`.

The method:

```php
\Mautic\LeadBundle\Entity\LeadField::getCharLengthLimit()
```

might return `null` that is passed to method:

```php
\Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper::updateColumnLength()
```

as 2nd argument, however `null` for that argument was not accepted. So the most natural way was to allow for nulls as 2nd argument.

I hope this solution is acceptable.

<details>
<summary>The error</summary>

## The error

> Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper::updateColumnLength(): Argument #2 ($length) must be of type int, null given, called in /var/www/html/app/bundles/LeadBundle/Field/CustomFieldColumn.php on line 173

<img width="1394" height="1196" alt="Screenshot 2025-10-23 at 21 44 48" src="https://github.com/user-attachments/assets/39f51859-578c-41a0-bee8-1dc6d077713a" />

</details>

# 📋 Steps to test this PR

1. Click the `gear` icon in top right corner
2. Select `Custom Field` menu item
3. Click the `New` blue button
4. Enter any `Label`
5. Select `Select: Multiple Choices` as `Data Type`
6. Add at least 2 `Options`
7. Click the `Save & Close` blue button

## Expected

The new Custom Field is saved without any error

## See the attached video

https://github.com/user-attachments/assets/19b2ce40-4734-4b80-b16f-7fe9a6523488