### PR TITLE
Register mautic:phpunit:config command in test environment only

### DIFF
--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -68,5 +68,4 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.core.model.auditlog', Mautic\CoreBundle\Model\AuditLogModel::class);
     $services->alias('mautic.core.model.notification', Mautic\CoreBundle\Model\NotificationModel::class);
     $services->alias('mautic.core.model.form', Mautic\CoreBundle\Model\FormModel::class);
-    $services->set(Mautic\CoreBundle\Test\PhpUnitConfigCommand::class);
 };

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/TestPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/TestPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection\Compiler;
 
+use Mautic\CoreBundle\Test\PhpUnitConfigCommand;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -21,5 +22,6 @@ final class TestPass implements CompilerPassInterface
         $container->removeAlias(\Symfony\Contracts\HttpClient\HttpClientInterface::class);
         $container->register(\Symfony\Component\HttpClient\MockHttpClient::class, \Symfony\Component\HttpClient\MockHttpClient::class)->setAutowired(true)->setPublic(true);
         $container->setAlias(\Symfony\Contracts\HttpClient\HttpClientInterface::class, \Symfony\Component\HttpClient\MockHttpClient::class);
+        $container->register(PhpUnitConfigCommand::class, PhpUnitConfigCommand::class)->addTag('console.command');
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #16061 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes #16061.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `bin/console --env=test mautic:phpunit:config 3`. You should get output like:
    ```
    <?xml version="1.0" encoding="UTF-8"?>
    <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
    <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        backupGlobals="false"
        backupStaticProperties="false"
        colors="true"
        processIsolation="false"
        stopOnFailure="false"
        bootstrap="../vendor/autoload.php"
        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
        failOnRisky="true"
        failOnWarning="true"
        displayDetailsOnTestsThatTriggerDeprecations="true"
        displayDetailsOnPhpunitDeprecations="true"
        displayDetailsOnTestsThatTriggerErrors="true"
        displayDetailsOnTestsThatTriggerNotices="true"
        displayDetailsOnTestsThatTriggerWarnings="true"
        cacheDirectory="../var/cache/phpunit"
      >
      <source>
        <include>
          <directory>bundles</directory>
    ```
3. Run `bin/console --env=prod mautic:phpunit:config 3`. You should get output like:
    ```
     There are no commands defined in the "mautic:phpunit" namespace.  
                                                                        
      Did you mean one of these?                                        
          mautic                                                        
          mautic:anonymize                                              
          mautic:assets                                                 
          mautic:broadcasts                                             
          mautic:cache                                                  
          mautic:campaign                 
    ```

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->