### PR TITLE
Fix release workflow uploading prerelease package to m.mautic.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,8 +243,8 @@ jobs:
   upload-release-asset:
     name: Upload release asset to m.mautic.org
     needs: [release, test-fresh-install, test-update-install]
-    # We only want this job to run in Mautic's repo, not in forks
-    if: github.repository_owner == 'mautic' && needs.release.outputs.is-prerelease
+    # We only want this job to run in Mautic's repo, not in forks. Upload only stable releases, not pre-releases.
+    if: github.repository_owner == 'mautic' && needs.release.outputs.is-prerelease == 'false'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

This PR fixes a condition bug in the `upload-release-asset` job that caused pre-release builds to be uploaded to m.mautic.org instead of only stable releases.

The condition `&& needs.release.outputs.is-prerelease` was truthy for both 'true' and 'false' string values. 
All values written to `$GITHUB_OUTPUT` are treated as strings, even when written as true, false, 1, or 0.
Added `== 'false'` to correctly restrict uploads to stable releases only.
