### PR TITLE
fix: preserve tokenized email redirects with blocked tracking

### DIFF
--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -50,7 +50,8 @@ class ContactRequestHelper
     public function getContactFromQuery(array $queryFields = []): ?Lead
     {
         $request = $this->getCurrentRequest();
-        if ($request && $request->cookies->get('Blocked-Tracking')) {
+        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
+        if ($blockedTracking && empty($queryFields['ct'])) {
             return null;
         }
 
@@ -91,6 +92,10 @@ class ContactRequestHelper
             return null;
         }
 
+        if ($blockedTracking) {
+            return $this->trackedContact;
+        }
+
         $this->prepareContactFromRequest();
 
         return $this->trackedContact;
@@ -103,7 +108,7 @@ class ContactRequestHelper
     {
         $request = $this->getCurrentRequest();
 
-        if ($request && $request->cookies->get('Blocked-Tracking')) {
+        if ($request && $request->cookies->get('Blocked-Tracking') && !isset($this->queryFields['ct'])) {
             throw new ContactNotFoundException();
         }
 

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\LeadBundle\Helper;
 
-use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -51,20 +50,28 @@ class ContactRequestHelper
     public function getContactFromQuery(array $queryFields = []): ?Lead
     {
         $request = $this->getCurrentRequest();
-        if ($this->isBlockedTrackingWithoutClickthrough($request, $queryFields)) {
+        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
+        if ($blockedTracking && empty($queryFields['ct'])) {
             return null;
         }
-
-        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
 
         $ipAddress = $this->ipLookupHelper->getIpAddress();
         if (!$ipAddress->isTrackable()) {
             return null;
         }
 
-        $queryFields = $this->normalizeClickthroughQueryFields($queryFields);
-        if ($this->isBotClickthroughHit($queryFields, $request, $ipAddress)) {
-            return null;
+        $dateTime  = new \DateTime();
+        $userAgent = $request ? $request->server->get('HTTP_USER_AGENT') : '';
+        if (!empty($queryFields['ct'])) {
+            $queryFields['ct'] = (is_array($queryFields['ct'])) ? $queryFields['ct'] : ClickthroughHelper::decodeArrayFromUrl($queryFields['ct']);
+        }
+
+        if (isset($queryFields['ct']['stat'])) {
+            /** @var Stat $stat */
+            $stat = $this->statRepository->findOneBy(['trackingHash' => $queryFields['ct']['stat']]);
+            if (null !== $stat && $this->botRatioHelper->isHitByBot($stat, $dateTime, $ipAddress, (string) $userAgent)) {
+                return null;
+            }
         }
 
         unset($queryFields['page_url']); // This is set now automatically by PageModel
@@ -92,44 +99,6 @@ class ContactRequestHelper
         $this->prepareContactFromRequest();
 
         return $this->trackedContact;
-    }
-
-    private function isBlockedTrackingWithoutClickthrough(?Request $request, array $queryFields): bool
-    {
-        return (bool) ($request && $request->cookies->get('Blocked-Tracking') && empty($queryFields['ct']));
-    }
-
-    private function normalizeClickthroughQueryFields(array $queryFields): array
-    {
-        if (empty($queryFields['ct'])) {
-            return $queryFields;
-        }
-
-        $queryFields['ct'] = is_array($queryFields['ct'])
-            ? $queryFields['ct']
-            : ClickthroughHelper::decodeArrayFromUrl($queryFields['ct']);
-
-        return $queryFields;
-    }
-
-    private function isBotClickthroughHit(array $queryFields, ?Request $request, IpAddress $ipAddress): bool
-    {
-        if (!isset($queryFields['ct']['stat'])) {
-            return false;
-        }
-
-        /** @var Stat|null $stat */
-        $stat = $this->statRepository->findOneBy(['trackingHash' => $queryFields['ct']['stat']]);
-        if (null === $stat) {
-            return false;
-        }
-
-        return $this->botRatioHelper->isHitByBot(
-            $stat,
-            new \DateTime(),
-            $ipAddress,
-            (string) ($request ? $request->server->get('HTTP_USER_AGENT') : '')
-        );
     }
 
     /**

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Helper;
 
+use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -50,28 +51,20 @@ class ContactRequestHelper
     public function getContactFromQuery(array $queryFields = []): ?Lead
     {
         $request = $this->getCurrentRequest();
-        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
-        if ($blockedTracking && empty($queryFields['ct'])) {
+        if ($this->isBlockedTrackingWithoutClickthrough($request, $queryFields)) {
             return null;
         }
+
+        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
 
         $ipAddress = $this->ipLookupHelper->getIpAddress();
         if (!$ipAddress->isTrackable()) {
             return null;
         }
 
-        $dateTime  = new \DateTime();
-        $userAgent = $request ? $request->server->get('HTTP_USER_AGENT') : '';
-        if (!empty($queryFields['ct'])) {
-            $queryFields['ct'] = (is_array($queryFields['ct'])) ? $queryFields['ct'] : ClickthroughHelper::decodeArrayFromUrl($queryFields['ct']);
-        }
-
-        if (isset($queryFields['ct']['stat'])) {
-            /** @var Stat $stat */
-            $stat = $this->statRepository->findOneBy(['trackingHash' => $queryFields['ct']['stat']]);
-            if (null !== $stat && $this->botRatioHelper->isHitByBot($stat, $dateTime, $ipAddress, (string) $userAgent)) {
-                return null;
-            }
+        $queryFields = $this->normalizeClickthroughQueryFields($queryFields);
+        if ($this->isBotClickthroughHit($queryFields, $request, $ipAddress)) {
+            return null;
         }
 
         unset($queryFields['page_url']); // This is set now automatically by PageModel
@@ -99,6 +92,44 @@ class ContactRequestHelper
         $this->prepareContactFromRequest();
 
         return $this->trackedContact;
+    }
+
+    private function isBlockedTrackingWithoutClickthrough(?Request $request, array $queryFields): bool
+    {
+        return (bool) ($request && $request->cookies->get('Blocked-Tracking') && empty($queryFields['ct']));
+    }
+
+    private function normalizeClickthroughQueryFields(array $queryFields): array
+    {
+        if (empty($queryFields['ct'])) {
+            return $queryFields;
+        }
+
+        $queryFields['ct'] = is_array($queryFields['ct'])
+            ? $queryFields['ct']
+            : ClickthroughHelper::decodeArrayFromUrl($queryFields['ct']);
+
+        return $queryFields;
+    }
+
+    private function isBotClickthroughHit(array $queryFields, ?Request $request, IpAddress $ipAddress): bool
+    {
+        if (!isset($queryFields['ct']['stat'])) {
+            return false;
+        }
+
+        /** @var Stat|null $stat */
+        $stat = $this->statRepository->findOneBy(['trackingHash' => $queryFields['ct']['stat']]);
+        if (null === $stat) {
+            return false;
+        }
+
+        return $this->botRatioHelper->isHitByBot(
+            $stat,
+            new \DateTime(),
+            $ipAddress,
+            (string) ($request ? $request->server->get('HTTP_USER_AGENT') : '')
+        );
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -21,6 +21,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
@@ -242,6 +243,42 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
 
         $helper = $this->getContactRequestHelper();
         $this->assertEquals($this->trackedContact->getId(), $helper->getContactFromQuery($query)->getId());
+    }
+
+    public function testBlockedTrackingCookieStillAllowsClickthroughIdentification(): void
+    {
+        $query = [
+            'ct' => [
+                'stat' => 'abc123',
+            ],
+        ];
+
+        $request = new Request();
+        $request->cookies->set('Blocked-Tracking', '1');
+        $request->server->set('HTTP_USER_AGENT', 'phpunit');
+        $this->requestStack->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $contact = new Lead();
+
+        $this->dispatcher->method('dispatch')
+            ->willReturnCallback(function (ContactIdentificationEvent $event) use ($contact) {
+                $event->setIdentifiedContact($contact, 'email');
+
+                return $event;
+            });
+
+        $this->contactTracker->expects($this->once())
+            ->method('setTrackedContact')
+            ->with($contact);
+
+        $this->leadModel->expects($this->never())
+            ->method('setFieldValues');
+
+        $helper       = $this->getContactRequestHelper();
+        $foundContact = $helper->getContactFromQuery($query);
+
+        $this->assertSame($contact, $foundContact);
     }
 
     private function getContactRequestHelper(): ContactRequestHelper

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -4,6 +4,7 @@ namespace Mautic\PageBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Exception\InvalidDecodedStringException;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
@@ -511,33 +512,66 @@ class PublicController extends AbstractFormController
         $ipAddress = $ipLookupHelper->getIpAddress();
 
         $isHitTrackable = false;
-        if ($ct) {
-            if ($ipAddress->isTrackable()) {
-                // Search replace lead fields in the URL
+        if (null !== $ct && '' !== $ct) {
+            /** @var PageModel $pageModel */
+            $pageModel = $this->getModel('page');
+
+            try {
+                $decodedClickthrough = is_array($ct) ? $ct : ClickthroughHelper::decodeArrayFromUrl($ct);
+
                 /** @var LeadModel $leadModel */
                 $leadModel = $this->getModel('lead');
+                /** @var \Mautic\EmailBundle\Entity\StatRepository $emailStatRepository */
+                $emailStatRepository = $this->doctrine->getManager()->getRepository(\Mautic\EmailBundle\Entity\Stat::class);
 
-                /** @var PageModel $pageModel */
-                $pageModel = $this->getModel('page');
+                // Resolve the contact for tokenized redirect URLs even when tracking is temporarily blocked.
+                $lead        = null;
+                $emailTokens = [];
+                if (!empty($decodedClickthrough['stat'])) {
+                    $stat = $emailStatRepository->findOneBy(['trackingHash' => $decodedClickthrough['stat']]);
+                    if (null !== $stat) {
+                        $emailTokens = $stat->getTokens();
+                        $statLead    = $stat->getLead();
+                        if ($statLead instanceof Lead) {
+                            $lead = $statLead;
+                        }
+                    }
+                }
 
-                try {
-                    $lead           = $contactRequestHelper->getContactFromQuery(['ct' => $ct]);
+                if (!empty($decodedClickthrough['lead']) && is_numeric($decodedClickthrough['lead'])) {
+                    $lead ??= $leadModel->getEntity((int) $decodedClickthrough['lead']);
+                }
+
+                if (!$lead) {
+                    $lead = $contactRequestHelper->getContactFromQuery(['ct' => $decodedClickthrough]);
+                }
+
+                if ($ipAddress->isTrackable()) {
                     $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
-                } catch (InvalidDecodedStringException $e) {
-                    // Invalid ct value so we must unset it
-                    // and process the request without it
+                }
+            } catch (InvalidDecodedStringException $e) {
+                // Invalid ct value so we must unset it
+                // and process the request without it
 
-                    $logger->error(sprintf('Invalid clickthrough value: %s', $ct), ['exception' => $e]);
+                $logger->error(sprintf('Invalid clickthrough value: %s', $ct), ['exception' => $e]);
 
-                    $request->request->set('ct', '');
-                    $request->query->set('ct', '');
+                $request->request->remove('ct');
+                $request->query->remove('ct');
+                $lead = null;
+                if ($ipAddress->isTrackable()) {
                     $lead           = $contactRequestHelper->getContactFromQuery();
                     $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
                 }
+                $emailTokens = [];
+            }
 
-                $leadArray            = ($lead) ? $primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead) : [];
+            if (!empty($emailTokens)) {
+                $url = str_replace(array_keys($emailTokens), $emailTokens, $url);
+            }
 
-                $url = TokenHelper::findLeadTokens($url, $leadArray, true);
+            if ($lead) {
+                $leadArray = $primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
+                $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
             }
 
             if (str_contains($url, $this->generateUrl('mautic_asset_download'))) {

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -518,7 +518,6 @@ class PublicController extends AbstractFormController
 
             try {
                 $decodedClickthrough = is_array($ct) ? $ct : ClickthroughHelper::decodeArrayFromUrl($ct);
-
                 /** @var LeadModel $leadModel */
                 $leadModel = $this->getModel('lead');
                 /** @var \Mautic\EmailBundle\Entity\StatRepository $emailStatRepository */

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 
 namespace Mautic\PageBundle\Tests\Controller;
 
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\Redirect;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -55,5 +62,140 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/page-a');
 
         Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('redirectUrlProvider')]
+    public function testRedirectWithSpecialCharsInQuery(string $url): void
+    {
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082cf0');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        $this->client->followRedirects(false);
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s', $redirect->getRedirectId()));
+
+        $response = $this->client->getResponse();
+        \assert($response instanceof RedirectResponse);
+        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        Assert::assertSame($url, $response->getTargetUrl());
+    }
+
+    /**
+     * @return iterable<string, array<string, string>>
+     */
+    public static function redirectUrlProvider(): iterable
+    {
+        yield 'The spaces in the query part must not be encoded with plus signs.' => [
+            'url' => 'https://google.com?q=this%20has%20spaces',
+        ];
+
+        yield 'The dot in the query part must not be replaced with underscore.' => [
+            'url' => 'https://google.com?registrants.source=email',
+        ];
+    }
+
+    public function testRedirectWithCorrectHitUrl(): void
+    {
+        $url            = 'https://example.com/test?registrants.source=email';
+        $emailAddress   = 'testemail@domain.tld';
+        $lead           = new Lead();
+        $lead->setEmail($emailAddress);
+        $this->em->persist($lead);
+
+        $stat = new Stat();
+        $stat->setTrackingHash('62970e83798e0668813916');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress($emailAddress);
+        $this->em->persist($stat);
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082cf0');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        $ct = $this->getEncodedClickThroughValue($stat->getTrackingHash(), (int) $lead->getId());
+
+        $this->logoutUser();
+
+        $this->client->followRedirects(false);
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct));
+
+        $response = $this->client->getResponse();
+        \assert($response instanceof RedirectResponse);
+        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        Assert::assertSame($url, $response->getTargetUrl(), 'The dots in the query part must be preserved.');
+
+        $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
+        Assert::assertNotNull($hit);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('blockedTrackingCookieProvider')]
+    public function testRedirectReplacesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(bool $blockedTracking): void
+    {
+        $resolvedToken = 'resolved-preference-token';
+        $url           = 'https://example.com/preferences?token={contactfield=preference_token}';
+
+        $lead = new Lead();
+        $lead->setEmail('redirect-test@example.com');
+        $this->em->persist($lead);
+
+        $stat = new Stat();
+        $stat->setTrackingHash('blockedtrackinghash123');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress('redirect-test@example.com');
+        $stat->setLead($lead);
+        $stat->setTokens([
+            '{contactfield=preference_token}' => $resolvedToken,
+        ]);
+        $this->em->persist($stat);
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082d0');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        if ($blockedTracking) {
+            $this->client->getCookieJar()->set(new Cookie('Blocked-Tracking', '1'));
+        }
+
+        $ct = $this->getEncodedClickThroughValue($stat->getTrackingHash(), (int) $lead->getId());
+
+        $this->logoutUser();
+
+        $this->client->followRedirects(false);
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct));
+
+        $response = $this->client->getResponse();
+        \assert($response instanceof RedirectResponse);
+        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        Assert::assertSame(
+            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            $response->getTargetUrl()
+        );
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function blockedTrackingCookieProvider(): iterable
+    {
+        yield 'without blocked tracking cookie' => [false];
+        yield 'with blocked tracking cookie' => [true];
+    }
+
+    private function getEncodedClickThroughValue(string $trackingHash, int $leadId): string
+    {
+        return ClickthroughHelper::encodeArrayForUrl(
+            [
+                'source' => [],
+                'email'  => null,
+                'stat'   => $trackingHash,
+                'lead'   => $leadId,
+            ]
+        );
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -133,10 +133,10 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('blockedTrackingCookieProvider')]
-    public function testRedirectReplacesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(bool $blockedTracking): void
+    public function testRedirectReplacesStoredEmailFieldValueWhenBlockedTrackingCookieIsPresent(bool $blockedTracking): void
     {
-        $resolvedToken = 'resolved-preference-token';
-        $url           = 'https://example.com/preferences?token={contactfield=preference_token}';
+        $resolvedUuid = '20a72128-75b4-468e-b8e6-0f0af25e4bcd';
+        $url          = 'https://example.com/preferences?uuid={contactfield=preference_uuid}';
 
         $lead = new Lead();
         $lead->setEmail('redirect-test@example.com');
@@ -148,7 +148,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         $stat->setEmailAddress('redirect-test@example.com');
         $stat->setLead($lead);
         $stat->setTokens([
-            '{contactfield=preference_token}' => $resolvedToken,
+            '{contactfield=preference_uuid}' => $resolvedUuid,
         ]);
         $this->em->persist($stat);
 
@@ -173,7 +173,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         \assert($response instanceof RedirectResponse);
         Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
         Assert::assertSame(
-            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            sprintf('https://example.com/preferences?uuid=%s', $resolvedUuid),
             $response->getTargetUrl()
         );
     }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -135,8 +135,8 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('blockedTrackingCookieProvider')]
     public function testRedirectReplacesStoredEmailFieldValueWhenBlockedTrackingCookieIsPresent(bool $blockedTracking): void
     {
-        $resolvedUuid = '20a72128-75b4-468e-b8e6-0f0af25e4bcd';
-        $url          = 'https://example.com/preferences?uuid={contactfield=preference_uuid}';
+        $resolvedValue = 'weekly-digest';
+        $url           = 'https://example.com/preferences?choice={contactfield=preferred_choice}';
 
         $lead = new Lead();
         $lead->setEmail('redirect-test@example.com');
@@ -148,7 +148,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         $stat->setEmailAddress('redirect-test@example.com');
         $stat->setLead($lead);
         $stat->setTokens([
-            '{contactfield=preference_uuid}' => $resolvedUuid,
+            '{contactfield=preferred_choice}' => $resolvedValue,
         ]);
         $this->em->persist($stat);
 
@@ -173,7 +173,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         \assert($response instanceof RedirectResponse);
         Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
         Assert::assertSame(
-            sprintf('https://example.com/preferences?uuid=%s', $resolvedUuid),
+            sprintf('https://example.com/preferences?choice=%s', $resolvedValue),
             $response->getTargetUrl()
         );
     }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -2,7 +2,10 @@
 
 namespace Mautic\PageBundle\Tests\Controller;
 
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Exception\InvalidDecodedStringException;
 use Mautic\CoreBundle\Factory\ModelFactory;
@@ -345,17 +348,10 @@ class PublicControllerTest extends MauticMysqlTestCase
             ->method('isTrackable')
             ->willReturn(true);
 
-        $getContactFromRequestCallback = function ($queryFields) use ($clickTrough) {
-            if (empty($queryFields)) {
-                return null;
-            }
-
-            throw new InvalidDecodedStringException($clickTrough);
-        };
-
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects(self::once())
             ->method('getContactFromQuery')
-            ->willReturnCallback($getContactFromRequestCallback);
+            ->with([])
+            ->willReturn(null);
 
         $routerMock = $this->createMock(Router::class);
         $routerMock->expects(self::once())
@@ -441,17 +437,10 @@ class PublicControllerTest extends MauticMysqlTestCase
             ->method('isTrackable')
             ->willReturn(true);
 
-        $getContactFromRequestCallback = function ($queryFields) use ($clickThrough) {
-            if (empty($queryFields)) {
-                return null;
-            }
-
-            throw new InvalidDecodedStringException($clickThrough);
-        };
-
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects(self::once())
             ->method('getContactFromQuery')
-            ->willReturnCallback($getContactFromRequestCallback);
+            ->with([])
+            ->willReturn(null);
 
         $routerMock = $this->createMock(Router::class);
         $routerMock->expects(self::once())
@@ -499,6 +488,129 @@ class PublicControllerTest extends MauticMysqlTestCase
             $redirectId
         );
         self::assertSame($targetUrl, $response->getTargetUrl());
+        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+    }
+
+    public function testRedirectUsesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(): void
+    {
+        $redirectId      = 'tokenizedRedirectId';
+        $redirectUrl     = 'https://example.com/preferences?token={contactfield=preference_token}';
+        $resolvedToken   = 'stored-token-value';
+        $trackingHash    = 'trackinghash123';
+        $clickThrough    = ClickthroughHelper::encodeArrayForUrl([
+            'source' => [],
+            'email'  => null,
+            'stat'   => $trackingHash,
+            'lead'   => 42,
+        ]);
+        $lead            = new Lead();
+        $emailStat       = $this->createMock(\Mautic\EmailBundle\Entity\Stat::class);
+        $leadModel       = $this->createMock(LeadModel::class);
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $objectManager   = $this->createMock(ObjectManager::class);
+        $repository      = $this->createMock(ObjectRepository::class);
+        $routerMock      = $this->createMock(Router::class);
+
+        $this->redirectModel->expects(self::once())
+            ->method('getRedirectById')
+            ->with($redirectId)
+            ->willReturn($this->redirect);
+
+        $this->modelFactory->expects(self::exactly(3))
+            ->method('getModel')
+            ->withConsecutive(['page.redirect'], ['page'], ['lead'])
+            ->willReturnOnConsecutiveCalls($this->redirectModel, $this->pageModel, $leadModel);
+
+        $this->redirect->expects(self::once())
+            ->method('isPublished')
+            ->with(false)
+            ->willReturn(true);
+
+        $this->redirect->expects(self::once())
+            ->method('getUrl')
+            ->willReturn($redirectUrl);
+
+        $this->ipLookupHelper->expects(self::once())
+            ->method('getIpAddress')
+            ->willReturn($this->ipAddress);
+
+        $this->ipAddress->expects(self::once())
+            ->method('isTrackable')
+            ->willReturn(false);
+
+        $emailStat->expects(self::once())
+            ->method('getTokens')
+            ->willReturn([
+                '{contactfield=preference_token}' => $resolvedToken,
+            ]);
+
+        $emailStat->expects(self::once())
+            ->method('getLead')
+            ->willReturn($lead);
+
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => $trackingHash])
+            ->willReturn($emailStat);
+
+        $objectManager->expects(self::once())
+            ->method('getRepository')
+            ->with(\Mautic\EmailBundle\Entity\Stat::class)
+            ->willReturn($repository);
+
+        $managerRegistry->expects(self::once())
+            ->method('getManager')
+            ->willReturn($objectManager);
+
+        $this->contactRequestHelper->expects(self::never())
+            ->method('getContactFromQuery');
+
+        $this->primaryCompanyHelper->expects(self::once())
+            ->method('getProfileFieldsWithPrimaryCompany')
+            ->with($lead)
+            ->willReturn([]);
+
+        $routerMock->expects(self::once())
+            ->method('generate')
+            ->with('mautic_asset_download')
+            ->willReturn('/asset');
+
+        $this->internalContainer
+            ->expects(self::once())
+            ->method('get')
+            ->willReturnMap([
+                ['router', Container::EXCEPTION_ON_INVALID_REFERENCE, $routerMock],
+            ]);
+
+        $this->request->cookies->set('Blocked-Tracking', '1');
+        $this->request->query->set('ct', $clickThrough);
+
+        $controller = new PublicController(
+            $managerRegistry,
+            $this->modelFactory,
+            $this->createMock(UserHelper::class),
+            $this->createMock(CoreParametersHelper::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(Translator::class),
+            $this->createMock(FlashBag::class),
+            new RequestStack(),
+            $this->createMock(CorePermissions::class)
+        );
+        $controller->setContainer($this->internalContainer);
+
+        $response = $controller->redirectAction(
+            $this->request,
+            $this->contactRequestHelper,
+            $this->primaryCompanyHelper,
+            $this->ipLookupHelper,
+            $this->logger,
+            $redirectId
+        );
+
+        self::assertSame(
+            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            $response->getTargetUrl()
+        );
         self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
     }
 

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -124,6 +124,27 @@ class PublicControllerTest extends MauticMysqlTestCase
     }
 
     /**
+     * @param array<int, array{0: string, 1: object}> $expectedCalls
+     */
+    private function expectGetModelSequence(array $expectedCalls): void
+    {
+        $invocation = 0;
+
+        $this->modelFactory->expects(self::exactly(count($expectedCalls)))
+            ->method('getModel')
+            ->willReturnCallback(function (string $alias) use (&$invocation, $expectedCalls) {
+                self::assertArrayHasKey($invocation, $expectedCalls);
+
+                [$expectedAlias, $returnValue] = $expectedCalls[$invocation];
+                self::assertSame($expectedAlias, $alias);
+
+                ++$invocation;
+
+                return $returnValue;
+            });
+    }
+
+    /**
      * Test that the appropriate variant is displayed based on hit counts and variant weights.
      */
     public function testVariantPageWeightsAreAppropriate(): void
