### PR TITLE
Fixed call to member function on null for the mautic:max-mind:purge command

### DIFF
--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -116,15 +116,19 @@ EOT
         return $result->fetchAllAssociative();
     }
 
-    private function purgeData(string $contactId, string $ip): bool
+    private function purgeData(string $contactId, string $ip): void
     {
         /** @var Lead $lead */
         $lead       = $this->leadRepository->findOneBy(['id' => $contactId]);
         $matchedIps = array_filter($lead->getIpAddresses()->getValues(), fn ($item): bool => $item->getIpAddress() == $ip);
 
+        if (!$matchedIps) {
+            return;
+        }
+
         // We only purge data from the contact if it matches the data in the IP details
         if ($ipDetails = $matchedIps[0]->getIpDetails()) {
-            return false;
+            return;
         }
 
         $changed = false;
@@ -147,10 +151,6 @@ EOT
 
         if ($changed) {
             $this->leadRepository->saveEntity($lead);
-
-            return true;
         }
-
-        return false;
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MaxMindDoNotSellPurgeCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Functional\Command;
+
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+
+final class MaxMindDoNotSellPurgeCommandTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        file_put_contents(sys_get_temp_dir().'/do_not_sell_test.json', json_encode([
+            'exclusions' => [
+                [
+                    'exclusion_type' => 'ccpa_do_not_sell',
+                    'data_type'      => 'network',
+                    'value'          => '9.9.9.9/32',
+                ],
+            ],
+        ]));
+
+        $this->configParams['maxmind_do_not_sell_list_path'] = sys_get_temp_dir().'/do_not_sell_test.json';
+
+        parent::setUp();
+    }
+
+    public function testLoadedList3IsReached(): void
+    {
+        $lead = new Lead();
+        $lead->setFirstname('Test');
+        $this->em->persist($lead);
+
+        $ip = new IpAddress();
+        $ip->setIpAddress('9.9.9.9');
+        $this->em->persist($ip);
+
+        $lead->addIpAddress($ip);
+        $this->em->flush();
+
+        $lead->getIpAddresses()->clear();
+
+        $tester = $this->testSymfonyCommand('mautic:max-mind:purge');
+
+        $this->assertSame(0, $tester->getStatusCode());
+
+        $this->assertStringContainsString('Found 1 contacts', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

### Description : 
 -  Call to a member function getIpDetails() on null on MaxMindDoNotSellPurgeCommand.php:146

### Steps to test this PR:
 - Take a pull locally and run test app/bundles/CoreBundle/Tests/Unit/IpLookup/MatchedIpsGuardTest.php
 - Remove line 
```php
if (!$matchedIps) {
    return;
} 
```
from function `purgeData()` in file `app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php`
     and again run the test, it should throw same error : Error: Call to a member function getIpDetails() on null