### PR TITLE
Fix duplicate query parameter in the page redirect.

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -229,7 +229,18 @@ class UrlHelper
             $parsedQuery = Query::parse($query);
 
             if ($parsedQuery) {
-                $encodedQuery = Query::build($parsedQuery, PHP_QUERY_RFC3986);
+                $queryItems = [];
+
+                // Remove duplicate query parameters from query.
+                foreach ($parsedQuery as $index => $item) {
+                    if (is_array($item) && !str_ends_with($index, '[]')) {
+                        $item = array_last($item);
+                    }
+
+                    $queryItems[$index] = $item;
+                }
+
+                $encodedQuery = Query::build($queryItems, PHP_QUERY_RFC3986);
                 $url          = str_replace('?'.$query, '?'.$encodedQuery, $url);
             }
         }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -3,6 +3,7 @@
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\UrlHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UrlHelperTest extends \PHPUnit\Framework\TestCase
 {
@@ -105,6 +106,30 @@ class UrlHelperTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    #[DataProvider('provideUrlsForSanitizeQueryParameters')]
+    public function testSanitizeQueryParameters(string $url, string $expected): void
+    {
+        self::assertSame($expected, UrlHelper::sanitizeAbsoluteUrl($url));
+    }
+
+    public static function provideUrlsForSanitizeQueryParameters(): \Generator
+    {
+        yield 'With array list parameter' => [
+            'https://some.test.url/asset/1:examplefilejpg?par[]=one&par[]=two&ct=parameter',
+            'https://some.test.url/asset/1:examplefilejpg?par%5B%5D=one&par%5B%5D=two&ct=parameter',
+        ];
+
+        yield 'With array hash parameter' => [
+            'https://some.test.url/asset/1:examplefilejpg?par[a]=one&par[b]=two&ct=parameter',
+            'https://some.test.url/asset/1:examplefilejpg?par%5Ba%5D=one&par%5Bb%5D=two&ct=parameter',
+        ];
+
+        yield 'With duplicated parameter' => [
+            'https://some.test.url/asset/1:examplefilejpg?ct=parameter&ct=dummy_click_through',
+            'https://some.test.url/asset/1:examplefilejpg?ct=dummy_click_through',
+        ];
+    }
+
     public function testGetUrlsFromPlaintextWithHttp(): void
     {
         $this->assertEquals(
@@ -188,7 +213,7 @@ STRING
         $this->assertFalse(UrlHelper::isValidUrl('notvalidurlé'));
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('dataDecodeAmpersands')]
+    #[DataProvider('dataDecodeAmpersands')]
     public function testDecodeAmpersands(string $value, string $expected): void
     {
         $this->assertSame($expected, UrlHelper::decodeAmpersands($value));

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -540,7 +540,7 @@ class PublicControllerTest extends MauticMysqlTestCase
 
         yield 'With click-through parameter' => [
             'https://some.test.url/asset/1:examplefilejpg?ct=parameter',
-            'https://some.test.url/asset/1:examplefilejpg?ct=parameter&ct=dummy_click_through',
+            'https://some.test.url/asset/1:examplefilejpg?ct=dummy_click_through',
         ];
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Fixed the slight issue in #15725 


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Check the code works.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->