### PR TITLE
fix #14409: Extract body content in Code Editor to prevent head duplication

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -78,6 +78,30 @@ class CodeEditor {
   }
 
   /**
+   * Extract body content from HTML code.
+   * If the code contains a full HTML document with <html> tag,
+   * only extract the body content to prevent head elements from
+   * being duplicated into the body when saved.
+   * @param {string} code - The HTML code from the code editor
+   * @returns {string} - The body content or original code if no html tag found
+   */
+  extractBodyContent(code) {
+    const trimmedCode = code.trim();
+
+    if (trimmedCode.includes('<html') || trimmedCode.includes('<!DOCTYPE')) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(trimmedCode, 'text/html');
+      const body = doc.body;
+
+      if (body && body.innerHTML) {
+        return body.innerHTML;
+      }
+    }
+
+    return trimmedCode;
+  }
+
+  /**
    * Update the main editors canvas content with the
    * content from modals editor.
    * @todo show validation results in UI
@@ -92,7 +116,13 @@ class CodeEditor {
     try {
       // delete canvas and set new content
       this.editor.DomComponents.getWrapper().set('content', '');
-      this.editor.setComponents(code.trim())
+
+      let componentCode = code.trim();
+      if (!ContentService.isMjmlMode(this.editor)) {
+        componentCode = this.extractBodyContent(code);
+      }
+
+      this.editor.setComponents(componentCode)
 
       // Reinitialize the content after parsing MJML.
       // This can be removed once the issue with self-closing tags is resolved in grapesjs-mjml.

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -102,6 +102,28 @@ class CodeEditor {
   }
 
   /**
+   * Extract head content from HTML code.
+   * Used to preserve user head modifications (styles, scripts, meta) when saving.
+   * @param {string} code - The HTML code from the code editor
+   * @returns {string|null} - The head innerHTML or null if no head found
+   */
+  extractHeadContent(code) {
+    const trimmedCode = code.trim();
+
+    if (trimmedCode.includes('<html') || trimmedCode.includes('<!DOCTYPE')) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(trimmedCode, 'text/html');
+      const head = doc.head;
+
+      if (head && head.innerHTML.trim()) {
+        return head.innerHTML;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Update the main editors canvas content with the
    * content from modals editor.
    * @todo show validation results in UI
@@ -118,11 +140,23 @@ class CodeEditor {
       this.editor.DomComponents.getWrapper().set('content', '');
 
       let componentCode = code.trim();
+      // Preserve user head modifications before stripping to body content
+      let userHeadContent = null;
       if (!ContentService.isMjmlMode(this.editor)) {
+        userHeadContent = this.extractHeadContent(code);
         componentCode = this.extractBodyContent(code);
       }
 
-      this.editor.setComponents(componentCode)
+      this.editor.setComponents(componentCode);
+
+      // Restore preserved head content after setComponents() clears it
+      // This fixes the data-loss regression where head edits were silently dropped
+      if (userHeadContent !== null) {
+        const canvasDoc = this.editor.Canvas.getDocument();
+        if (canvasDoc && canvasDoc.head) {
+          canvasDoc.head.innerHTML = userHeadContent;
+        }
+      }
 
       // Reinitialize the content after parsing MJML.
       // This can be removed once the issue with self-closing tags is resolved in grapesjs-mjml.

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/codeMode/codeEditor.js
@@ -93,7 +93,7 @@ class CodeEditor {
       const doc = parser.parseFromString(trimmedCode, 'text/html');
       const body = doc.body;
 
-      if (body && body.innerHTML) {
+      if (body) {
         return body.innerHTML;
       }
     }


### PR DESCRIPTION
## Summary
Fixes the issue where code editor in landing pages duplicates <head> content when saving.

## Changes
- Added extractBodyContent() method in codeEditor.js
- This method detects full HTML documents and only extracts body content
- Prevents <head> content from being duplicated into <body>