### PR TITLE
[NOT-FOR-MERGE] Reduce Import Memory/Time: Cache Default Field Metadata

### DIFF
--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -6,20 +6,27 @@ use Mautic\LeadBundle\Entity\CustomFieldEntityInterface;
 
 trait DefaultValueTrait
 {
+    private array $cachedDefaultFields = [];
+
     /**
      * @param string $object
      */
     protected function setEntityDefaultValues(CustomFieldEntityInterface $entity, $object = 'lead')
     {
-        if (!$entity->getId()) {
-            $fields = $this->leadFieldModel->getFieldListWithProperties($object);
-            foreach ($fields as $alias => $field) {
-                // Prevent defaults from overwriting values already set
-                $value = $entity->getFieldValue($alias);
+        if ($entity->getId()) {
+            return;
+        }
 
-                if ((null === $value || '' === $value) && '' !== $field['defaultValue'] && null !== $field['defaultValue']) {
-                    $entity->addUpdatedField($alias, $field['defaultValue']);
-                }
+        if (!isset($this->cachedDefaultFields[$object])) {
+            $this->cachedDefaultFields[$object] = $this->leadFieldModel->getFieldListWithProperties($object);
+        }
+
+        foreach ($this->cachedDefaultFields[$object] as $alias => $field) {
+            // Prevent defaults from overwriting values already set
+            $value = $entity->getFieldValue($alias);
+
+            if ((null === $value || '' === $value) && '' !== $field['defaultValue'] && null !== $field['defaultValue']) {
+                $entity->addUpdatedField($alias, $field['defaultValue']);
             }
         }
     }

--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -6,6 +6,7 @@ use Mautic\LeadBundle\Entity\CustomFieldEntityInterface;
 
 trait DefaultValueTrait
 {
+    /** @var array<string, array<string, array<string, mixed>>> */
     private array $cachedDefaultFields = [];
 
     /**

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -650,7 +650,7 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
                 return true;
             }));
 
-        $this->fieldModelMock->expects($this->exactly(2))
+        $this->fieldModelMock->expects($this->exactly(1))
             ->method('getFieldListWithProperties')
             ->willReturn([]);
 


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

Backport of #15959

## Description
Adds request-local caching for `getFieldListWithProperties()` in `DefaultValueTrait::setEntityDefaultValues()` (keyed by object type: `lead` / `company`).

In batch operations, the same field metadata was loaded repeatedly for each new entity, causing avoidable memory growth and overhead.

### Performance impact
- Field metadata lookup is now executed once per object type per request, instead of once per entity.
- In local batch import testing (6000 contacts):
```
# BEFORE
Import 1 with 6001 rows is starting.
 6001/6001 [============================] 100%
6001 lines were processed, 6000 items created, 0 items updated, 1 items ignored in 41.62 s
Peak memory usage: 150 MB

# AFTER
Import 2 with 6001 rows is starting.
 6001/6001 [============================] 100%
6001 lines were processed, 6000 items created, 0 items updated, 1 items ignored in 37.58 s
Peak memory usage: 26.39 MB
```


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run a contact import with multiple rows.
3. Confirm import behavior is unchanged:
    - contacts are created/updated as expected,
    - default values are still applied to empty custom fields.
4. Optionally compare before/after logs for memory and runtime in batch imports.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->