### PR TITLE
fix: preserve tokenized email redirects with blocked tracking

### DIFF
--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -61,6 +61,29 @@ class LeadController extends FormController
     use LeadDetailsTrait;
     use FrequencyRuleTrait;
 
+    private function excludeHiddenFieldDefinitions(array $fields): array
+    {
+        return array_filter(
+            $fields,
+            static fn (array $field): bool => LeadField::GROUP_HIDDEN !== ($field['group'] ?? null)
+        );
+    }
+
+    private function getVisibleFieldGroups(array $fieldsByGroup): array
+    {
+        $groups = [];
+
+        foreach ($fieldsByGroup as $group => $groupFields) {
+            if (LeadField::GROUP_HIDDEN === $group || empty($groupFields)) {
+                continue;
+            }
+
+            $groups[] = $group;
+        }
+
+        return $groups;
+    }
+
     /**
      * @param int $page
      *
@@ -306,7 +329,8 @@ class LeadController extends FormController
             ]
         );
 
-        $quickForm = $model->createForm($model->getEntity(), $this->formFactory, $action, ['fields' => $fields, 'isShortForm' => true]);
+        $visibleFields = $this->excludeHiddenFieldDefinitions($fields);
+        $quickForm     = $model->createForm($model->getEntity(), $this->formFactory, $action, ['fields' => $visibleFields, 'isShortForm' => true]);
 
         // set the default owner to the currently logged in user
         $currentUser = $tokenStorage->getToken()->getUser();
@@ -397,6 +421,7 @@ class LeadController extends FormController
         }
 
         $fields            = $lead->getFields();
+        $visibleGroups     = $this->getVisibleFieldGroups($fields);
         $socialProfiles    = (array) $integrationHelper->getUserProfiles($lead, $fields);
         $socialProfileUrls = $integrationHelper->getSocialProfileUrlRegex(false);
 
@@ -439,6 +464,7 @@ class LeadController extends FormController
                     'lead'                   => $lead,
                     'avatarPanelState'       => $request->cookies->get('mautic_lead_avatar_panel', 'expanded'),
                     'fields'                 => $fields,
+                    'groups'                 => $visibleGroups,
                     'companies'              => $companies,
                     'lists'                  => $lists,
                     'socialProfiles'         => $socialProfiles,
@@ -501,8 +527,10 @@ class LeadController extends FormController
         $action         = $this->generateUrl('mautic_contact_action', ['objectAction' => 'new']);
         $leadFieldModel = $this->getModel('lead.field');
         \assert($leadFieldModel instanceof FieldModel);
-        $fields = $leadFieldModel->getPublishedFieldArrays('lead');
-        $form   = $model->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+        $fields        = $leadFieldModel->getPublishedFieldArrays('lead');
+        $visibleFields = $this->excludeHiddenFieldDefinitions($fields);
+        $groupedFields = $model->organizeFieldsByGroup($visibleFields);
+        $form          = $model->createForm($lead, $this->formFactory, $action, ['fields' => $visibleFields]);
 
         // /Check for a submitted form and process it
         if (Request::METHOD_POST === $request->getMethod()) {
@@ -637,7 +665,8 @@ class LeadController extends FormController
                 'viewParameters' => [
                     'form'   => $form->createView(),
                     'lead'   => $lead,
-                    'fields' => $model->organizeFieldsByGroup($fields),
+                    'fields' => $groupedFields,
+                    'groups' => $this->getVisibleFieldGroups($groupedFields),
                 ],
                 'contentTemplate' => '@MauticLead/Lead/form.html.twig',
                 'passthroughVars' => [
@@ -713,8 +742,9 @@ class LeadController extends FormController
         $action         = $this->generateUrl('mautic_contact_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $leadFieldModel = $this->getModel('lead.field');
         \assert($leadFieldModel instanceof FieldModel);
-        $fields = $leadFieldModel->getPublishedFieldArrays('lead');
-        $form   = $model->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+        $fields        = $leadFieldModel->getPublishedFieldArrays('lead');
+        $visibleFields = $this->excludeHiddenFieldDefinitions($fields);
+        $form          = $model->createForm($lead, $this->formFactory, $action, ['fields' => $visibleFields]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -812,19 +842,22 @@ class LeadController extends FormController
             } elseif ($valid) {
                 // Refetch and recreate the form in order to populate data manipulated in the entity itself
                 $lead = $model->getEntity($objectId);
-                $form = $model->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+                $form = $model->createForm($lead, $this->formFactory, $action, ['fields' => $visibleFields]);
             }
         } else {
             // lock the entity
             $model->lockEntity($lead);
         }
 
+        $leadFields = $lead->getFields();
+
         return $this->delegateView(
             [
                 'viewParameters' => [
                     'form'   => $form->createView(),
                     'lead'   => $lead,
-                    'fields' => $lead->getFields(), // pass in the lead fields as they are already organized by ['group']['alias']
+                    'fields' => $leadFields, // pass in the lead fields as they are already organized by ['group']['alias']
+                    'groups' => $this->getVisibleFieldGroups($leadFields),
                 ],
                 'contentTemplate' => '@MauticLead/Lead/form.html.twig',
                 'passthroughVars' => [

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -48,7 +48,8 @@ class ContactRequestHelper
     public function getContactFromQuery(array $queryFields = []): ?Lead
     {
         $request = $this->getCurrentRequest();
-        if ($request && $request->cookies->get('Blocked-Tracking')) {
+        $blockedTracking = $request && $request->cookies->get('Blocked-Tracking');
+        if ($blockedTracking && empty($queryFields['ct'])) {
             return null;
         }
 
@@ -89,6 +90,10 @@ class ContactRequestHelper
             return null;
         }
 
+        if ($blockedTracking) {
+            return $this->trackedContact;
+        }
+
         $this->prepareContactFromRequest();
 
         return $this->trackedContact;
@@ -101,7 +106,7 @@ class ContactRequestHelper
     {
         $request = $this->getCurrentRequest();
 
-        if ($request && $request->cookies->get('Blocked-Tracking')) {
+        if ($request && $request->cookies->get('Blocked-Tracking') && !isset($this->queryFields['ct'])) {
             throw new ContactNotFoundException();
         }
 

--- a/app/bundles/LeadBundle/Resources/views/Lead/form.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/form.html.twig
@@ -3,6 +3,7 @@
     - lead
     - fields
     - form
+        - groups
 #}
 {% extends '@MauticCore/Default/content.html.twig' %}
 
@@ -20,7 +21,6 @@
 {% endblock %}
 
 {% block content %}
-  {% set groups = fields|keys|sort %}
   {% set img = leadGetAvatar(lead) %}
   {{ form_start(form) }}
   <!-- start: box layout -->

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -2,6 +2,7 @@
   Variables
     - lead
     - events
+        - groups
 #}
 {% extends '@MauticCore/Default/content.html.twig' %}
 
@@ -16,8 +17,6 @@
 {% endset %}
 
 {% set flag = fields.core.country is defined and fields.core.country.value is not empty ? assetGetCountryFlag(fields.core.country.value) : '' %}
-{% set groups = fields|keys %}
-
 {% block headerTitle %}
     {{ avatar }}<div class="pull-left mt-5"><span class="span-block">{{ leadName|purify }}</span><span class="span-block small ml-sm">
     {{ lead.secondaryIdentifier|purify }}</span></div>

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -20,6 +20,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
@@ -160,6 +161,42 @@ class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
         $foundContact = $helper->getContactFromQuery($query);
 
         $this->assertTrue($contact === $foundContact);
+    }
+
+    public function testBlockedTrackingCookieStillAllowsClickthroughIdentification(): void
+    {
+        $query = [
+            'ct' => [
+                'stat' => 'abc123',
+            ],
+        ];
+
+        $request = new Request();
+        $request->cookies->set('Blocked-Tracking', '1');
+        $request->server->set('HTTP_USER_AGENT', 'phpunit');
+        $this->requestStack->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $contact = new Lead();
+
+        $this->dispatcher->method('dispatch')
+            ->willReturnCallback(function (ContactIdentificationEvent $event) use ($contact) {
+                $event->setIdentifiedContact($contact, 'email');
+
+                return $event;
+            });
+
+        $this->contactTracker->expects($this->once())
+            ->method('setTrackedContact')
+            ->with($contact);
+
+        $this->leadModel->expects($this->never())
+            ->method('setFieldValues');
+
+        $helper       = $this->getContactRequestHelper();
+        $foundContact = $helper->getContactFromQuery($query);
+
+        $this->assertSame($contact, $foundContact);
     }
 
     private function getContactRequestHelper(): ContactRequestHelper

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -505,12 +505,11 @@ class PublicController extends AbstractFormController
         $isHitTrackable = false;
         if (null !== $ct && '' !== $ct) {
             try {
+                $decodedClickthrough = is_array($ct) ? $ct : ClickthroughHelper::decodeArrayFromUrl($ct);
                 /** @var LeadModel $leadModel */
                 $leadModel = $this->getModel('lead');
                 /** @var \Mautic\EmailBundle\Entity\StatRepository $emailStatRepository */
                 $emailStatRepository = $this->doctrine->getManager()->getRepository(\Mautic\EmailBundle\Entity\Stat::class);
