### PR TITLE
Fixing the webhook test check

### DIFF
--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -26,7 +26,7 @@ class PrivateAddressChecker
     public function __construct(
         private $dnsResolver = null,
     ) {
-        $this->dnsResolver = $dnsResolver ?? 'gethostbynamel';
+        $this->dnsResolver = $dnsResolver ?? 'gethostbyname';
     }
 
     /**
@@ -41,44 +41,36 @@ class PrivateAddressChecker
 
     public function isPrivateUrl(string $url): bool
     {
-        try {
-            $parsedUrl = parse_url($url);
+        $parsedUrl = parse_url($url);
 
-            if (!isset($parsedUrl['host'])) {
-                throw new \InvalidArgumentException('Invalid URL format');
-            }
+        if (!isset($parsedUrl['host'])) {
+            throw new \InvalidArgumentException('Invalid URL format');
+        }
 
-            $host = strtolower($parsedUrl['host']);
+        $host = strtolower($parsedUrl['host']);
 
-            if ('localhost' === $host) {
+        if ('localhost' === $host) {
+            return true;
+        }
+
+        // Handle IPv6 addresses with brackets
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $ip = substr($host, 1, -1); // Remove brackets
+
+            return $this->isPrivateIp($ip);
+        }
+
+        if (!filter_var($host, FILTER_VALIDATE_IP)) {
+            $ip = $this->resolveHostName($host);
+
+            if ($this->isPrivateIp($ip)) {
                 return true;
             }
 
-            // Handle IPv6 addresses with brackets
-            if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
-                $ip = substr($host, 1, -1); // Remove brackets
-
-                return $this->isPrivateIp($ip);
-            }
-
-            if (!filter_var($host, FILTER_VALIDATE_IP)) {
-                $ips = ($this->dnsResolver)($host);
-                if (false === $ips) {
-                    throw new \InvalidArgumentException('Could not resolve hostname');
-                }
-                foreach ($ips as $ip) {
-                    if ($this->isPrivateIp($ip)) {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return $this->isPrivateIp($host);
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('URL validation failed: '.$e->getMessage());
+            return false;
         }
+
+        return $this->isPrivateIp($host);
     }
 
     public function isPrivateIp(string $ip): bool
@@ -162,20 +154,25 @@ class PrivateAddressChecker
             }
 
             // Resolve hostname to IPs and check if any are in allowed addresses
-            $ips = ($this->dnsResolver)($host);
-            if (false === $ips) {
-                throw new \InvalidArgumentException('Could not resolve hostname');
-            }
+            $ip = $this->resolveHostName($host);
 
-            foreach ($ips as $ip) {
-                if (in_array($ip, $this->allowedPrivateAddresses, true)) {
-                    return true;
-                }
+            if (in_array($ip, $this->allowedPrivateAddresses, true)) {
+                return true;
             }
 
             return false;
-        } catch (\Exception $e) {
+        } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException('URL validation failed: '.$e->getMessage());
         }
+    }
+
+    private function resolveHostName(string $host): string
+    {
+        $ip = ($this->dnsResolver)($host);
+        if ($host === $ip) {
+            throw new \InvalidArgumentException("Could not resolve hostname {$host}");
+        }
+
+        return $ip;
     }
 }

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -24,9 +24,8 @@ class PrivateAddressChecker
      * @param callable|null $dnsResolver
      */
     public function __construct(
-        private $dnsResolver = null,
+        private $dnsResolver = 'gethostbyname',
     ) {
-        $this->dnsResolver = $dnsResolver ?? 'gethostbyname';
     }
 
     /**
@@ -153,7 +152,7 @@ class PrivateAddressChecker
                 return in_array($host, $this->allowedPrivateAddresses, true);
             }
 
-            // Resolve hostname to IPs and check if any are in allowed addresses
+            // Resolve hostname to an IP address and check if any are in allowed addresses
             $ip = $this->resolveHostName($host);
 
             if (in_array($ip, $this->allowedPrivateAddresses, true)) {

--- a/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
@@ -21,11 +21,11 @@ class PrivateAddressCheckerTest extends TestCase
         $this->checkerWithMockedDns = new PrivateAddressChecker(
             function (string $host) {
                 return match ($host) {
-                    'private.example.com' => ['192.168.1.1'],
-                    'public.example.com'  => ['203.0.113.1'],
-                    'api.example.com'     => ['8.8.8.8'],
-                    'localhost'           => ['127.0.0.1'],
-                    default               => false,
+                    'private.example.com' => '192.168.1.1',
+                    'public.example.com'  => '203.0.113.1',
+                    'api.example.com'     => '8.8.8.8',
+                    'localhost'           => '127.0.0.1',
+                    default               => $host,
                 };
             }
         );
@@ -136,7 +136,7 @@ class PrivateAddressCheckerTest extends TestCase
     public function testUnresolvableHostname(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URL validation failed: Could not resolve hostname');
+        $this->expectExceptionMessage('Could not resolve hostname unresolvable.example.com');
         $this->checkerWithMockedDns->isPrivateUrl('http://unresolvable.example.com');
     }
 

--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -23,7 +23,7 @@ class AjaxController extends CommonAjaxController
             );
         } catch (\InvalidArgumentException $e) {
             return $this->createErrorResponse($e->getMessage());
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return $this->createErrorResponse(
                 'mautic.webhook.label.warning'
             );

--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -21,7 +21,9 @@ class AjaxController extends CommonAjaxController
             return $this->createErrorResponse(
                 'mautic.webhook.error.private_address'
             );
-        } catch (\Exception) {
+        } catch (\InvalidArgumentException $e) {
+            return $this->createErrorResponse($e->getMessage());
+        } catch (\Exception $e) {
             return $this->createErrorResponse(
                 'mautic.webhook.label.warning'
             );


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.slack.com/archives/C02GEN0SG/p1770879657730789

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

A [security fix](https://github.com/mautic/mautic/commit/dc5bb1466c9a48fd34768dc8ff5888716b2916ba) that was meant to disallow local network discovery had several flaws:
1. Typo in `gethostbynamel` function
2. The function `gethostbyname` doesn't return array on success but string
3. The function `gethostbyname` doesn't return false on failure but the same string as it was inputted.
4. The `URL validation failed: ` prefix was duplicated.

This lead to an issue that:
1. No webhooks were going out unless at least 1 URL was added to the private allow list.
2. No valuable error message was outputted about what's wrong. Just "Error Detected" which isn't helpful. And it was going for this generic message because it was failing on type checks (expected array, given string). This is due to catching generic `Exception` on several places which is bad practice because it catches these hard errors.


### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test that webhooks work without filling in any allow-listed private webhook URL in the webhook config.
3. Test that you get a meaningful error if you input some not-existing domain like `https://kasfhskfhkasdjfhaskdfjasofjasdkf.dsfsdfs`
<img width="555" height="163" alt="Screenshot 2026-02-12 at 10 27 16" src="https://github.com/user-attachments/assets/3c05fc61-b39f-46fe-aeaa-6c1717da511f" />

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->