### PR TITLE
fix: tolerate select autofill html variants

### DIFF
--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -219,12 +219,14 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 break;
             case 'select':
             case 'country':
-                $regex = '/<select\s*id="mauticform_input_'.$formName.'_'.$alias.'"(.*?)<\/select>/is';
+                $escapedIdAttr = preg_quote('id="mauticform_input_'.$formName.'_'.$alias.'"', '/');
+                $regex         = '/<select\b(?=[^>]*'.$escapedIdAttr.')[^>]*>.*?<\/select>/is';
                 if (preg_match($regex, $formHtml, $match)) {
-                    $origText = $match[0];
-                    $replace  = str_replace(
-                        '<option value="'.$this->sanitizeValue($value).'">',
-                        '<option value="'.$this->sanitizeValue($value).'" selected="selected">',
+                    $origText       = $match[0];
+                    $sanitizedValue = $this->sanitizeValue($value);
+                    $replace        = preg_replace(
+                        '/<option\s+value="'.preg_quote($sanitizedValue, '/').'"\s*>/i',
+                        '<option value="'.$sanitizedValue.'" selected="selected">',
                         $origText
                     );
                     $formHtml = str_replace($origText, $replace, $formHtml);

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -100,6 +100,20 @@ class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
                 '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
                 'Select lists should have their values set appropriately via GET.',
             ],
+            [
+                self::getField('Select', 'select'),
+                'myvalue',
+                '<select name="mauticform[select]" value="{contactfield=myvalue}" id="mauticform_input_mautic_select" class="mauticform-selectbox"><option value="myvalue">My Value</option></select>',
+                '<select name="mauticform[select]" value="{contactfield=myvalue}" id="mauticform_input_mautic_select" class="mauticform-selectbox"><option value="myvalue" selected="selected">My Value</option></select>',
+                'Select lists should match the form field even when the id attribute is not the first select attribute.',
+            ],
+            [
+                self::getField('Select', 'select'),
+                'myvalue',
+                '<select id="mauticform_input_mautic_select"><option value="myvalue" >My Value</option></select>',
+                '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
+                'Select lists should match the option tag even when there is whitespace before the closing angle bracket.',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #16099

This keeps the fix intentionally narrow:
- match the target `<select>` by `id` regardless of attribute order in the opening tag
- tolerate optional whitespace before `>` when selecting the matching `<option>`
- add focused regression cases for both HTML variants

Verification:
- `git diff --check`
- local PHPUnit run was not completed in this workspace because PHP / vendor tooling is not available on PATH here, so I kept the change limited to the reported helper and its unit test coverage.