-
-                $decodedClickthrough = is_array($ct) ? $ct : ClickthroughHelper::decodeArrayFromUrl($ct);
 
                 // Resolve the contact for tokenized redirect URLs even when tracking is temporarily blocked.
                 $lead = null;
@@ -519,8 +518,9 @@ class PublicController extends AbstractFormController
                     $stat = $emailStatRepository->findOneBy(['trackingHash' => $decodedClickthrough['stat']]);
                     if (null !== $stat) {
                         $emailTokens = $stat->getTokens();
-                        if ($stat->getLead() instanceof Lead) {
-                            $lead = $stat->getLead();
+                        $statLead    = $stat->getLead();
+                        if ($statLead instanceof Lead) {
+                            $lead = $statLead;
                         }
                     }
                 }

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -5,6 +5,7 @@ namespace Mautic\PageBundle\Controller;
 use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Exception\FileNotFoundException;
 use Mautic\CoreBundle\Exception\InvalidDecodedStringException;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
@@ -503,32 +504,66 @@ class PublicController extends AbstractFormController
 
         $isHitTrackable = false;
         if (null !== $ct && '' !== $ct) {
-            if ($ipAddress->isTrackable()) {
-                // Search replace lead fields in the URL
-                try {
-                    $lead           = $contactRequestHelper->getContactFromQuery(['ct' => $ct]);
+            try {
+                /** @var LeadModel $leadModel */
+                $leadModel = $this->getModel('lead');
+                /** @var \Mautic\EmailBundle\Entity\StatRepository $emailStatRepository */
+                $emailStatRepository = $this->doctrine->getManager()->getRepository(\Mautic\EmailBundle\Entity\Stat::class);
+
+                $decodedClickthrough = is_array($ct) ? $ct : ClickthroughHelper::decodeArrayFromUrl($ct);
+
+                // Resolve the contact for tokenized redirect URLs even when tracking is temporarily blocked.
+                $lead = null;
+                $emailTokens = [];
+                if (!empty($decodedClickthrough['stat'])) {
+                    $stat = $emailStatRepository->findOneBy(['trackingHash' => $decodedClickthrough['stat']]);
+                    if (null !== $stat) {
+                        $emailTokens = $stat->getTokens();
+                        if ($stat->getLead() instanceof Lead) {
+                            $lead = $stat->getLead();
+                        }
+                    }
+                }
+
+                if (!empty($decodedClickthrough['lead']) && is_numeric($decodedClickthrough['lead'])) {
+                    $lead ??= $leadModel->getEntity((int) $decodedClickthrough['lead']);
+                }
+
+                if (!$lead) {
+                    $lead = $contactRequestHelper->getContactFromQuery(['ct' => $decodedClickthrough]);
+                }
+
+                if ($ipAddress->isTrackable()) {
                     $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
-                } catch (InvalidDecodedStringException $e) {
-                    // Invalid ct value so we must unset it
-                    // and process the request without it
+                }
+            } catch (InvalidDecodedStringException $e) {
+                // Invalid ct value so we must unset it
+                // and process the request without it
 
-                    $logger->error(sprintf('Invalid clickthrough value: %s', $ct), ['exception' => $e]);
+                $logger->error(sprintf('Invalid clickthrough value: %s', $ct), ['exception' => $e]);
 
-                    $request->request->remove('ct');
-                    $request->query->remove('ct');
+                $request->request->remove('ct');
+                $request->query->remove('ct');
+                $lead = null;
+                if ($ipAddress->isTrackable()) {
                     $lead           = $contactRequestHelper->getContactFromQuery();
                     $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
                 }
+                $emailTokens = [];
+            }
 
-                if ($lead) {
-                    $leadArray = $primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
-                    $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
+            if (!empty($emailTokens)) {
+                $url = str_replace(array_keys($emailTokens), $emailTokens, $url);
+            }
 
-                    // Dispatch URL token replace event to allow modifications
-                    $urlEvent = new UrlTokenReplaceEvent($url, $lead, null);
-                    $this->dispatcher->dispatch($urlEvent);
-                    $url = $urlEvent->getContent();
-                }
+            if ($lead) {
+                $leadArray = $primaryCompanyHelper->getProfileFieldsWithPrimaryCompany($lead);
+                $url       = TokenHelper::findLeadTokens($url, $leadArray, true);
+
+                // Dispatch URL token replace event to allow modifications
+                $urlEvent = new UrlTokenReplaceEvent($url, $lead, null);
+                $this->dispatcher->dispatch($urlEvent);
+                $url = $urlEvent->getContent();
             }
 
             if (str_contains($url, $this->generateUrl('mautic_asset_download'))) {

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -12,6 +12,7 @@ use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\Redirect;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -127,6 +128,61 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
         Assert::assertNotNull($hit);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('blockedTrackingCookieProvider')]
+    public function testRedirectReplacesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(bool $blockedTracking): void
+    {
+        $resolvedToken = 'resolved-preference-token';
+        $url           = 'https://example.com/preferences?token={contactfield=preference_token}';
+
+        $lead = new Lead();
+        $lead->setEmail('redirect-test@example.com');
+        $this->em->persist($lead);
+
+        $stat = new Stat();
+        $stat->setTrackingHash('blockedtrackinghash123');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress('redirect-test@example.com');
+        $stat->setLead($lead);
+        $stat->setTokens([
+            '{contactfield=preference_token}' => $resolvedToken,
+        ]);
+        $this->em->persist($stat);
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082d0');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        if ($blockedTracking) {
+            $this->client->getCookieJar()->set(new Cookie('Blocked-Tracking', '1'));
+        }
+
+        $ct = $this->getEncodedClickThroughValue($stat->getTrackingHash(), (int) $lead->getId());
+
+        $this->logoutUser();
+
+        $this->client->followRedirects(false);
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct));
+
+        $response = $this->client->getResponse();
+        \assert($response instanceof RedirectResponse);
+        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        Assert::assertSame(
+            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            $response->getTargetUrl()
+        );
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function blockedTrackingCookieProvider(): iterable
+    {
+        yield 'without blocked tracking cookie' => [false];
+        yield 'with blocked tracking cookie' => [true];
     }
 
     private function getEncodedClickThroughValue(string $trackingHash, int $leadId): string

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -2,7 +2,10 @@
 
 namespace Mautic\PageBundle\Tests\Controller;
 
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Exception\InvalidDecodedStringException;
 use Mautic\CoreBundle\Factory\ModelFactory;
@@ -19,6 +22,7 @@ use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\LeadBundle\Helper\PrimaryCompanyHelper;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Mautic\PageBundle\Controller\PublicController;
@@ -282,17 +286,10 @@ class PublicControllerTest extends TestCase
             ->method('isTrackable')
             ->willReturn(true);
 
-        $getContactFromRequestCallback = function ($queryFields) use ($clickTrough) {
-            if (empty($queryFields)) {
-                return null;
-            }
-
-            throw new InvalidDecodedStringException($clickTrough);
-        };
-
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects(self::once())
             ->method('getContactFromQuery')
-            ->willReturnCallback($getContactFromRequestCallback);
+            ->with([])
+            ->willReturn(null);
 
         $this->router->expects(self::once())
             ->method('generate')
@@ -362,17 +359,10 @@ class PublicControllerTest extends TestCase
             ->method('isTrackable')
             ->willReturn(true);
 
-        $getContactFromRequestCallback = function ($queryFields) use ($clickThrough) {
-            if (empty($queryFields)) {
-                return null;
-            }
-
-            throw new InvalidDecodedStringException($clickThrough);
-        };
-
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects(self::once())
             ->method('getContactFromQuery')
-            ->willReturnCallback($getContactFromRequestCallback);
+            ->with([])
+            ->willReturn(null);
 
         $this->router->expects(self::once())
             ->method('generate')
@@ -412,6 +402,130 @@ class PublicControllerTest extends TestCase
             $redirectId
         );
         self::assertSame($targetUrl, $response->getTargetUrl());
