### PR TITLE
Refactor: Add native return type to AjaxLookupModelInterface::getLookupResults and add tests

### DIFF
--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -135,13 +135,7 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
         return self::$channels;
     }
 
-    /**
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
         switch ($type) {

--- a/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
+++ b/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
@@ -22,6 +22,7 @@ trait AjaxLookupControllerTrait
         $limit     = (int) $request->query->get('limit', '0');
         $start     = (int) $request->query->get('start', '0');
 
+
         if (!$modelName) {
             throw new BadRequestException('The searchKey parameter is required.');
         }

--- a/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
+++ b/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
@@ -22,7 +22,6 @@ trait AjaxLookupControllerTrait
         $limit     = (int) $request->query->get('limit', '0');
         $start     = (int) $request->query->get('start', '0');
 
-
         if (!$modelName) {
             throw new BadRequestException('The searchKey parameter is required.');
         }

--- a/app/bundles/CoreBundle/Model/AjaxLookupModelInterface.php
+++ b/app/bundles/CoreBundle/Model/AjaxLookupModelInterface.php
@@ -17,7 +17,7 @@ interface AjaxLookupModelInterface
      * @param string|array<int,string> $filter
      * @param array<string, mixed>     $options
      *
-     * @return array<string, array<int, string>>
+     * @return array<string, array<int, string>>|array<array<string, mixed>>
      */
     public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array;
 

--- a/app/bundles/CoreBundle/Model/AjaxLookupModelInterface.php
+++ b/app/bundles/CoreBundle/Model/AjaxLookupModelInterface.php
@@ -17,9 +17,9 @@ interface AjaxLookupModelInterface
      * @param string|array<int,string> $filter
      * @param array<string, mixed>     $options
      *
-     * @return mixed
+     * @return array<string, array<int, string>>
      */
