### PR TITLE
fix: preserve apostrophes in custom field default values

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -236,7 +236,7 @@ class FieldType extends AbstractType
          * Used as as form modifier before trying to set data
          */
         $formModifier = function (FormEvent $event) use ($listChoices, $type, $options, $disableDefaultValue): array {
-            $cleaningRules = [];
+            $cleaningRules = ['defaultValue' => 'raw'];
             $form          = $event->getForm();
             $data          = $event->getData();
             $type          = (is_array($data)) ? ($data['type'] ?? $type) : $data->getType();
@@ -248,8 +248,6 @@ class FieldType extends AbstractType
                     $constraints = new Assert\Callback([$this, 'validateDefaultValue']);
                     // no break
                 case 'multiselect':
-                    $cleaningRules['defaultValue'] = 'raw';
-
                     if (is_array($data)) {
                         $properties = $data['properties'] ?? [];
                     } else {

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -223,6 +223,42 @@ class FieldFunctionalTest extends MauticMysqlTestCase
         );
     }
 
+    public function testDefaultValueWithApostropheIsNotEncodedOnRepeatedSave(): void
+    {
+        $label   = 'Apostrophe default field';
+        $default = "Owner's choice";
+
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        $form = $crawler->selectButton('Save')->form();
+        $form['leadfield[label]']->setValue($label);
+        $form['leadfield[type]']->setValue('text');
+        $form['leadfield[defaultValue]']->setValue($default);
+
+        $this->client->submit($form);
+
+        /** @var LeadField|null $field */
+        $field = $this->em->getRepository(LeadField::class)->findOneBy(['label' => $label]);
+        Assert::assertNotNull($field);
+        Assert::assertSame($default, $field->getDefaultValue());
+
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/edit/'.$field->getId());
+
+        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+
+        $form = $crawler->selectButton('Save')->form();
+        $this->client->submit($form);
+
+        $this->em->clear();
+
+        /** @var LeadField|null $field */
+        $field = $this->em->getRepository(LeadField::class)->find($field->getId());
+        Assert::assertNotNull($field);
+        Assert::assertSame($default, $field->getDefaultValue());
+    }
+
     public function testFieldsSearchByIds(): void
     {
         $urlEncodedSearch = urlencode('ids:2,3');


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch) | ✔️ |
| New feature/enhancement? (use the a.x branch) | ❌ |
| Deprecations? | ❌ |
| BC breaks? (use the c.x branch) | ❌ |
| Automated tests included? | ✔️ |
| Related user documentation PR URL | N/A |
| Related developer documentation PR URL | N/A |
| Issue(s) addressed | N/A |

## Description

Custom field default values are sanitized on save through the generic form cleaner, which converts apostrophes to `&#39;`. Saving the same field again then re-encodes the stored entity value, producing nested entities such as `&#38;#39;`.

This change preserves `defaultValue` as raw input during the custom field form submit flow so the stored value remains stable across repeated saves while output escaping remains the responsibility of the render layer.

A functional regression test was added to verify that a text custom field default value containing an apostrophe survives an initial save and a subsequent save without being re-encoded.

### 📋 Steps to test this PR:

1. Create a new text custom field.
2. Set the default value to a string containing an apostrophe, for example `Owner's choice`.
3. Save the field and reopen it for editing.
4. Save it again without changing the default value.
5. Confirm the default value still appears as `Owner's choice` and is not converted to `&#39;` or nested entities.
6. Run the functional coverage in `FieldFunctionalTest`.