### PR TITLE
Fix TypeError in DateOptionFactory with 3+ OR date filters

### DIFF
--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -119,11 +119,16 @@ class ContactSegmentFilterFactory
             ]);
 
             if ('or' === strtolower($filter['glue']) && '=' === $filter['operator']) {
-                if (!isset($arrStacks[$key])) {
-                    $arrStacks[$key] = [];
+                // Don't group date type filters - they require special processing
+                // by DateOptionFactory and don't support IN operator with arrays
+                if (isset($filter['type']) && 'date' === $filter['type']) {
+                    array_push($shrinkedFilters, $filter);
+                } else {
+                    if (!isset($arrStacks[$key])) {
+                        $arrStacks[$key] = [];
+                    }
+                    array_push($arrStacks[$key], $filter);
                 }
-
-                array_push($arrStacks[$key], $filter);
             } else { // glue = and
                 // if 'or' followed by 'and', it becomes - or (cond1 and cond2)
                 if (isset($arrStacks[$previousKey]) && count($arrStacks[$previousKey]) > 0) { /** @phpstan-ignore-line `Comparison operation ">" between 0 and 0 is always false.` I don't see anything wrong. Seems to be a PHPSTAN issue https://github.com/phpstan/phpstan/issues/3831 */

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -119,9 +119,9 @@ class ContactSegmentFilterFactory
             ]);
 
             if ('or' === strtolower($filter['glue']) && '=' === $filter['operator']) {
-                // Don't group date type filters - they require special processing
+                // Don't group date/datetime type filters - they require special processing
                 // by DateOptionFactory and don't support IN operator with arrays
-                if (isset($filter['type']) && 'date' === $filter['type']) {
+                if (isset($filter['type']) && in_array($filter['type'], ['date', 'datetime'], true)) {
                     array_push($shrinkedFilters, $filter);
                 } else {
                     if (!isset($arrStacks[$key])) {

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryFunctionalTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Segment;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+/**
+ * Functional tests for ContactSegmentFilterFactory.
+ *
+ * @see \Mautic\LeadBundle\Segment\ContactSegmentFilterFactory
+ */
+final class ContactSegmentFilterFactoryFunctionalTest extends MauticMysqlTestCase
+{
+    /**
+     * Test that segments with 3+ date filters using OR logic don't throw TypeError.
+     *
+     * When multiple OR'd date filters with '=' operator exist, the mergeFilters() method
+     * was grouping them into a single IN filter with an array value. This caused
+     * DateOptionFactory::getDateOption() to fail because str_contains() expects a string.
+     *
+     * This test creates leads with different date_identified values and verifies that:
+     * 1. The segment update command completes without TypeError
+     * 2. The correct leads are included/excluded from the segment
+     *
+     * @see https://github.com/mautic/mautic/issues/15701
+     */
+    public function testSegmentWithMultipleDateFiltersAndOrLogicDoesNotThrowTypeError(): void
+    {
+        $application = new Application(self::$kernel);
+        $application->setAutoExit(false);
+        $applicationTester = new ApplicationTester($application);
+
+        /** @var LeadRepository $leadRepository */
+        $leadRepository = $this->em->getRepository(Lead::class);
+
+        // Create leads with different date_identified values
+        $leadToday = new Lead();
+        $leadToday->setFirstname('Today');
+        $leadToday->setLastname('Lead');
+        $leadToday->setDateIdentified(new \DateTime('midnight today +10 seconds'));
+        $leadRepository->saveEntity($leadToday);
+
+        $leadYesterday = new Lead();
+        $leadYesterday->setFirstname('Yesterday');
+        $leadYesterday->setLastname('Lead');
+        $leadYesterday->setDateIdentified(new \DateTime('midnight today -10 seconds'));
+        $leadRepository->saveEntity($leadYesterday);
+
+        $leadLastWeek = new Lead();
+        $leadLastWeek->setFirstname('LastWeek');
+        $leadLastWeek->setLastname('Lead');
+        // Use a date that's definitely within "last week" range
+        $leadLastWeek->setDateIdentified(new \DateTime('midnight monday last week +2 days'));
+        $leadRepository->saveEntity($leadLastWeek);
+
+        // This lead should NOT match any filter (2 months ago)
+        $leadOld = new Lead();
+        $leadOld->setFirstname('Old');
+        $leadOld->setLastname('Lead');
+        $leadOld->setDateIdentified(new \DateTime('-2 months'));
+        $leadRepository->saveEntity($leadOld);
+
+        // Create segment with 3+ OR'd date filters (this triggers the bug)
+        $segment = new LeadList();
+        $segment->setName('Test Multiple Date Filters');
+        $segment->setAlias('test_multiple_date_filters_'.uniqid());
+        $segment->setPublicName('Test Multiple Date Filters');
+        $segment->setIsPublished(true);
+        $segment->setFilters([
+            [
+                'glue'     => 'and',
+                'field'    => 'date_identified',
+                'object'   => 'lead',
+                'type'     => 'datetime',
+                'operator' => '=',
+                'filter'   => 'today',
+                'display'  => null,
+            ],
+            [
+                'glue'     => 'or',
+                'field'    => 'date_identified',
+                'object'   => 'lead',
+                'type'     => 'datetime',
+                'operator' => '=',
+                'filter'   => 'yesterday',
+                'display'  => null,
+            ],
+            [
+                'glue'     => 'or',
+                'field'    => 'date_identified',
+                'object'   => 'lead',
+                'type'     => 'datetime',
+                'operator' => '=',
+                'filter'   => 'last week',
+                'display'  => null,
+            ],
+        ]);
+
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        // Run the segment update command - this throws TypeError without the fix
+        $exitCode = $applicationTester->run([
+            'command' => 'mautic:segments:update',
+            '-i'      => $segment->getId(),
+        ]);
+
+        $this->assertSame(0, $exitCode, 'Segment update command should complete successfully without TypeError: '.$applicationTester->getDisplay());
+
+        // Verify segment membership - get all leads in the segment
+        $segmentMembers = $this->em->getRepository(ListLead::class)->findBy(['list' => $segment->getId()]);
+        $memberLeadIds  = array_map(fn (ListLead $member) => $member->getLead()->getId(), $segmentMembers);
+
+        // Leads matching the date filters should be in the segment
+        $this->assertContains($leadToday->getId(), $memberLeadIds, 'Lead identified today should be in segment');
+        $this->assertContains($leadYesterday->getId(), $memberLeadIds, 'Lead identified yesterday should be in segment');
+        $this->assertContains($leadLastWeek->getId(), $memberLeadIds, 'Lead identified last week should be in segment');
+
+        // Lead that doesn't match any filter should NOT be in the segment
+        $this->assertNotContains($leadOld->getId(), $memberLeadIds, 'Lead identified 2 months ago should NOT be in segment');
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #15701

## Description

This PR fixes a `TypeError` in `DateOptionFactory::getDateOption()` that occurs when a segment contains 3 or more date filters combined with OR logic.

### Root Cause

When multiple OR'd filters with `=` operator exist, `ContactSegmentFilterFactory::mergeFilters()` groups them into a single `IN` filter with an array value. This optimization works for most field types, but `DateOptionFactory` expects string values and calls `str_contains()` on the timeframe, causing a `TypeError`.

The grouping only happens when there are 3+ filters (see `groupFilters()` method which skips grouping for `count < 3`), which explains why 2 date filters work but 3+ fail.

### Solution

Skip the filter grouping optimization for `date` type filters in `ContactSegmentFilterFactory::mergeFilters()`. Date filters require special processing by `DateOptionFactory` (for anniversary dates, relative intervals, etc.) and don't support the `IN` operator with array values.

---

### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Go to **Segments → New Segment**
3. Add 3 date filters with OR logic:
   - Filter 1: `Birthday` equals `birthday` (OR)
   - Filter 2: `Birthday` equals `birthday +1 days` (OR)
   - Filter 3: `Birthday` equals `birthday +2 days` (OR)
4. Save the segment
5. Run: `php bin/console mautic:segments:update`
6. **Expected**: Segment rebuilds successfully without errors
7. **Before fix**: `TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given`