### PR TITLE
POC/WIP: Better Testing Experience for Marketers: Email Open Sim + Admin View Warning

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -23,6 +23,14 @@ return [
                 'path'       => '/emails-map-stats/{objectId}/{isVariant}/{dateFrom}/{dateTo}',
                 'controller' => 'Mautic\EmailBundle\Controller\EmailMapStatsController::viewAction',
             ],
+            'mautic_email_test_open' => [
+                'path'         => '/emails/testopen/{objectId}',
+                'controller'   => 'Mautic\EmailBundle\Controller\EmailController::testOpenAction',
+                'methods'      => ['GET'],
+                'requirements' => [
+                    'objectId' => '\d+',
+                ],
+            ],
             'mautic_email_action' => [
                 'path'       => '/emails/{objectAction}/{objectId}',
                 'controller' => 'Mautic\EmailBundle\Controller\EmailController::executeAction',

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1717,3 +1717,60 @@ class EmailController extends FormController
         $clonedEmail->setDraft($cloningEmail->getDraft());
     }
 }
+    /**
+     * Simulates an email open for the given Stat row.
+     *
+     * Calls EmailModel::hitEmail() with the Stat entity directly (same as
+     * the tracking pixel), so all downstream events fire: campaigns, points,
+     * webhooks, open_details logging.
+     *
+     * Route:      GET /emails/testopen/{objectId}
+     * Permission: email:emails:edit
+     */
+    public function testOpenAction(int $objectId): \Symfony\Component\HttpFoundation\Response
+    {
+        if (!$this->security->isGranted('email:emails:edit')) {
+            return $this->accessDenied();
+        }
+
+        /** @var \Mautic\EmailBundle\Model\EmailModel $model */
+        $model = $this->getModel('email');
+
+        /** @var \Mautic\EmailBundle\Entity\Stat|null $stat */
+        $stat = $model->getStatRepository()->getEntity($objectId);
+
+        if (!$stat || !$stat->getLead()) {
+            return $this->notFound();
+        }
+
+        $leadId    = $stat->getLead()->getId();
+        $returnUrl = $this->generateUrl('mautic_contact_action', [
+            'objectAction' => 'view',
+            'objectId'     => $leadId,
+        ]);
+
+        if ($stat->getIsRead()) {
+            return $this->postActionRedirect([
+                'returnUrl' => $returnUrl,
+                'flashes'   => [[
+                    'type' => 'notice',
+                    'msg'  => 'mautic.email.timeline.test_open.already_read',
+                ]],
+            ]);
+        }
+
+        $fakeRequest = new \Symfony\Component\HttpFoundation\Request();
+        $fakeRequest->server->set('REMOTE_ADDR', '127.0.0.1');
+        $fakeRequest->server->set('HTTP_USER_AGENT', 'Mautic/TestOpen');
+
+        $model->hitEmail($stat, $fakeRequest, false, false);
+
+        return $this->postActionRedirect([
+            'returnUrl' => $returnUrl,
+            'flashes'   => [[
+                'type' => 'notice',
+                'msg'  => 'mautic.email.timeline.test_open.success',
+            ]],
+        ]);
+    }
+}

--- a/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
@@ -55,4 +55,18 @@
         {% endif %}
       {% endif %}
     </div>
+    {% if item.isFailed == 0 and item.isRead == 0 %}
+
+    <div class="mt-sm">
+        <a href="{{ path('mautic_email_test_open', {'objectId': item.id}) }}"
+           class="btn btn-xs btn-default"
+           data-toggle="confirmation"
+           data-message="{{ 'mautic.email.timeline.test_open.confirm'|trans }}"
+           data-confirm-text="{{ 'mautic.core.yes'|trans|e }}" data-confirm-callback="executeAction"
+           data-cancel-text="{{ 'mautic.core.form.cancel'|trans|e }}">
+            <i class="ri-eye-line"></i>
+            {{ 'mautic.email.timeline.test_open'|trans }}
+        </a>
+    </div>
+    {% endif %}
 {% endif %}

--- a/app/bundles/EmailBundle/Translations/en_US/messages.ini
+++ b/app/bundles/EmailBundle/Translations/en_US/messages.ini
@@ -477,3 +477,8 @@ mautic.email.send.dnc.tooltip="If you select this, your email will be sent to pe
 mautic.email.send.dnc.confirmation="If you select this, your email will be sent to people who meet the stated criteria, including those who unsubscribed. Only emails that are transactional, have critical information, or are prompted by recipient actions should bypass the unsubscribe status. Proceed?"
 mautic.email.send.dnc.confirmation.confirm.text="Yes"
 mautic.email.send.dnc.confirmation.cancel.text="Cancel"
