### PR TITLE
[NOT-FOR-MERGE] Optimize excluded segments query to prevent full table scans - M5

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -868,7 +868,11 @@ class EmailRepository extends CommonRepository
 
         $queryBuilder = $connection->createQueryBuilder();
         $queryBuilder->select('ll.lead_id')
-            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads', 'll')
+            /**
+             * Uses FORCE INDEX to ensure the PRIMARY key (leadlist_id, lead_id) is used,
+             * preventing full table scans on large lead_lists_leads tables.
+             */
+            ->from(MAUTIC_TABLE_PREFIX.'lead_lists_leads ll FORCE INDEX (`PRIMARY`)')
             ->where($queryBuilder->expr()->in('ll.leadlist_id', $excludedListIds));
 
         return $queryBuilder;


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

Port of https://github.com/mautic/mautic/pull/15950 for M5