### PR TITLE
fix: Extract body content in code editor to prevent head duplication

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -96,7 +96,7 @@ class CodeEditor {
       // Parse HTML to extract only <body> content to prevent <head> duplication
       const parser = new DOMParser();
       const doc = parser.parseFromString(code, 'text/html');
-      const bodyContent = doc.body.innerHTML;
+      const bodyContent = doc.body?.innerHTML || code;
       this.editor.setComponents(bodyContent.trim());
 
       // Reinitialize the content after parsing MJML.

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -92,7 +92,13 @@ class CodeEditor {
     try {
       // delete canvas and set new content
       this.editor.DomComponents.getWrapper().set('content', '');
-      this.editor.setComponents(code.trim())
+
+      // Parse HTML to extract only <body> content to prevent <head> duplication
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(code, 'text/html');
+      const bodyContent = doc.body.innerHTML;
+    
+      this.editor.setComponents(bodyContent.trim());
 
       // Reinitialize the content after parsing MJML.
       // This can be removed once the issue with self-closing tags is resolved in grapesjs-mjml.

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -97,7 +97,6 @@ class CodeEditor {
       const parser = new DOMParser();
       const doc = parser.parseFromString(code, 'text/html');
       const bodyContent = doc.body.innerHTML;
-    
       this.editor.setComponents(bodyContent.trim());
 
       // Reinitialize the content after parsing MJML.


### PR DESCRIPTION
## Description
Fixes an issue where switching to code edit mode and saving caused `<head>` content to be duplicated into the `<body>` section repeatedly.

The GrapesJS `setComponents` method expects body content only, but the code editor was passing the full HTML string (including `<head>`). This fix parses the HTML and extracts only the `body.innerHTML` before passing it to the editor.

## Changes
- Added DOM parsing to `codeEditor.js` to separate head/body content
- Ensures only body content is passed to `editor.setComponents()`

## Related Issue
Fixes #14409

## Testing
- Reproduced the issue: Create landing page → Code mode → Save → Duplicates observed.
- Applied fix: Duplicates no longer appear after multiple save cycles.
- Tested on: Firefox, Chrome, Safari (as per issue report).