### PR TITLE
[NOT-FOR-MERGE] MTC-10252 M5 Update contact campaign action datetime tokens when different timezones

### DIFF
--- a/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
@@ -93,7 +93,6 @@ final class ImportCompanySubscriber implements EventSubscriberInterface
             return;
         }
 
-
         $matchedFields = $event->getForm()->getData();
         $skipIfExists  = ArrayHelper::pickValue('skip_if_exists', $matchedFields, false);
         $event->setSkipIfExists((bool) $skipIfExists);

--- a/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
@@ -93,6 +93,7 @@ final class ImportCompanySubscriber implements EventSubscriberInterface
             return;
         }
 
+
         $matchedFields = $event->getForm()->getData();
         $skipIfExists  = ArrayHelper::pickValue('skip_if_exists', $matchedFields, false);
         $event->setSkipIfExists((bool) $skipIfExists);

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -63,13 +63,13 @@ class CustomFieldHelper
                 $dtHelper = new DateTimeHelper($value, null, 'local');
                 switch ($type) {
                     case 'datetime':
-                        $value = $dtHelper->toLocalString('Y-m-d H:i:s');
+                        $value = $dtHelper->toUtcString('Y-m-d H:i:s');
                         break;
                     case 'date':
-                        $value = $dtHelper->toLocalString('Y-m-d');
+                        $value = $dtHelper->toUtcString('Y-m-d');
                         break;
                     case 'time':
-                        $value = $dtHelper->toLocalString('H:i:s');
+                        $value = $dtHelper->toUtcString('H:i:s');
                         break;
                 }
                 break;

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -92,9 +92,9 @@ class CustomFieldHelperTest extends \PHPUnit\Framework\TestCase
         ];
 
         $expected = [
-            'customdate'         => (new DateTimeHelper('-1 day'))->toLocalString('Y-m-d'),
-            'customdatetime'     => (new DateTimeHelper('-1 day'))->toLocalString('Y-m-d H:i:s'),
-            'customtime'         => (new DateTimeHelper('-20 minutes'))->toLocalString('H:i:s'),
+            'customdate'         => (new DateTimeHelper('-1 day'))->toUtcString('Y-m-d'),
+            'customdatetime'     => (new DateTimeHelper('-1 day'))->toUtcString('Y-m-d H:i:s'),
+            'customtime'         => (new DateTimeHelper('-20 minutes'))->toUtcString('H:i:s'),
             'customnulldatetime' => null,
         ];
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>

With the campaign action “update contact” we can set timestamps using placeholders like “now”. When the contact runs through the campaign, the contact field should then be filled with the current timestamp. This works fine in UTC. However, when using other timezones like Europe/Berlin, the time added for the timezone doubles.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->