### PR TITLE
[NOT-FOR-MERGE] Disable Upcoming Emails Dashboard Widget

### DIFF
--- a/app/assets/dashboards/alternative-default.json
+++ b/app/assets/dashboards/alternative-default.json
@@ -87,16 +87,6 @@
             "template": null
         },
         {
-            "name": "Upcoming Emails",
-            "width": 25,
-            "height": 330,
-            "ordering": 10,
-            "type": "upcoming.emails",
-            "params": [
-            ],
-            "template": null
-        },
-        {
             "name": "Top Contact Creators",
             "width": 100,
             "height": 330,

--- a/app/assets/dashboards/default.json
+++ b/app/assets/dashboards/default.json
@@ -36,13 +36,6 @@
             "height": 330,
             "ordering": 3,
             "type": "recent.activity"
-        },
-        {
-            "name": "Upcoming Emails",
-            "width": 50,
-            "height": 330,
-            "ordering": 4,
-            "type": "upcoming.emails"
         }
     ]
 }

--- a/app/migrations/Version20260116120000.php
+++ b/app/migrations/Version20260116120000.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
+
+final class Version20260116120000 extends PreUpAssertionMigration
+{
+    protected function preUpAssertions(): void
+    {
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM {$this->prefix}widgets WHERE type = 'upcoming.emails'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Cannot restore deleted widgets as we don't have the original data
+    }
+}


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

This MR disables the "Upcoming Emails" widget by default to improve dashboard performance. The widget is known to be resource-intensive and offers limited utility as it only displays campaign emails.

### Changes
*   **Default Config:** Removed the widget from `default.json` and `alternative-default.json` for new users.
*   **Cleanup:** Added a migration to remove the widget from existing user dashboards.

### Migration
To apply this change to existing users, run:
```bash
bin/console doctrine:migrations:execute 'Mautic\Migrations\Version20260116120000' --up
```
