### PR TITLE
Campaign event cache TTL, make it configurable

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -357,5 +357,6 @@ return [
         'import_campaigns_dir'                                                                  => '%kernel.project_dir%/var/import',
         'campaign_republish_behavior'                                                           => Mautic\CampaignBundle\Enum\RepublishBehavior::COUNT_ALL_TIME->value,
         'campaign_contact_count_cache_ttl'                                                      => 43200, // 12 hours in seconds
+        'campaign_event_cache_ttl'                => 600, //seconds
     ],
 ];

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -357,6 +357,6 @@ return [
         'import_campaigns_dir'                                                                  => '%kernel.project_dir%/var/import',
         'campaign_republish_behavior'                                                           => Mautic\CampaignBundle\Enum\RepublishBehavior::COUNT_ALL_TIME->value,
         'campaign_contact_count_cache_ttl'                                                      => 43200, // 12 hours in seconds
-        'campaign_event_cache_ttl'                => 600, //seconds
+        'campaign_event_cache_ttl'                                                              => 600, // seconds
     ],
 ];

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -1158,8 +1158,8 @@ class CampaignController extends AbstractStandardFormController
             $cacheTTL = (int) $this->coreParametersHelper->get('campaign_event_cache_ttl');
             /** @var LeadEventLogRepository $eventLogRepo */
             $eventLogRepo               = $this->doctrine->getManager()->getRepository(LeadEventLog::class);
-            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateTo, $cacheTTL);
-            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateTo, $cacheTTL);
+            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateTo, null, $cacheTTL);
+            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateTo, null, $cacheTTL);
         }
 
         return [

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -344,7 +344,7 @@ class CampaignController extends AbstractStandardFormController
             $dateTo   = $dateTo->modify('+1 day');
         }
 
-        $hasCampaignLeads = $this->getCampaignModel()->getRepository()->hasCampaignLeads($objectId);
+        $hasCampaignLeads = $this->getCampaignModel()->getRepository()->hasCampaignLeads($objectId, (int) $this->coreParametersHelper->get('campaign_event_cache_ttl'));
         $logCounts        = $this->processCampaignLogCounts($objectId, $dateFrom, $dateTo);
 
         $campaignLogCounts          = $logCounts['campaignLogCounts'] ?? [];
