### PR TITLE
Project Search display 1000 entities

### DIFF
--- a/app/bundles/ProjectBundle/Controller/AjaxController.php
+++ b/app/bundles/ProjectBundle/Controller/AjaxController.php
@@ -29,7 +29,7 @@ final class AjaxController extends CommonAjaxController
         $searchKey   = $request->query->get('searchKey', '');
         $searchValue = $request->query->get($searchKey, '');
         $filter      = $searchValue ?: $request->query->get('search', '');
-        $limit       = (int) $request->query->get('limit', '10');
+        $limit       = (int) $request->query->get('limit', '1000');
         $start       = (int) $request->query->get('start', '0');
 
         $results = $projectModel->getLookupResults($entityType, $filter, $limit, $start);

--- a/app/bundles/ProjectBundle/Form/Type/ProjectListEntityType.php
+++ b/app/bundles/ProjectBundle/Form/Type/ProjectListEntityType.php
@@ -30,7 +30,7 @@ final class ProjectListEntityType extends AbstractType
             'lookup_arguments'                  => fn (Options $options): array => [
                 'type'    => $options['entityType'],
                 'filter'  => '$data',
-                'limit'   => 100,
+                'limit'   => 1000,
                 'start'   => 0,
                 'options' => [
                     'entityType' => $options['entityType'],

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ProjectBundle\Tests\Functional\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Model\EmailModel;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProjectEntityLookupLimitTest extends MauticMysqlTestCase
+{
+    private const LOOKUP_CHOICE_LIST_URL = '/s/ajax?action=project:getLookupChoiceList';
+
+    /**
+     * Create 2000 test emails.
+     */
+    private function createTestEmails(): void
+    {
+        /** @var EmailModel $emailModel */
+        $emailModel = self::getContainer()->get(EmailModel::class);
+
+        for ($i = 1; $i <= 2000; ++$i) {
+            $email = new Email();
+            $email->setName('Common Autocomplete Email '.$i);
+            $email->setSubject('Subject '.$i);
+            $email->setEmailType('template');
+            $email->setTemplate('blank');
+            $emailModel->saveEntity($email);
+        }
+    }
+
+    /**
+     * Test: AJAX search with a common keyword
+     * Must return exactly 1000 results.
+     */
+    public function testAjaxSearchReturnsExactly1000Results(): void
+    {
+        // Arrange: seed 2000 emails
+        $this->createTestEmails();
+
+        // Act: trigger AJAX lookup endpoint
+        $this->client->request('GET', self::LOOKUP_CHOICE_LIST_URL, [
+            'entityType' => 'email',
+            'filter'     => 'Common',
+        ]);
+
+        // Assert: response is valid
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+
+        $decoded = json_decode($response->getContent(), true);
+        Assert::assertIsArray($decoded, 'Response must be a JSON array.');
+
+        $count = count($decoded);
+
+        // ✅ Must return exactly 1000 items
+        Assert::assertSame(
+            1000,
+            $count,
+            "AJAX autocomplete search should return exactly 1000 results, got {$count}."
+        );
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [ YES]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [ ] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/mautic-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes 

#### Description:

Searching any entity to add to a project displays only 10 entities in Project

#### Steps to test this PR:

- Create more than 10 lets say 20-30 emails or any other entity with name containing test

- Do not attach them with project so that we can add them in Project.

- Click on Add entities to project or add new to project button on projects page

- Select the entity and search for test

- It should return all emails or page or any entity added above in search box dropdown which are not attached already to that project. (More than 10 if available)
- This should work for both on Initial load autocomplete and when search something by typing.

Before you can see not all entities are loaded when searching for "test":
<img width="666" height="429" alt="Screenshot 2026-02-12 at 15 26 28" src="https://github.com/user-attachments/assets/334a6a81-8db1-4c0d-ae03-f46aa20d6c30" />

After all the entities are loaded and can be selected:
<img width="624" height="406" alt="Screenshot 2026-02-12 at 15 27 15" src="https://github.com/user-attachments/assets/86c5b1cf-c62c-43da-aceb-f6b97127caa9" />
