### PR TITLE
[MTC-8579] remove ct param from redirect

### DIFF
--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -503,6 +503,7 @@ class PublicController extends AbstractFormController
         $query = $request->query->all();
 
         $ct = $query['ct'] ?? null;
+        unset($query['ct']);
 
         // Tak on anything left to the URL
         if (count($query)) {

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -415,7 +415,7 @@ class PublicControllerTest extends MauticMysqlTestCase
             $this->logger,
             $redirectId
         );
-        self::assertSame('https://someurl.test/?ct=someClickTroughValue', $response->getTargetUrl());
+        self::assertSame('https://someurl.test/', $response->getTargetUrl());
     }
 
     /**
@@ -426,7 +426,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         $redirectId   = 'dummy_redirect_id';
         $clickThrough = 'dummy_click_through';
         $redirectUrl  = 'https://some.test.url/asset/1:examplefilejpg';
-        $targetUrl    = 'https://some.test.url/asset/1:examplefilejpg?ct=dummy_click_through%3Fct%3Ddummy_click_through';
+        $targetUrl    = 'https://some.test.url/asset/1:examplefilejpg?ct=dummy_click_through';
 
         $this->redirectModel->expects(self::once())
             ->method('getRedirectById')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #14272 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR fixes issue with ct parameter added after redirect: https://github.com/mautic/mautic/issues/14272

I didn't find any reason for the `ct` parameter to be persisted when a contact is redirected from Mautic. It may cause problems with some external pages, as described in the issue.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new segment
3. Create a new contact, add contact to segment
4. Create a new segment email
5. Open the Builder and add a link to your webpage
6. Save email and sent to contact
7. Open email and click on the link
8. Check contact history and see that the pagehit 
9. Check that the URL does not contain tracking parameter “ct=”

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->