### PR TITLE
fix(Lead): Remove unsubscribe header from direct contact emails

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1479,6 +1479,7 @@ class LeadController extends FormController
                         }
 
                         // Set Content
+                        $mailer->setEmailType(MailHelper::EMAIL_TYPE_TRANSACTIONAL);
                         $mailer->setReplyTo($email['from']);
                         $mailer->setBody($email['body']);
                         $mailer->parsePlainText($email['body']);

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
@@ -64,5 +64,8 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
         Assert::assertStringContainsString('admin@test-beta.mautibot.com', $message->getFrom()[0]->getAddress());
         Assert::assertStringContainsString('Admin', $message->getFrom()[0]->getName());
         Assert::assertStringNotContainsString('This should be overwritten by the form content', $email);
+
+        Assert::assertFalse($message->getHeaders()->has('List-Unsubscribe'));
+        Assert::assertFalse($message->getHeaders()->has('List-Unsubscribe-Post'));
     }
 }


### PR DESCRIPTION
Ensures that emails sent directly to a contact via the "Send Email" action are correctly marked as transactional. This prevents the automatic addition of a `List-Unsubscribe` header, which is inappropriate for one-to-one communication. A functional test has been updated to assert that this header is not present.
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This pull request fixes an issue where emails sent directly to a contact from their profile page were being treated as marketing emails, incorrectly including a `List-Unsubscribe` header.

The fix explicitly sets the email type to `transactional` in the `LeadController`, which prevents the unsubscribe header from being added to this type of one-to-one communication.

The corresponding functional test has been updated to assert that the `List-Unsubscribe` and `List-Unsubscribe-Post` headers are not present in the sent email.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to a contact's profile page.
3. From the dropdown menu on the top right, select "Send email".
4. Fill in a subject and a message, then click "Send".
5. Check the email that was sent (e.g., using Mailpit, which is available in DDEV at `https://<project-name>.ddev.site:8026`).
6. View the source of the email and verify that it **does not** contain a `List-Unsubscribe` or `List-Unsubscribe-Post` header.