### PR TITLE
Properly process CSP headers.

### DIFF
--- a/plugins/MauticFocusBundle/Assets/js/focus.js
+++ b/plugins/MauticFocusBundle/Assets/js/focus.js
@@ -242,15 +242,22 @@ Mautic.launchFocusBuilder = function (forceFetch) {
         mQuery('.preview-body').html('');
 
         Mautic.ajaxActionRequest('plugin:focus:checkIframeAvailability', data, function (response) {
-            if (response.errorMessage.length) {
+            if (response.errorMessage && response.errorMessage.length) {
                 mQuery('.website-placeholder')
                     .addClass('has-error')
                     .find('.help-block')
                     .html(response.errorMessage)
+                    .removeClass('hide');
                 mQuery('#builder-overlay').hide();
                 mQuery('#websiteCanvas').html('');
                 mQuery('.builder-panel-top p button').prop('disabled', false);
                 return;
+            } else {
+                mQuery('.website-placeholder')
+                    .removeClass('has-error')
+                    .find('.help-block')
+                    .html('')
+                    .removeClass('hide');
             }
 
             mQuery('#builder-overlay').addClass('hide');

--- a/plugins/MauticFocusBundle/Config/config.php
+++ b/plugins/MauticFocusBundle/Config/config.php
@@ -56,6 +56,8 @@ return [
                 'class'     => MauticPlugin\MauticFocusBundle\Helper\IframeAvailabilityChecker::class,
                 'arguments' => [
                     'translator',
+                    'mautic.native.connector',
+                    'mautic.helper.core_parameters',
                 ],
             ],
         ],

--- a/plugins/MauticFocusBundle/Helper/IframeAvailabilityChecker.php
+++ b/plugins/MauticFocusBundle/Helper/IframeAvailabilityChecker.php
@@ -2,11 +2,11 @@
 
 namespace MauticPlugin\MauticFocusBundle\Helper;
 
-use Symfony\Component\HttpClient\HttpClient;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -16,6 +16,8 @@ class IframeAvailabilityChecker
 {
     public function __construct(
         private TranslatorInterface $translator,
+        private HttpClientInterface $httpClient,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 
@@ -34,17 +36,12 @@ class IframeAvailabilityChecker
                     '%url%' => str_replace('http://', 'https://', $url),
                 ]);
         } else {
-            $client = HttpClient::create([
-                'headers' => [
-                    'User-Agent' => 'Mautic',
-                ],
-            ]);
+            $mauticUrl = $this->coreParametersHelper->get('site_url');
 
             try {
-                /** @var ResponseInterface $httpResponse */
-                $httpResponse = $client->request(Request::METHOD_GET, $url);
+                $httpResponse = $this->httpClient->request(Request::METHOD_GET, $url);
 
-                $blockingHeader = $this->checkHeaders($httpResponse->getHeaders(false));
+                $blockingHeader = $this->checkHeaders($httpResponse->getHeaders(false), $url, $mauticUrl);
 
                 if ('' !== $blockingHeader) {
                     $responseContent['errorMessage'] = $this->translator->trans(
@@ -86,21 +83,83 @@ class IframeAvailabilityChecker
      *
      * @return string Blocking header if problem found
      */
-    private function checkHeaders(array $headers): string
+    private function checkHeaders(array $headers, string $externalUrl, string $mauticUrl): string
     {
-        $return = '';
+        $return  = '';
+        $headers = array_change_key_case($headers, CASE_LOWER);
 
         if ($this->headerContains($headers, 'x-frame-options')) {
             // @see https://stackoverflow.com/questions/31944552/iframe-refuses-to-display
             $return = 'x-frame-options: SAMEORIGIN';
         }
 
-        if ($this->headerContains($headers, 'content-security-policy', "frame-ancestors 'self'")) {
-            // https://seznam.cz
+        if ($this->headerContains($headers, 'content-security-policy', 'frame-ancestors')) {
             // Refused to display 'https://www.seznam.cz/' in a frame because an ancestor violates the following
             // Content Security Policy directive: "frame-ancestors 'self'".
             // @see https://stackoverflow.com/questions/31944552/iframe-refuses-to-display
+            // But according to the
+            // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors
+            // 'self' can be anywhere, and additionally this should pass if 'self' matches current URL.
+            $header = $headers['content-security-policy'][0];
+
+            $headerParts    = explode(';', $header);
+            $frameAncestors = array_find(
+                $headerParts,
+                static fn (string $part): bool => str_starts_with(trim($part), 'frame-ancestors'));
+
+            if (!is_string($frameAncestors)) {
+                return $return;
+            }
+
+            $frameAncestors = trim($frameAncestors);
+
+            if ('frame-ancestors' === $frameAncestors) {
+                return $return;
+            }
+
+            $headerCSPValue      = trim(str_replace('frame-ancestors', '', $frameAncestors));
+            $frameAncestorValues = array_map(static fn (string $value): string => trim($value), explode(' ', $headerCSPValue));
+            $externalDomain      = \parse_url($externalUrl, \PHP_URL_HOST);
+            $externalProtocol    = \parse_url($externalUrl, \PHP_URL_SCHEME);
+
             $return = 'content-security-policy';
+
+            // Paths, IP address and wildcards (of path, IP) are not implemented.
+            foreach ($frameAncestorValues as $frameAncestorValue) {
+                // If IFrame is forbidden. Return the header to produce an error.
+                if ("'none'" === $frameAncestorValue) {
+                    return 'content-security-policy';
+                }
+
+                // If IFrame is hosted on the same domain as Mautic.
+                if ("'self'" === $frameAncestorValue && $mauticUrl === $externalUrl) {
+                    $return = '';
+                }
+
+                // If <scheme-source> matches.
+                if ($externalProtocol.':' === $frameAncestorValue) {
+                    $return = '';
+                }
+
+                // The "http:" also permits loading using https protocol.
+                if ('https' === $externalProtocol && 'http:' === $frameAncestorValue) {
+                    $return = '';
+                }
+
+                // If IFrame is hosted on exact allowed URL.
+                if ($frameAncestorValue === $externalUrl) {
+                    $return = '';
+                }
+
+                if (str_contains($frameAncestorValue, '//*.')) {
+                    $cspValue  = str_replace('//*.', '//', $frameAncestorValue);
+                    $cspDomain = \parse_url($cspValue, \PHP_URL_HOST);
+
+                    if (str_ends_with($cspDomain, $externalDomain)) {
+                        $return = '';
+                    }
+                }
+            }
         }
 
         return $return;
@@ -108,15 +167,9 @@ class IframeAvailabilityChecker
 
     private function headerContains(array $headers, string $name, ?string $content = null): bool
     {
-        $headers = array_change_key_case($headers, CASE_LOWER);
-
         if (array_key_exists($name, $headers)) {
-            if (null !== $content) {
-                if (str_starts_with($headers[$name][0], $content)) {
-                    return true;
-                } else {
-                    return false;
-                }
+            if (null !== $content && array_key_exists(0, $headers[$name])) {
+                return str_contains($headers[$name][0], $content);
             }
 
             return true;

--- a/plugins/MauticFocusBundle/Tests/Unit/Helper/IframeAvailabilityCheckerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Unit/Helper/IframeAvailabilityCheckerTest.php
@@ -2,9 +2,15 @@
 
 namespace MauticPlugin\MauticFocusBundle\Tests\Unit\Helper;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use MauticPlugin\MauticFocusBundle\Helper\IframeAvailabilityChecker;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class IframeAvailabilityCheckerTest extends \PHPUnit\Framework\TestCase
@@ -14,12 +20,24 @@ class IframeAvailabilityCheckerTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $translator;
 
+    /**
+     * @var MockObject&HttpClientInterface
+     */
+    private MockObject $httpClient;
+
+    /**
+     * @var MockObject&CoreParametersHelper
+     */
+    private MockObject $parametersHelper;
+
     private IframeAvailabilityChecker $helper;
 
     public function setUp(): void
     {
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->helper     = new IframeAvailabilityChecker($this->translator);
+        $this->translator       = $this->createMock(TranslatorInterface::class);
+        $this->httpClient       = $this->createMock(HttpClientInterface::class);
+        $this->parametersHelper = $this->createMock(CoreParametersHelper::class);
+        $this->helper           = new IframeAvailabilityChecker($this->translator, $this->httpClient, $this->parametersHelper);
     }
 
     public function testCheckProtocolMismatch(): void
@@ -42,10 +60,267 @@ class IframeAvailabilityCheckerTest extends \PHPUnit\Framework\TestCase
             )
             ->willReturn($translatedErrorMessage);
 
-        /** @var JsonResponse $response */
+        $this->httpClient->expects($this->never())
+            ->method('request');
+
+        $this->parametersHelper->expects($this->never())
+            ->method('get');
+
         $response = $this->helper->check($url, $currentScheme);
 
         $responseBody = json_decode($response->getContent(), true);
         $this->assertEquals($expectedResponseContent, $responseBody);
+    }
+
+    public function testCheckLeadsToException(): void
+    {
+        $currentScheme           = 'https';
+        $url                     = 'https://qwant.com';
+        $mauticUrl               = 'https://mautic.org';
+        $exceptionMessage        = 'Exception!';
+        $expectedResponseContent = [
+            'status'       => 0,
+            'errorMessage' => $exceptionMessage,
+        ];
+
+        $this->translator->expects($this->never())
+            ->method('trans');
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $url)
+            ->willThrowException(new \Exception($exceptionMessage));
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($url, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    public function testCheckXFrameOptions(): void
+    {
+        $currentScheme           = 'https';
+        $url                     = 'https://qwant.com';
+        $mauticUrl               = 'https://mautic.org';
+        $translatedErrorMessage  = 'error';
+        $expectedResponseContent = [
+            'status'       => 0,
+            'errorMessage' => $translatedErrorMessage,
+        ];
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with(
+                'mautic.focus.blocking.iframe.header',
+                [
+                    '%url%'    => $url,
+                    '%header%' => 'x-frame-options: SAMEORIGIN',
+                ]
+            )
+            ->willReturn($translatedErrorMessage);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->with(false)
+            ->willReturn(['x-frame-options' => ['SAMEORIGIN']]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $url)
+            ->willReturn($response);
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($url, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    public function testCheckCSPFrameAncestorsError(): void
+    {
+        $currentScheme           = 'https';
+        $url                     = 'https://qwant.com';
+        $mauticUrl               = 'https://mautic.org';
+        $translatedErrorMessage  = 'error';
+        $expectedResponseContent = [
+            'status'       => 0,
+            'errorMessage' => $translatedErrorMessage,
+        ];
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with(
+                'mautic.focus.blocking.iframe.header',
+                [
+                    '%url%'    => $url,
+                    '%header%' => 'content-security-policy',
+                ]
+            )
+            ->willReturn($translatedErrorMessage);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->with(false)
+            ->willReturn(['content-security-policy' => ["img-src 'self'; frame-ancestors https://domain.tld 'self';"]]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $url)
+            ->willReturn($response);
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($url, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    public function testCheckCSPFrameAncestorsErrorWhenNone(): void
+    {
+        $currentScheme           = 'https';
+        $url                     = 'https://qwant.com';
+        $mauticUrl               = 'https://mautic.org';
+        $translatedErrorMessage  = 'error';
+        $expectedResponseContent = [
+            'status'       => 0,
+            'errorMessage' => $translatedErrorMessage,
+        ];
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with(
+                'mautic.focus.blocking.iframe.header',
+                [
+                    '%url%'    => $url,
+                    '%header%' => 'content-security-policy',
+                ]
+            )
+            ->willReturn($translatedErrorMessage);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->with(false)
+            ->willReturn(['content-security-policy' => ["img-src 'self'; frame-ancestors https://domain.tld ".$url.' '.$mauticUrl." 'self' 'none' ".$url.';']]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $url)
+            ->willReturn($response);
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($url, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    public function testCheckCSPFrameAncestorsOkWhenEmpty(): void
+    {
+        $currentScheme           = 'https';
+        $mauticUrl               = 'https://mautic.org';
+        $externalUrl             = 'https://qwant.com';
+        $expectedResponseContent = [
+            'status'       => 1,
+            'errorMessage' => '',
+        ];
+
+        $this->translator->expects($this->never())
+            ->method('trans');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->with(false)
+            ->willReturn(['content-security-policy' => ["img-src 'self'; frame-ancestors ;"]]);
+        $response->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(Response::HTTP_OK);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $externalUrl)
+            ->willReturn($response);
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($externalUrl, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    #[DataProvider('provideOkFrameAncestors')]
+    public function testCheckCSPFrameAncestorsOk(string $externalUrl, string $frameAncestors): void
+    {
+        $currentScheme           = 'https';
+        $mauticUrl               = 'https://mautic.org';
+        $expectedResponseContent = [
+            'status'       => 1,
+            'errorMessage' => '',
+        ];
+
+        $this->translator->expects($this->never())
+            ->method('trans');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())
+            ->method('getHeaders')
+            ->with(false)
+            ->willReturn(['content-security-policy' => ["img-src 'self'; frame-ancestors ".$frameAncestors.';']]);
+        $response->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(Response::HTTP_OK);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with(Request::METHOD_GET, $externalUrl)
+            ->willReturn($response);
+
+        $this->parametersHelper->expects($this->once())
+            ->method('get')
+            ->with('site_url')
+            ->willReturn($mauticUrl);
+
+        $response = $this->helper->check($externalUrl, $currentScheme);
+
+        $responseBody = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        Assert::assertSame($expectedResponseContent, $responseBody);
+    }
+
+    public static function provideOkFrameAncestors(): \Generator
+    {
+        yield "'self' and hosted on Mautic instance" => ['https://mautic.org', "https://domain.tld 'self'"];
+        yield "First 'self' and hosted on Mautic instance" => ['https://mautic.org', "'self' https://domain.tld"];
+        yield 'https is allowed' => ['https://external.tld', "https://domain.tld 'self' https:"];
+        yield "First 'self' https is allowed" => ['https://external.tld', "'self' https://domain.tld https:"];
+        yield 'http is allowed on https' => ['https://external.tld', "https://domain.tld 'self' http:"];
+        yield "First 'self' http is allowed on https" => ['https://external.tld', "'self' https://domain.tld http:"];
+        yield 'Exact URL' => ['https://external.tld', "https://domain.tld 'self' https://external.tld"];
+        yield "First 'self' exact URL" => ['https://external.tld', "'self' https://domain.tld https://external.tld"];
+        yield 'Wildcard URL' => ['https://external.tld', "https://domain.tld 'self' https://*.external.tld"];
+        yield "First 'self' wildcard URL" => ['https://external.tld', "'self' https://domain.tld https://*.external.tld"];
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Issue(s) addressed                     | Fixes #15568  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
PR presents the bugfix for the processing of `frame-ancestors` CSP header in Focus feature.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create Focus item: /s/focus/new
3. Open the builder, enter the domain that blocks iframe, e.g. https://seznam.cz 
<img width="1900" height="992" alt="image" src="https://github.com/user-attachments/assets/e2972589-ecd5-46ed-b5b3-5220949639d3" />
4. Check the error message is visible.

5. Enter the domain that does not block the CSP header: https://mautic.org
6. See that the error message disappears.
7. Enter the domain, that blocks the iframe with the other rule than 'self' at the start.
8. See the error message is present.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->