### PR TITLE
fix: `executeOrRescheduleScheduledEvents` gets the same contacts twice when using database replication

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -425,7 +425,8 @@ class LeadEventLogRepository extends CommonRepository
             )
             ->setParameter('eventId', (int) $eventId)
             ->setParameter('now', $now)
-            ->setParameter('true', true, Types::BOOLEAN);
+            ->setParameter('true', true, Types::BOOLEAN)
+            ->orderBy('o.lead', 'ASC');
 
         $this->updateOrmQueryFromContactLimiter('o', $q, $limiter);
 

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -265,10 +265,11 @@ class ScheduledExecutioner implements ExecutionerInterface, ResetInterface
 
             $this->processSignalService->throwExceptionIfSignalIsCaught();
 
-            // Set min contact id so we don't get the same contacts when facing database replication lag
-            $maxId = max([0, ...array_map(fn($log) => $log->getLead()->getId(), $logs->toArray())]);
-            if ($maxId > 0) {
-                $this->limiter->setBatchMinContactId($maxId+1);
+            // Check whether this is batch case
+            if (!$this->limiter->getContactId()) {
+                // Update the contact ID cursor to prevent duplicate processing when reader instances still show these records as scheduled due to replication lag.
+                $maxId = max([0, ...array_map(fn($log) => $log->getLead()->getId(), $logs->toArray())]);
+                $this->limiter->setBatchMinContactId($maxId + 1);
             }
 
             // Get next batch

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -265,6 +265,12 @@ class ScheduledExecutioner implements ExecutionerInterface, ResetInterface
 
             $this->processSignalService->throwExceptionIfSignalIsCaught();
 
+            // Set min contact id so we don't get the same contacts when facing database replication lag
+            $maxId = max([0, ...array_map(fn($log) => $log->getLead()->getId(), $logs->toArray())]);
+            if ($maxId > 0) {
+                $this->limiter->setBatchMinContactId($maxId+1);
+            }
+
             // Get next batch
             $this->scheduledContactFinder->clear($fetchedContacts);
             $logs = $this->repo->getScheduled($eventId, $this->now, $this->limiter);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Function `executeOrRescheduleScheduledEvents` gets the same contacts twice when using database replication

- This function will call function `getScheduled` to get contact batch
- The query inside `getScheduled` is finding rows that have `isScheduled` as `true` in table `campaign_lead_event_log`.
- After finishing each batch, `isScheduled` of those rows is updated to `false`.
- However, when using database cluster, reader instances have replication lag
- Reader instances might not update `isScheduled` in time before the new batch is executed.
- Therefore, same rows can be picked up twice.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Set up database cluster that has replication
2. Use database reader/writer endpoints separately (Or use sql proxy tool like ProxySQL to distribute read/write queries to reader/writer instances)
3. Set up crontab to "mautic:campaigns:trigger" with at least 30 threads so it is fast enough to see replication lag in reader instances
4. The same contacts should not get the same emails twice with code in this PR.


<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->