### PR TITLE
Fix scheduled report crash when using MIN/MAX on date columns

### DIFF
--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -211,7 +211,7 @@ class ReportDataResult
     /**
      * @param array<mixed> $aggregatorVal
      */
-    public function calcTotal(string $calcFunction, int $rowsCount, array &$aggregatorVal, float|string|null $previousVal = null): float|int|string|null
+    public function calcTotal(string $calcFunction, int $rowsCount, array &$aggregatorVal, float|int|string|null $previousVal = null): float|int|string|null
     {
         switch ($calcFunction) {
             case 'COUNT':

--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -193,7 +193,14 @@ class ReportDataResult
     {
         foreach ($this->columnKeys as $k) {
             if (isset($data['aggregatorColumns']) && array_key_exists($k, $data['aggregatorColumns'])) {
-                $this->types[$k] = (str_starts_with($k, 'AVG')) ? 'float' : 'int';
+                if (str_starts_with($k, 'AVG')) {
+                    $this->types[$k] = 'float';
+                } elseif (str_starts_with($k, 'MIN') || str_starts_with($k, 'MAX')) {
+                    $underlyingColumn = $data['aggregatorColumns'][$k];
+                    $this->types[$k]  = $data['columns'][$underlyingColumn]['type'] ?? 'int';
+                } else {
+                    $this->types[$k] = 'int';
+                }
             } else {
                 $dataColumn      = $data['dataColumns'][$k];
                 $this->types[$k] = $data['columns'][$dataColumn]['type'];
@@ -204,7 +211,7 @@ class ReportDataResult
     /**
      * @param array<mixed> $aggregatorVal
      */
-    public function calcTotal(string $calcFunction, int $rowsCount, array &$aggregatorVal, ?float $previousVal = null): float|int|null
+    public function calcTotal(string $calcFunction, int $rowsCount, array &$aggregatorVal, float|string|null $previousVal = null): float|int|string|null
     {
         switch ($calcFunction) {
             case 'COUNT':

--- a/app/bundles/ReportBundle/Tests/Crate/ReportDataResultTest.php
+++ b/app/bundles/ReportBundle/Tests/Crate/ReportDataResultTest.php
@@ -193,4 +193,50 @@ class ReportDataResultTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(Fixtures::getValidReportWithAggregatedColumnsKeys(), $reportDataResultWithAggregatedColumns->getColumnKeys());
         $this->assertEmpty($reportDataResultWithAggregatedColumnsInvalid->getColumnKeys());
     }
+
+    public function testDateAggregatedColumnsComputeTotals(): void
+    {
+        $reportDataResult = new ReportDataResult(Fixtures::getValidReportResultWithDateAggregatedColumns());
+
+        $totals = $reportDataResult->getTotals();
+
+        $this->assertSame('2021-12-01 18:42:24', $totals['MIN es.date_sent']);
+        $this->assertSame('2026-04-12 22:59:11', $totals['MAX es.date_sent']);
+        $this->assertSame(40017, $totals['COUNT l.email']);
+    }
+
+    public function testDateAggregatedColumnsPreserveType(): void
+    {
+        $reportDataResult = new ReportDataResult(Fixtures::getValidReportResultWithDateAggregatedColumns());
+
+        $this->assertSame('datetime', $reportDataResult->getType('MIN es.date_sent'));
+        $this->assertSame('datetime', $reportDataResult->getType('MAX es.date_sent'));
+        $this->assertSame('int', $reportDataResult->getType('COUNT l.email'));
+    }
+
+    public function testCalcTotalMinMaxWithDateStrings(): void
+    {
+        $reportDataResult = new ReportDataResult(Fixtures::getValidReportResult());
+
+        $values = ['2021-12-01 18:42:24', '2024-02-16 00:42:17'];
+        $result = $reportDataResult->calcTotal('MIN', 2, $values);
+        $this->assertSame('2021-12-01 18:42:24', $result);
+
+        $values = ['2021-12-01 18:42:24', '2024-02-16 00:42:17'];
+        $result = $reportDataResult->calcTotal('MAX', 2, $values);
+        $this->assertSame('2024-02-16 00:42:17', $result);
+    }
+
+    public function testCalcTotalMinMaxWithPreviousDateValue(): void
+    {
+        $reportDataResult = new ReportDataResult(Fixtures::getValidReportResult());
+
+        $values = ['2024-02-16 00:42:17'];
+        $result = $reportDataResult->calcTotal('MIN', 1, $values, '2021-12-01 18:42:24');
+        $this->assertSame('2021-12-01 18:42:24', $result);
+
+        $values = ['2021-12-01 18:42:24'];
+        $result = $reportDataResult->calcTotal('MAX', 1, $values, '2026-04-12 22:59:11');
+        $this->assertSame('2026-04-12 22:59:11', $result);
+    }
 }

--- a/app/bundles/ReportBundle/Tests/Fixtures.php
+++ b/app/bundles/ReportBundle/Tests/Fixtures.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\ReportBundle\Tests;
 
+use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
+
 class Fixtures
 {
     /**
@@ -324,13 +326,13 @@ class Fixtures
     }
 
     /**
-     * @return array<float>
+     * @return array<float|int>
      */
     public static function getValidReportDataAggregatedTotals(): array
     {
         return [
             'SUM es.is_read' => 60,
-            'AVG es.is_read' => 0.3333,
+            'AVG es.is_read' => round(0.6666 / 2, FormatterHelper::FLOAT_PRECISION),
             'COUNT l.id'     => 160,
         ];
     }
@@ -434,6 +436,69 @@ class Fixtures
                     'paginate'       => true,
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function getValidReportResultWithDateAggregatedColumns(): array
+    {
+        return [
+            'dateFrom'     => self::getDateFrom(),
+            'dateTo'       => self::getDateTo(),
+            'totalResults' => '2',
+            'data'         => [
+                [
+                    'e_id'             => '1',
+                    'e_name'           => 'Welcome',
+                    'MIN es.date_sent' => '2021-12-01 18:42:24',
+                    'MAX es.date_sent' => '2026-04-12 22:59:11',
+                    'COUNT l.email'    => '13676',
+                ],
+                [
+                    'e_id'             => '2',
+                    'e_name'           => 'Renew',
+                    'MIN es.date_sent' => '2024-02-16 00:42:17',
+                    'MAX es.date_sent' => '2026-04-12 14:21:55',
+                    'COUNT l.email'    => '26341',
+                ],
+            ],
+            'dataColumns' => [
+                'e_id'             => 'e.id',
+                'e_name'           => 'e.name',
+                'MIN es.date_sent' => 'es.date_sent',
+                'MAX es.date_sent' => 'es.date_sent',
+                'COUNT l.email'    => 'l.email',
+            ],
+            'columns' => [
+                'e.id' => [
+                    'label' => 'ID',
+                    'type'  => self::getIntegerType(),
+                    'alias' => 'e_id',
+                ],
+                'e.name' => [
+                    'label' => 'Name',
+                    'type'  => self::getStringType(),
+                    'alias' => 'e_name',
+                ],
+                'es.date_sent' => [
+                    'label' => 'Date Sent',
+                    'type'  => self::getDateType(),
+                    'alias' => 'date_sent',
+                ],
+                'l.email' => [
+                    'label' => 'Email',
+                    'type'  => self::getEmailType(),
+                    'alias' => 'email',
+                ],
+            ],
+            'aggregatorColumns' => [
+                'MIN es.date_sent' => 'es.date_sent',
+                'MAX es.date_sent' => 'es.date_sent',
+                'COUNT l.email'    => 'l.email',
+            ],
+            'limit' => 0,
         ];
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Scheduled reports that use MIN or MAX aggregation on date/datetime columns (e.g. "first email sent" or "last email sent") crash with a `TypeError` because the return type only allowed numbers, not date strings.

**What was wrong:**
- The report engine assumed all aggregated values are numeric, hardcoding `int` as the type for every aggregated column
- When MIN/MAX was applied to a datetime column, PHP's `min()`/`max()` correctly returned a date string, but the strict return type rejected it

**What this fixes:**
- MIN/MAX aggregations now preserve the original column type instead of forcing `int`
- The `calcTotal()` method accepts and returns string values so date comparisons work correctly
- Numeric aggregations (SUM, COUNT, AVG) are unchanged

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a report with columns that use MIN or MAX aggregation on a date/datetime field (e.g. `es.date_sent` from email stats)
3. Run the report — it should display correct min/max date values without errors
4. Verify existing reports with numeric aggregations (SUM, COUNT, AVG) still work as expected