### PR TITLE
Fix regex operators on date fields causing DateTime parsing error

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -534,8 +534,13 @@ class CampaignSubscriber implements EventSubscriberInterface
                 $fieldType  = '';
                 $fieldValue = $value;
                 if (isset($fields[$field])) {
-                    $fieldValue = CustomFieldHelper::fieldValueTransfomer($fields[$field], $value);
                     $fieldType  = $fields[$field]['type'];
+                    // Keep regex values unchanged so they are evaluated as patterns
+                    // Otherwise CustomFieldHelper::fieldValueTransfomer would attempt to parse
+                    // the regex as a DateTime string, which would throw an error
+                    if (!in_array($operator, [OperatorOptions::REGEXP, OperatorOptions::NOT_REGEXP])) {
+                        $fieldValue = CustomFieldHelper::fieldValueTransfomer($fields[$field], $value);
+                    }
                 }
 
                 // Preventing date/datetime fields to fail on empty/notEmpty

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Tests\Traits\LeadFieldTestTrait;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupContactScore;
@@ -1120,5 +1121,81 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $campaignLead->setDateAdded(new \DateTime());
         $this->em->persist($campaignLead);
         $campaign->addLead($lead->getId(), $campaignLead);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('regexOperatorProvider')]
+    public function testRegexOperatorOnDateFieldCondition(string $operator, string $regex, string $fieldValue, bool $expectedResult): void
+    {
+        $this->useCleanupRollback = false;
+
+        // Create the custom date field
+        $this->createField([
+            'type'        => 'date',
+            'alias'       => 'test_date',
+            'label'       => 'Test Date',
+            'isPublished' => true,
+        ]);
+
+        // Create a contact and set the custom field value
+        $contact   = $this->createContact('john.doe@example.com');
+        $leadModel = static::getContainer()->get('mautic.lead.model.lead');
+        $leadModel->setFieldValues($contact, ['test_date' => $fieldValue]);
+        $leadModel->saveEntity($contact);
+
+        $this->em->flush();
+        $this->em->clear();
+        $contact = $this->contactRepository->getEntity($contact->getId());
+
+        $eventArgs = [
+            'lead'  => $contact,
+            'event' => [
+                'type'       => 'lead.field_value',
+                'eventType'  => 'condition',
+                'properties' => [
+                    'field'    => 'test_date',
+                    'value'    => $regex,
+                    'operator' => $operator,
+                ],
+            ],
+            'eventDetails'    => [],
+            'systemTriggered' => true,
+            'eventSettings'   => [],
+        ];
+
+        // Required: CampaignSubscriber::onCampaignTriggerCondition only supports CampaignExecutionEvent (deprecated)
+        // @phpstan-ignore-next-line new.deprecated
+        $event = new CampaignExecutionEvent($eventArgs, true);
+
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+
+        // The test passes if no exception is thrown and the result is as expected
+        $dispatcher->dispatch($event, LeadEvents::ON_CAMPAIGN_TRIGGER_CONDITION);
+
+        $this->assertSame($expectedResult, $event->getResult(), 'Regex operator should not cause exception and should match as expected.');
+
+        // Clean up
+        $fieldModel = static::getContainer()->get('mautic.lead.model.field');
+        $field      = $fieldModel->getEntityByAlias('test_date');
+        if ($field) {
+            $fieldModel->deleteEntity($field);
+        }
+    }
+
+    /**
+     * @return array<int, array{string, string, string, bool}>
+     */
+    public static function regexOperatorProvider(): array
+    {
+        return [
+            // [operator, regex, fieldValue, expectedResult]
+            [OperatorOptions::REGEXP, "^\d{4}-03-24$", '2026-03-24', true],
+            [OperatorOptions::REGEXP, "^\d{4}-12-31$", '2026-03-24', false],
+            [OperatorOptions::REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', true],
+            [OperatorOptions::REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', false],
+            [OperatorOptions::NOT_REGEXP, "^\d{4}-12-31$", '2026-03-24', true],
+            [OperatorOptions::NOT_REGEXP, "^\d{4}-03-24$", '2026-03-24', false],
+            [OperatorOptions::NOT_REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', true],
+            [OperatorOptions::NOT_REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', false],
+        ];
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

I ran into a bug when trying to use a regex operator on a custom date field in a campaign condition. When providing a regex pattern, it would throw a DateTime parsing error.

```
martin@ubuntu-dev:~/vsc/mautic$ ddev exec bin/console mautic:campaigns:trigger
Triggering events for campaign 1
Triggering events for newly added contacts
1 total events(s) to be processed in batches of 100 contacts
 1/1 [============================] 100%22:25:13 ERROR     [mautic] DateMalformedStringException: Failed to parse time string (^\d{4}-12-\d{2}$) at position 0 (^): Unexpected character (uncaught exception) at /var/www/html/app/bundles/CoreBundle/Helper/DateTimeHelper.php line 70 while running console command `mautic:campaigns:trigger`
[stack trace]
#0 /var/www/html/app/bundles/CoreBundle/Helper/DateTimeHelper.php(70): DateTime->__construct()
#1 /var/www/html/app/bundles/CoreBundle/Helper/DateTimeHelper.php(41): Mautic\CoreBundle\Helper\DateTimeHelper->setDateTime()
#2 /var/www/html/app/bundles/LeadBundle/Helper/CustomFieldHelper.php(67): Mautic\CoreBundle\Helper\DateTimeHelper->__construct()
#3 /var/www/html/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php(537): Mautic\LeadBundle\Helper\CustomFieldHelper::fieldValueTransfomer()
#4 /var/www/html/vendor/symfony/event-dispatcher/Debug/WrappedListener.php(115): Mautic\LeadBundle\EventListener\CampaignSubscriber->onCampaignTriggerCondition()
#5 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(206): Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke()
#6 /var/www/html/vendor/symfony/event-dispatcher/EventDispatcher.php(56): Symfony\Component\EventDispatcher\EventDispatcher->callListeners()
#7 /var/www/html/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php(126): Symfony\Component\EventDispatcher\EventDispatcher->dispatch()
#8 /var/www/html/app/bundles/CampaignBundle/Executioner/Dispatcher/ConditionDispatcher.php(21): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
#9 /var/www/html/app/bundles/CampaignBundle/Executioner/Event/ConditionExecutioner.php(60): Mautic\CampaignBundle\Executioner\Dispatcher\ConditionDispatcher->dispatchEvent()
#10 /var/www/html/app/bundles/CampaignBundle/Executioner/Event/ConditionExecutioner.php(36): Mautic\CampaignBundle\Executioner\Event\ConditionExecutioner->dispatchEvent()
#11 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(133): Mautic\CampaignBundle\Executioner\Event\ConditionExecutioner->execute()
#12 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(98): Mautic\CampaignBundle\Executioner\EventExecutioner->executeLogs()
#13 /var/www/html/app/bundles/CampaignBundle/Executioner/EventExecutioner.php(169): Mautic\CampaignBundle\Executioner\EventExecutioner->executeForContacts()
#14 /var/www/html/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(168): Mautic\CampaignBundle\Executioner\EventExecutioner->executeEventsForContacts()
#15 /var/www/html/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php(67): Mautic\CampaignBundle\Executioner\KickoffExecutioner->executeOrScheduleEvent()
#16 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(376): Mautic\CampaignBundle\Executioner\KickoffExecutioner->execute()
#17 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(327): Mautic\CampaignBundle\Command\TriggerCampaignCommand->executeKickoff()
#18 /var/www/html/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php(271): Mautic\CampaignBundle\Command\TriggerCampaignCommand->triggerCampaign()
#19 /var/www/html/vendor/symfony/console/Command/Command.php(341): Mautic\CampaignBundle\Command\TriggerCampaignCommand->execute()
#20 /var/www/html/vendor/symfony/console/Application.php(1102): Symfony\Component\Console\Command\Command->run()
#21 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(123): Symfony\Component\Console\Application->doRunCommand()
#22 /var/www/html/vendor/symfony/console/Application.php(356): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand()
#23 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(77): Symfony\Component\Console\Application->doRun()
#24 /var/www/html/vendor/symfony/console/Application.php(195): Symfony\Bundle\FrameworkBundle\Console\Application->doRun()
#25 /var/www/html/bin/console(16): Symfony\Component\Console\Application->run()
#26 {main} ["hostname" => "mautic-web","pid" => 3330]
22:25:13 CRITICAL  [console] Error thrown while running command "mautic:campaigns:trigger". Message: "Failed to parse time string (^\d{4}-12-\d{2}$) at position 0 (^): Unexpected character" ["exception" => DateMalformedStringException { …},"command" => "mautic:campaigns:trigger","message" => "Failed to parse time string (^\d{4}-12-\d{2}$) at position 0 (^): Unexpected character"] ["hostname" => "mautic-web","pid" => 3330]
22:25:13 WARNING   [mautic] Command `mautic:campaigns:trigger` exited with status code 1 ["hostname" => "mautic-web","pid" => 3330]

In DateTimeHelper.php line 70:
                                                                                          
  Failed to parse time string (^\d{4}-12-\d{2}$) at position 0 (^): Unexpected character  
                                                                                          

mautic:campaigns:trigger [-i|--campaign-id [CAMPAIGN-ID]] [--campaign-limit [CAMPAIGN-LIMIT]] [--contact-id [CONTACT-ID]] [--contact-ids [CONTACT-IDS]] [--min-contact-id [MIN-CONTACT-ID]] [--max-contact-id [MAX-CONTACT-ID]] [--thread-id [THREAD-ID]] [--max-threads [MAX-THREADS]] [--kickoff-only] [--scheduled-only] [--inactive-only] [-l|--batch-limit [BATCH-LIMIT]] [-d|--exclude [EXCLUDE]] [--bypass-locking] [-t|--timeout TIMEOUT] [-x|--lock_mode LOCK_MODE] [-f|--force]

Failed to execute command `bin/console mautic:campaigns:trigger`: exit status 1
```

Interestingly, this works correctly in segment filter, but not in campaign condition.

The issue was that the field value was always passed to `CustomFieldHelper::fieldValueTransfomer` without considering the operator. Since the operator isn't passed into that method, regex values ended up being treated as DateTime strings, which caused the exception.

This change skips the transformation step for `regex` and `!regex` operators so the value is handled as a pattern, making campaign conditions behave consistently with segment filters.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a custom field of type `Date`.
3. Create a contact and set that custom date field to `2026-03-24`.
4. Create a new segment.
5. Add the contact to that segment.
6. Create a new campaign.
7. Set the campaign contact source to the segment you just created.
8. Add a `Contact field value` condition. Select the custom date field, choose the `regexp` operator, and use a value `^\d{4}-03-\d{2}$`.
9. Add an `Adjust contact points` action to both the positive and negative paths of the condition. For example, add 2 points on the matched path and 3 points on the non-matched path.
10. Save the campaign.
11. Run `ddev exec bin/console mautic:campaigns:trigger`.
12. Verify that no error is thrown.
13. Confirm that the condition is evaluated correctly. In this example, the regex should match `2026-03-24`, so the contact should go through the positive path.

<img width="769" height="398" alt="image" src="https://github.com/user-attachments/assets/648d62da-3bc9-48f2-ae0d-153122bbd7e8" />

<img width="636" height="459" alt="image" src="https://github.com/user-attachments/assets/ecc70c89-38bf-4d24-a168-d8cf3cf155c4" />

<img width="501" height="581" alt="image" src="https://github.com/user-attachments/assets/dc748345-c601-4f41-8925-a4b07bbdc3fb" />

<img width="911" height="443" alt="image" src="https://github.com/user-attachments/assets/12261a4a-a7f1-4312-a1e8-442a2a04e85c" />

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->