### PR TITLE
Fix Composer installs and GH actions by adding temporary gaufrette/extras repository

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -113,6 +113,11 @@
     {
       "type": "git",
       "url": "https://github.com/mautic/SymfonyBridgeBundle.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/mautic/gaufrette-extras.git",
+      "only": ["gaufrette/extras"]
     }
   ],
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,11 @@
     {
       "type": "git",
       "url": "https://github.com/mautic/oauth2-php"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/mautic/gaufrette-extras.git",
+      "only": ["gaufrette/extras"]
     }
   ],
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c217dc4fbd7922ee58ce1f21d2b4dbb2",
+    "content-hash": "50ee7521afc0ffb910b05837c5fdb0a6",
     "packages": [
         {
             "name": "api-platform/core",
@@ -3361,14 +3361,8 @@
             "version": "v0.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Gaufrette/extras.git",
-                "reference": "a2af9a8c53591a4c43a38249e17bcdefdcea8a23"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Gaufrette/extras/zipball/a2af9a8c53591a4c43a38249e17bcdefdcea8a23",
-                "reference": "a2af9a8c53591a4c43a38249e17bcdefdcea8a23",
-                "shasum": ""
+                "url": "https://github.com/mautic/gaufrette-extras.git",
+                "reference": "07e10eb879c83ca2f7be8e9b7020f3ca93d165c9"
             },
             "require": {
                 "knplabs/gaufrette": "~0.4"
@@ -3384,18 +3378,22 @@
                     "Gaufrette\\Extras\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Gaufrette\\Extras\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "KnpLabs Team",
-                    "homepage": "http://knplabs.com"
-                },
-                {
                     "name": "Albin Kerouanton",
                     "email": "albin.kerouanton@knplabs.com"
+                },
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
                 },
                 {
                     "name": "The contributors",
@@ -3403,11 +3401,7 @@
                 }
             ],
             "description": "Provides extra features (prefixed fs, resolvable fs) to Gaufrette",
-            "support": {
-                "issues": "https://github.com/Gaufrette/extras/issues",
-                "source": "https://github.com/Gaufrette/extras/tree/master"
-            },
-            "time": "2017-06-17T15:28:53+00:00"
+            "time": "2026-03-03T13:22:33+00:00"
         },
         {
             "name": "geoip2/geoip2",
@@ -6220,7 +6214,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "2fabbc300101103f225472902d287b15e3af8c3a"
+                "reference": "a44fe615b1486f2c8cc60c11002192b5c9fed2bc"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -19047,5 +19041,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds a temporary Git repository reference to https://github.com/mautic/gaufrette-extras so Composer can resolve the `gaufrette/extras` dependency. The original source repository (https://github.com/Gaufrette/extras), which provided the `gaufrette/extras` package, no longer exists for unknown reasons.

This is a temporary solution to restore our GitHub Actions and Composer based installs until the upstream situation is clarified. See: https://github.com/KnpLabs/Gaufrette/issues/721


```
$ ddev composer clear-cache
$ ddev composer update gaufrette/extras -W
```

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Confirm that GitHub Actions checks are green.
<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->