### PR TITLE
[NOT-FOR-MERGE] Fix save form while WYSIWYG is in source code mode

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -126,6 +126,27 @@ Mautic.ajaxifyForm = function (formName) {
         e.preventDefault();
         var form = mQuery(this);
 
+        // Sync Froala editors in code view mode before AJAX submission
+        // This triggers the same event that would fire on native form submit
+        if (typeof mauticFroalaEnabled !== 'undefined' && mauticFroalaEnabled) {
+            form.find('textarea.editor').each(function() {
+                var froalaInstance = mQuery(this).data('froala.editor');
+                if (froalaInstance && froalaInstance.events) {
+                    froalaInstance.events.trigger('form.submit');
+                }
+            });
+        }
+
+        // Sync CKEditor content (including source mode) before AJAX submission
+        if (typeof ckEditors !== 'undefined' && ckEditors.size > 0) {
+            form.find('textarea.editor').each(function() {
+                var editor = ckEditors.get(this);
+                if (editor && typeof editor.updateSourceElement === 'function') {
+                    editor.updateSourceElement();
+                }
+            });
+        }
+
         if (MauticVars.formSubmitInProgress) {
             return false;
         } else {


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

Here is a shortened version of your PR description:

### Summary
Fixes an issue where Froala and CKEditor content failed to persist when saving forms via AJAX while in **Source/Code view**. Changes were lost because Mautic’s AJAX submission bypasses the native `submit` events these editors rely on to sync data to the underlying textarea.

### Changes
Manual synchronization is now triggered before AJAX submission:
*   **Froala:** Triggers the `form.submit` event to activate built-in sync logic.
*   **CKEditor:** Calls `updateSourceElement()` to force a sync from the editor to the textarea.

### Steps to test this PR
1.  **Froala:** Edit Dynamic Content in code view $\rightarrow$ Save (without toggling back) $\rightarrow$ Verify changes persist.
2.  **CKEditor:** Edit Dynamic Content in source view $\rightarrow$ Save (without toggling back) $\rightarrow$ Verify changes persist.
3.  Verify normal WYSIWYG mode still saves correctly for both editors.
4.  Verify "Apply" (Save & Stay) functionality works as expected.