### PR TITLE
Fix alignment of buttons in Project popover on Campaigns list

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -11315,6 +11315,9 @@ code:hover > .copy-icon {
   display: flex;
   flex-direction: column;
 }
+.project-popover__actions .btn ~ .btn {
+  margin-left: 0;
+}
 .modal.fade .modal-dialog {
   -webkit-transform: scale(0.95);
   -ms-transform: scale(0.95);

--- a/app/bundles/CoreBundle/Assets/css/app/less/custom.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/custom.less
@@ -627,6 +627,12 @@ code:hover > .copy-icon {
 .project-popover__actions {
   display: flex;
   flex-direction: column;
+
+  .btn {
+    & ~ .btn {
+      margin-left: 0;
+    }
+  }
 }
 
 .modal.fade .modal-dialog {


### PR DESCRIPTION
# Summary

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | n/a
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #15579

# Description
The buttons in the popover were misaligned due to CSS styles required when buttons are placed horizontally, one after another. This issue can occur in other parts of the application when buttons are placed vertically (other popovers?). I have resolved this globally for the Project popover.

Please see a comparison 👇

| Before | After |
| - | - |
| <img width="1338" height="936" alt="Screenshot 2025-10-22 at 20 59 07" src="https://github.com/user-attachments/assets/7a81c94e-f372-4803-9ba9-94a6d375353a" /> | <img width="1338" height="936" alt="Screenshot 2025-10-22 at 20 58 34" src="https://github.com/user-attachments/assets/1fc7ee17-7718-4c4c-91b3-256a2c74575f" /> |

# 📋 Steps to test this PR:

1. Create a campaign and save
2. Add a project to the campaign
3. Go to projects list and hover over the name of the project associated with the campaign.