@@ -326,10 +347,11 @@ class PublicControllerTest extends MauticMysqlTestCase
             ->with($redirectId)
             ->willReturn($this->redirect);
 
-        $this->modelFactory->expects(self::exactly(3))
-            ->method('getModel')
-            ->withConsecutive(['page.redirect'], ['lead'], ['page'])
-            ->willReturnOnConsecutiveCalls($this->redirectModel, $this->leadModel, $this->pageModel);
+        $this->expectGetModelSequence([
+            ['page.redirect', $this->redirectModel],
+            ['lead', $this->leadModel],
+            ['page', $this->pageModel],
+        ]);
 
         $this->redirect->expects(self::once())
             ->method('isPublished')
@@ -415,10 +437,11 @@ class PublicControllerTest extends MauticMysqlTestCase
             ->with($redirectId)
             ->willReturn($this->redirect);
 
-        $this->modelFactory->expects(self::exactly(3))
-            ->method('getModel')
-            ->withConsecutive(['page.redirect'], ['lead'], ['page'])
-            ->willReturnOnConsecutiveCalls($this->redirectModel, $this->leadModel, $this->pageModel);
+        $this->expectGetModelSequence([
+            ['page.redirect', $this->redirectModel],
+            ['lead', $this->leadModel],
+            ['page', $this->pageModel],
+        ]);
 
         $this->redirect->expects(self::once())
             ->method('isPublished')
