### PR TITLE
fix: use strict comparison for isEmpty to allow saving value 0 in contact fields

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -680,14 +680,18 @@ class LeadModel extends FormModel
                         $newValue = implode('|', $newValue);
                     }
 
-                    $isEmpty = (null == $newValue || '' == $newValue);
+                    // Use strict comparison to correctly handle value 0 (integer/string).
+                    // Loose comparison `null == 0` and `'' == 0` both return true in PHP,
+                    // causing numeric value 0 to be incorrectly treated as empty/blank.
+                    $isEmpty = (null === $newValue || '' === $newValue);
                     if ($curValue !== $newValue && (!$isEmpty || ($isEmpty && $overwriteWithBlank))) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);
                     }
 
                     // if empty, check for social media data to plug the hole
-                    if (empty($newValue) && !empty($socialCache)) {
+                    // Use strict null/empty-string check to avoid treating 0 as empty
+                    if ((null === $newValue || '' === $newValue) && !empty($socialCache)) {
                         foreach ($socialCache as $service => $details) {
                             // check to see if a field has been assigned
 


### PR DESCRIPTION
Fixes #15030

## Problem

When saving a contact field with numeric value 0 via REST API, the value was silently ignored.

## Root Cause

LeadModel::setFieldValues() used PHP loose comparison:

Before (buggy): empty check was: null == 0 -> true, '' == 0 -> true

This caused integer/string 0 to be treated as empty/blank and skipped.

## Fix

Changed to strict comparison (===) that correctly handles value 0.

After: null === 0 -> false, '' === 0 -> false

Strict comparison table:
- null -> isEmpty=true (correct)
- '' -> isEmpty=true (correct)
- 0 -> isEmpty=false (now fixed)
- '0' -> isEmpty=false (now fixed)
- 1 -> isEmpty=false (correct)

Also fixed social cache fallback check to use strict comparison,
preventing 0 values from being overwritten by social cache data.

## Testing

1. Create a Number type custom field for contacts
2. Via REST API, PATCH the contact to set field value to 0
3. Before fix: value is ignored
4. After fix: value is correctly saved as 0

## Impact
- No breaking changes
- null and empty string still treated as empty
- Integer and string 0 now correctly treated as valid values

Made with [Cursor](https://cursor.com)