### PR TITLE
feat: Display stat description above value in stat tiles

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Modules/stat--icon.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Modules/stat--icon.html.twig
@@ -9,15 +9,15 @@
                         <i class="ri-information-line ml-3" data-toggle="tooltip" title="{{ stat.tooltip|trans }}"></i>
                     {% endif %}
                 </span>
+                {% if stat.desc is defined %}
+                    <span class="text-secondary small mb-sm ellipsis">{{ stat.desc|trans }}</span>
+                {% endif %}
                 <span class="d-flex lh-1 ai-center jc-space-between fs-40">
                     <div class="fw-b {% if stat.link is defined and stat.value != 0 and stat.value != '0%' %}text-interactive{% endif %}" {% if stat.value_attr is defined %}{{ stat.value_attr|raw }}{% endif %}>{% if stat.value == 0 or stat.value == '0%' %}--{% else %}{{ stat.value|raw }}{% endif %}</div>
                     {% if stat.icon is defined and stat.icon and (stat.link is not defined or stat.value == 0) %}
                         <i class="{{ stat.icon }} fs-22" aria-hidden="true"></i>
                     {% endif %}
                 </span>
-                {% if stat.desc is defined %}
-                    <span class="text-secondary small mt-md ellipsis">{{ stat.desc|trans }}</span>
-                {% endif %}
             </div>  
         {% endset %}
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Move the description text (e.g., percentage like "18.77%") to appear **above** the main value in stat-icon tiles instead of below. This improves visual hierarchy by showing the context (percentage) before the absolute number.

| Before                                 | After
| -------------------------------------- | ---
| Value (617) on top, Percentage (18.77%) below | Percentage (18.77%) on top, Value (617) below

**Changes:**
- Moved `stat.desc` block before the value block in `stat--icon.html.twig`
- Changed margin from `mt-md` (margin-top) to `mb-sm` (margin-bottom) for proper spacing

**Affected areas:**
This change affects all stat tiles that use the `stat--icon` component with a `desc` field, including:
- Email details (Read percentage)
- Form details
- Asset details
- SMS details
- Other bundle detail pages


Before:

<img width="650" height="408" alt="image" src="https://github.com/user-attachments/assets/fd7abe25-0730-4069-86e3-45dabf4b7e05" />



After:

<img width="640" height="415" alt="image" src="https://github.com/user-attachments/assets/9e8a183f-9fab-4ab8-b842-da25526f4a55" />


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Navigate to any Email detail page
3. Verify that the "Read" stat tile shows the percentage (e.g., "18.77%") **above** the main value (e.g., "617")
4. Check other detail pages (Forms, Assets) to ensure the stat tiles display correctly