### PR TITLE
Surfacing a helpful error message to the user

### DIFF
--- a/.github/prompts/write-test.prompt.md
+++ b/.github/prompts/write-test.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: 'agent'
+agent: 'agent'
 tools: ['testFailure', 'usages']
 description: 'Generate a functional test for highlighted code'
 ---
@@ -22,6 +22,7 @@ Good practices:
 - Provide property, param and return types. If not possible to use native types you can always specify the types in the docblock. Mautic uses PHPSTAN so be sure to add types so the PHPSTAN won't fail.
 - Use `$this->assertResponseIsSuccessful();` to assert successful requests.
 - Use PHPUNIT's data providers to test multiple scenarios in a single test method.
+- Use PHP attributes for PHPUnit annotations (e.g., `#[\PHPUnit\Framework\Attributes\DataProvider('methodName')]` instead of `@dataProvider`).
 
 Suggestions for AI:
 - Do not modify the production code unless requested. Always just modify the test code.

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -43,7 +43,7 @@ class PrivateAddressChecker
     {
         $parsedUrl = parse_url($url);
 
-        if (!isset($parsedUrl['host'])) {
+        if (false === $parsedUrl || !isset($parsedUrl['host'])) {
             throw new \InvalidArgumentException('Invalid URL format');
         }
 

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -171,8 +171,7 @@ class PrivateAddressChecker
     /**
      * Resolves the given hostname to an array of IP addresses.
      *
-     * @return array<string> List of resolved IP addresses.
-     *
+     * @return array<string> list of resolved IP addresses
      * @return array<string> List of resolved IP addresses
      */
     private function resolveHostName(string $host): array

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -41,44 +41,40 @@ class PrivateAddressChecker
 
     public function isPrivateUrl(string $url): bool
     {
-        try {
-            $parsedUrl = parse_url($url);
+        $parsedUrl = parse_url($url);
 
-            if (!isset($parsedUrl['host'])) {
-                throw new \InvalidArgumentException('Invalid URL format');
-            }
-
-            $host = strtolower($parsedUrl['host']);
-
-            if ('localhost' === $host) {
-                return true;
-            }
-
-            // Handle IPv6 addresses with brackets
-            if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
-                $ip = substr($host, 1, -1); // Remove brackets
-
-                return $this->isPrivateIp($ip);
-            }
-
-            if (!filter_var($host, FILTER_VALIDATE_IP)) {
-                $ips = ($this->dnsResolver)($host);
-                if (false === $ips) {
-                    throw new \InvalidArgumentException('Could not resolve hostname');
-                }
-                foreach ($ips as $ip) {
-                    if ($this->isPrivateIp($ip)) {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return $this->isPrivateIp($host);
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException('URL validation failed: '.$e->getMessage());
+        if (!isset($parsedUrl['host'])) {
+            throw new \InvalidArgumentException('Invalid URL format');
         }
+
+        $host = strtolower($parsedUrl['host']);
+
+        if ('localhost' === $host) {
+            return true;
+        }
+
+        // Handle IPv6 addresses with brackets
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $ip = substr($host, 1, -1); // Remove brackets
+
+            return $this->isPrivateIp($ip);
+        }
+
+        if (!filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = ($this->dnsResolver)($host);
+            if (false === $ips) {
+                throw new \InvalidArgumentException('Could not resolve hostname');
+            }
+            foreach ($ips as $ip) {
+                if ($this->isPrivateIp($ip)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->isPrivateIp($host);
     }
 
     public function isPrivateIp(string $ip): bool

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -61,10 +61,7 @@ class PrivateAddressChecker
         }
 
         if (!filter_var($host, FILTER_VALIDATE_IP)) {
-            $ips = ($this->dnsResolver)($host);
-            if (false === $ips) {
-                throw new \InvalidArgumentException('Could not resolve hostname');
-            }
+            $ips = $this->resolveHostName($host);
             foreach ($ips as $ip) {
                 if ($this->isPrivateIp($ip)) {
                     return true;
@@ -157,11 +154,7 @@ class PrivateAddressChecker
                 return in_array($host, $this->allowedPrivateAddresses, true);
             }
 
-            // Resolve hostname to IPs and check if any are in allowed addresses
-            $ips = ($this->dnsResolver)($host);
-            if (false === $ips) {
-                throw new \InvalidArgumentException('Could not resolve hostname');
-            }
+            $ips = $this->resolveHostName($host);
 
             foreach ($ips as $ip) {
                 if (in_array($ip, $this->allowedPrivateAddresses, true)) {
@@ -173,5 +166,20 @@ class PrivateAddressChecker
         } catch (\Exception $e) {
             throw new \InvalidArgumentException('URL validation failed: '.$e->getMessage());
         }
+    }
+
+    /**
+     * Resolve hostname to IPs and check if any are in allowed addresses.
+     *
+     * @return array<string> List of resolved IP addresses
+     */
+    private function resolveHostName(string $host): array
+    {
+        $ips = ($this->dnsResolver)($host);
+        if (false === $ips) {
+            throw new \InvalidArgumentException("Could not resolve hostname {$host}");
+        }
+
+        return $ips;
     }
 }

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -169,7 +169,9 @@ class PrivateAddressChecker
     }
 
     /**
-     * Resolve hostname to IPs and check if any are in allowed addresses.
+     * Resolves the given hostname to an array of IP addresses.
+     *
+     * @return array<string> List of resolved IP addresses.
      *
      * @return array<string> List of resolved IP addresses
      */

--- a/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
@@ -136,7 +136,7 @@ class PrivateAddressCheckerTest extends TestCase
     public function testUnresolvableHostname(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('URL validation failed: Could not resolve hostname');
+        $this->expectExceptionMessage('Could not resolve hostname unresolvable.example.com');
         $this->checkerWithMockedDns->isPrivateUrl('http://unresolvable.example.com');
     }
 

--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -33,16 +33,21 @@ class AjaxController extends CommonAjaxController
     private function processWebhookTest(Request $request, Client $client, PathsHelper $pathsHelper): JsonResponse
     {
         $url = $this->validateUrl($request);
+
         if (!$url) {
-            return $this->createErrorResponse('mautic.webhook.label.no.url');
+            throw new \InvalidArgumentException('mautic.webhook.label.no.url');
         }
 
-        $selectedTypes = InputHelper::cleanArray($request->request->all()['types']) ?? [];
-        $payloadPaths  = $this->getPayloadPaths($selectedTypes, $pathsHelper);
-        $payload       = $this->loadPayloads($payloadPaths);
-        $secret        = InputHelper::string($request->request->get('secret'));
+        $selectedTypes = InputHelper::cleanArray($request->request->all()['types'] ?? []);
 
-        $response = $client->post($url, $payload, $secret);
+        if (!$selectedTypes) {
+            throw new \InvalidArgumentException('mautic.webhook.label.no.events');
+        }
+
+        $payloadPaths = $this->getPayloadPaths($selectedTypes, $pathsHelper);
+        $payload      = $this->loadPayloads($payloadPaths);
+        $secret       = InputHelper::string($request->request->get('secret'));
+        $response     = $client->post($url, $payload, $secret);
 
         return $this->createResponseFromStatusCode($response->getStatusCode());
     }

--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -21,6 +21,8 @@ class AjaxController extends CommonAjaxController
             return $this->createErrorResponse(
                 'mautic.webhook.error.private_address'
             );
+        } catch (\InvalidArgumentException $e) {
+            return $this->createErrorResponse($e->getMessage());
         } catch (\Exception) {
             return $this->createErrorResponse(
                 'mautic.webhook.label.warning'

--- a/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\WebhookBundle\Tests\Functional\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AjaxControllerTest extends MauticMysqlTestCase
+{
+    public function testSendHookTestWithMissingUrl(): void
+    {
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=webhook:sendHookTest',
+            [
+                'url'    => '',
+                'secret' => 'test-secret',
+                'types'  => ['mautic.lead_post_save_new'],
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        Assert::assertIsArray($content);
+        Assert::assertArrayHasKey('html', $content);
+        Assert::assertStringContainsString('has-error', $content['html']);
+        Assert::assertStringContainsString('No URL specified', $content['html']);
+    }
+
+    public function testSendHookTestWithMissingTypes(): void
+    {
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=webhook:sendHookTest',
+            [
+                'url'    => 'https://example.com/webhook',
+                'secret' => 'test-secret',
+                'types'  => [],
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        Assert::assertIsArray($content);
+        Assert::assertArrayHasKey('html', $content);
+        Assert::assertStringContainsString('has-error', $content['html']);
+        Assert::assertStringContainsString('No events selected', $content['html']);
+    }
+
+    public function testSendHookTestWithPrivateAddress(): void
+    {
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=webhook:sendHookTest',
+            [
+                'url'    => 'http://localhost/webhook',
+                'secret' => 'test-secret',
+                'types'  => ['mautic.lead_post_save_new'],
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        Assert::assertIsArray($content);
+        Assert::assertArrayHasKey('html', $content);
+        Assert::assertStringContainsString('has-error', $content['html']);
+        Assert::assertStringContainsString('private IP address range', $content['html']);
+    }
+
+    #[DataProvider('provideInvalidUrls')]
+    public function testSendHookTestWithInvalidUrls(string $url, string $expectedError): void
+    {
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=webhook:sendHookTest',
+            [
+                'url'    => $url,
+                'secret' => 'test-secret',
+                'types'  => ['mautic.lead_post_save_new'],
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        Assert::assertIsArray($content);
+        Assert::assertArrayHasKey('html', $content);
+        Assert::assertStringContainsString('has-error', $content['html']);
+        Assert::assertStringContainsString($expectedError, $content['html']);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideInvalidUrls(): iterable
+    {
+        yield 'empty string' => [
+            '',
+            'No URL specified',
+        ];
+
+        yield 'whitespace only' => [
+            '   ',
+            'No URL specified',
+        ];
+    }
+
+    #[DataProvider('provideMissingOrEmptyTypes')]
+    public function testSendHookTestWithMissingOrEmptyTypes(mixed $types): void
+    {
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=webhook:sendHookTest',
+            [
+                'url'    => 'https://example.com/webhook',
+                'secret' => 'test-secret',
+                'types'  => $types,
+            ],
+            [],
+            $this->createAjaxHeaders()
+        );
+
+        $response = $this->client->getResponse();
+        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $content = json_decode($response->getContent(), true);
+        Assert::assertIsArray($content);
+        Assert::assertArrayHasKey('html', $content);
+        Assert::assertStringContainsString('has-error', $content['html']);
+        Assert::assertStringContainsString('No events selected', $content['html']);
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideMissingOrEmptyTypes(): iterable
+    {
+        yield 'empty array' => [[]];
+        yield 'null value' => [null];
+    }
+}

--- a/app/bundles/WebhookBundle/Translations/en_US/messages.ini
+++ b/app/bundles/WebhookBundle/Translations/en_US/messages.ini
@@ -16,6 +16,7 @@ mautic.webhook.secret.tooltip="This field will autogenerate if no value is provi
 mautic.webhook.label.success="Success!"
 mautic.webhook.label.warning="Error Detected!"
 mautic.webhook.label.no.url="No URL specified"
+mautic.webhook.label.no.events="No events selected"
 mautic.webhook.no.logs="No Webhooks Logs"
 mautic.webhook.no.logs_desc="This webhook hasn't been executed yet so there aren't any logs available"
 mautic.webhook.permissions.header="Webhook Permissions"


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://mautic.slack.com/archives/C02GEN0SG/p1770879657730789, https://forum.mautic.org/t/mautic-6-0-6-webhook-not-executing/37352

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The message during webhook test is not very helpful:
<img width="552" height="146" alt="Screenshot 2026-02-12 at 10 56 25" src="https://github.com/user-attachments/assets/d4b305c0-b22d-45fb-8270-81a6ab5b8d87" />

This PR is surfacing the exception messages so they show to the user what's actually wrong:
<img width="536" height="131" alt="Screenshot 2026-02-12 at 10 58 45" src="https://github.com/user-attachments/assets/d404512f-5894-4709-a002-b39c063a03b8" />



### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Test that public URLs are sending webhooks to
3. Test that you get a meaningful error if you input some not-existing domain like `https://kasfhskfhkasdjfhaskdfjasofjasdkf.dsfsdfs`


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->