### PR TITLE
Updating Elfinder to v13 that supports PHP 8.5

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -46,7 +46,7 @@
     "giggsey/libphonenumber-for-php": "^8.12",
     "guzzlehttp/guzzle": "^7.6",
     "guzzlehttp/oauth-subscriber": "^0.8.1",
-    "helios-ag/fm-elfinder-bundle": "^12.3",
+    "helios-ag/fm-elfinder-bundle": "^13.0",
     "illuminate/collections": "^10.48",
     "ip2location/ip2location-php": "^7.2",
     "javer/sp-bundle": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4020,34 +4020,34 @@
         },
         {
             "name": "helios-ag/fm-elfinder-bundle",
-            "version": "12.7.3",
+            "version": "13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/helios-ag/FMElfinderBundle.git",
-                "reference": "8041092383efda82faee697dc1119840a4345eca"
+                "reference": "4b62c623bd3e724078810ced0f87c4f84866a5fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/helios-ag/FMElfinderBundle/zipball/8041092383efda82faee697dc1119840a4345eca",
-                "reference": "8041092383efda82faee697dc1119840a4345eca",
+                "url": "https://api.github.com/repos/helios-ag/FMElfinderBundle/zipball/4b62c623bd3e724078810ced0f87c4f84866a5fe",
+                "reference": "4b62c623bd3e724078810ced0f87c4f84866a5fe",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^8.1",
                 "studio-42/elfinder": "~2.1.62",
-                "symfony/asset": "^6.4 || ^7.0",
-                "symfony/form": "^6.4 || ^7.0",
-                "symfony/framework-bundle": "^6.4 || ^7.0",
-                "symfony/twig-bundle": "^6.4 || ^7.0"
+                "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+                "symfony/form": "^6.4 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "dev-master",
                 "matthiasnoback/symfony-config-test": "^6.0",
                 "matthiasnoback/symfony-dependency-injection-test": "^6.0",
                 "php-coveralls/php-coveralls": "^2.0",
-                "symfony/finder": "^6.4 || ^7.0",
-                "symfony/phpunit-bridge": "^6.4 || ^7.0.1"
+                "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+                "symfony/phpunit-bridge": "^6.4 || ^7.0.1 || ^8.0"
             },
             "suggest": {
                 "barryvdh/elfinder-flysystem-driver": "Flysystem driver for elfinder",
@@ -4090,9 +4090,9 @@
             ],
             "support": {
                 "issues": "https://github.com/helios-ag/FMElfinderBundle/issues",
-                "source": "https://github.com/helios-ag/FMElfinderBundle/tree/12.7.3"
+                "source": "https://github.com/helios-ag/FMElfinderBundle/tree/13"
             },
-            "time": "2025-06-19T11:47:45+00:00"
+            "time": "2025-12-09T05:04:37+00:00"
         },
         {
             "name": "illuminate/collections",
@@ -6153,7 +6153,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "2d44db4b08ad18a3223304ba04b8817b3a6c390a"
+                "reference": "df7477843ebd157ca35a8abfd52c339117dfa75c"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6184,7 +6184,7 @@
                 "giggsey/libphonenumber-for-php": "^8.12",
                 "guzzlehttp/guzzle": "^7.6",
                 "guzzlehttp/oauth-subscriber": "^0.8.1",
-                "helios-ag/fm-elfinder-bundle": "^12.3",
+                "helios-ag/fm-elfinder-bundle": "^13.0",
                 "illuminate/collections": "^10.48",
                 "ip2location/ip2location-php": "^7.2",
                 "javer/sp-bundle": "^2.0",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/pull/15721

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The Elfinder PHP dependency is emitting PHP deprecation warnings on PHP 8.5. See https://github.com/mautic/mautic/pull/15721

The code change in this PR was generated by updating the version in `app/composer.json` and then running command `composer update helios-ag/fm-elfinder-bundle` 

This PR is upgrading it to the latest version [13](https://github.com/helios-ag/FMElfinderBundle/releases/tag/13). Yea, no 13.0.0, but just 13. I don't even see any breaking changes in the release notes nor in the code diff.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Execute `composer install` in order to get the new dependency version.
3. Go to Dynamic Web Content
4. Create New
5. In the text editor upload an image to the content. 

The image should be uploaded correctly and visible in the textarea

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->