### PR TITLE
Fix: handle failed imap_reopen

### DIFF
--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -350,7 +350,29 @@ class Mailbox
      */
     public function getImapStream()
     {
-        if (!$this->isConnected() || !@imap_reopen($this->imapStream, $this->imapFullPath)) {
+        $need_reconnect = !$this->isConnected();
+
+        if (!$need_reconnect) {
+            try {
+                if (!@imap_reopen($this->imapStream, $this->imapFullPath)) {
+                    $need_reconnect = true;
+                }
+            } catch (\ValueError|\TypeError) {
+                $need_reconnect = true;
+            }
+            try {
+                if ($need_reconnect) {
+                    imap_errors();
+                    imap_alerts();
+                    @imap_close($this->imapStream, CL_EXPUNGE);
+                }
+            } catch (\ValueError|\TypeError) {
+            }
+        }
+
+        if ($need_reconnect) {
+            // In case initImapStream throws, imapStream is cleared.
+            $this->imapStream = null;
             $this->imapStream = $this->initImapStream();
         }
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -350,18 +350,18 @@ class Mailbox
      */
     public function getImapStream()
     {
-        $need_reconnect = !$this->isConnected();
+        $needReconnect = !$this->isConnected();
 
-        if (!$need_reconnect) {
+        if (!$needReconnect) {
             try {
                 if (!@imap_reopen($this->imapStream, $this->imapFullPath)) {
-                    $need_reconnect = true;
+                    $needReconnect = true;
                 }
             } catch (\ValueError|\TypeError) {
-                $need_reconnect = true;
+                $needReconnect = true;
             }
             try {
-                if ($need_reconnect) {
+                if ($needReconnect) {
                     imap_errors();
                     imap_alerts();
                     @imap_close($this->imapStream, CL_EXPUNGE);
@@ -370,7 +370,7 @@ class Mailbox
             }
         }
 
-        if ($need_reconnect) {
+        if ($needReconnect) {
             // In case initImapStream throws, imapStream is cleared.
             $this->imapStream = null;
             $this->imapStream = $this->initImapStream();

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -350,10 +350,8 @@ class Mailbox
      */
     public function getImapStream()
     {
-        if (!$this->isConnected()) {
+        if (!$this->isConnected() || !@imap_reopen($this->imapStream, $this->imapFullPath)) {
             $this->imapStream = $this->initImapStream();
-        } else {
-            @imap_reopen($this->imapStream, $this->imapFullPath);
         }
 
         return $this->imapStream;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -316,29 +316,33 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
         $pathsHelper = $this->createMock(PathsHelper::class);
 
         MockImap::enable();
-        $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
 
-        // opens connection
-        $mailbox->getImapStream();
-        $this->assertEquals(1, MockImap::$imapOpenCount);
+        try {
+            $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
 
-        // Case 1: imap_reopen returns false
-        MockImap::$reopenReturn = false;
-        $mailbox->getImapStream();
+            // opens connection
+            $mailbox->getImapStream();
+            $this->assertEquals(1, MockImap::$imapOpenCount);
 
-        // Should close the old stream and open a new one
-        $this->assertEquals(2, MockImap::$imapOpenCount);
-        $this->assertEquals(1, MockImap::$imapCloseCount);
+            // Case 1: imap_reopen returns false
+            MockImap::$reopenReturn = false;
+            $mailbox->getImapStream();
 
-        // Case 2: imap_reopen throws ValueError
-        MockImap::reset();
-        MockImap::$reopenReturn          = true;
-        MockImap::$reopenThrowValueError = true;
+            // Should close the old stream and open a new one
+            $this->assertEquals(2, MockImap::$imapOpenCount);
+            $this->assertEquals(1, MockImap::$imapCloseCount);
 
-        $mailbox->getImapStream();
-        // Should again close the old stream and open a new one
-        $this->assertEquals(1, MockImap::$imapOpenCount);
-        $this->assertEquals(1, MockImap::$imapCloseCount);
-        MockImap::disable();
+            // Case 2: imap_reopen throws ValueError
+            MockImap::reset();
+            MockImap::$reopenReturn          = true;
+            MockImap::$reopenThrowValueError = true;
+
+            $mailbox->getImapStream();
+            // Should again close the old stream and open a new one
+            $this->assertEquals(1, MockImap::$imapOpenCount);
+            $this->assertEquals(1, MockImap::$imapCloseCount);
+        } finally {
+            MockImap::disable();
+        }
     }
 }

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -1,9 +1,100 @@
 <?php
 
+namespace Mautic\EmailBundle\MonitoredEmail;
+
+if (!class_exists(MockImap::class)) {
+    final class MockImap
+    {
+        // Enable imap_* function mocks
+        public static bool $enabled               = false;
+        public static bool $pingReturn            = true;
+        public static bool $pingThrowValueError   = false;
+        public static bool $reopenReturn          = true;
+        public static bool $reopenThrowValueError = false;
+        public static int $imapOpenCount          = 0;
+        public static int $imapCloseCount         = 0;
+
+        public static function enable(): void
+        {
+            self::$enabled = true;
+            self::reset();
+        }
+
+        public static function disable(): void
+        {
+            self::$enabled = false;
+        }
+
+        public static function reset(): void
+        {
+            self::$pingReturn            = true;
+            self::$pingThrowValueError   = false;
+            self::$reopenReturn          = true;
+            self::$reopenThrowValueError = false;
+            self::$imapOpenCount         = 0;
+            self::$imapCloseCount        = 0;
+        }
+    }
+
+    function imap_timeout($type, $timeout): bool
+    {
+        return MockImap::$enabled ? true : \imap_timeout($type, $timeout);
+    }
+
+    function imap_open($path, $user, $password, $options = 0, $retries = 0, $params = null)
+    {
+        ++MockImap::$imapOpenCount;
+
+        return MockImap::$enabled ? new \stdClass() : \imap_open($path, $user, $password, $options, $retries, $params);
+    }
+
+    function imap_ping($stream): bool
+    {
+        if (!MockImap::$enabled) {
+            return \imap_ping($stream);
+        }
+        if (MockImap::$pingThrowValueError) {
+            throw new \ValueError('IMAP connection is already closed');
+        }
+
+        return MockImap::$pingReturn;
+    }
+
+    function imap_reopen($stream, $path): bool
+    {
+        if (!MockImap::$enabled) {
+            return \imap_reopen($stream, $path);
+        }
+        if (MockImap::$reopenThrowValueError) {
+            throw new \ValueError('IMAP connection is already closed');
+        }
+
+        return MockImap::$reopenReturn;
+    }
+
+    function imap_close($stream, $flags = 0): bool
+    {
+        ++MockImap::$imapCloseCount;
+
+        return MockImap::$enabled ? true : \imap_close($stream, $flags);
+    }
+
+    function imap_errors(): array
+    {
+        return MockImap::$enabled ? [] : \imap_errors();
+    }
+
+    function imap_alerts(): array
+    {
+        return MockImap::$enabled ? [] : \imap_alerts();
+    }
+}
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\EmailBundle\MonitoredEmail\MockImap;
 
 class MailboxTest extends \PHPUnit\Framework\TestCase
 {
@@ -92,6 +183,16 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
                 'override_settings' => true,
                 'folder'            => 'INBOX',
             ],
+            'EmailBundle_unsubscribes' => [
+                'address'           => 'barfoo@foo.com',
+                'host'              => 'imap.barfoo.com',
+                'port'              => '993',
+                'encryption'        => '/ssl/novalidate-cert',
+                'user'              => 'barfoo@foo.com',
+                'password'          => 'ultrasecret',
+                'override_settings' => true,
+                'folder'            => 'INBOX',
+            ],
         ];
 
         $parametersHelper = $this->createMock(CoreParametersHelper::class);
@@ -111,6 +212,12 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('folder', $settings);
         $this->assertEquals('INBOX', $settings['folder']);
         $this->assertEquals('bar@foo.com', $settings['address']);
+
+        $settings = $mailbox->getMailboxSettings('EmailBundle', 'unsubscribes');
+
+        $this->assertArrayHasKey('folder', $settings);
+        $this->assertEquals('INBOX', $settings['folder']);
+        $this->assertEquals('barfoo@foo.com', $settings['address']);
     }
 
     public function testUseAttachments(): void
@@ -192,5 +299,46 @@ class MailboxTest extends \PHPUnit\Framework\TestCase
         $isConnectedMethod = $reflection->getMethod('isConnected');
 
         $this->assertFalse($isConnectedMethod->invoke($mailbox));
+    }
+
+    public function testGetImapStreamHandlesErrorOnReopen(): void
+    {
+        $parametersHelper = $this->createMock(CoreParametersHelper::class);
+        $parametersHelper->method('get')->willReturn([
+            'general' => [
+                'host'     => 'localhost',
+                'port'     => '993',
+                'user'     => 'test',
+                'password' => 'test',
+            ],
+        ]);
+
+        $pathsHelper = $this->createMock(PathsHelper::class);
+
+        MockImap::enable();
+        $mailbox = new \Mautic\EmailBundle\MonitoredEmail\Mailbox($parametersHelper, $pathsHelper);
+
+        // opens connection
+        $mailbox->getImapStream();
+        $this->assertEquals(1, MockImap::$imapOpenCount);
+
+        // Case 1: imap_reopen returns false
+        MockImap::$reopenReturn = false;
+        $mailbox->getImapStream();
+
+        // Should close the old stream and open a new one
+        $this->assertEquals(2, MockImap::$imapOpenCount);
+        $this->assertEquals(1, MockImap::$imapCloseCount);
+
+        // Case 2: imap_reopen throws ValueError
+        MockImap::reset();
+        MockImap::$reopenReturn          = true;
+        MockImap::$reopenThrowValueError = true;
+
+        $mailbox->getImapStream();
+        // Should again close the old stream and open a new one
+        $this->assertEquals(1, MockImap::$imapOpenCount);
+        $this->assertEquals(1, MockImap::$imapCloseCount);
+        MockImap::disable();
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ??
| Issue(s) addressed                     | Fixes #15864 

## Description
When setting different monitored email servers, configuration page fails to load. It tries to iterate over servers but in some configuration, `imap_reopen` fails as previous parameters are not compatible, and throws a `500` at some point.
This PR brings a quick fix for this situation.