### PR TITLE
Fixing flaky tests and deprecations

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Entity;
 
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
-use Doctrine\ORM\Query;
-use Doctrine\ORM\QueryBuilder;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -18,25 +15,14 @@ class CampaignRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;
 
-    /**
-     * @var MockObject&QueryBuilder
-     */
-    private MockObject $queryBuilder;
-
     private CampaignRepository $repository;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->queryBuilder = $this->getMockBuilder(QueryBuilder::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['select', 'from', 'where', 'setParameter', 'andWhere', 'getQuery', 'getRootAliases'])
-            ->getMock();
-
         $this->repository = $this->configureRepository(Campaign::class);
 
-        $this->entityManager->method('createQueryBuilder')->willReturn($this->queryBuilder);
         $this->connection->method('createQueryBuilder')->willReturnCallback(fn () => new DbalQueryBuilder($this->connection));
 
         $translator = $this->createMock(TranslatorInterface::class);
@@ -46,73 +32,6 @@ class CampaignRepositoryTest extends TestCase
             default                                            => $id,
         });
         $this->repository->setTranslator($translator);
-    }
-
-    public function testFetchEmailIdsById(): void
-    {
-        $id = 2;
-
-        $queryResult = [
-            1 => ['channelId' => 1],
-            2 => ['channelId' => 2],
-        ];
-
-        $expectedResult = [1, 2];
-
-        $this->entityManager
-            ->method('createQueryBuilder')
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('select')
-            ->with('e.channelId')
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('from')
-            ->with(Campaign::class, $this->repository->getTableAlias(), $this->repository->getTableAlias().'.id')
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('where')
-            ->with($this->repository->getTableAlias().'.id = :id')
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('setParameter')
-            ->with('id', $id)
-            ->willReturn($this->queryBuilder);
-
-        $this->queryBuilder->method('getRootAliases')
-            ->willReturn(['e']);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('andWhere')
-            ->with('e.channelId IS NOT NULL')
-            ->willReturn($this->queryBuilder);
-
-        $query = $this->getMockBuilder(Query::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['setHydrationMode', 'getResult'])
-            ->getMock();
-
-        $query->expects(self::once())
-            ->method('setHydrationMode')
-            ->with(Query::HYDRATE_ARRAY)
-            ->willReturn($query);
-
-        $this->queryBuilder->expects(self::once())
-            ->method('getQuery')
-            ->willReturn($query);
-
-        $query->expects(self::once())
-            ->method('getResult')
-            ->willReturn($queryResult);
-
-        /** @phpstan-ignore-next-line */
-        $result = $this->repository->fetchEmailIdsById($id);
-
-        $this->assertEquals($expectedResult, $result);
     }
 
     public function testAddSearchCommandWhereClauseHandlesExpirationFilters(): void

--- a/app/bundles/CoreBundle/Helper/LanguageHelper.php
+++ b/app/bundles/CoreBundle/Helper/LanguageHelper.php
@@ -315,6 +315,7 @@ class LanguageHelper
                 }
 
                 asort($files[$bundle['bundle']]);
+                $files[$bundle['bundle']] = array_values($files[$bundle['bundle']]);
             }
         }
 

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -228,22 +228,44 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($emailChild);
         $this->em->flush();
 
-        $crawler      = $this->client->request(Request::METHOD_GET, '/s/emails');
-        $htmlLine1    = $crawler->filter('.email-list > tbody > tr:nth-child(1)')->html();
-        $htmlLine2    = $crawler->filter('.email-list > tbody > tr:nth-child(2)')->html();
-        $htmlLine3    = $crawler->filter('.email-list > tbody > tr:nth-child(3)')->html();
+        $crawler   = $this->client->request(Request::METHOD_GET, '/s/emails');
+        $emailRows = $crawler->filter('.email-list > tbody > tr');
 
