### PR TITLE
Fix form theme template lookup support for style.html.twig

### DIFF
--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -420,12 +420,11 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         $styleToRender = '@MauticForm/Builder/_style.html.twig';
         $formToRender  = '@MauticForm/Builder/form.html.twig';
 
-        if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/_style.html.twig')) {
-            $styleToRender = '@themes/'.$theme.'/html/MauticFormBundle/Builder/_style.html.twig';
-        }
-
-        if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/style.html.twig')) {
-            $styleToRender = '@themes/'.$theme.'/html/MauticFormBundle/Builder/style.html.twig';
+        foreach (['_style', 'style'] as $styleFile) {
+            $stylePath = "@themes/{$theme}/html/MauticFormBundle/Builder/{$styleFile}.html.twig";
+            if ($this->twig->getLoader()->exists($stylePath)) {
+                $styleToRender = $stylePath;
+            }
         }
 
         if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/form.html.twig')) {

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -423,6 +423,11 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/_style.html.twig')) {
             $styleToRender = '@themes/'.$theme.'/html/MauticFormBundle/Builder/_style.html.twig';
         }
+
+        if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/style.html.twig')) {
+            $styleToRender = '@themes/'.$theme.'/html/MauticFormBundle/Builder/style.html.twig';
+        }
+
         if ($this->twig->getLoader()->exists('@themes/'.$theme.'/html/MauticFormBundle/Builder/form.html.twig')) {
             $formToRender = '@themes/'.$theme.'/html/MauticFormBundle/Builder/form.html.twig';
         }


### PR DESCRIPTION
## Summary
This PR adds support for the simplified `style.html.twig` template filename in form themes, following the same pattern as existing template lookups. This allows themes to use either the legacy `_style.html.twig` or the cleaner `style.html.twig` naming convention.

### Changes Made:
- Added template lookup for `style.html.twig` in FormModel.php
- Maintains backward compatibility with existing `_style.html.twig` templates
- Follows existing pattern used for other template lookups

## Test plan
- [ ] Create a custom theme with a `style.html.twig` file in `themes/[theme-name]/html/MauticFormBundle/Builder/`
- [ ] Configure a form to use this theme
- [ ] Verify that the style template is properly loaded and applied
- [ ] Test that existing themes with `_style.html.twig` continue to work