### PR TITLE
fix(LeadBundle): allow creating tags with numeric names

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -546,19 +546,33 @@ class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($data);
     }
 
+    /**
+     * @param array<int, string> $tags
+     *
+     * @return array<int, Tag>
+     */
+    private function getNewLeadTags(array $tags, LeadModel $leadModel): array
+    {
+        $newTags     = [];
+        $tagRepository = $leadModel->getTagRepository();
+
+        foreach ($tags as $tag) {
+            $existingTag = is_numeric($tag) ? $tagRepository->find((int) $tag) : null;
+            if (!$existingTag) {
+                $newTags[] = $tagRepository->getTagByNameOrCreateNewOne($tag);
+            }
+        }
+
+        return $newTags;
+    }
+
     public function addLeadTagsAction(Request $request, LeadModel $leadModel): JsonResponse
     {
         $tags = $request->request->get('tags');
         $tags = json_decode($tags, true);
 
         if (is_array($tags)) {
-            $newTags = [];
-
-            foreach ($tags as $tag) {
-                if (!is_numeric($tag)) {
-                    $newTags[] = $leadModel->getTagRepository()->getTagByNameOrCreateNewOne($tag);
-                }
-            }
+            $newTags = $this->getNewLeadTags($tags, $leadModel);
 
             if (!empty($newTags)) {
                 $leadModel->getTagRepository()->saveEntities($newTags);


### PR DESCRIPTION
## Description

The addLeadTagsAction used is_numeric() to skip creating tags for existing tag IDs, but this also prevented creating new tags with numeric names like "2". When users tried to create a tag named "2", the system either assigned existing tag ID 2 or threw an error if no such tag existed.

## Changes

- Check if numeric tag values correspond to existing tag IDs before deciding to create a new tag
- If no existing tag with that ID is found, create/get a tag with the given name (even if numeric)

Fixes #16083

## Related

- #16076 (tag creation Enter key fix)