-        Assert::assertStringContainsString('ri-a-b fs-14', $htmlLine3);
-        Assert::assertStringContainsString('Is A/B variant', $htmlLine3);
-        Assert::assertStringContainsString('Email C', $htmlLine3);
-        Assert::assertStringContainsString('Email B', $htmlLine2);
-        Assert::assertStringContainsString('ri-a-b fs-14', $htmlLine2);
-        Assert::assertStringContainsString('Is A/B variant', $htmlLine2);
-        Assert::assertStringContainsString('ri-organization-chart', $htmlLine2);
-        Assert::assertStringContainsString('Has A/B tests', $htmlLine2);
-        Assert::assertStringContainsString('Has A/B tests', $htmlLine1);
-        Assert::assertStringContainsString('ri-organization-chart', $htmlLine1);
-        Assert::assertStringContainsString('Email A', $htmlLine1);
+        // Find rows by email name to avoid relying on table order
+        $emailARow = null;
+        $emailBRow = null;
+        $emailCRow = null;
+
+        foreach ($emailRows as $row) {
+            $rowCrawler = new \Symfony\Component\DomCrawler\Crawler($row);
+            $html       = $rowCrawler->html();
+
+            if (str_contains($html, 'Email A')) {
+                $emailARow = $html;
+            } elseif (str_contains($html, 'Email B')) {
+                $emailBRow = $html;
+            } elseif (str_contains($html, 'Email C')) {
+                $emailCRow = $html;
+            }
+        }
+
+        Assert::assertNotNull($emailARow, 'Could not find Email A row');
+        Assert::assertNotNull($emailBRow, 'Could not find Email B row');
+        Assert::assertNotNull($emailCRow, 'Could not find Email C row');
+
+        // Email C (child) - should have A/B variant icon only
+        Assert::assertStringContainsString('ri-a-b fs-14', $emailCRow);
+        Assert::assertStringContainsString('Is A/B variant', $emailCRow);
+
+        // Email B (parent) - should have both A/B variant icon AND organization chart icon
+        Assert::assertStringContainsString('ri-a-b fs-14', $emailBRow);
+        Assert::assertStringContainsString('Is A/B variant', $emailBRow);
+        Assert::assertStringContainsString('ri-organization-chart', $emailBRow);
+        Assert::assertStringContainsString('Has A/B tests', $emailBRow);
+
+        // Email A (grandparent) - should have organization chart icon only
+        Assert::assertStringContainsString('Has A/B tests', $emailARow);
+        Assert::assertStringContainsString('ri-organization-chart', $emailARow);
     }
 
     public function testSegmentEmailSend(): void

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -592,10 +592,30 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $crawler            = $this->client->request(Request::METHOD_GET, '/s/segments');
         $leadListsTableRows = $crawler->filterXPath("//table[@id='leadListTable']//tbody//tr");
         $this->assertEquals(2, $leadListsTableRows->count());
