### PR TITLE
Fix Twig RuntimeError on user edit page when userPath/rolePath is empty

### DIFF
--- a/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
+++ b/app/bundles/UserBundle/Resources/views/User/recent_activity.html.twig
@@ -135,7 +135,7 @@
 								{% endif %}
 							</div>
 							<div class="media-body">
-								{% if log.object == 'user' %}
+								{% if log.object == 'user' and userPath is defined and userPath is not empty %}
 									{% if log.action == 'update' %}
 										{{ 'mautic.user.user.form.user'|trans }}
 										<a href="{{ path('mautic_user_action', {objectAction: 'edit', objectId: userPath[0]}) }}" data-toggle="ajax">
@@ -148,7 +148,7 @@
 										{{ 'mautic.user.user.form.created_by'|trans }}
 									{% endif %}
 
-								{% elseif log.object == 'role' %}
+								{% elseif log.object == 'role' and rolePath is defined and rolePath is not empty %}
 									{% if log.action == 'create' %}
 										{{ 'mautic.role.role'|trans }}
 										<a href="{{ path('mautic_role_action', {objectAction: 'edit', objectId: rolePath[0]}) }}" data-toggle="ajax">

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -207,4 +207,60 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
 
         return $user;
     }
+
+    /**
+     * The recent-activity panel rendered on the user edit page (recent_activity.html.twig)
+     * builds `userPath`/`rolePath` by matching an audit-log row's details against the
+     * currently loaded users/roles. When the referenced user or role no longer exists
+     * (deleted), no match is found and the path array stays empty/undefined. Pre-fix,
+     * the template accessed `userPath[0]`/`rolePath[0]` unconditionally and threw a Twig
+     * RuntimeError ("Key \"0\" does not exist as the sequence/mapping is empty"). This
+     * asserts GET /s/users/edit/{id} renders successfully instead of returning a 500.
+     *
+     * AuditLogRepository::getLogsForUser() filters on `bundle = 'user'` AND
+     * `userId = :user_id` (the acting user, not objectId), so the log's userId must be
+     * the edited user's own id for it to appear in this panel at all.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataAuditLogObjectTypes')]
+    public function testEditActionDoesNotCrashWhenAuditLogReferencesDeletedEntity(string $auditLogObject): void
+    {
+        $role = new Role();
+        $role->setName('Audit Log Test Role');
+        $role->setIsAdmin(false);
+        $this->em->persist($role);
+
+        $user = $this->userSetter($role);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        // A nonexistent id stands in for a user/role that has since been deleted. The
+        // template never reads objectId directly (it matches on `details` against the
+        // currently loaded users/roles), but this documents the scenario under test.
+        $deletedEntityId = 999999;
+
+        $auditLog = $this->auditLogSetter(
+            $user->getId(),
+            $user->getUsername(),
+            'user',
+            $auditLogObject,
+            $deletedEntityId,
+            'update',
+            ['lastLogin' => ['2024-01-01 00:00:00', '2024-02-22 10:30:00']]
+        );
+        $this->em->persist($auditLog);
+        $this->em->flush();
+
+        $this->client->request('GET', '/s/users/edit/'.$user->getId());
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function dataAuditLogObjectTypes(): iterable
+    {
+        yield 'deleted user reference' => ['user'];
+        yield 'deleted role reference' => ['role'];
+    }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Deprecations?     | no
| BC breaks?        | no
| Automated tests   | no
| Related issue(s)  | Fixes #14882

## Description

The "Recent Activity" panel on the user edit page (`/s/users/edit/{id}`) crashes with a fatal `Twig\Error\RuntimeError`:

```
Key "0" does not exist as the sequence/mapping is empty
in "@MauticUser/User/recent_activity.html.twig"
```

### Root cause

In `recent_activity.html.twig`, the variables `userPath` and `rolePath` are initialized as empty arrays (`[]`) and only populated when audit log entries can be matched to existing user/role records. When no match is found — which happens on fresh installs, after a user changes their email, or when the audit log references records that no longer match — the arrays remain empty. The template then unconditionally accesses `userPath[0]` and `rolePath[0]`, causing the fatal error.

### Fix

Add `and userPath is defined and userPath is not empty` / `and rolePath is defined and rolePath is not empty` guards to the conditional checks before accessing array indices. Unresolvable activity entries are gracefully skipped instead of crashing the page.

### History

- **#14882** reported this bug on 5.2.x and was closed as stale
- **#14884** applied a partial fix (merged into `5.2` only) that addressed the `emailIsMatch` condition for user creation, but did not add guards for the render section and was never merged forward to `5.x` or `7.x`
- This PR completes the fix by guarding all unprotected array accesses in the render section

### Steps to reproduce

1. Fresh Mautic install, create an admin user
2. Navigate to `/s/users/edit/1`
3. Page crashes with 500 error

### Steps to test

1. Apply this patch on a fresh Mautic 7.x install
2. Navigate to `/s/users/edit/1`
3. Page loads without error — recent activity panel renders correctly, skipping entries that can't be resolved