### PR TITLE
Always link the asset on tracked downloads (incl. system-entry path)

### DIFF
--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -233,10 +233,9 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         }
 
         $download->setTrackingId($trackingId);
+        $download->setAsset($asset);
 
         if (empty($systemEntry)) {
-            $download->setAsset($asset);
-
             $this->getRepository()->upDownloadCount($asset->getId(), 1, $isUnique);
         }
 

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -286,6 +286,78 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('http://localhost', $download->getReferer());
     }
 
+    /**
+     * Regression test: a system-entry tracked download (e.g. recorded when an email
+     * with an asset attachment is sent) must still link to the asset on the Download
+     * row. Previously setAsset() was inside the `empty($systemEntry)` guard, so
+     * emailed-asset tracking persisted rows with asset_id = NULL — orphans which then
+     * crashed the contact timeline once Asset::getSlug() was added in 7.1.0.
+     */
+    public function testTrackDownloadLinksAssetForSystemEntry(): void
+    {
+        $asset = new Asset();
+        $lead  = new Lead();
+
+        $this->ipLookupHelper->method('isRequestTrackable')->willReturn(true);
+
+        $request          = $this->createMock(Request::class);
+        $serverBag        = $this->createMock(ServerBag::class);
+        $request->server  = $serverBag;
+
+        $serverBag->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('HTTP_REFERER'))
+            ->willReturn('http://localhost');
+
+        // System-entry path consults only utm_* params (5 calls); the user-triggered
+        // 'ct' lookup is skipped because that block is gated on empty($systemEntry).
+        $request->expects($this->exactly(5))
+            ->method('get')
+            ->willReturnCallback(function (...$parameters) {
+                self::assertContains($parameters[0], ['utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_term']);
+
+                return null;
+            });
+
+        $ipAddress = new IpAddress('127.0.0.1');
+        $this->ipLookupHelper->expects($this->exactly(2))
+            ->method('getIpAddress')
+            ->willReturn($ipAddress);
+
+        $this->eventDispatcher->expects($this->once())
+            ->method('hasListeners')
+            ->with($this->equalTo(AssetEvents::ASSET_ON_LOAD))
+            ->willReturn(false);
+
+        // Per-asset download counter must NOT bump for system-entry tracking;
+        // emailed-attachment tracking should not inflate the public download stat.
+        $this->entityManager->expects($this->never())
+            ->method('getRepository');
+
+        /** @var ?Download $persisted */
+        $persisted = null;
+        $this->entityManager->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(function ($downloadPersist) use (&$persisted) {
+                $persisted = $downloadPersist;
+
+                return $downloadPersist instanceof Download;
+            }));
+        $this->entityManager->expects($this->once())->method('flush');
+        $this->entityManager->expects($this->once())
+            ->method('detach')
+            ->with($this->callback(function ($downloadDetach) use (&$persisted) {
+                self::assertSame($downloadDetach, $persisted);
+
+                return true;
+            }));
+
+        $this->assetModel->trackDownload($asset, $request, 200, ['lead' => $lead]);
+
+        self::assertSame($asset, $persisted->getAsset(), 'Download row must link to the asset even on the system-entry path.');
+        self::assertSame($lead, $persisted->getLead());
+    }
+
     #[DataProvider('getEntityBySlugsProvider')]
     public function testGetEntityBySlugs(
         string $slug,


### PR DESCRIPTION
## Summary

\`AssetModel::trackDownload()\` calls \`Download::setAsset()\` inside an \`empty(\$systemEntry)\` guard. The system-entry path — used by \`MailHelper::createAssetDownloadEntries()\` to record per-recipient asset tracking when an email with an attachment is sent — therefore persists \`asset_downloads\` rows with \`asset_id = NULL\` even though the asset is in scope at the call site.

Long-running installs accumulate large numbers of these orphan rows. As of 7.1.0, \`Asset::getSlug()\` throws \`LogicException: "This asset must be saved before it can be used in a URL."\` when called on an unsaved Asset, and \`AssetBundle\AssetModel::generateUrl()\` calls \`getSlug()\` unconditionally — so any contact whose engagement timeline contains one of these orphan rows now 500s the entire contact-view page (see #16078 for the defensive fix on the rendering side).

This PR fixes the orphan source.

## Diagnosis on a long-running prod install

\`\`\`sql
SELECT COUNT(*), MIN(date_download), MAX(date_download)
FROM asset_downloads WHERE asset_id IS NULL;
-- 11,640 rows, oldest 2022-05-31, newest is recent
\`\`\`

The FK \`asset_downloads.asset_id\` → \`assets.id\` is correctly defined as \`ON DELETE CASCADE\` (matches the entity), so cascaded asset deletes were never the cause — orphans were being inserted directly by app code via the system-entry path.

## Changes

\`app/bundles/AssetBundle/Model/AssetModel.php\` — move \`\$download->setAsset(\$asset)\` outside the \`empty(\$systemEntry)\` guard. The per-asset \`upDownloadCount\` call stays inside the guard, preserving the existing semantic that emailed-attachment tracking does not inflate the public download stat.

## Test

Adds \`AssetModelTest::testTrackDownloadLinksAssetForSystemEntry()\` which exercises the system-entry branch and asserts:
- the persisted \`Download\` is linked to the asset;
- \`upDownloadCount\` is *not* invoked (preserves existing stat semantics).

## Relationship to #16078

#16078 makes the contact timeline tolerate orphan rows that already exist in long-running DBs. This PR stops new orphans from being created. They're complementary — #16078 should ship even with this fix, because pre-existing orphans persist until cleaned up. Sites carrying historical orphans may also wish to run a one-off \`DELETE FROM asset_downloads WHERE asset_id IS NULL\` (after a backup).

## Manual test plan
- [ ] Send an email with an asset attachment to a contact; ensure the history shows the asset for the contact
- [ ] As a contact, download an asset repeatedly and check the counter still increments