### PR TITLE
Fix database encoding error from invalid UTF-8 in page hit query data

### DIFF
--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -1220,6 +1220,21 @@ class PageModel extends FormModel implements GlobalSearchInterface
     private function cleanQuery(array $query): array
     {
         foreach ($query as $key => $value) {
+            if (is_array($value)) {
+                // Recurse so nested array params (e.g. the `ct` clickthrough
+                // payload) get the same sanitization instead of bypassing it.
+                $query[$key] = $this->cleanQuery($value);
+                continue;
+            }
+
+            if (!is_string($value)) {
+                continue;
+            }
+
+            // Strip invalid UTF-8 sequences to prevent database encoding errors
+            // (e.g. raw \xAD soft hyphen bytes from copy-pasted Word content)
+            $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+
             if (filter_var($value, FILTER_VALIDATE_URL)) {
                 $query[$key] = InputHelper::url($value);
             } else {

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -115,6 +115,74 @@ final class PageModelTest extends PageTestAbstract
     }
 
     /**
+     * Regression test for PR #15985: a byte that is not valid standalone UTF-8
+     * (e.g. \xAD, a raw "soft hyphen" pasted from Word content) must not survive
+     * cleanQuery(), because $query is persisted to the page_hits.query column - a
+     * Doctrine "array"-typed column serialized via serialize() with no UTF-8
+     * validation of its own. If an invalid byte reaches that INSERT, MySQL rejects
+     * it under STRICT_TRANS_TABLES with "SQLSTATE 1366 Incorrect string value".
+     * The `ct` case covers the clickthrough payload, which getHitQuery() decodes
+     * into a nested array before cleanQuery() runs.
+     *
+     * @param array<string, mixed> $query
+     * @param array<int, string>   $path  nested keys to the string leaf under test
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidUtf8QueryPayloads')]
+    public function testCleanQueryStripsInvalidUtf8Bytes(array $query, array $path): void
+    {
+        $pageModel           = $this->getPageModel();
+        $pageModelReflection = new \ReflectionClass($pageModel::class);
+        $cleanQueryMethod    = $pageModelReflection->getMethod('cleanQuery');
+        $result              = $cleanQueryMethod->invokeArgs($pageModel, [$query]);
+
+        $value = $result;
+        foreach ($path as $segment) {
+            $this->assertIsArray($value, sprintf('Expected an array at query path up to "%s"', $segment));
+            $this->assertArrayHasKey($segment, $value, sprintf('Missing expected key "%s"', $segment));
+            $value = $value[$segment];
+        }
+
+        $this->assertIsString($value);
+        $this->assertTrue(
+            mb_check_encoding($value, 'UTF-8'),
+            sprintf(
+                'Value at query path [%s] is not valid UTF-8 (bytes: %s) - an invalid byte here '.
+                'will crash the page_hits.query INSERT under STRICT_TRANS_TABLES (SQLSTATE 1366).',
+                implode('.', $path),
+                bin2hex($value)
+            )
+        );
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: array<int, string>}>
+     */
+    public static function provideInvalidUtf8QueryPayloads(): iterable
+    {
+        // \xAD is a lone "soft hyphen" byte: >0x7F so not plain ASCII, and not a valid
+        // UTF-8 lead/continuation byte on its own, so mb_check_encoding() rejects it.
+        $invalidUtf8 = "before\xADafter";
+
+        yield 'invalid byte in a top-level string param' => [
+            [
+                'page_title' => $invalidUtf8,
+                'page_url'   => 'https://example.com/page',
+            ],
+            ['page_title'],
+        ];
+
+        yield 'invalid byte nested inside the ct clickthrough array param' => [
+            [
+                'page_title' => 'Testpage',
+                'ct'         => [
+                    'source' => $invalidUtf8,
+                ],
+            ],
+            ['ct', 'source'],
+        ];
+    }
+
+    /**
      * Test getHitQuery when the hit is a Request
      * (e.g. POST Ajax or Landingpage hit).
      */


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| New feature?      | no
| Deprecations?     | no
| BC breaks?        | no
| Automated tests   | no
| Related issue(s)  | Fixes #14995

## Description

Invalid UTF-8 byte sequences in tracked URL query parameters cause a fatal `SQLSTATE[22007]: Incorrect string value` error when Mautic persists page hit data. This crashes the Doctrine EntityManager and blocks all subsequent campaign processing in the same worker process.

### Root cause

The `cleanQuery()` method in `PageModel` sanitizes query values via `InputHelper::clean()` (which uses `FILTER_SANITIZE_SPECIAL_CHARS`) and `InputHelper::url()`, but neither strips invalid UTF-8 byte sequences. When a tracked URL contains raw non-UTF-8 bytes — most commonly `\xAD` (soft hyphen in Latin-1/Windows-1252, but invalid as a standalone byte in UTF-8) from copy-pasted Word/Outlook content — the data reaches MariaDB/MySQL which rejects it under `STRICT_TRANS_TABLES` mode.

The cascade:
1. `page_hits.query` INSERT fails with encoding error
2. `PageHitNotificationHandler` throws because the Hit entity is null
3. Doctrine EntityManager closes permanently
4. All subsequent operations in that worker process fail

### Fix

Add `mb_convert_encoding($value, 'UTF-8', 'UTF-8')` in `cleanQuery()` before the existing sanitization. This strips any invalid UTF-8 sequences while preserving all valid characters, preventing the database-level error.

Also adds a `!is_string($value)` guard to skip non-string values in the query array.

### Steps to reproduce

1. Create an email with a tracking link containing a soft hyphen character (copy from Word/Outlook)
2. Send the email and have a recipient click the link
3. Mautic logs: `SQLSTATE[22007]: Incorrect string value: '\xADd_all...' for column 'query'`
4. EntityManager closes, blocking further campaign processing

### Steps to test

1. Apply this patch
2. Insert a test page hit with invalid UTF-8 in the query string
3. Confirm the hit is persisted without error (invalid bytes are stripped)
4. Confirm valid UTF-8 characters (including proper soft hyphens `\xC2\xAD`) are preserved