@@ -1155,10 +1155,11 @@ class CampaignController extends AbstractStandardFormController
             $campaignLogCounts          = $summaryRepo->getCampaignLogCounts($id, $dateFrom, $dateTo);
             $campaignLogCountsProcessed = $this->getCampaignLogCountsProcessed($campaignLogCounts);
         } else {
+            $cacheTTL = (int) $this->coreParametersHelper->get('campaign_event_cache_ttl');
             /** @var LeadEventLogRepository $eventLogRepo */
             $eventLogRepo               = $this->doctrine->getManager()->getRepository(LeadEventLog::class);
-            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateTo);
-            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateTo);
+            $campaignLogCounts          = $eventLogRepo->getCampaignLogCounts($id, false, false, false, $dateFrom, $dateTo, $cacheTTL);
+            $campaignLogCountsProcessed = $eventLogRepo->getCampaignLogCounts($id, true, false, false, $dateFrom, $dateTo, $cacheTTL);
         }
 
         return [

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -542,11 +542,12 @@ class CampaignRepository extends CommonRepository
             ->setMaxResults(1);
 
         if ($this->getReplicaConnection()->getConfiguration()->getResultCache()) {
-            $results = $this->getReplicaConnection()->executeCacheQuery(
+            $cacheKey = str_replace(['\\', ':'], '_', __METHOD__).'_'.$campaignId;
+            $results  = $this->getReplicaConnection()->executeCacheQuery(
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile($cacheTTL, __METHOD__)
+                new QueryCacheProfile($cacheTTL, $cacheKey)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -542,12 +542,11 @@ class CampaignRepository extends CommonRepository
             ->setMaxResults(1);
 
         if ($this->getReplicaConnection()->getConfiguration()->getResultCache()) {
-            $cacheKey = str_replace(['\\', ':'], '_', __METHOD__).'_'.$campaignId;
             $results  = $this->getReplicaConnection()->executeCacheQuery(
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile($cacheTTL, $cacheKey)
+                new QueryCacheProfile($cacheTTL)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -526,7 +526,7 @@ class CampaignRepository extends CommonRepository
     /**
      * Returns true if the campaign has at least one lead.
      */
-    public function hasCampaignLeads(int $campaignId): bool
+    public function hasCampaignLeads(int $campaignId, int $cacheTTL = 0): bool
     {
         $q = $this->getReplicaConnection()->createQueryBuilder();
 
@@ -546,7 +546,7 @@ class CampaignRepository extends CommonRepository
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile(600)
+                new QueryCacheProfile($cacheTTL, __METHOD__)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -220,7 +220,7 @@ class LeadEventLogRepository extends CommonRepository
         ?\DateTimeInterface $dateFrom = null,
         ?\DateTimeInterface $dateTo = null,
         ?int $eventId = null,
-        int $cacheTTL = 0
+        int $cacheTTL = 0,
     ): array {
         $join = $all ? 'leftJoin' : 'innerJoin';
 
@@ -290,11 +290,12 @@ class LeadEventLogRepository extends CommonRepository
         }
 
         if ($this->_em->getConnection()->getConfiguration()->getResultCache()) {
-            $results = $this->_em->getConnection()->executeCacheQuery(
+            $cacheKey = str_replace(['\\', ':'], '_', __METHOD__).'_'.$campaignId;
+            $results  = $this->_em->getConnection()->executeCacheQuery(
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile($cacheTTL, __METHOD__)
+                new QueryCacheProfile($cacheTTL, $cacheKey)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -290,12 +290,11 @@ class LeadEventLogRepository extends CommonRepository
         }
 
         if ($this->_em->getConnection()->getConfiguration()->getResultCache()) {
-            $cacheKey = str_replace(['\\', ':'], '_', __METHOD__).'_'.$campaignId;
             $results  = $this->_em->getConnection()->executeCacheQuery(
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile($cacheTTL, $cacheKey)
+                new QueryCacheProfile($cacheTTL)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -220,6 +220,7 @@ class LeadEventLogRepository extends CommonRepository
         ?\DateTimeInterface $dateFrom = null,
         ?\DateTimeInterface $dateTo = null,
         ?int $eventId = null,
+        int $cacheTTL = 0
     ): array {
         $join = $all ? 'leftJoin' : 'innerJoin';
 
@@ -293,7 +294,7 @@ class LeadEventLogRepository extends CommonRepository
                 $q->getSQL(),
                 $q->getParameters(),
                 $q->getParameterTypes(),
-                new QueryCacheProfile(600)
+                new QueryCacheProfile($cacheTTL, __METHOD__)
             )->fetchAllAssociative();
         } else {
             $results = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Controller;
+
+use function GuzzleHttp\json_decode;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\DomCrawler\Crawler;
+
+class CampaignEventStatsTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['campaign_use_summary']     = false;
+        $this->configParams['campaign_event_cache_ttl'] = 3;
+
+        parent::setUp();
+    }
+
+    public function testCountsProcessedCampaignsMethodCountsProcessedCampaignsCorrectly(): void
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Test Campaign');
+        $this->em->persist($campaign);
+
+        $lead = new Lead();
+        $lead->setFirstname('Test Lead');
+        $this->em->persist($lead);
+
+        $campaignEvent1 = new Event();
+        $campaignEvent1->setCampaign($campaign);
+        $campaignEvent1->setName('Send Email 1');
+        $campaignEvent1->setType('email.send');
+        $campaignEvent1->setEventType('action');
+        $campaignEvent1->setProperties([]);
+        $this->em->persist($campaignEvent1);
+
+        $campaignEvent2 = new Event();
+        $campaignEvent2->setCampaign($campaign);
+        $campaignEvent2->setName('Jump to send email 1');
+        $campaignEvent2->setType('campaign.jump_to_event');
+        $campaignEvent2->setEventType('action');
+        $campaignEvent2->setProperties([]);
+        $this->em->persist($campaignEvent2);
+
+        $campaignLead = new CampaignLead();
+        $campaignLead->setCampaign($campaign);
+        $campaignLead->setLead($lead);
+        $campaignLead->setDateAdded(new \DateTime());
+        $this->em->persist($campaignLead);
+
+        $leadEventLog1 = new LeadEventLog();
+        $leadEventLog1->setLead($lead);
+        $leadEventLog1->setEvent($campaignEvent1);
+        $leadEventLog1->setIsScheduled(true);
+        $leadEventLog1->setRotation(1);
+        $this->em->persist($leadEventLog1);
+
+        $leadEventLog3 = new LeadEventLog();
+        $leadEventLog3->setLead($lead);
+        $leadEventLog3->setEvent($campaignEvent1);
+        $leadEventLog1->setRotation(2);
+        $this->em->persist($leadEventLog3);
+
+        $this->em->flush();
+
+        $eventsStatistics         = $this->getEventsStatistics($campaign);
+
+        $expectedEventsStatistics = [
+            0 => [
+                'successPercent' => '100%',
+                'completed'      => '1',
+                'pending'        => '1',
+            ],
+            1 => [
+                'successPercent' => '0%',
+                'completed'      => '0',
+                'pending'        => '0',
+            ],
+        ];
+
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+
+        $leadEventLog2 = new LeadEventLog();
+        $leadEventLog2->setLead($lead);
+        $leadEventLog2->setEvent($campaignEvent2);
+        $leadEventLog1->setRotation(1);
+        $this->em->persist($leadEventLog2);
+        $this->em->flush();
+
+        $eventsStatistics         = $this->getEventsStatistics($campaign);
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+
+        sleep(5);
+
+        $eventsStatistics         = $this->getEventsStatistics($campaign);
+
+        $expectedEventsStatistics = [
+            0 => [
+                'successPercent' => '100%',
+                'completed'      => '1',
+                'pending'        => '1',
+            ],
+            1 => [
+                'successPercent' => '100%',
+                'completed'      => '1',
+                'pending'        => '0',
+            ],
+        ];
+
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+    }
+
+    private function getTestCrawler(Campaign $campaign): Crawler
+    {
+        $now    = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $before = $now->modify('-1 month');
+        $after  = $now->modify('+1 month');
+        $url    = sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
+        $this->client->request('GET', $url);
+        $response = $this->client->getResponse();
+        $body     = json_decode($response->getContent(), true);
+        $this->client->restart();
+
+        return new Crawler($body['actions']);
+    }
+
+    private function getEventsStatistics(Campaign $campaign): array
+    {
+        $crawler = $this->getTestCrawler($campaign);
+        $events  = [];
+        for ($eventIndex = 0;; ++$eventIndex) {
+            $node = $crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3);
+            if (1 > $node->count()) {
+                break;
+            }
+            $events[] = [
+                'successPercent' => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3)->html()),
+                'completed'      => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3 + 1)->html()),
+                'pending'        => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3 + 2)->html()),
+            ];
+        }
+
+        return $events;
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CampaignBundle\Entity\Event;
-use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
-use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
@@ -28,35 +25,15 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
 
     public function testCountsProcessedCampaignsMethodCountsProcessedCampaignsCorrectly(): void
     {
-        $campaign = new Campaign();
-        $campaign->setName('Test Campaign');
-        $this->em->persist($campaign);
+        $campaign = $this->createCampaign('Test Campaign');
 
-        $lead = new Lead();
-        $lead->setFirstname('Test Lead');
-        $this->em->persist($lead);
+        $lead= $this->createLead('Test Lead');
 
-        $campaignEvent1 = new Event();
-        $campaignEvent1->setCampaign($campaign);
-        $campaignEvent1->setName('Send Email 1');
-        $campaignEvent1->setType('email.send');
-        $campaignEvent1->setEventType('action');
-        $campaignEvent1->setProperties([]);
-        $this->em->persist($campaignEvent1);
+        $campaignEvent1 = $this->createEvent('Send Email 1', $campaign, 'email.send', 'action');
 
-        $campaignEvent2 = new Event();
-        $campaignEvent2->setCampaign($campaign);
-        $campaignEvent2->setName('Jump to send email 1');
-        $campaignEvent2->setType('campaign.jump_to_event');
-        $campaignEvent2->setEventType('action');
-        $campaignEvent2->setProperties([]);
-        $this->em->persist($campaignEvent2);
+        $campaignEvent2 = $this->createEvent('ump to send email 1', $campaign, 'campaign.jump_to_event', 'action');
 
-        $campaignLead = new CampaignLead();
-        $campaignLead->setCampaign($campaign);
-        $campaignLead->setLead($lead);
-        $campaignLead->setDateAdded(new \DateTime());
-        $this->em->persist($campaignLead);
+        $this->addContactToCampaign($lead, $campaign);
 
         $this->createCampaignLeadEventLog($lead, $campaignEvent1, $campaign, 1, true);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -86,7 +86,7 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
             ],
         ];
 