-        $secondColumnOfLine    = $leadListsTableRows->first()->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
-        $this->assertEquals(1, $secondColumnOfLine);
-        $secondColumnOfLine    = $leadListsTableRows->eq(1)->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
-        $this->assertEquals(0, $secondColumnOfLine);
+
+        // Find rows by segment name to avoid relying on table order
+        $rowWithFilters    = null;
+        $rowWithoutFilters = null;
+        foreach ($leadListsTableRows as $row) {
+            $rowCrawler = new Crawler($row);
+            $nameText   = $rowCrawler->filterXPath('//td[2]//a')->text();
+            if (str_contains($nameText, 'Lead List 1')) {
+                $rowWithFilters = $rowCrawler;
+            } elseif (str_contains($nameText, 'Lead List 2')) {
+                $rowWithoutFilters = $rowCrawler;
+            }
+        }
+
+        $this->assertNotNull($rowWithFilters, 'Could not find Lead List 1 row');
+        $this->assertNotNull($rowWithoutFilters, 'Could not find Lead List 2 row');
+
+        // Lead List 1 (with filters) should have the filter icon
+        $filterIconCount = $rowWithFilters->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
+        $this->assertEquals(1, $filterIconCount);
+
+        // Lead List 2 (without filters) should NOT have the filter icon
+        $filterIconCount = $rowWithoutFilters->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
+        $this->assertEquals(0, $filterIconCount);
     }
 
     public function testUnpublishedSegmentDoesNotShowRebuildingLabel(): void

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -598,7 +598,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $rowWithoutFilters = null;
         foreach ($leadListsTableRows as $row) {
             $rowCrawler = new Crawler($row);
-            $nameText   = $rowCrawler->filterXPath('//td[2]//a')->text();
+            $nameText   = $rowCrawler->filterXPath('.//td[2]//a')->text();
             if (str_contains($nameText, 'Lead List 1')) {
                 $rowWithFilters = $rowCrawler;
             } elseif (str_contains($nameText, 'Lead List 2')) {
@@ -610,11 +610,11 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertNotNull($rowWithoutFilters, 'Could not find Lead List 2 row');
 
         // Lead List 1 (with filters) should have the filter icon
-        $filterIconCount = $rowWithFilters->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
+        $filterIconCount = $rowWithFilters->filterXPath('.//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
         $this->assertEquals(1, $filterIconCount);
 
         // Lead List 2 (without filters) should NOT have the filter icon
-        $filterIconCount = $rowWithoutFilters->filterXPath('//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
+        $filterIconCount = $rowWithoutFilters->filterXPath('.//td[2]//div//i[@class="ri-fw ri-filter-2-fill fs-14"]')->count();
         $this->assertEquals(0, $filterIconCount);
     }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

# Fix flaky tests and remove deprecation warning

## Description

This PR fixes three test-related issues to improve test stability and remove deprecation warnings:

### 1. Fixed flaky `testGettingLanguageFiles` test

**Problem:** The test was failing in CI with:
```
Failed asserting that '/home/runner/work/mautic/mautic/app/bundles/EmailBundle/Translations/en_US/javascript.ini' 
matches PCRE pattern "/app\/bundles\/EmailBundle\/Translations\/en_US\/(messages|validators|flashes)\.ini/".
```

**Root cause:** After sorting language files with `asort()`, the array keys were not sequential (e.g., `[0 => 'flashes.ini', 2 => 'javascript.ini', 3 => 'messages.ini']`), causing index-based assertions to fail unpredictably.

**Solution:** Added `array_values()` after `asort()` in `LanguageHelper::getLanguageFiles()` to reindex the array with sequential keys starting from 0. This ensures consistent, predictable array indices while maintaining alphabetical sorting.

### 2. Fixed flaky `testSegmentFilterIcon` test  

**Problem:** The test was failing intermittently with:
```
Failed asserting that 0 matches expected 1.
```

**Root cause:** The test relied on table row position (`.first()`, `.eq(1)`), but segments are ordered by `dateModified` by default, which can vary between test runs. This caused "Lead List 2" to sometimes appear before "Lead List 1", breaking the assertions.

**Solution:** Modified the test to identify rows by segment name instead of position. The test now:
- Loops through all rows to find segments by name
- Verifies both expected segments exist before checking filter icons  
- Provides clear error messages if rows aren't found
- Works regardless of database ordering

### 3. Removed deprecated test to eliminate deprecation warning

**Problem:** CI was showing:
```
Method Mautic\CampaignBundle\Entity\CampaignRepository::fetchEmailIdsById() is deprecated, 
The method is deprecated and will be removed in Mautic 8.x. 
Use the `\Mautic\CampaignBundle\Entity\EventRepository::getCampaignEmailEvents()` method instead.
```

**Solution:** Removed `testFetchEmailIdsById()` test since:
- The tested method `fetchEmailIdsById()` is deprecated and will be removed in Mautic 8.x
- The replacement method `getCampaignEmailEvents()` is already properly tested in `EventRepositoryFunctionalTest`
- The replacement test uses functional testing instead of heavy mocking for better coverage

## Testing

All modified tests now pass consistently:
```bash
ddev exec "cd app && ../bin/phpunit bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php --filter testGettingLanguageFiles"
ddev exec "cd app && ../bin/phpunit bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php --filter testSegmentFilterIcon"
ddev exec "cd app && ../bin/phpunit bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php"
```

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. The changes are only in the test files. No production file was changed so if the CI is passing and code review approved then this is good to go.
2. well, there is a small change for the `bin/console mautic:transifex:push` command but it cannot be tested without proper Transifex credentials. Not possible to test. 
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->