-    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []);
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array;
 
     /**
      * @return CommonRepository<T>

--- a/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Controller;
 
+use Mautic\ChannelBundle\Entity\Channel;
+use Mautic\ChannelBundle\Entity\Message;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Company;
@@ -30,7 +32,6 @@ class AjaxLookupControllerTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $response = $this->client->getResponse();
-        $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('[{"text":"Test Company","value":"'.$company->getId().'"}]', $response->getContent());
     }
 
@@ -104,5 +105,36 @@ class AjaxLookupControllerTest extends MauticMysqlTestCase
         $this->assertCount(1, $content, 'Should return one group');
         $this->assertCount(1, $content[0]['items'], 'Should return only sms');
         $this->assertSame('Test Template Sms', $content[0]['items'][(string) $templateSms->getId()]);
+    }
+
+    public function testMessageLookupWithOptions(): void
+    {
+        $channel = new Channel();
+        $channel->setChannel('email');
+        $channel->setChannelId(12);
+        $channel->setIsEnabled(true);
+
+        $message = new Message();
+        $message->setName('API message 1');
+        $message->addChannel($channel);
+
+        $this->em->persist($channel);
+        $this->em->persist($message);
+        $this->em->flush();
+
+        $params = [
+            'action'       => 'channel:getLookupChoiceList',
+            'searchKey'    => 'channel.message',
+            'channel_message' => 'message',
+        ];
+
+        $this->client->request(Request::METHOD_GET, '/s/ajax', $params);
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->client->getResponse();
+        $content  = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $content, 'Should return only Message');
+        $this->assertSame('API message 1', $content[0]['text']);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\SmsBundle\Entity\Sms;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class AjaxLookupControllerTest extends MauticMysqlTestCase
+{
+    public function testCompanyLookupWithOptions(): void
+    {
+        $company = new Company();
+        $company->setName('Test Company');
+        $this->em->persist($company);
+        $this->em->flush();
+
+        $params = [
+            'action'       => 'lead:getLookupChoiceList',
+            'searchKey'    => 'lead.company',
+            'lead_company' => 'Test',
+        ];
+
+        $this->client->request(Request::METHOD_GET, '/s/ajax', $params);
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->client->getResponse();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('[{"text":"Test Company","value":"'.$company->getId().'"}]', $response->getContent());
+    }
+
+    public function testEmailLookupWithEmailTypeOption(): void
+    {
+        $templateEmail = new Email();
+        $templateEmail->setName('Test Template Email');
+        $templateEmail->setEmailType('template');
+        $templateEmail->setSubject('Test');
+        $templateEmail->setCustomHtml('test');
+
+        $listEmail = new Email();
+        $listEmail->setName('Test List Email');
+        $listEmail->setEmailType('list');
+        $listEmail->setSubject('Test');
+        $listEmail->setCustomHtml('test');
+
+        $this->em->persist($templateEmail);
+        $this->em->persist($listEmail);
+        $this->em->flush();
+
+        $params = [
+            'action'     => 'email:getLookupChoiceList',
+            'searchKey'  => 'email',
+            'email_type' => 'template',
+            'email'      => 'Test',
+        ];
+
+        $this->client->request(Request::METHOD_GET, '/s/ajax', $params);
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->client->getResponse();
+        $content  = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $content, 'Should return one group');
+        $this->assertCount(1, $content[0]['items'], 'Should return one email');
+        $this->assertSame('Test Template Email', $content[0]['items'][(string) $templateEmail->getId()]);
+    }
+
+    public function testSmsLookupWithEmailTypeOption(): void
+    {
+        $templateSms = new Sms();
+        $templateSms->setName('Test Template Sms');
+        $templateSms->setSmsType('template');
+        $templateSms->setMessage('Test');
+        $templateSms->setIsPublished(true);
+
+
+        $listSms = new Sms();
+        $listSms->setName('Test list Sms');
+        $listSms->setSmsType('list');
+        $listSms->setMessage('Test');
+        $listSms->setIsPublished(true);
+
+        $this->em->persist($templateSms);
+        $this->em->persist($listSms);
+        $this->em->flush();
+
+        $params = [
+            'action'    => 'sms:getLookupChoiceList',
+            'searchKey' => 'sms',
+            'sms_type'  => 'template',
+            'sms'       => 'sms',
+        ];
+
+        $this->client->request(Request::METHOD_GET, '/s/ajax', $params);
+        $this->assertResponseIsSuccessful();
+        $response = $this->client->getResponse();
+        $content  = json_decode($response->getContent(), true);
+
+        $this->assertCount(1, $content, 'Should return one group');
+        $this->assertCount(1, $content[0]['items'], 'Should return only sms');
+        $this->assertSame('Test Template Sms', $content[0]['items'][(string) $templateSms->getId()]);
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Controller/AjaxLookupControllerTest.php
@@ -10,7 +10,6 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\SmsBundle\Entity\Sms;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 class AjaxLookupControllerTest extends MauticMysqlTestCase
@@ -79,7 +78,6 @@ class AjaxLookupControllerTest extends MauticMysqlTestCase
         $templateSms->setMessage('Test');
         $templateSms->setIsPublished(true);
 
-
         $listSms = new Sms();
         $listSms->setName('Test list Sms');
         $listSms->setSmsType('list');
@@ -123,8 +121,8 @@ class AjaxLookupControllerTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $params = [
-            'action'       => 'channel:getLookupChoiceList',
-            'searchKey'    => 'channel.message',
+            'action'          => 'channel:getLookupChoiceList',
+            'searchKey'       => 'channel.message',
             'channel_message' => 'message',
         ];
 

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -305,15 +305,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
         return $chart->render();
     }
 
-    /**
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     *
-     * @return mixed[]
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
         switch ($type) {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2081,14 +2081,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         );
     }
 
-    /**
-     * @param string $type
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
         switch ($type) {

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -277,13 +277,7 @@ class NotificationModel extends FormModel implements AjaxLookupModelInterface, G
         return $this->pageTrackableModel->getTrackableList('notification', $notificationId);
     }
 
-    /**
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
         switch ($type) {

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -517,13 +517,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         return $this->pageTrackableModel->getTrackableList('sms', $smsId);
     }
 
-    /**
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
         switch ($type) {

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -23,13 +23,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class TweetModel extends FormModel implements AjaxLookupModelInterface
 {
-    /**
-     * @param string $filter
-     * @param int    $limit
-     * @param int    $start
-     * @param array  $options
-     */
-    public function getLookupResults($type, $filter = '', $limit = 10, $start = 0, $options = []): array
+    public function getLookupResults(string $type, string|array $filter = '', int $limit = 10, int $start = 0, array $options = []): array
     {
         $results = [];
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ✔️
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR refactors the `getLookupResults` method in the `AjaxLookupModelInterface` to include a native array return type. All implementing classes have been updated to match the new method signature. This change improves code quality and type safety.                                                             
                                                                                                                                                            
Additionally, a new test class, `AjaxLookupControllerTest`, has been added to provide test coverage for the Ajax lookup functionality, ensuring that lookups for entities such as Companies, Emails, and SMS messages work as expected with various options.  


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a test message, a few with type Segment, and a few with Template.
3. Add a Send text message event to Campaign
4. Do a lookup