### PR TITLE
Fixing Campaign API  PUT

### DIFF
--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -183,7 +183,7 @@ class CampaignApiController extends CommonApiController
 
             foreach ($entity->getEvents() as $currentEvent) {
                 if (!in_array($currentEvent->getId(), $requestEventIds)) {
-                    $deletedEvents[] = $currentEvent->getId();
+                    $deletedEvents[] = ['id' => $currentEvent->getId()];
                 }
             }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Api;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\LeadList;
+
+final class CampaignApiEventDeleteTest extends MauticMysqlTestCase
+{
+    public function testEventAndSourceDeleteViaPutReproducesApiBug(): void
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test Campaign');
+
+        $segment = new LeadList();
+        $segment->setName('Test');
+        $segment->setPublicName('Test');
+        $segment->setAlias('test');
+
+        // Create events
+        $event1 = new Event();
+        $event1->setName('Event 1');
+        $event1->setType('email.send');
+        $event1->setEventType('action');
+        $event1->setCampaign($campaign);
+
+        $event2 = new Event();
+        $event2->setName('Event 2');
+        $event2->setType('lead.changescore');
+        $event2->setEventType('action');
+        $event2->setCampaign($campaign);
+
+        $campaign->addEvent('event1', $event1);
+        $campaign->addEvent('event2', $event2);
+        $campaign->addList($segment);
+
+        $this->em->persist($segment);
+        $this->em->persist($event1);
+        $this->em->persist($event2);
+        $this->em->persist($campaign);
+        $this->em->flush();
+        $this->assertGreaterThan(0, $campaign->getId(), 'Campaign should be saved with an ID');
+        $this->client->request('GET', '/api/campaigns');
+        $this->assertResponseIsSuccessful();
+
+        // Step 1: GET the campaign (like API Library test does)
+        $this->client->request('GET', "/api/campaigns/{$campaign->getId()}");
+        $this->assertResponseIsSuccessful();
+
+        $data   = json_decode($this->client->getResponse()->getContent(), true);
+        $events = $data['campaign']['events'];
+
+        // Step 2: Remove last event with array_pop (exactly like API Library test)
+        array_pop($events);
+
+        // Step 3: PUT request to update campaign (this triggers the SQL error)
+        $payload = [
+            'name'   => $campaign->getName(),
+            'events' => $events,
+            'lists'  => [['id' => $segment->getId()]],
+        ];
+
+        $this->client->request('PUT', "/api/campaigns/{$campaign->getId()}/edit", $payload);
+        $this->assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/pull/15528

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

When https://github.com/mautic/mautic/pull/15528 was merged the [API Library tests](https://github.com/mautic/api-library/blob/9093806f8ce18c747e647f65dcf8c7120c65ffde/tests/Api/CampaignsTest.php#L322) started to fail:
```
1) Mautic\Tests\Api\CampaignsTest::testEventAndSourceDeleteViaPut
The response has unexpected status code (500).

Response: {"errors":[{"message":"Looks like I encountered an error (error #500). If I do it again, please report me to the system administrator!","code":500,"type":null}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:349
```

The issue in the logs was:
```
mautic.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\SyntaxErrorException: "An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1" at /var/www/html/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php line 86 {"exception":"[object] (Doctrine\\DBAL\\Exception\\SyntaxErrorException(code: 1064): An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1 at /var/www/html/vendor/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php:86)
```

I was able to recreate the issue with a new functional test in this repository and found that it was an issue of an array format. So the fix was a one-liner.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. I'd say that if the CI executes the new test successfully and if the API Library tests are passing with this PR then we are good to merge.
3. But if you'd want to be super diligent and test manually then the issue can be reproduced if you create a campaign with at least 2 events and then create a PUT API request that will contain only 1 of the 2 events. The PUT method should delete the one that is not present in the API request and that's what triggered the SQL error.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->