### PR TITLE
fix: allow Enter key to create new tags alongside Escape

### DIFF
--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -155,10 +155,10 @@ Mautic.leadOnLoad = function (container, response) {
     // Adding behavior to be able to create new tags by pressing the `Enter` or `Escape` key
     // when the search field is active (ie: the tag name we are typing is a substring of an existing tag)
     mQuery('#lead_tags_chosen input').keyup(function(el) {
-        const newTag = mQuery('#lead_tags_chosen input').val();
+        const newTag = mQuery('#lead_tags_chosen input').val().trim();
         if ((el.key === "Escape" || el.key === "Enter") && newTag !== '') {
             const selectElement = mQuery('#lead_tags').get();
-            const selectedValues = mQuery('#lead_tags').val();
+            const selectedValues = mQuery('#lead_tags').val() || [];
             const payload = [...selectedValues, newTag];
 
             Mautic.activateLabelLoadingIndicator(mQuery(selectElement).attr('id'));

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -152,11 +152,11 @@ Mautic.leadOnLoad = function (container, response) {
         mQuery(container + ' .panel-companies .ri-check-line').tooltip({html: true});
     }
 
-    // Adding behavior to be able to create new tags by pressing the `Escape` key
+    // Adding behavior to be able to create new tags by pressing the `Enter` or `Escape` key
     // when the search field is active (ie: the tag name we are typing is a substring of an existing tag)
     mQuery('#lead_tags_chosen input').keyup(function(el) {
         const newTag = mQuery('#lead_tags_chosen input').val();
-        if (el.key === "Escape" && newTag !== '') {
+        if ((el.key === "Escape" || el.key === "Enter") && newTag !== '') {
             const selectElement = mQuery('#lead_tags').get();
             const selectedValues = mQuery('#lead_tags').val();
             const payload = [...selectedValues, newTag];


### PR DESCRIPTION
## Description

The tag creation handler in lead.js only checked for the Escape key when creating new tags from the tag search input. This meant users pressing Enter to create a tag would see nothing happen, while Escape worked as expected.

This PR adds Enter as an accepted key alongside Escape in the #lead_tags_chosen input keyup handler.

Fixes #16076

## Verification

- The condition now reads: if ((el.key === "Escape" || el.key === "Enter") && newTag !== '')
- Updated comment to reflect both supported keys
- No other logic changed

## Related issues

- #15857 (same issue in campaign composer)