### PR TITLE
Fixed with trim while custom field saving.

### DIFF
--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -827,6 +827,21 @@ class FieldModel extends FormModel
 
         // validate properties
         $type   = $entity->getType();
+
+        // Trim select field option values BEFORE validation + save
+        if (('select' === $type || 'multiselect' === $type)
+            && isset($properties['list']) && is_array($properties['list'])
+        ) {
+            foreach ($properties['list'] as &$item) {
+                if (isset($item['label'])) {
+                    $item['label'] = trim($item['label']);
+                }
+                if (isset($item['value'])) {
+                    $item['value'] = trim($item['value']);
+                }
+            }
+        }
+
         $result = FormFieldHelper::validateProperties($type, $properties);
         if ($result[0]) {
             $entity->setProperties($properties);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2501,10 +2501,10 @@ class LeadModel extends FormModel
                     ? $field['properties']
                     : unserialize($field['properties']);
 
-                $flattenedAllowedValues = array_map(fn ($item): string => html_entity_decode($item['value'], ENT_QUOTES), $allowedValues['list']);
+                $flattenedAllowedValues = array_map(fn ($item): string => trim(html_entity_decode($item['value'], ENT_QUOTES)), $allowedValues['list']);
 
                 $fieldValue = $entity->getFieldValue($field['alias'], $group);
-                if (!empty($allowedValues['list']) && !in_array($fieldValue, $flattenedAllowedValues)) {
+                if (!empty($allowedValues['list']) && !in_array(trim($fieldValue), $flattenedAllowedValues)) {
                     // if the set value of the field is not present allowed values array,
                     // update the field value to null
                     $entity->addUpdatedField($field['alias'], null);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2497,6 +2497,11 @@ class LeadModel extends FormModel
                 } elseif ('select' !== $field['type']) {
                     continue;
                 }
+
+                if (null === $fieldValue || '' === $fieldValue) {
+                    continue;
+                }
+
                 $allowedValues = is_array($field['properties'])
                     ? $field['properties']
                     : unserialize($field['properties']);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2498,6 +2498,8 @@ class LeadModel extends FormModel
                     continue;
                 }
 
+                $fieldValue = $entity->getFieldValue($field['alias'], $group);
+
                 if (null === $fieldValue || '' === $fieldValue) {
                     continue;
                 }
@@ -2508,7 +2510,6 @@ class LeadModel extends FormModel
 
                 $flattenedAllowedValues = array_map(fn ($item): string => trim(html_entity_decode($item['value'], ENT_QUOTES)), $allowedValues['list']);
 
-                $fieldValue = $entity->getFieldValue($field['alias'], $group);
                 if (!empty($allowedValues['list']) && !in_array(trim($fieldValue), $flattenedAllowedValues)) {
                     // if the set value of the field is not present allowed values array,
                     // update the field value to null

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2497,20 +2497,14 @@ class LeadModel extends FormModel
                 } elseif ('select' !== $field['type']) {
                     continue;
                 }
-
-                $fieldValue = $entity->getFieldValue($field['alias'], $group);
-
-                if (null === $fieldValue || '' === $fieldValue) {
-                    continue;
-                }
-
                 $allowedValues = is_array($field['properties'])
                     ? $field['properties']
                     : unserialize($field['properties']);
 
-                $flattenedAllowedValues = array_map(fn ($item): string => trim(html_entity_decode($item['value'], ENT_QUOTES)), $allowedValues['list']);
+                $flattenedAllowedValues = array_map(fn ($item): string => html_entity_decode($item['value'], ENT_QUOTES), $allowedValues['list']);
 
-                if (!empty($allowedValues['list']) && !in_array(trim($fieldValue), $flattenedAllowedValues)) {
+                $fieldValue = $entity->getFieldValue($field['alias'], $group);
+                if (!empty($allowedValues['list']) && !in_array($fieldValue, $flattenedAllowedValues)) {
                     // if the set value of the field is not present allowed values array,
                     // update the field value to null
                     $entity->addUpdatedField($field['alias'], null);

--- a/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Functional\Model;
+
+use Mautic\CampaignBundle\Entity\Event as CampaignEvent;
+use Mautic\CampaignBundle\Model\EventModel;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\LeadBundle\Entity\LeadField;
+
+class LeadModelSelectFieldTrimTest extends MauticMysqlTestCase
+{
+    use CreateTestEntitiesTrait;
+
+    public function testCampaignEventValueIsNormalizedWhenCustomFieldTrailingSpacesChanged(): void
+    {
+        // Create custom field
+        $field = new LeadField();
+        $field->setLabel('Industry Type');
+        $field->setAlias('industry_type');
+        $field->setObject('lead');
+        $field->setIsPublished(true);
+        $field->setType('select');
+        $field->setProperties([
+            'list' => [
+                ['label' => 'Automotive', 'value' => 'Automotive'],
+                ['label' => 'Technology', 'value' => 'Technology'],
+            ],
+        ]);
+        $this->em->persist($field);
+        $this->em->flush();
+
+        $campaign = $this->createCampaign('Industry Campaign');
+
+        $event = $this->createEvent(
+            'Update Industry',
+            $campaign,
+            'lead.update.field',
+            'action',
+            [
+                'leadField' => 'industry_type',
+                'value'     => 'Automotive',
+            ]
+        );
+
+        $this->em->flush();
+        $this->em->clear();
+
+        // Modify custom field (add trailing spaces)
+        $updatedField = $this->em->getRepository(LeadField::class)
+          ->findOneBy(['alias' => 'industry_type']);
+
+        $updatedField->setProperties([
+            'list' => [
+                ['label' => 'Automotive ', 'value' => 'Automotive '],
+                ['label' => 'Technology ', 'value' => 'Technology '],
+            ],
+        ]);
+
+        $this->em->persist($updatedField);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var EventModel $eventModel */
+        $eventModel = $this->getContainer()->get('mautic.campaign.model.event');
+
+        // Reload event after custom field change
+        $eventEntity = $this->em->getRepository(CampaignEvent::class)
+          ->findOneBy(['name' => 'Update Industry']);
+
+        // Trigger normalization (your fix runs inside EventModel::saveEntity)
+        $eventModel->saveEntity($eventEntity);
+
+        $this->em->clear();
+
+        // Validate result
+        $reloadedEvent = $this->em->getRepository(CampaignEvent::class)
+          ->findOneBy(['name' => 'Update Industry']);
+
+        $props = $reloadedEvent->getProperties();
+
+        $this->assertSame('Automotive', trim($props['value']));
+    }
+}


### PR DESCRIPTION

**Description:**
Select type custom field's options can be saved with trailing spaces, which leads to issues when updating contacts from campaign events.

**Steps to Reproduce**
 - Create a SELECT type custom field with some options. 
 - Create a campaign which has the update contact field action for created select field and save campaign.
 - Next, go back to the custom field and add an additional space after the values, and then save.
 - Go back to the campaign, and you’ll see that the current campaign select value is still set. In this case, it still remains and   makes the user think the campaign is set up correctly.
 - After campaign execution you will notice that the field value is not updated for contacts, the new value is display under the old value in contact’s audit log.

**Steps to test this PR:**
Create custom field (Select) and assign some values to its (select1, select2, select3)
Then create contact and assign them values (select1) to all contacts
Create segment so that all contacts should come under this segment
Create campaign with same segment selected and update contact action and update same custom field (select2) for segments contact.
Now lets not publish the campaign, and first edit custom field in form and add space after select 1 , select 2 , select 3 , key and value both and save custom field,
Now come back to campaign and publish it and when campaign gets trigger check if contacts custom field has been updated from select 1 to select2 ...



<img width="1149" height="602" alt="Screenshot 2025-12-08 at 5 34 02 PM" src="https://github.com/user-attachments/assets/d59661e2-a0d6-439f-bb19-3aa444704d33" />
<img width="698" height="243" alt="Screenshot 2025-12-08 at 5 34 15 PM" src="https://github.com/user-attachments/assets/8920c113-5140-444d-9699-f33b1d0edce9" />
<img width="1057" height="747" alt="Screenshot 2025-12-08 at 5 34 42 PM" src="https://github.com/user-attachments/assets/def56b2d-a41a-4643-9c3e-0a776a552c97" />


