### PR TITLE
[NOT-FOR-MERGE] Hide Segment ID in preference center -- M5

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/LeadListType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadListType.php
@@ -30,7 +30,7 @@ class LeadListType extends AbstractType
                     if (empty($options['preference_center_only'])) {
                         $choices[$l['name'].' ('.$l['id'].')'] = $l['id'];
                     } else {
-                        $choices[empty($l['publicName']) ? $l['name'].' ('.$l['id'].')' : $l['publicName'].' ('.$l['id'].')'] = $l['id'];
+                        $choices[empty($l['publicName']) ? $l['name'] : $l['publicName']] = $l['id'];
                     }
                 }
 


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

When displaying segments in the contact preference center, IDs should not be shown to end users. The LeadListType form type was appending IDs in both contexts. Updated to conditionally hide IDs when preference_center_only option is set, while keeping them visible in the admin panel. Also removed stray debug text from the preference options template.

<img width="814" height="499" alt="image" src="https://github.com/user-attachments/assets/1321a8d9-16a1-40e9-9e4b-f0511d26094b" />