+
+mautic.email.timeline.test_open="Test Open"
+mautic.email.timeline.test_open.confirm="This will simulate an email open for this contact, triggering any campaign actions or points tied to email opens. Continue?"
+mautic.email.timeline.test_open.success="Email open event simulated successfully."
+mautic.email.timeline.test_open.already_read="This email is already marked as opened — no action taken."

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -424,7 +424,7 @@ class PublicController extends AbstractFormController
             ]
         );
         if (!$this->security->isAnonymous()) {
-            return $notSuccessResponse;
+            return new \Symfony\Component\HttpFoundation\JsonResponse(['success' => 0, 'isAdmin' => true]);
         }
 
         /** @var PageModel $model */

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -185,6 +185,22 @@ class BuildJsSubscriber implements EventSubscriberInterface
 JS;
 
         $event->appendJs($js, 'Mautic Tracking Pixel');
+
+        $ghostJs = <<<'GHOSTJS'
+(function() {
+    document.addEventListener('mauticPageEventDelivered', function(e) {
+        var response = e.detail && e.detail.response;
+        if (!response || !response.isAdmin) return;
+        if (document.getElementById('mautic-admin-ghost')) return;
+        var el = document.createElement('div');
+        el.id = 'mautic-admin-ghost';
+        el.style.cssText = 'position:fixed;bottom:20px;left:20px;z-index:99999;background:rgba(0,0,0,0.7);color:#fff;padding:8px 14px;border-radius:8px;font-family:sans-serif;font-size:13px;display:flex;align-items:center;gap:8px;pointer-events:none;';
+        el.innerHTML = '<span style="font-size:20px">👻</span><span>Tracking events disabled</span>';
+        document.body.appendChild(el);
+    });
+})();
+GHOSTJS;
+        $event->appendJs($ghostJs, 'Mautic Admin Ghost Indicator');
     }
 
     public function onBuildJsForVideo(BuildJsEvent $event): void


### PR DESCRIPTION
Adds a Test Open button to Email Sent timeline entries (is_read=0). Calls EmailModel::hitEmail() with the Stat entity directly, identical to a real tracking pixel hit, so campaigns, points and webhooks all fire.

No subscriber changes needed - item.id and item.isRead are already present in the extra.stat array passed to the timeline template.

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

# feat(EmailBundle): add "Test Open" button to contact timeline

## Summary

Adds a **Test Open** button to `Email Sent` entries in the contact timeline
when the email has not yet been opened (`is_read = 0`).

Clicking it calls `EmailModel::hitEmail()` with the `Stat` entity directly —
the exact same codepath as a real tracking pixel hit — so all downstream
events fire correctly: campaign branches, point triggers, webhooks, and
`email_stats` open details.

## Motivation

- QA / testing campaign branches that depend on email opens without needing
  a real mail client to open the email
- Demonstrating Mautic behaviour to clients
- Debugging tracking pixel issues (confirms the open pipeline works end-to-end)

## Files changed

### `app/bundles/EmailBundle/Config/config.php`
New GET route `mautic_email_test_open` declared before the `{objectAction}`
wildcard so Symfony's router matches the literal `testopen` segment correctly.

### `app/bundles/EmailBundle/Controller/EmailController.php`
New `testOpenAction(int $objectId)` method:
- Checks `email:emails:edit` permission
- Fetches the `Stat` entity by PK
- Guards against already-read stats (returns a notice flash, no double-fire)
- Builds a minimal synthetic `Request` with `IP: 127.0.0.1` and
  `User-Agent: Mautic/TestOpen`
- Calls `$model->hitEmail($stat, $fakeRequest, false, false)` — identical to
  a real pixel hit, fires all downstream events
- Redirects back to the contact view with a success flash

### `app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig`
Adds a confirmation-dialog button at the bottom of each `Email Sent` entry
where `item.isRead` is falsy. Uses `data-toggle="confirmation"` and
`data-confirm-callback="executeAction"` — consistent with other action links
in Mautic (e.g. dashboard delete).

### `app/bundles/EmailBundle/Translations/en_US/messages.ini`
Four new keys:
- `mautic.email.timeline.test_open`
- `mautic.email.timeline.test_open.confirm`
- `mautic.email.timeline.test_open.success`
- `mautic.email.timeline.test_open.already_read`

## Implementation notes

- No subscriber changes required — `item.id` and `item.isRead` are already
  present in the `extra.stat` array passed to the timeline template.
- `$activeRequest = false` in the `hitEmail()` call bypasses the
  session-based duplicate-open guard, which would otherwise block a
  backend-initiated open.
- The button disappears after a real or simulated open (condition on
  `item.isRead`), so it cannot be accidentally fired twice.
- Failed sends (`item.isFailed`) are excluded from showing the button.
- No CSRF token needed — consistent with other Mautic confirmation-dialog
  action links.

## Testing steps

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
1. Send a test email to a contact via **Send Example**. Open the contact timeline — expand the `Email Sent` entry
3. **Test Open** button is visible
4. Click → confirmation dialog → confirm
5. Flash message: *"Email open event simulated successfully."*
6. Timeline now shows an `Email Read` entry
7. Campaign actions / points tied to email opens have fired
8. The **Test Open** button is gone from the `Email Sent` entry
9. On an already-opened entry — button does not appear
10. On a failed send entry — button does not appear

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->