### PR TITLE
[NOT-FOR-MERGE] DWC does not render on buttons and or links

### DIFF
--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -185,6 +185,14 @@ class DynamicContentSubscriber implements EventSubscriberInterface
         foreach ($tokens as $token => $dwc) {
             $result[$token] = $dwc['content'];
         }
+
+        // DOMDocument URL-encodes { -> %7B and } -> %7D inside HTML attribute values (e.g. href).
+        // Replace those URL-encoded tokens first with HTML-stripped content to avoid injecting HTML markup
+        // into attribute values, then replace the plain tokens in the rest of the content normally.
+        foreach ($result as $token => $replacement) {
+            $encodedToken = str_replace(['{', '}'], ['%7B', '%7D'], $token);
+            $content      = str_replace($encodedToken, strip_tags($replacement), $content);
+        }
         $content = str_replace(array_keys($result), array_values($result), $content);
 
         $event->setContent($content);

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
@@ -258,6 +258,76 @@ HTML;
         $this->subscriber->decodeTokens($event);
     }
 
+    /**
+     * Test that DWC tokens inside href attributes are replaced correctly.
+     * DOMDocument URL-encodes curly braces in attributes ({->%7B, }->%7D),
+     * and the replacement must use strip_tags() to avoid injecting HTML into attributes.
+     */
+    public function testDecodeTokensWithDwcTokenInHrefAttribute(): void
+    {
+        $content = <<<HTML
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <h2>Hello there!</h2>
+        <a href="{dwc=link-token}">Click here</a>
+    </body>
+</html>
+
+HTML;
+
+        $expected = <<<HTML
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <h2>Hello there!</h2>
+        <a href="https://example.com/path">Click here</a>
+    </body>
+</html>
+
+HTML;
+        // DWC content contains HTML tags that should be stripped when used in href
+        $dwcContent = '<p>https://example.com/path</p>';
+        $event      = $this->createMock(PageDisplayEvent::class);
+        $contact    = new Lead();
+
+        $event->expects($this->once())
+            ->method('getContent')
+            ->willReturn($content);
+
+        $event->method('getLead')
+            ->willReturn(null);
+
+        $this->security->expects($this->once())
+            ->method('isAnonymous')
+            ->willReturn(true);
+
+        $this->contactTracker->expects($this->once())
+            ->method('getContact')
+            ->willReturn($contact);
+
+        $this->dynamicContentHelper->expects($this->once())
+            ->method('findDwcTokens')
+            ->with($content, $contact)
+            ->willReturn([
+                '{dwc=link-token}' => [
+                    'content' => $dwcContent,
+                    'filters' => [],
+                ],
+            ]);
+
+        $this->dynamicContentHelper->expects($this->never())
+            ->method('getDynamicContentForLead');
+
+        $event->expects($this->once())
+            ->method('setContent')
+            ->with($expected);
+
+        $this->subscriber->decodeTokens($event);
+    }
+
     public function testOnTokenReplacement(): void
     {
         $content = <<< HTML


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

## Summary
  Fix DWC token replacement when tokens appear inside HTML attributes (e.g., `href`).

  ## Problem
  PHP's `DOMDocument` URL-encodes curly braces in attribute values, converting `{dwc=...}` to `%7Bdwc=...%7D`. The token replacement logic then fails to find and replace the encoded tokens, resulting in broken links and attributes.

  ## Solution
  Implement two-pass token replacement:
  1. **First pass** — Replace URL-encoded tokens (`%7Bdwc=...%7D`) with `strip_tags()`-stripped content to prevent HTML injection into attributes
  2. **Second pass** — Replace plain tokens in body content with full HTML replacement