### PR TITLE
Display plugin version in Manage Plugins

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -318,6 +318,8 @@ Mautic.processPageContent = function (response) {
  * Initiate various functions on page load, manual or ajax
  */
 Mautic.onPageLoad = function (container, response, inModal) {
+    mQuery(container).trigger('mautic:onPageLoad:before', [container, response, inModal]);
+
     Mautic.initDateRangePicker(container + ' #daterange_date_from', container + ' #daterange_date_to');
 
     //initiate links
@@ -723,6 +725,8 @@ Mautic.onPageLoad = function (container, response, inModal) {
             }
         }, false));
     }
+
+    mQuery(container).trigger('mautic:onPageLoad:after', [container, response, inModal]);
 };
 
 Mautic.setDynamicContentEditors = function(container) {

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -214,6 +214,9 @@ class ConfigController extends AbstractFormController
 
         $useConfigFormNotes = $integrationObject instanceof ConfigFormNotesInterface;
 
+        $plugin  = $integrationObject->getIntegrationSettings()->getPlugin();
+        $version = $plugin?->getVersion();
+
         return $this->delegateView(
             [
                 'viewParameters' => [
@@ -235,6 +238,7 @@ class ConfigController extends AbstractFormController
                     'activeLink'    => '#mautic_plugin_index',
                     'mauticContent' => 'integrationsConfig',
                     'route'         => false,
+                    'pluginVersion' => $version,
                 ],
             ]
         );

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -320,3 +320,18 @@ Mautic.getIntegrationCampaignStatus = function (el, settings) {
         "GET"
     );
 };
+
+Mautic.initPluginEvents = function () {
+    const $integrationModal = mQuery('#IntegrationEditModal');
+
+    $integrationModal.off('mautic:onPageLoad:before');
+    $integrationModal.on('mautic:onPageLoad:before', function(e, container, response) {
+        if (container === '#IntegrationEditModal' && response && response.pluginVersion) {
+            const $modalLabel = mQuery('#IntegrationEditModal-label');
+            if ($modalLabel.find('.plugin-version-badge').length === 0) {
+                const versionHtml = ' <span class="plugin-version-badge label label-default ml-xs">v' + response.pluginVersion + '</span>';
+                $modalLabel.append(versionHtml);
+            }
+        }
+    });
+};

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -329,8 +329,11 @@ Mautic.initPluginEvents = function () {
         if (container === '#IntegrationEditModal' && response && response.pluginVersion) {
             const $modalLabel = mQuery('#IntegrationEditModal-label');
             if ($modalLabel.find('.plugin-version-badge').length === 0) {
-                const versionHtml = ' <span class="plugin-version-badge label label-default ml-xs">v' + response.pluginVersion + '</span>';
-                $modalLabel.append(versionHtml);
+                const $badge = mQuery('<span>')
+                    .addClass('plugin-version-badge label label-default ml-xs')
+                    .text('v' + String(response.pluginVersion));
+
+                $modalLabel.append(' ').append($badge);
             }
         }
     });

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -338,6 +338,9 @@ class PluginController extends FormController
             }
         }
 
+        $plugin  = $entity->getPlugin();
+        $version = $plugin?->getVersion();
+
         return $this->delegateView(
             [
                 'viewParameters' => [
@@ -355,6 +358,7 @@ class PluginController extends FormController
                     'mauticContent' => 'integrationConfig',
                     'route'         => false,
                     'sidebar'       => $this->renderView('@MauticCore/LeftPanel/index.html.twig'),
+                    'pluginVersion' => $version,
                 ],
             ]
         );
@@ -395,6 +399,7 @@ class PluginController extends FormController
                     'activeLink'    => '#mautic_plugin_index',
                     'mauticContent' => 'integration',
                     'route'         => false,
+                    'pluginVersion' => $bundle->getVersion(),
                 ],
             ]
         );

--- a/app/bundles/PluginBundle/Resources/views/Integration/grid.html.twig
+++ b/app/bundles/PluginBundle/Resources/views/Integration/grid.html.twig
@@ -35,7 +35,7 @@
 
 {% block content %}
   {% if isIndex %}
-    <div id="page-list-wrapper" class="panel panel-default">
+    <div id="page-list-wrapper" class="panel panel-default" data-onload-callback="initPluginEvents">
         <div class="panel-body">
             <div class="box-layout">
                 <div class="row">

--- a/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
+++ b/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
@@ -51,7 +51,7 @@ class PluginControllerTest extends MauticMysqlTestCase
     public function testReturnPluginVersion(): void
     {
         $this->testSymfonyCommand('mautic:plugins:install');
-        $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/plugins/config/MauticFocusBundle');
+        $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/plugins/info/MauticFocusBundle');
 
         $response = $this->client->getResponse();
         Assert::assertTrue($response->isOk());

--- a/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
+++ b/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
@@ -47,4 +47,20 @@ class PluginControllerTest extends MauticMysqlTestCase
         $crawler     = $this->client->submit($form);
         Assert::assertStringContainsString('A value is required.', $crawler->filter('#integration_details_apiKeys div')->html());
     }
+
+    public function testReturnPluginVersion(): void
+    {
+        $this->testSymfonyCommand('mautic:plugins:install');
+        $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/plugins/config/MauticFocusBundle');
+
+        $response = $this->client->getResponse();
+        Assert::assertTrue($response->isOk());
+
+        $content = $response->getContent();
+        Assert::assertJson($content);
+
+        $data = json_decode($content, true);
+        Assert::assertArrayHasKey('pluginVersion', $data);
+        Assert::assertSame('1.0', $data['pluginVersion']);
+    }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
  - Display plugin version badge in integration/plugin configuration modals
  - Add custom jQuery events (mautic:onPageLoad:before/after) for extensibility

Changes
  - Pass pluginVersion from controllers to modal views
  - Add version badge rendering via JavaScript when modal opens

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Manage Plugins page (Config -> Plugins)
3. Click on any plugin on the list
4. Verify version badge appears next to modal title

<img width="612" height="237" alt="image" src="https://github.com/user-attachments/assets/b3614f32-dd78-4bbf-8410-06cd6c68e32a" />
