### PR TITLE
Fixing changing campaign event connections from true to false

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -432,7 +432,7 @@ Mautic.campaignEventOnLoad = function (container, response) {
 
     Mautic.campaignBuilderLabels[domEventId] = (response.label) ? response.label : '';
 
-    if (!response.success && Mautic.campaignBuilderConnectionRequiresUpdate) {
+    if (response.formSubmitted && !response.success && Mautic.campaignBuilderConnectionRequiresUpdate) {
         // Modal exited - check to see if a connection needs to be removed
         Mautic.campaignBuilderInstance.deleteConnection(Mautic.campaignBuilderLastConnection);
     }

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -174,6 +174,7 @@ class EventController extends CommonFormController
         $passthroughVars = [
             'mauticContent' => 'campaignEvent',
             'success'       => $success,
+            'formSubmitted' => $form->isSubmitted(),
             'route'         => false,
         ];
 
@@ -315,6 +316,7 @@ class EventController extends CommonFormController
         $passthroughVars = [
             'mauticContent' => 'campaignEvent',
             'success'       => !$cancelled && $valid,
+            'formSubmitted' => $form->isSubmitted(),
             'route'         => false,
             'modifiedEvents'=> $modifiedEvents,
             'eventId'       => $event['id'] ?? '',

--- a/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
@@ -65,6 +65,7 @@ final class EventControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('condition', $responseData['eventType']);
         $this->assertSame('campaignEvent', $responseData['mauticContent']);
         $this->assertSame(1, $responseData['closeModal']);
+        Assert::assertTrue($responseData['formSubmitted'], $response->getContent());
     }
 
     /**
@@ -312,6 +313,7 @@ final class EventControllerFunctionalTest extends MauticMysqlTestCase
             $event1->getName(),
             $response['event']['name']
         );
+        Assert::assertFalse($response['formSubmitted'], $this->client->getResponse()->getContent());
     }
 
     public function testEventsAreDeleted(): void


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

When changing the connection for campaign conditions or decisions from the green to red path (or vice versa) then it will open the campaign event modal window but the new connection gets deleted.

Before the fix:

https://github.com/user-attachments/assets/80a7da08-68d9-48d3-95d8-3e2147695abc

After the fix:

https://github.com/user-attachments/assets/ef9e004c-983b-48a6-bcc9-b3cf5b313c7d


This is because the "success" check of the response loading the modal window was false. It is false because the form wasn't submitted. I really fear to change anything in this code because I can't tell what can break if I change it. So I figured the simplest and the least risky option would be to only delete the connection only if the success is false (as it as before) but also the form must be actually submitted.

The check was added in https://github.com/mautic/mautic/commit/c8f978db5a344627db4aad5724893035842e97e3#diff-78870f6f861e427300f06a9dd7c0a90061996b8a904247b0bb8ef6ba65ac8aa2R42 if anyone wants to dig deeper into the history.

I think the reason why the modal window is opened in the first place is that if you do this operation for a decision you must define a delay otherwise the decision would always flow to the red connection because decisions are waiting for some interaction of a contact like opening an email. So there must be some delay defined to give the contact some time to perform the opening.

#### Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a campaign similar to the one above.
3. Remove the green connection and add the red connection instead.

Before the change: A modal window opens and the red connection disappears.

After the change: A modal window opens and the red connection stais.

#### Other areas of Mautic that may be affected by the change:
1. Just the campaign event creation and edit code.

#### List deprecations along with the new alternative:
1. None

<!--
If you have any deprecations, list them here along with the new alternative.
If you have any backwards compatibility breaks, list them here.
-->

[//]: # ( As applicable: )
#### List of areas covered by the unit and/or functional tests:
1. The automated tests are checking that when calling the route for editing a campaign event without submitting the form, the new `formSubmitted` property is false. And when calling the route with submitting the form it is true.
