### PR TITLE
Updating guzzlehttp/oauth-subscribe and https://github.com/joomla-framework/filter due to security

### DIFF
--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -47,7 +47,7 @@ class InputHelper
         if (empty(self::$htmlFilter)) {
             // Most of Mautic's HTML uses include full HTML documents so use blacklist method
             self::$htmlFilter               = new InputFilter([], [], 1, 1);
-            self::$htmlFilter->tagBlacklist = [
+            self::$htmlFilter->blockedTags  = [
                 'applet',
                 'bgsound',
                 'base',
@@ -60,7 +60,7 @@ class InputHelper
                 'object',
             ];
 
-            self::$htmlFilter->attrBlacklist = [
+            self::$htmlFilter->blockedAttributes = [
                 'codebase',
                 'dynsrc',
                 'lowsrc',
@@ -78,7 +78,7 @@ class InputHelper
                     'span',
                 ], [], 0, 1);
 
-            self::$strictHtmlFilter->attrBlacklist = [
+            self::$strictHtmlFilter->blockedAttributes = [
                 'codebase',
                 'dynsrc',
                 'lowsrc',

--- a/app/composer.json
+++ b/app/composer.json
@@ -52,7 +52,7 @@
     "javer/sp-bundle": "^2.0",
     "jbroadway/urlify": "^1.0",
     "jms/serializer-bundle": "^5.4",
-    "joomla/filter": "~1.4.4",
+    "joomla/filter": "~3.0.5",
     "kamermans/guzzle-oauth2-subscriber": "^1.0",
     "klapaudius/oauth-server-bundle": "5.1.3",
     "knplabs/gaufrette": "~0.9.0",

--- a/app/composer.json
+++ b/app/composer.json
@@ -45,7 +45,7 @@
     "geoip2/geoip2": "~2.0",
     "giggsey/libphonenumber-for-php": "^8.12",
     "guzzlehttp/guzzle": "^7.6",
-    "guzzlehttp/oauth-subscriber": "^0.6.0",
+    "guzzlehttp/oauth-subscriber": "^0.8.0",
     "helios-ag/fm-elfinder-bundle": "^12.3",
     "illuminate/collections": "^10.48",
     "ip2location/ip2location-php": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4937,26 +4937,28 @@
         },
         {
             "name": "joomla/filter",
-            "version": "1.4.4",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filter.git",
-                "reference": "09733d70db6c6d91e53e0e0d0fcde9b8638175c4"
+                "reference": "06c9e672d15099622dbb56c8e2a7461ce26d37f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/09733d70db6c6d91e53e0e0d0fcde9b8638175c4",
-                "reference": "09733d70db6c6d91e53e0e0d0fcde9b8638175c4",
+                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/06c9e672d15099622dbb56c8e2a7461ce26d37f6",
+                "reference": "06c9e672d15099622dbb56c8e2a7461ce26d37f6",
                 "shasum": ""
             },
             "require": {
-                "joomla/string": "~1.3|~2.0",
-                "php": "^5.3.10|~7.0|^8.0"
+                "joomla/string": "^3.0",
+                "php": "^8.1.0"
             },
             "require-dev": {
-                "joomla/coding-standards": "~2.0@alpha",
-                "joomla/language": "~1.3",
-                "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
+                "joomla/language": "^3.0",
+                "phpstan/phpstan": "1.12.27",
+                "phpstan/phpstan-deprecation-rules": "1.2.1",
+                "phpunit/phpunit": "^9.5.28",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "suggest": {
                 "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
@@ -4964,7 +4966,8 @@
             "type": "joomla-package",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-2.0-dev": "2.0-dev",
+                    "dev-3.x-dev": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4985,49 +4988,48 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/filter/issues",
-                "source": "https://github.com/joomla-framework/filter/tree/1.4.4"
+                "source": "https://github.com/joomla-framework/filter/tree/3.0.5"
             },
-            "funding": [
-                {
-                    "url": "https://community.joomla.org/sponsorship-campaigns.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/joomla",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-03-29T12:14:25+00:00"
+            "time": "2025-09-30T15:42:09+00:00"
         },
         {
             "name": "joomla/string",
-            "version": "1.4.6",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/string.git",
-                "reference": "728ba9e39a8f1bd15b75ab878f57fa505184b8ab"
+                "reference": "0b3d33564db389e27346f7e275c694897c939434"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/728ba9e39a8f1bd15b75ab878f57fa505184b8ab",
-                "reference": "728ba9e39a8f1bd15b75ab878f57fa505184b8ab",
+                "url": "https://api.github.com/repos/joomla-framework/string/zipball/0b3d33564db389e27346f7e275c694897c939434",
+                "reference": "0b3d33564db389e27346f7e275c694897c939434",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.10|^7.0|^8.0"
+                "php": "^8.1.0",
+                "symfony/deprecation-contracts": "^2|^3"
+            },
+            "conflict": {
+                "doctrine/inflector": "<1.2"
             },
             "require-dev": {
-                "joomla/coding-standards": "^2.0@alpha",
-                "joomla/test": "^1.0",
-                "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0|^7.0|^8.0"
+                "doctrine/inflector": "^1.2",
+                "joomla/test": "^3.0",
+                "phpstan/phpstan": "1.12.27",
+                "phpstan/phpstan-deprecation-rules": "1.2.1",
+                "phpunit/phpunit": "^9.5.28",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "suggest": {
+                "doctrine/inflector": "To use the string inflector",
                 "ext-mbstring": "For improved processing"
             },
             "type": "joomla-package",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-2.0-dev": "2.0-dev",
+                    "dev-3.x-dev": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5065,19 +5067,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/string/issues",
-                "source": "https://github.com/joomla-framework/string/tree/1.4.6"
+                "source": "https://github.com/joomla-framework/string/tree/3.0.4"
             },
-            "funding": [
-                {
-                    "url": "https://community.joomla.org/sponsorship-campaigns.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/joomla",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-01-25T15:16:52+00:00"
+            "time": "2025-07-19T15:25:56+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -6160,7 +6152,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "990861e2170d635c793d437e02f4b4b628029bb6"
+                "reference": "2f385c2e07fc61e2a8a5bfc3621d7b31412a2d5b"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6197,7 +6189,7 @@
                 "javer/sp-bundle": "^2.0",
                 "jbroadway/urlify": "^1.0",
                 "jms/serializer-bundle": "^5.4",
-                "joomla/filter": "~1.4.4",
+                "joomla/filter": "~3.0.5",
                 "kamermans/guzzle-oauth2-subscriber": "^1.0",
                 "klapaudius/oauth-server-bundle": "5.1.3",
                 "knplabs/gaufrette": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -3731,33 +3731,35 @@
         },
         {
             "name": "guzzlehttp/oauth-subscriber",
-            "version": "0.6.0",
+            "version": "0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/oauth-subscriber.git",
-                "reference": "8d6cab29f8397e5712d00a383eeead36108a3c1f"
+                "reference": "92b619b03bd21396e51c62e6bce83467d2ce8f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/oauth-subscriber/zipball/8d6cab29f8397e5712d00a383eeead36108a3c1f",
-                "reference": "8d6cab29f8397e5712d00a383eeead36108a3c1f",
+                "url": "https://api.github.com/repos/guzzle/oauth-subscriber/zipball/92b619b03bd21396e51c62e6bce83467d2ce8f53",
+                "reference": "92b619b03bd21396e51c62e6bce83467d2ce8f53",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^6.5|^7.2",
-                "guzzlehttp/psr7": "^1.7|^2.0",
-                "php": ">=5.5.0"
+                "guzzlehttp/guzzle": "^7.9",
+                "guzzlehttp/psr7": "^2.7",
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|^9.3.3"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "suggest": {
                 "ext-openssl": "Required to sign using RSA-SHA1"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "0.6-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
@@ -3771,22 +3773,50 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
                 }
             ],
             "description": "Guzzle OAuth 1.0 subscriber",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "Guzzle",
                 "oauth"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/oauth-subscriber/issues",
-                "source": "https://github.com/guzzle/oauth-subscriber/tree/0.6.0"
+                "source": "https://github.com/guzzle/oauth-subscriber/tree/0.8.1"
             },
-            "time": "2021-07-13T12:01:32+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/oauth-subscriber",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-06T19:15:59+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -6130,7 +6160,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "cbe507843402a9a06eee4e09d65cf471304411c8"
+                "reference": "990861e2170d635c793d437e02f4b4b628029bb6"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6160,7 +6190,7 @@
                 "geoip2/geoip2": "~2.0",
                 "giggsey/libphonenumber-for-php": "^8.12",
                 "guzzlehttp/guzzle": "^7.6",
-                "guzzlehttp/oauth-subscriber": "^0.6.0",
+                "guzzlehttp/oauth-subscriber": "^0.8.0",
                 "helios-ag/fm-elfinder-bundle": "^12.3",
                 "illuminate/collections": "^10.48",
                 "ip2location/ip2location-php": "^7.2",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR is updating the [guzzlehttp/oauth-subscribe](https://github.com/guzzle/oauth-subscriber) package to the latest version as the GH Actions started to fail today for all PRs on the Composer Installation step with
```
  Problem 1
    - Root composer.json requires mautic/core-lib * -> satisfiable by mautic/core-lib[7.x-dev].
    - mautic/core-lib 7.x-dev requires guzzlehttp/oauth-subscriber ^0.6.0 -> found guzzlehttp/oauth-subscriber[dev-master, 0.6.0, 0.6.x-dev] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-pg71-gz29-h5sq") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
  Problem 2
    - Root composer.json requires mautic/theme-reachout * -> satisfiable by mautic/theme-reachout[dev-ff6e4393fb6df8b80386d64a578213317928e1af, 7.x-dev].
    - mautic/core-lib 7.x-dev requires guzzlehttp/oauth-subscriber ^0.6.0 -> found guzzlehttp/oauth-subscriber[dev-master, 0.6.0, 0.6.x-dev] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-pg71-gz29-h5sq") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
    - mautic/theme-reachout[dev-ff6e4393fb6df8b80386d64a578213317928e1af, 7.x-dev] require mautic/core-lib >=7.0 -> satisfiable by mautic/core-lib[7.x-dev].
```

Once I upgraded that package I got the same issue with [joomla/filter](https://github.com/joomla-framework/filter):
```
  Problem 1
    - Root composer.json requires mautic/core-lib * -> satisfiable by mautic/core-lib[7.x-dev].
    - mautic/core-lib 7.x-dev requires joomla/filter ~1.4.4 -> found joomla/filter[1.4.4, 1.4.5, 1.4.6, 1.4.7] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-5x9t-bkbj-vmgp") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
  Problem 2
    - Root composer.json requires mautic/theme-reachout * -> satisfiable by mautic/theme-reachout[dev-20a90cb334b8c28e54c93a459f83a331acab843b, 7.x-dev].
    - mautic/core-lib 7.x-dev requires joomla/filter ~1.4.4 -> found joomla/filter[1.4.4, 1.4.5, 1.4.6, 1.4.7] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-5x9t-bkbj-vmgp") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
    - mautic/theme-reachout[dev-20a90cb334b8c28e54c93a459f83a331acab843b, 7.x-dev] require mautic/core-lib >=7.0 -> satisfiable by mautic/core-lib[7.x-dev].
 ```

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. The package affects oAuth1a. It's used in the Integrations bundle and I think there still aren't any publicly available plugins using that so this can be tested only by someone with a custom integration. However, as this required only a minor version update of the dependency there should be no breaking changes and we should be fine to merge once CI is green.
3. The joomla/filter package is used to sanitize input from HTTP requests on many places. We have quite good test coverage of it so again, if the CI is green we should be good.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->