### PR TITLE
fix: handle NULL text in makeLinks() to prevent 500 error (fixes #16009)

### DIFF
--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -173,8 +173,11 @@ class AssetExtension extends AbstractExtension
      * @param array<string> $protocols
      * @param array<mixed>  $attributes
      */
-    public function makeLinks(string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
+    public function makeLinks(?string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
     {
+        if (null === $text) {
+            return '';
+        }
         return $this->assetsHelper->makeLinks($text, $protocols, $attributes);
     }
 }


### PR DESCRIPTION
## Summary

Fixes [mautic/mautic#16009](https://github.com/mautic/mautic/issues/16009)

### Problem

When viewing a report with Data Source "Emails Sent" that includes the "Email: Subject" (e.subject) column, a **500 Internal Server Error** occurs if any records in the `email_stats` table have `email_id = NULL`.

This happens when emails are sent manually (not via campaign) or via broadcast without proper email association. The LEFT JOIN on the email table returns NULL for `e.subject`, which is then passed to `makeLinks()`.

```
TypeError: makeLinks(): Argument #1 ($text) must be of type string, null given
```

### Root Cause

`AssetExtension::makeLinks()` has a `string $text` type hint. When Twig passes NULL (from the template), PHP throws a TypeError before the function body can execute.

### Fix

Changed the parameter type from `string $text` to `?string $text` (nullable), and return an empty string early when NULL is passed:

```php
public function makeLinks(?string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
{
    if (null === $text) {
        return '';
    }
    return $this->assetsHelper->makeLinks($text, $protocols, $attributes);
}
```

### Testing

1. Have records in `email_stats` where `email_id IS NULL`
2. Create a report with Data Source: Emails Sent
3. Add column: Email Subject (e.subject)
4. View report — should **no longer** throw a 500 error

### Alternative Fix (SQL)

Use `COALESCE(e.subject, '')` in the report query. This PR fixes it at the application layer, which is more robust since `makeLinks()` can be called from multiple places.

---

Thank you to [@mautic](https://github.com/mautic) for maintaining this great open-source project!
