### PR TITLE
fix(assets): keep invalid historical rows from reaching LeadSubscriber

### DIFF
--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -53,7 +53,7 @@ class DownloadRepository extends CommonRepository
         $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('a.id as asset_id, d.date_download as dateDownload, a.title, d.id as download_id, d.lead_id')
             ->from(MAUTIC_TABLE_PREFIX.'asset_downloads', 'd')
-            ->leftJoin('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
+            ->join('d', MAUTIC_TABLE_PREFIX.'assets', 'a', 'd.asset_id = a.id');
 
         if ($leadId) {
             $query->where('d.lead_id = :leadId')


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16053


## Description

This PR fixes a contact timeline crash when historical asset download rows do not reference a valid asset.

`DownloadRepository::getLeadDownloads()` previously used a left join from `asset_downloads` to `assets`. If `asset_downloads.asset_id` was `NULL`, or pointed to a deleted/missing asset, the timeline query returned a row with `asset_id = NULL`.

`LeadSubscriber::onTimelineGenerate()` then passed that `NULL` value to `AssetModel::getEntity()`, which creates a new unsaved `Asset`. When Mautic tried to generate the asset download URL, `Asset::getSlug()` threw:

```text
This asset must be saved before it can be used in a URL.
```

The query now uses an inner join so only asset download rows with an existing related asset are returned for contact timeline rendering. This prevents invalid historical rows from breaking the contact detail page and keeps the timeline counter aligned with renderable events.

---
### 📋 Steps to test this PR:

1. Create or use a contact.
2. Insert an invalid contact-linked asset download row:

```sql
INSERT INTO asset_downloads (
    asset_id,
    ip_id,
    lead_id,
    date_download,
    code,
    tracking_id
) VALUES (
    NULL,
    1,
    <existing_contact_id>,
    NOW(),
    200,
    'reproduce-null-asset-download'
);
```

3. Open the affected contact detail page.
4. Before this PR, the page fails with:

```text
This asset must be saved before it can be used in a URL.
```

5. After this PR, the contact detail page loads successfully.
6. Valid asset download timeline entries should still be shown.
