### PR TITLE
[AssetBundle] Prevent API delete 500 when deleted asset has no ID during serialization

### DIFF
--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -60,6 +60,12 @@ class AssetApiController extends CommonApiController
      */
     protected function preSerializeEntity(object $entity, string $action = 'view'): void
     {
+        // During delete responses Doctrine may already de-reference the entity ID.
+        // In that case, generating a public slug is not possible and should be skipped.
+        if (null === $entity->getId()) {
+            return;
+        }
+
         $entity->setDownloadUrl(
             $this->model->generateUrl($entity, true)
         );

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -107,4 +107,32 @@ class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertStringContainsString('txt', $response['asset']['extension']);
         unlink($assetsPath.'/file.txt');
     }
+
+    public function testDeleteAssetReturnsSuccessAndEntityIsRemoved(): void
+    {
+        $payload = [
+            'file'            => 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
+            'storageLocation' => 'remote',
+            'title'           => 'asset for delete regression test',
+        ];
+
+        // Create asset first
+        $this->client->request('POST', 'api/assets/new', $payload);
+        $createResponse = $this->client->getResponse();
+        $this->assertResponseStatusCodeSame(201, $createResponse->getContent());
+
+        $createdAsset = json_decode($createResponse->getContent(), true);
+        $assetId      = $createdAsset['asset']['id'];
+        $this->assertNotEmpty($assetId);
+
+        // Delete must not fail with 500 due to post-delete serialization
+        $this->client->request('DELETE', sprintf('/api/assets/%d/delete', $assetId));
+        $deleteResponse = $this->client->getResponse();
+        $this->assertResponseStatusCodeSame(200, $deleteResponse->getContent());
+
+        // Verify the asset is actually removed
+        $this->client->request('GET', sprintf('/api/assets/%d', $assetId));
+        $getDeletedResponse = $this->client->getResponse();
+        $this->assertResponseStatusCodeSame(404, $getDeletedResponse->getContent());
+    }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes a 500 error on asset delete API responses.

After recent Asset slug/entity changes, `AssetApiController::preSerializeEntity()` always calls `generateUrl()`.  
During delete responses, Doctrine may already de-reference the entity ID, so `Asset::getSlug()` throws:

`LogicException: This asset must be saved before it can be used in a URL.`

That exception turns successful deletes into API 500 responses, which breaks downstream integration tests.

Fixes the regression posted here https://github.com/mautic/mautic/pull/15776#issuecomment-4006310947

---
### 📋 Steps to test this PR:

#### On API-library setup
1. Check out this PR branch on a local Mautic + api-library test setup.
2. Ensure API basic auth is enabled and valid.
3. Create and run a temporary debug script (`debug_test.php`) against the API library to verify create → delete → get flow:
```php
<?php
require __DIR__.'/vendor/autoload.php';
$config  = require __DIR__.'/tests/local.config.php';

$apiAuth = new Mautic\Auth\ApiAuth();
$auth    = $apiAuth->newAuth($config, $config['AuthMethod'] ?? 'BasicAuth');
$assets  = (new Mautic\MauticApi())->newApi('assets', $auth, $config['apiUrl']);

$create = $assets->create([
    'title' => 'debug delete',
    'storageLocation' => 'remote',
    'file' => 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
]);

$id = $create['asset']['id'] ?? null;
$delete = $assets->delete($id);
$get = $assets->get($id);

var_export(['create' => $create, 'delete' => $delete, 'getAfterDelete' => $get]);
```
4. Run it (example): [php debug_test.php](app://-/index.html#)
5. Expected:
    - create returns [asset.id](app://-/index.html#)
    - delete no longer returns 500
    - get after delete returns not found
6. Run targeted API library regressions:
    -  `vendor/bin/phpunit --filter "(AssetsTest::testCreateWithLocalFileGetAndDelete|AssetsTest::testCreateWithRemoteFileGetAndDelete|AssetsTest::testEditPut|CategoriesTest::testCreateGetAndDelete)" tests/Api --testdox`
7. Expected:
    - all four tests pass.

#### On bare php project

1. Ensure you have a Mautic instance running with this PR code applied and deployed.
2. Confirm Mautic API is enabled and Basic Auth is enabled.
3. Create a bare PHP test project:
   - `mkdir mautic-api-smoke && cd mautic-api-smoke`
   - `composer init --name="test/mautic-api-smoke" --no-interaction`
   - `composer require "mautic/api-library:^3.1" "guzzlehttp/guzzle:^7.10" "psr/log:^1.1" "symfony/var-dumper"`
4. Create `debug_test.php` in that bare project:

```php
<?php
require __DIR__.'/vendor/autoload.php';

$config = [
    'AuthMethod' => 'BasicAuth',
    'userName'   => 'YOUR_MAUTIC_USERNAME',
    'password'   => 'YOUR_MAUTIC_PASSWORD',
    'apiUrl'     => 'https://YOUR-MAUTIC-DOMAIN/api/',
];

$apiAuth = new Mautic\Auth\ApiAuth();
$auth    = $apiAuth->newAuth($config, $config['AuthMethod']);
$api     = new Mautic\MauticApi();

/** @var Mautic\Api\Assets $assets */
$assets = $api->newApi('assets', $auth, $config['apiUrl']);

$create = $assets->create([
    'title'           => 'debug delete check',
    'storageLocation' => 'remote',
    'file'            => 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf',
]);

$id = $create['asset']['id'] ?? null;
$delete = $id ? $assets->delete($id) : ['error' => 'create failed'];
$getAfterDelete = $id ? $assets->get($id) : null;

dump([
    'create' => $create,
    'delete' => $delete,
    'get_after_delete' => $getAfterDelete,
]);
```

5. Run:
	`php debug_test.php`

6. Expected:

   - create returns an asset with an id.
   - delete does not return a 500 error response.
   - get_after_delete returns not found for that asset ID.

 
> [!IMPORTANT]
> Replace the placeholder values for YOUR_MAUTIC_USERNAME, YOUR_MAUTIC_PASSWORD, and YOUR-MAUTIC-DOMAIN with valid credentials and your Mautic API URL before running the script.