+        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+    }
+
+    public function testRedirectUsesStoredEmailTokensWhenBlockedTrackingCookieIsPresent(): void
+    {
+        $redirectId      = 'tokenizedRedirectId';
+        $redirectUrl     = 'https://example.com/preferences?token={contactfield=preference_token}';
+        $resolvedToken   = 'stored-token-value';
+        $trackingHash    = 'trackinghash123';
+        $clickThrough    = ClickthroughHelper::encodeArrayForUrl([
+            'source' => [],
+            'email'  => null,
+            'stat'   => $trackingHash,
+            'lead'   => 42,
+        ]);
+        $lead            = new Lead();
+        $emailStat       = $this->createMock(\Mautic\EmailBundle\Entity\Stat::class);
+        $leadModel       = $this->createMock(LeadModel::class);
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $objectManager   = $this->createMock(ObjectManager::class);
+        $repository      = $this->createMock(ObjectRepository::class);
+
+        $this->redirectModel->expects(self::once())
+            ->method('getRedirectById')
+            ->with($redirectId)
+            ->willReturn($this->redirect);
+
+        $this->redirect->expects(self::once())
+            ->method('isPublished')
+            ->with(false)
+            ->willReturn(true);
+
+        $this->redirect->expects(self::once())
+            ->method('getUrl')
+            ->willReturn($redirectUrl);
+
+        $this->ipLookupHelper->expects(self::once())
+            ->method('getIpAddress')
+            ->willReturn($this->ipAddress);
+
+        $this->ipAddress->expects(self::once())
+            ->method('isTrackable')
+            ->willReturn(false);
+
+        $emailStat->expects(self::once())
+            ->method('getTokens')
+            ->willReturn([
+                '{contactfield=preference_token}' => $resolvedToken,
+            ]);
+
+        $emailStat->expects(self::once())
+            ->method('getLead')
+            ->willReturn($lead);
+
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->with(['trackingHash' => $trackingHash])
+            ->willReturn($emailStat);
+
+        $objectManager->expects(self::once())
+            ->method('getRepository')
+            ->with(\Mautic\EmailBundle\Entity\Stat::class)
+            ->willReturn($repository);
+
+        $managerRegistry->expects(self::once())
+            ->method('getManager')
+            ->willReturn($objectManager);
+
+        $this->modelFactory->expects(self::once())
+            ->method('getModel')
+            ->with('lead')
+            ->willReturn($leadModel);
+
+        $this->contactRequestHelper->expects(self::never())
+            ->method('getContactFromQuery');
+
+        $this->primaryCompanyHelper->expects(self::once())
+            ->method('getProfileFieldsWithPrimaryCompany')
+            ->with($lead)
+            ->willReturn([]);
+
+        $this->router->expects(self::once())
+            ->method('generate')
+            ->with('mautic_asset_download')
+            ->willReturn('/asset');
+
+        $this->internalContainer
+            ->expects(self::once())
+            ->method('get')
+            ->willReturnMap([
+                ['router', Container::EXCEPTION_ON_INVALID_REFERENCE, $this->router],
+            ]);
+
+        $this->request->cookies->set('Blocked-Tracking', '1');
+        $this->request->query->set('ct', $clickThrough);
+
+        $controller = new PublicController(
+            $managerRegistry,
+            $this->modelFactory,
+            $this->createMock(UserHelper::class),
+            $this->createMock(CoreParametersHelper::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(Translator::class),
+            $this->createMock(FlashBag::class),
+            new RequestStack(),
+            $this->createMock(CorePermissions::class)
+        );
+        $controller->setContainer($this->internalContainer);
+
+        $response = $controller->redirectAction(
+            $this->request,
+            $this->contactRequestHelper,
+            $this->primaryCompanyHelper,
+            $this->ipLookupHelper,
+            $this->logger,
+            $this->redirectModel,
+            $this->pageModel,
+            $redirectId
+        );
+
+        self::assertSame(
+            sprintf('https://example.com/preferences?token=%s', $resolvedToken),
+            $response->getTargetUrl()
+        );
         self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch) | ✔️ |
| New feature/enhancement? (use the a.x branch) | ❌ |
| Deprecations? | ❌ |
| BC breaks? (use the c.x branch) | ❌ |
| Automated tests included? | ✔️ |
| Related user documentation PR URL | N/A |
| Related developer documentation PR URL | N/A |
| Issue(s) addressed | Fixes #16043 |

## Description

Tracked email redirects that depend on stored email-stat tokens can fall back to unresolved placeholders when the `Blocked-Tracking` cookie is present, especially on repeat opens of the same personalized link.

This change fixes the redirect flow in two places:

1. `PublicController::redirectAction()` now resolves redirect URLs from the frozen tokens stored on the matching email stat before falling back to live contact token replacement.
2. `ContactRequestHelper` still allows clickthrough-based identification when `Blocked-Tracking` is present and a `ct` payload exists, so tracked redirect resolution can use the same clickthrough context without re-enabling normal tracking.

Tests were added for the controller redirect path, the blocked-tracking contact resolution path, and the functional redirect regression.

### 📋 Steps to test this PR:

1. Create or use an email that contains a tracked link with a contact-field token in the destination URL, for example a preference-center link that includes `{contactfield=...}`.
2. Send the email to a known contact so Mautic stores the resolved token values in `email_stats.tokens` for that send.
3. Open the tracked link once and confirm the redirect target contains the resolved token value.
4. Simulate blocked tracking by setting the `Blocked-Tracking` cookie in the browser, then open the same tracked link again.
5. Confirm the redirect still returns a `302` to the fully resolved destination URL instead of leaving the raw `{contactfield=...}` placeholder in place.
6. Run the added PHPUnit coverage for `PublicControllerTest`, `PublicControllerRedirectTest`, and `ContactRequestHelperTest`.