-        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics);
 
         $leadEventLog2 = new LeadEventLog();
         $leadEventLog2->setLead($lead);
@@ -96,7 +96,7 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $eventsStatistics         = $this->getEventsStatistics($campaign);
-        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics);
 
         sleep(5);
 
@@ -115,7 +115,7 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
             ],
         ];
 
-        Assert::assertSame($expectedEventsStatistics, $eventsStatistics, 'Events statistics doesn\'t match the actual events in the database.');
+        Assert::assertSame($expectedEventsStatistics, $eventsStatistics);
     }
 
     private function getTestCrawler(Campaign $campaign): Crawler
@@ -142,14 +142,15 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $crawler = $this->getTestCrawler($campaign);
         $events  = [];
         for ($eventIndex = 0;; ++$eventIndex) {
-            $node = $crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3);
+            $crawlerFilter = $crawler->filter('.campaign-event-list')->filter('span');
+            $node          = $crawlerFilter->eq($eventIndex * 3);
             if (1 > $node->count()) {
                 break;
             }
             $events[] = [
-                'successPercent' => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3)->html()),
-                'completed'      => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3 + 1)->html()),
-                'pending'        => trim($crawler->filter('.campaign-event-list')->filter('span')->eq($eventIndex * 3 + 2)->html()),
+                'successPercent' => trim($crawlerFilter->eq($eventIndex * 3)->html()),
+                'completed'      => trim($crawlerFilter->eq($eventIndex * 3 + 1)->html()),
+                'pending'        => trim($crawlerFilter->eq($eventIndex * 3 + 2)->html()),
             ];
         }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 
