### PR TITLE
Add clickable segment links in email details view

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -315,6 +315,18 @@
                                   </td>
                                   <td>{{ email.readCount }}</td>
                               </tr>
+                              {% if emailType == 'list' and email.lists|length > 0 %}
+                              <tr>
+                                  <td width="20%">
+                                      <span class="fw-b">{{ 'mautic.email.form.list'|trans }}</span>
+                                  </td>
+                                  <td>
+                                      {% for list in email.lists %}
+                                          <a href="{{ path('mautic_segment_action', {'objectAction': 'view', 'objectId': list.id}) }}" data-toggle="ajax">{{ list.name|purify }}</a>{% if not loop.last %}, {% endif %}
+                                      {% endfor %}
+                                  </td>
+                              </tr>
+                              {% endif %}
                               </tbody>
                           </table>
                       </div>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Adds clickable segment links to the email details view for segment (list) type emails.

When viewing a segment email's details, the associated contact segments are now displayed as clickable links that navigate to each segment's detail page. This improves navigation and makes it easier to understand which segments the email is targeting.

**Changes:**
- Added a new row in the email details collapsible section showing "Contact segment" with linked segment names
- Links use AJAX navigation (`data-toggle="ajax"`) for smooth UX
- Only displays for segment emails that have at least one segment associated
- Multiple segments are separated by commas

| Before                                 | After
| -------------------------------------- | ---
| No segment information shown           | Segment names shown as clickable links

<img width="767" height="695" alt="image" src="https://github.com/user-attachments/assets/aabf2d93-59a3-4951-9920-5fa7ca80b1f0" />


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally
2. Navigate to a segment email that has segments associated (e.g., `/s/emails/view/862`)
3. Click on the "Details" expander below the email subject
4. Verify the "Contact segment" row is visible with clickable segment names
5. Click on a segment name and verify it navigates to the segment detail page
6. Verify template emails or segment emails without segments do NOT show this row