### PR TITLE
Fix unsubscribe URL when email contains @ (rawurlencode urlEmail in path)

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1362,7 +1362,7 @@ class MailHelper
             if ($toEmail) {
                 $unsubscribeHash = $this->mailHashHelper->getEmailHash($toEmail);
                 $url             = $this->router->generate('mautic_email_unsubscribe',
-                    ['idHash' => $this->idHash, 'urlEmail' => $toEmail, 'secretHash' => $unsubscribeHash],
+                    ['idHash' => $this->idHash, 'urlEmail' => rawurlencode($toEmail), 'secretHash' => $unsubscribeHash],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 );
             } else {


### PR DESCRIPTION
## Problem
The unsubscribe link `{unsubscribe_url}` puts the contact email in the path: `/email/unsubscribe/{idHash}/{urlEmail}/{secretHash}`. When the email contains `@` (e.g. `user@example.com`), that character is not encoded. Many clients, proxies or servers truncate the path at `@` (RFC 3986 uses `@` for userinfo in the authority component), so the request never reaches the correct URL and unsubscribe fails.

## Solution
Use `rawurlencode($toEmail)` when passing `urlEmail` to the router in `MailHelper.php`. Symfony decodes path parameters in the controller, so no change is needed in `PublicController`.

## Affected versions
At least 5.x and 7.x (route with `urlEmail` in path).

Made with [Cursor](https://cursor.com)