### PR TITLE
Fix lifecycle dashboard widget height restriction

### DIFF
--- a/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
@@ -94,7 +94,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the pages limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -138,7 +138,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the assets limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }

--- a/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
@@ -57,7 +57,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
         if (!$event->isCached()) {
             $height = $event->getWidget()->getHeight();
-            $limit  = (int) round(($height - 80) / 75);
+            $limit  = (int) round(($height - 80) / 88);
             $logs   = $this->auditLogModel->getLogForObject(null, null, null, $limit);
 
             // Get names of log's items

--- a/app/bundles/CoreBundle/Resources/views/Helper/lifecycle.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/lifecycle.html.twig
@@ -19,7 +19,7 @@
         <div class="clearfix"></div>
         <div class="pull-left"><a href="{{ link[key] }}"> {{ value[key] }} Contacts</div></a>
         <div class="clearfix"></div>
-        <div style="height:{{ chartHeight / 2.3 }}px;">
+        <div style="height:{{ chartHeight / 3 }}px;">
             {% if  chartType is defined %}
           <canvas class="chart {{ chartType }}-chart" style="font-size:9px!important;">{{ chartData|json_encode }}</canvas>
             {% endif %}
@@ -32,7 +32,7 @@
         <div>
           <div class="chart-legend pt-sd pr-md pb-md pl-md"><h5>{{ 'mautic.lead.lifecycle.graph.stage.cycle'|trans }}</h5></div>
           <div class="clearfix"></div>
-          <div style="height:{{ chartHeight / 2.3 }}px;">
+          <div style="height:{{ chartHeight / 3 }}px;">
             <canvas class="chart liefechart-bar-chart" style="font-size: 9px!important;">{{ stages[key]|json_encode }}</canvas>
           </div>
           <div class="legend" style="font-size: 9px;"></div>
@@ -44,7 +44,7 @@
             <div>
                 <div class="chart-legend pt-sd pr-md pb-md pl-md"><h5>{{ 'mautic.lead.lifecycle.graph.device.granularity'|trans }}</h5></div>
                 <div class="clearfix"></div>
-                <div style="height:{{ chartHeight / 5 }}px;">
+                <div style="height:{{ chartHeight / 6 }}px;">
                     <canvas class="chart horizontal-bar-chart" style="font-size: 9px!important;">{{ devices[key]|json_encode }}</canvas>
                 </div>
                 <div class="legend" style="font-size: 9px;"></div>

--- a/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
+++ b/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
@@ -1,4 +1,4 @@
-<div class="tile" style="height: {{ widget.height|default('310') - 10 }}px;">
+<div class="tile" style="min-height: {{ widget.height|default('310') - 10 }}px;">
     <div class="card-header d-flex jc-space-between ai-center">
         <h4 class="fw-sb">{{ widget.name|purify }}</h4>
         {% if widget.id %}

--- a/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
+++ b/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
@@ -1,4 +1,4 @@
-<div class="tile" style="min-height: {{ widget.height|default('310') - 10 }}px;">
+<div class="tile" style="height: {{ widget.height|default('310') - 10 }}px;">
     <div class="card-header d-flex jc-space-between ai-center">
         <h4 class="fw-sb">{{ widget.name|purify }}</h4>
         {% if widget.id %}

--- a/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
@@ -185,7 +185,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
             $widget = $event->getWidget();
             $params = $widget->getParams();
             $height = $widget->getHeight();
-            $limit  = round(($height - 80) / 60);
+            $limit  = round(($height - 80) / 70);
 
             $upcomingEmails = $this->emailModel->getUpcomingEmails($limit, $canViewOthers);
 
@@ -346,6 +346,6 @@ class DashboardSubscriber extends MainDashboardSubscriber
      */
     private function getDefaultLimit(Widget $widget): float
     {
-        return round((($widget->getHeight() - 80) / 35) - 1);
+        return round((($widget->getHeight() - 80) / 44) - 1);
     }
 }

--- a/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
@@ -82,7 +82,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the pages limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -126,7 +126,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the pages limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -177,7 +177,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the forms limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -138,7 +138,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the list limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -186,7 +186,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
             if (empty($params['limit'])) {
                 // Count the list limit from the widget height
-                $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
             } else {
                 $limit = $params['limit'];
             }
@@ -296,7 +296,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the list limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -349,7 +349,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the list limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -395,7 +395,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the leads limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -444,7 +444,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the list limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }

--- a/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
@@ -118,7 +118,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the pages limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }
@@ -162,7 +162,7 @@ class DashboardSubscriber extends MainDashboardSubscriber
 
                 if (empty($params['limit'])) {
                     // Count the pages limit from the widget height
-                    $limit = round((($event->getWidget()->getHeight() - 80) / 35) - 1);
+                    $limit = round((($event->getWidget()->getHeight() - 80) / 44) - 1);
                 } else {
                     $limit = $params['limit'];
                 }


### PR DESCRIPTION
## Description

Fixes #15853

The lifecycle dashboard widget uses a fixed `height` on its tile container, which clips content when there is significant data (stages, devices, etc.). This changes the inline style from `height` to `min-height`, allowing the widget to expand vertically to show all data while maintaining the same minimum size.

## Changes

- **`app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig`**: Changed `height` to `min-height` on the tile container div.

## Before / After

**Before:** Widget content is clipped by a fixed height, hiding stages and device data.
**After:** Widget grows to accommodate all content while maintaining the configured size as a minimum.