@@ -491,11 +514,11 @@ class PublicControllerTest extends MauticMysqlTestCase
         self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
     }
 
-    public function testRedirectUsesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(): void
+    public function testRedirectUsesStoredEmailFieldValueWhenBlockedTrackingCookieIsPresent(): void
     {
         $redirectId      = 'tokenizedRedirectId';
-        $redirectUrl     = 'https://example.com/preferences?token={contactfield=preference_token}';
-        $resolvedToken   = 'stored-token-value';
+        $redirectUrl     = 'https://example.com/preferences?uuid={contactfield=preference_uuid}';
+        $resolvedUuid    = '20a72128-75b4-468e-b8e6-0f0af25e4bcd';
         $trackingHash    = 'trackinghash123';
         $clickThrough    = ClickthroughHelper::encodeArrayForUrl([
             'source' => [],
@@ -516,10 +539,11 @@ class PublicControllerTest extends MauticMysqlTestCase
             ->with($redirectId)
             ->willReturn($this->redirect);
 
-        $this->modelFactory->expects(self::exactly(3))
-            ->method('getModel')
-            ->withConsecutive(['page.redirect'], ['page'], ['lead'])
-            ->willReturnOnConsecutiveCalls($this->redirectModel, $this->pageModel, $leadModel);
+        $this->expectGetModelSequence([
+            ['page.redirect', $this->redirectModel],
+            ['page', $this->pageModel],
+            ['lead', $leadModel],
+        ]);
 
         $this->redirect->expects(self::once())
             ->method('isPublished')
@@ -541,7 +565,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         $emailStat->expects(self::once())
             ->method('getTokens')
             ->willReturn([
-                '{contactfield=preference_token}' => $resolvedToken,
+                '{contactfield=preference_uuid}' => $resolvedUuid,
             ]);
 
         $emailStat->expects(self::once())
@@ -608,7 +632,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         );
 
         self::assertSame(
-            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            sprintf('https://example.com/preferences?uuid=%s', $resolvedUuid),
             $response->getTargetUrl()
         );
         self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -517,8 +517,8 @@ class PublicControllerTest extends MauticMysqlTestCase
     public function testRedirectUsesStoredEmailFieldValueWhenBlockedTrackingCookieIsPresent(): void
     {
         $redirectId      = 'tokenizedRedirectId';
-        $redirectUrl     = 'https://example.com/preferences?uuid={contactfield=preference_uuid}';
-        $resolvedUuid    = '20a72128-75b4-468e-b8e6-0f0af25e4bcd';
+        $redirectUrl     = 'https://example.com/preferences?choice={contactfield=preferred_choice}';
+        $resolvedValue   = 'weekly-digest';
         $trackingHash    = 'trackinghash123';
         $clickThrough    = ClickthroughHelper::encodeArrayForUrl([
             'source' => [],
@@ -565,7 +565,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         $emailStat->expects(self::once())
             ->method('getTokens')
             ->willReturn([
-                '{contactfield=preference_uuid}' => $resolvedUuid,
+                '{contactfield=preferred_choice}' => $resolvedValue,
             ]);
 
         $emailStat->expects(self::once())
@@ -632,7 +632,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         );
 
         self::assertSame(
-            sprintf('https://example.com/preferences?uuid=%s', $resolvedUuid),
+            sprintf('https://example.com/preferences?choice=%s', $resolvedValue),
             $response->getTargetUrl()
         );
         self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16043

## Description

Tracked email redirects that depend on stored email-stat tokens can fall back to unresolved placeholders when the `Blocked-Tracking` cookie is present, especially on repeat opens of the same personalized link.

This change fixes the redirect flow in two places:

1. `PublicController::redirectAction()` now resolves redirect URLs from the frozen tokens stored on the matching email stat before falling back to live contact token replacement.
2. `ContactRequestHelper` still allows clickthrough-based identification when `Blocked-Tracking` is present and a `ct` payload exists, so tracked redirect resolution can use the same clickthrough context without re-enabling normal tracking.

Tests were added for the controller redirect path, the blocked-tracking contact resolution path, and the functional redirect regression.

---
### 📋 Steps to test this PR:

1. Create or use an email that contains a tracked link with a contact-field token in the destination URL, for example a preference-center link that includes `{contactfield=...}`.
2. Send the email to a known contact so Mautic stores the resolved token values in `email_stats.tokens` for that send.
3. Open the tracked link once and confirm the redirect target contains the resolved token value.
4. Simulate blocked tracking by setting the `Blocked-Tracking` cookie in the browser, then open the same tracked link again.
5. Confirm the redirect still returns a `302` to the fully resolved destination URL instead of leaving the raw `{contactfield=...}` placeholder in place.
6. Run the added PHPUnit coverage for `PublicControllerTest`, `PublicControllerRedirectTest`, and `ContactRequestHelperTest`.
