### PR TITLE
Fix for remote assets with query params

### DIFF
--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -184,7 +184,12 @@ class AssetType extends AbstractType
         if (!is_string($object) && $object instanceof Asset) {
             $fileName = $object->getOriginalFileName();
         }
-        $fileExtension    = pathinfo($fileName, PATHINFO_EXTENSION);
+        $path = parse_url((string) $fileName, PHP_URL_PATH);
+        if (!is_string($path) || '' === $path) {
+            $path = (string) $fileName;
+        }
+
+        $fileExtension = pathinfo($path, PATHINFO_EXTENSION);
         if (!in_array(strtolower($fileExtension), array_map('strtolower', $extensions), true)) {
             $context->buildViolation('mautic.asset.asset.error.file.extension', [
                 '%fileExtension%'=> $fileExtension,

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -30,7 +30,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $this->configParams['validate_remote_domains'] = false;
         $this->configParams['site_url']                = 'https://site.tld';
 
-        if (in_array($this->getName(false), ['testCreateNewRemoteAssetWithValidateRemoteDomainsEnabled', 'testCreateAndEditRemoteImageAssetWithQueryString'], true)) {
+        if (in_array($this->name(), ['testCreateNewRemoteAssetWithValidateRemoteDomainsEnabled', 'testCreateAndEditRemoteImageAssetWithQueryString'], true)) {
             $this->configParams['validate_remote_domains'] = true;
             $this->configParams['allowed_remote_domains']  = [
                 'first-allowed.tld',

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -30,15 +30,111 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $this->configParams['validate_remote_domains'] = false;
         $this->configParams['site_url']                = 'https://site.tld';
 
-        if ('testCreateNewRemoteAssetWithValidateRemoteDomainsEnabled' === $this->name()) {
+        if (in_array($this->getName(false), ['testCreateNewRemoteAssetWithValidateRemoteDomainsEnabled', 'testCreateAndEditRemoteImageAssetWithQueryString'], true)) {
             $this->configParams['validate_remote_domains'] = true;
             $this->configParams['allowed_remote_domains']  = [
                 'first-allowed.tld',
                 'second-allowed.tld',
+                'assets.example.test',
             ];
         }
 
         parent::setUp();
+    }
+
+    public function testCreateAndEditRemoteImageAssetWithQueryString(): void
+    {
+        $title   = 'Remote image asset with query string';
+        $fileUrl = 'https://assets.example.test/photos/friends-on-shore.jpeg?auto=compress&cs=tinysrgb&w=800&lazy=load';
+
+        $crawlerCreate = $this->client->request('GET', '/s/assets/new');
+        $createForm    = $crawlerCreate->selectButton('Save')->form();
+        $createForm->setValues([
+            'asset[title]'           => $title,
+            'asset[storageLocation]' => 'remote',
+            'asset[remotePath]'      => $fileUrl,
+        ]);
+
+        $crawlerAfterSubmit = $this->client->submit($createForm);
+        $this->assertResponseIsSuccessful();
+        Assert::assertCount(0, $crawlerAfterSubmit->filter('div.has-error'), 'Expected no validation errors for valid remote image URL with query string');
+
+        $asset = $this->em->getRepository(Asset::class)->findOneBy(['title' => $title]);
+        Assert::assertInstanceOf(Asset::class, $asset, 'Asset should be created successfully');
+
+        $crawlerEdit = $this->client->request('GET', '/s/assets/edit/'.$asset->getId());
+        $editForm    = $crawlerEdit->selectButton('Save')->form();
+
+        $crawlerAfterEdit = $this->client->submit($editForm);
+        $this->assertResponseIsSuccessful();
+        Assert::assertCount(0, $crawlerAfterEdit->filter('div.has-error'), 'Expected no validation errors when re-saving edited remote asset URL with query string');
+
+        $this->em->clear();
+        $editedAsset = $this->em->find(Asset::class, $asset->getId());
+        Assert::assertInstanceOf(Asset::class, $editedAsset);
+        Assert::assertSame('remote', $editedAsset->getStorageLocation());
+        Assert::assertSame($fileUrl, $editedAsset->getRemotePath());
+        Assert::assertSame('jpeg', strtolower((string) $editedAsset->getExtension()));
+    }
+
+    public function testCreateNewLocalZipAssetCanBeSaved(): void
+    {
+        $tmpId         = uniqid('tmp_', true);
+        $zipName       = 'ticket-15111.zip';
+        $assetTitle    = 'Local ZIP asset '.uniqid();
+        $tmpUploadFile = tempnam(sys_get_temp_dir(), 'asset_zip_');
+
+        if (false === $tmpUploadFile) {
+            self::fail('Unable to create temporary file for ZIP upload test.');
+        }
+
+        $zipArchive = new \ZipArchive();
+        $zipArchive->open($tmpUploadFile, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zipArchive->addFromString('readme.txt', 'ZIP upload test content');
+        $zipArchive->close();
+
+        $uploadedFile = new UploadedFile($tmpUploadFile, $zipName, 'application/zip', null, true);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/s/_uploader/asset/upload',
+            ['tempId' => $tmpId],
+            ['file'   => $uploadedFile]
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $uploadResponse = json_decode((string) $this->client->getResponse()->getContent(), true);
+        Assert::assertIsArray($uploadResponse);
+        Assert::assertArrayNotHasKey('error', $uploadResponse, (string) $this->client->getResponse()->getContent());
+        Assert::assertArrayHasKey('tmpFileName', $uploadResponse, (string) $this->client->getResponse()->getContent());
+
+        $response = $this->client->request(Request::METHOD_GET, '/s/assets/new');
+        $this->assertResponseIsSuccessful();
+
+        $form                               = $response->filter('form[name="asset"]')->form();
+        $data                               = $form->getPhpValues();
+        $data['asset']['tempId']            = $tmpId;
+        $data['asset']['tempName']          = $uploadResponse['tmpFileName'];
+        $data['asset']['originalFileName']  = $zipName;
+        $data['asset']['storageLocation']   = 'local';
+        $data['asset']['title']             = $assetTitle;
+        $data['asset']['description']       = 'Regression test for ZIP upload save flow';
+
+        $this->client->submit($form, $data);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringNotContainsString(
+            'Upload failed as the file extension, zip',
+            (string) $this->client->getResponse()->getContent()
+        );
+
+        $asset = $this->em->getRepository(Asset::class)->findOneBy(['title' => $assetTitle]);
+        Assert::assertInstanceOf(Asset::class, $asset);
+        Assert::assertSame('zip', strtolower((string) $asset->getExtension()));
+
+        if (file_exists($tmpUploadFile)) {
+            unlink($tmpUploadFile);
+        }
     }
 
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -39,6 +39,15 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
             ];
         }
 
+        if ('testCreateNewLocalZipAssetCanBeSaved' === $this->name()) {
+            $allowedExtensions = $this->configParams['allowed_extensions'] ?? [];
+            if (!in_array('zip', $allowedExtensions, true)) {
+                $allowedExtensions[] = 'zip';
+            }
+
+            $this->configParams['allowed_extensions'] = $allowedExtensions;
+        }
+
         parent::setUp();
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [y]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [y] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes 

#### Description:

This PR fixes remote asset extension validation when the URL contains query parameters.

Previously, validation extracted the extension from the full URL string, so values like `jpeg?auto=...` were treated as the extension and rejected.

Technical summary:
- In `app/bundles/AssetBundle/Form/Type/AssetType.php`, extension extraction now parses the URL path via `parse_url(..., PHP_URL_PATH)` before calling `pathinfo(...)`.
- In `app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php`, functional test coverage was added for creating and re-saving a remote image asset with query parameters in the URL.
- The same test file also includes a local ZIP upload/save regression test to guard existing behavior.

#### Steps to test this PR:

##### Scenario: Remote asset URL with query string can be created and edited
1. Create a remote asset using:
`https://assets.example.test/photos/friends-on-shore.jpeg?auto=compress&cs=tinysrgb&w=800&lazy=load`
1. Save the asset.
1. Open the same asset for edit and save again.

Before: extension validation could incorrectly read `jpeg?...` and fail.
Now: no validation error; asset saves correctly.

##### Optional regression check: Local ZIP asset upload still works
1. Go to Assets and create a new local asset.
1. Upload a `.zip` file and submit.

Expected: ZIP asset is saved successfully.

#### Other areas of Mautic that may be affected by the change:
1. Asset upload/validation handling (local and remote URL extension parsing).

#### List deprecations along with the new alternative:
1. None

#### List of areas covered by the unit and/or functional tests:
1. `app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php`