-use function GuzzleHttp\json_decode;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -126,12 +126,17 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $url    = sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
         $this->client->request('GET', $url);
         $response = $this->client->getResponse();
-        $body     = json_decode($response->getContent(), true);
+        $body     = \json_decode($response->getContent(), true);
         $this->client->restart();
+        $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
+        $this->loginUser($user);
 
         return new Crawler($body['actions']);
     }
 
+    /**
+     * @return array<int, array<string, string>>
+     */
     private function getEventsStatistics(Campaign $campaign): array
     {
         $crawler = $this->getTestCrawler($campaign);

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -90,7 +90,7 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $now    = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         $before = $now->modify('-1 month');
         $after  = $now->modify('+1 month');
-        $url    = sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
+        $url    = sprintf('/s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
         $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         $body     = \json_decode($response->getContent(), true);

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -7,7 +7,6 @@ namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
-use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -94,9 +93,6 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         $body     = \json_decode($response->getContent(), true);
-        $this->client->restart();
-        $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
-        $this->loginUser($user);
 
         return new Crawler($body['actions']);
     }

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -7,8 +7,8 @@ namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
-use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
@@ -16,6 +16,8 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class CampaignEventStatsTest extends MauticMysqlTestCase
 {
+    use CreateTestEntitiesTrait;
+
     protected function setUp(): void
     {
         $this->configParams['campaign_use_summary']     = false;
@@ -56,18 +58,9 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
         $campaignLead->setDateAdded(new \DateTime());
         $this->em->persist($campaignLead);
 
-        $leadEventLog1 = new LeadEventLog();
-        $leadEventLog1->setLead($lead);
-        $leadEventLog1->setEvent($campaignEvent1);
-        $leadEventLog1->setIsScheduled(true);
-        $leadEventLog1->setRotation(1);
-        $this->em->persist($leadEventLog1);
+        $this->createCampaignLeadEventLog($lead, $campaignEvent1, $campaign, 1, true);
 
-        $leadEventLog3 = new LeadEventLog();
-        $leadEventLog3->setLead($lead);
-        $leadEventLog3->setEvent($campaignEvent1);
-        $leadEventLog1->setRotation(2);
-        $this->em->persist($leadEventLog3);
+        $this->createCampaignLeadEventLog($lead, $campaignEvent1, $campaign, 2);
 
         $this->em->flush();
 
@@ -88,11 +81,8 @@ class CampaignEventStatsTest extends MauticMysqlTestCase
 
         Assert::assertSame($expectedEventsStatistics, $eventsStatistics);
 
-        $leadEventLog2 = new LeadEventLog();
-        $leadEventLog2->setLead($lead);
-        $leadEventLog2->setEvent($campaignEvent2);
-        $leadEventLog1->setRotation(1);
-        $this->em->persist($leadEventLog2);
+        $this->createCampaignLeadEventLog($lead, $campaignEvent2, $campaign, 1);
+
         $this->em->flush();
 
         $eventsStatistics         = $this->getEventsStatistics($campaign);

--- a/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
+++ b/app/bundles/CoreBundle/Tests/Functional/CreateTestEntitiesTrait.php
@@ -7,6 +7,7 @@ namespace Mautic\CoreBundle\Tests\Functional;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog as CampaignLeadEventLog;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Company;
@@ -196,5 +197,19 @@ trait CreateTestEntitiesTrait
         $this->em->persist($project);
 
         return $project;
+    }
+
+    private function createCampaignLeadEventLog(Lead $lead, Event $event, ?Campaign $campaign, int $rotation = 1, bool $isScheduled =  false): CampaignLeadEventLog
+    {
+        $campaignLeadEventLog = new CampaignLeadEventLog();
+        $campaignLeadEventLog->setLead($lead);
+        $campaignLeadEventLog->setEvent($event);
+        $campaignLeadEventLog->setCampaign($campaign);
+        $campaignLeadEventLog->setRotation($rotation);
+        $campaignLeadEventLog->setIsScheduled($isScheduled);
+
+        $this->em->persist($campaignLeadEventLog);
+
+        return $campaignLeadEventLog;
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
As a Mautic Engineer, I want to update cache ttl in config.php file for updating cache time of campaigns
So that we can update it for instances and get execution count reflected on UI as per our requirement.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add/Update value of key `campaign_event_cache_ttl ` to 60  in instance config.php (it means 60 seconds)
3. Create campaign
4. After execution of campaign, event stats should be updated in 60 second only instead 10 minutes

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->