### PR TITLE
fix(CoreBundle): lower footer z-index to prevent dropdown overlap

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app.css
+++ b/app/bundles/CoreBundle/Assets/css/app.css
@@ -2372,7 +2372,7 @@ html.responsejs.sidebar-open-ltr .sidebar-left {
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1000;
+  z-index: 999;
   height: 46px;
   line-height: 46px;
   background-color: transparent;

--- a/app/bundles/CoreBundle/Assets/css/app/less/variables.less
+++ b/app/bundles/CoreBundle/Assets/css/app/less/variables.less
@@ -62,7 +62,7 @@
 //## common footer variable.
 @footer-height:                             46px;
 @footer-bg:                                 transparent;
-@footer-zindex:                             @content-zindex;  // 1000
+@footer-zindex:                             (@content-zindex - 1);  // 1000
 
 
 @brand-facebook:        #3b5998;


### PR DESCRIPTION
## Description

Fixes a UI bug where the copyright footer text overlaps dropdown menus when they open near the bottom of the page.

## Root Cause

The app footer (#app-footer) had z-index: 1000, which matched Bootstrap's .dropdown-menu z-index. When two positioned elements share the same z-index, the one that appears later in the DOM order wins. Since the footer is rendered after the dropdown in the page structure, it would visually overlay the dropdown options.

## Changes

- **variables.less**: Changed @footer-zindex from @content-zindex to (@content-zindex - 1)
- **app.css**: Changed #app-footer z-index from 1000 to 999

## Verification

Dropdown menus now render above the footer since 1000 > 999.

Fixes #16065