### PR TITLE
[NOT-FOR-MERGE] Fix jump to action locator overlay for M5

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -2171,11 +2171,19 @@ Mautic.highlightJumpTarget = function(event, el) {
     if (highlightedAlready) {
         parentEventElement.data('highlighted', false);
         overlay.hide();
+        overlay.off('click.closejump');
         parentEventElement.css("z-index", 1010);
         jumpTarget.css("z-index", 1010);
     } else {
+        if (mQuery('[data-highlighted="true"]').length) {
+            mQuery('[data-highlighted="true"]').find('.highlight-jump-target').click();
+        }
+
         parentEventElement.data('highlighted', true);
         overlay.show();
+        overlay.on('click.closejump', function() {
+            element.click();
+        });
         parentEventElement.css("z-index", 2010);
         jumpTarget.css("z-index", 2010);
     }


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

This PR fixes the issue with jump to action locator overlay that can't be closed by clicking on the overlay.