### PR TITLE
Fix save DWC form while WYSIWYG is in source code mode

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -126,6 +126,16 @@ Mautic.ajaxifyForm = function (formName) {
         e.preventDefault();
         var form = mQuery(this);
 
+        // Sync CKEditor content (including source mode) before AJAX submission
+        if (typeof ckEditors !== 'undefined' && ckEditors.size > 0) {
+            form.find('textarea.editor').each(function() {
+                var editor = ckEditors.get(this);
+                if (editor && typeof editor.updateSourceElement === 'function') {
+                    editor.updateSourceElement();
+                }
+            });
+        }
+
         if (MauticVars.formSubmitInProgress) {
             return false;
         } else {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Fixes an issue where CKEditor content failed to persist when saving forms via AJAX while in **Source/Code view**. Changes were lost because Mautic’s AJAX submission bypasses the native `submit` events these editors rely on to sync data to the underlying textarea.

### Changes
Manual synchronization is now triggered before AJAX submission:
*   **CKEditor:** Calls `updateSourceElement()` to force a sync from the editor to the textarea.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Components -> Dynamic Web content -> New
3. Fill Internal name field
4. Switch CKEditor to Source mode (click source button on the toolbar)
5. Add some HTML, for example `<p>Test <strong>HTML CONTENT</strong></p>`
6. Save DWC (without toggling back to WYSIWYG mode
7. Verify changes persist.
8. Verify normal WYSIWYG mode still saves correctly.
9.  Verify "Apply" (Save & Stay) functionality works as expected.
10.  Verify that CKEditor still works correctly with Email forms  and other content forms

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->