### PR TITLE
[NOT-FOR-MERGE] Display plugin version in Manage Plugins -- M5

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -316,6 +316,8 @@ Mautic.processPageContent = function (response) {
  * Initiate various functions on page load, manual or ajax
  */
 Mautic.onPageLoad = function (container, response, inModal) {
+    mQuery(container).trigger('mautic:onPageLoad:before', [container, response, inModal]);
+
     Mautic.initDateRangePicker(container + ' #daterange_date_from', container + ' #daterange_date_to');
 
     //initiate links
@@ -724,6 +726,8 @@ Mautic.onPageLoad = function (container, response, inModal) {
             }
         }, false));
     }
+
+    mQuery(container).trigger('mautic:onPageLoad:after', [container, response, inModal]);
 };
 
 Mautic.setDynamicContentEditors = function(container) {

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -214,6 +214,9 @@ class ConfigController extends AbstractFormController
 
         $useConfigFormNotes = $integrationObject instanceof ConfigFormNotesInterface;
 
+        $plugin  = $integrationObject->getIntegrationConfiguration()->getPlugin();
+        $version = $plugin?->getVersion();
+
         return $this->delegateView(
             [
                 'viewParameters' => [
@@ -235,6 +238,7 @@ class ConfigController extends AbstractFormController
                     'activeLink'    => '#mautic_plugin_index',
                     'mauticContent' => 'integrationsConfig',
                     'route'         => false,
+                    'pluginVersion' => $version,
                 ],
             ]
         );

--- a/app/bundles/PluginBundle/Assets/js/plugin.js
+++ b/app/bundles/PluginBundle/Assets/js/plugin.js
@@ -346,3 +346,18 @@ Mautic.getIntegrationCampaigns = function (el, settings) {
         "GET"
     );
 };
+
+Mautic.initPluginEvents = function () {
+    const $integrationModal = mQuery('#IntegrationEditModal');
+
+    $integrationModal.off('mautic:onPageLoad:before');
+    $integrationModal.on('mautic:onPageLoad:before', function(e, container, response) {
+        if (container === '#IntegrationEditModal' && response && response.pluginVersion) {
+            const $modalLabel = mQuery('#IntegrationEditModal-label');
+            if ($modalLabel.find('.plugin-version-badge').length === 0) {
+                const versionHtml = ' <span class="plugin-version-badge label label-default ml-xs">v' + response.pluginVersion + '</span>';
+                $modalLabel.append(versionHtml);
+            }
+        }
+    });
+};

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -335,6 +335,9 @@ class PluginController extends FormController
             }
         }
 
+        $plugin  = $entity->getPlugin();
+        $version = $plugin?->getVersion();
+
         return $this->delegateView(
             [
                 'viewParameters' => [
@@ -352,6 +355,7 @@ class PluginController extends FormController
                     'mauticContent' => 'integrationConfig',
                     'route'         => false,
                     'sidebar'       => $this->get('twig')->render('@MauticCore/LeftPanel/index.html.twig'),
+                    'pluginVersion' => $version,
                 ],
             ]
         );
@@ -395,6 +399,7 @@ class PluginController extends FormController
                     'activeLink'    => '#mautic_plugin_index',
                     'mauticContent' => 'integration',
                     'route'         => false,
+                    'pluginVersion' => $bundle->getVersion(),
                 ],
             ]
         );

--- a/app/bundles/PluginBundle/Resources/views/Integration/grid.html.twig
+++ b/app/bundles/PluginBundle/Resources/views/Integration/grid.html.twig
@@ -35,7 +35,7 @@
 
 {% block content %}
   {% if isIndex %}
-    <div id="page-list-wrapper" class="panel panel-default">
+    <div id="page-list-wrapper" class="panel panel-default" data-onload-callback="initPluginEvents">
         <div class="panel-body">
             <div class="box-layout">
                 <div class="row">

--- a/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
+++ b/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PluginBundle\Tests\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Request;
+
+class PluginControllerTest extends MauticMysqlTestCase
+{
+    public function testReturnPluginVersion(): void
+    {
+        $this->testSymfonyCommand('mautic:plugins:install');
+        $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/plugins/info/MauticFocusBundle');
+
+        $response = $this->client->getResponse();
+        Assert::assertTrue($response->isOk());
+
+        $content = $response->getContent();
+        Assert::assertJson($content);
+
+        $data = json_decode($content, true);
+        Assert::assertArrayHasKey('pluginVersion', $data);
+        Assert::assertSame('1.0', $data['pluginVersion']);
+    }
+}


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

This is a backport of #15789 for M5.