### PR TITLE
Fix formatting of Salesforce error message in translations

### DIFF
--- a/plugins/MauticCrmBundle/Translations/en_US/messages.ini
+++ b/plugins/MauticCrmBundle/Translations/en_US/messages.ini
@@ -81,9 +81,7 @@ mautic.salesforce.form.activity_included_events="Events to include in the activi
 mautic.salesforce.form.activity.events.tooltip="Select the events that will be sent to the integration as activity."
 mautic.connectwise.activity.name="Activity Name"
 mautic.salesforce.error.opt-out_permission.header = "Incorrect Salesforce permissions."
-mautic.salesforce.error.opt-out_permission.message = 'It appears you have not configured your Salesforce permissions correctly.<br/>
-<a href = "https://help.salesforce.com/articleView?id=000214338&language=en_US&type=1" target="_blank">Click here to learn more.</a>'
-mautic.plugin.integration.campaigns.connectwise.activity.type="Activity Type"
+mautic.salesforce.error.opt-out_permission.message = "It appears you have not configured your Salesforce permissions correctly.<br/><a href = \"https://help.salesforce.com/articleView?id=000214338&language=en_US&type=1\" target=\"_blank\">Click here to learn more.</a>"mautic.plugin.integration.campaigns.connectwise.activity.type="Activity Type"
 mautic.plugin.integration.campaigns.connectwise.members="Assign to member"
 mautic.plugin.config.push.activities="Push contact activities"
 mautic.plugin.config.integration.restart="Restart integration"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/15611

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
double quotes were not escaped in HTML