### PR TITLE
Option to skip contact last active logging

### DIFF
--- a/app/bundles/LeadBundle/Event/LeadGetCurrentEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadGetCurrentEvent.php
@@ -10,7 +10,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class LeadGetCurrentEvent extends Event
 {
-    private ?Lead $contact = null;
+    private ?Lead $contact                    = null;
+    private bool $skipContactLastActiveLogged = false;
 
     public function __construct(private ?Request $request = null)
     {
@@ -29,5 +30,15 @@ final class LeadGetCurrentEvent extends Event
     public function setContact(?Lead $contact): void
     {
         $this->contact = $contact;
+    }
+
+    public function skipContactLastActiveLogged(): void
+    {
+        $this->skipContactLastActiveLogged = true;
+    }
+
+    public function isSkipContactLastActiveLogged(): bool
+    {
+        return $this->skipContactLastActiveLogged;
     }
 }

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalLastActiveTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalLastActiveTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Tracker;
+
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Event\LeadGetCurrentEvent;
+use Mautic\LeadBundle\Helper\ContactRequestHelper;
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Model\PageModel;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+final class ContactTrackerFunctionalLastActiveTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['track_contact_by_ip'] = true;
+
+        parent::setUp();
+    }
+
+    /**
+     * @return iterable<string,array{bool}>
+     */
+    public static function dataSkipContactLastActiveLogged(): iterable
+    {
+        yield 'Skipping turned off' => [false];
+        yield 'Skipping turned on' => [true];
+    }
+
+    #[DataProvider('dataSkipContactLastActiveLogged')]
+    public function testSkipContactLastActiveLogged(bool $skip): void
+    {
+        $this->logoutUser();
+
+        if ($skip) {
+            $eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
+            $eventDispatcher->addListener(LeadGetCurrentEvent::class, function (LeadGetCurrentEvent $event) {
+                $event->skipContactLastActiveLogged();
+            });
+        }
+
+        $ipAddress = new IpAddress('127.0.0.1');
+        $this->em->persist($ipAddress);
+
+        $lead = new Lead();
+        $lead->setEmail('testemail@domain.tld');
+        $lead->addIpAddress($ipAddress);
+        $this->em->persist($lead);
+
+        $stat = new Stat();
+        $stat->setTrackingHash('62970e83798e0668813916');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress($lead->getEmail());
+        $this->em->persist($stat);
+
+        $page = new Page();
+        $page->setTitle('Page');
+        $page->setAlias('page');
+        $page->setCustomHtml('<html><body>Content</body></html>');
+        $this->em->persist($page);
+        $this->em->flush();
+
+        Assert::assertFalse($this->isLastActiveDateSet($lead->getId()));
+
+        $request = new Request([
+            'ct' => ClickthroughHelper::encodeArrayForUrl([
+                'source' => [],
+                'email'  => null,
+                'stat'   => $stat->getTrackingHash(),
+                'lead'   => $lead->getId(),
+            ]),
+        ]);
+        $pageModel       = self::getContainer()->get(PageModel::class);
+        $trackerHelper   = self::getContainer()->get(ContactRequestHelper::class);
+        $query           = $pageModel->getHitQuery($request, $page);
+        $trackerHelper->getContactFromQuery($query);
+
+        Assert::assertSame(!$skip, $this->isLastActiveDateSet($lead->getId()));
+    }
+
+    private function isLastActiveDateSet(int $id): bool
+    {
+        return (bool) $this->em->getRepository(Lead::class)->createQueryBuilder('l')
+            ->select('l.lastActive')
+            ->where('l.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -202,6 +202,10 @@ class ContactTracker
             return $contact;
         }
 
+        if ($event->isSkipContactLastActiveLogged()) {
+            $this->contactLastActiveLogged = true;
+        }
+
         if ($lead = $this->getContactByTrackedDevice()) {
             return $lead;
         }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -297,10 +297,10 @@ class PublicController extends AbstractFormController
             $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
             $content = $event->getContent();
 
-            $model->hitPage($entity, $request, Response::HTTP_OK, $lead, $query);
+            $isHitTrackable = $model->hitPage($entity, $request, Response::HTTP_OK, $lead, $query);
 
             $response = new Response($content);
-            if ($request->cookies->has('Blocked-Tracking')) {
+            if (!$isHitTrackable || $request->cookies->has('Blocked-Tracking')) {
                 $deviceTrackingService->clearTrackingCookies();
             }
 


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     |  <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds an option to skip updating the contact's `lastActive` timestamp during contact tracking. This is useful for scenarios where page hits should be recorded but shouldn't affect the contact's last active date (e.g., automated/system-driven page loads, pixel tracking that shouldn't count as genuine user activity).

### How it works

A new `skipContactLastActiveLogged()` method is added to `LeadGetCurrentEvent`. Event listeners can call this method to signal that the current request should not update the contact's `lastActive` field. When skipped, `ContactTracker` sets its internal `contactLastActiveLogged` flag to `true` early, preventing the downstream logic from writing a new last-active timestamp.

Additionally, in `PublicController`, the return value of `hitPage()` is now used to determine whether tracking cookies should be cleared — if the hit wasn't trackable (e.g., bot detection returned `false`), cookies are cleared alongside the existing `Blocked-Tracking` cookie check.

### Changes

- **`LeadGetCurrentEvent`** — Added `skipContactLastActiveLogged()` and `isSkipContactLastActiveLogged()` methods
- **`ContactTracker`** — Checks `isSkipContactLastActiveLogged()` after event dispatch and pre-sets the flag to prevent last-active update
- **`PublicController`** — Uses `hitPage()` return value to decide whether to clear tracking cookies
- **New test** — Functional test covering both skip-on and skip-off scenarios

---

### Steps to test this PR:
1. This PR is not possible to test without changing the codebase.
2. Just make sure that contacts' `lastActive` field is updated when page hit is triggered (e.g., via clickthrough link).
3. The added functionality is covered via functional tests.
