### PR TITLE
fix recursive \Mautic\EmailBundle\MonitoredEmail\Mailbox::isGmail call

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -242,7 +242,7 @@ class Mailbox
      */
     public function isGmail()
     {
-        return $this->isGmail();
+        return $this->isGmail;
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the 7.x branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌

## Description

Must have been a typo
```php
public function isGmail()
{
    return $this->isGmail();
}
```