### PR TITLE
Fix preference center duplicating DOCTYPE and wrapping entire page in form

### DIFF
--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -228,9 +228,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
      */
     private function handlePreferenceCenterReplacements(string $content, array $params): string
     {
-        $xpath = $this->createDOMXPathForContent($content);
-
-        $content = $this->replacePreferenceCenterTokens($xpath->document->saveHTML(), $params);
+        $content = $this->replacePreferenceCenterTokens($content, $params);
 
         return $this->wrapPreferenceCenterInFormTag($content, $params);
     }
@@ -432,30 +430,44 @@ final class BuilderSubscriber implements EventSubscriberInterface
             return $content;
         }
 
-        $xpath = $this->createDOMXPathForContent($content);
-        $node  = $this->getFirstNodeThatContainsAPreferenceCenterToken($xpath);
+        $xpath    = $this->createDOMXPathForContent($content);
+        $nodeList = $xpath->query('//*[@data-prefs-center-first="1"]');
 
-        if (null === $node) {
+        if (false === $nodeList || 0 === $nodeList->length) {
             return $content;
         }
 
-        $parentNode = $this->getFirstParentNodeThatContainsAllFormInputs($node);
+        $firstNode  = $nodeList->item(0);
+        $parentNode = $this->getFirstParentNodeThatContainsAllFormInputs($firstNode);
+
+        // If the parent is <body> or <html>, create a wrapper div around the preference center
+        // elements so the entire page is not wrapped in a form. This allows users to add
+        // other forms (like {form=1}) to the preference center page.
+        if (in_array($parentNode->nodeName, ['body', 'html'], true)) {
+            $wrapper = $parentNode->ownerDocument->createElement('div');
+            $wrapper->setAttribute('class', 'preference-center-form-wrapper');
+
+            // Collect all preference center nodes to move them into the wrapper
+            $prefNodes = [];
+            for ($i = 0; $i < $nodeList->length; ++$i) {
+                $prefNodes[] = $nodeList->item($i);
+            }
+
+            // Insert wrapper before the first preference center node
+            $firstNode->parentNode->insertBefore($wrapper, $firstNode);
+
+            // Move all preference center nodes into the wrapper
+            foreach ($prefNodes as $prefNode) {
+                $wrapper->appendChild($prefNode);
+            }
+
+            $parentNode = $wrapper;
+        }
 
         $parentNode->insertBefore(new \DOMElement('startform'), $parentNode->firstChild);
         $parentNode->appendChild(new \DOMElement('endform'));
 
         return str_replace(['<startform></startform>', '<endform></endform>'], [$params['startform'], '</form>'], $xpath->document->saveHTML());
-    }
-
-    private function getFirstNodeThatContainsAPreferenceCenterToken(\DOMXPath $xpath): ?\DOMNode
-    {
-        $nodeList = $xpath->query('//*[@data-prefs-center-first="1"]');
-
-        if (false !== $nodeList) {
-            return $nodeList->item(0);
-        }
-
-        return null;
     }
 
     private function getFirstParentNodeThatContainsAllFormInputs(\DOMNode $node): \DOMNode

--- a/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
@@ -124,6 +124,59 @@ final class PreferencePageTest extends MauticMysqlTestCase
         Assert::assertStringContainsString($segment->getName(), $content);
     }
 
+    public function testDoctypeIsPreserved(): void
+    {
+        $page = new Page();
+        $page->setIsPreferenceCenter(true);
+        $page->setCustomHtml('<!DOCTYPE html><html><body><div>{segmentlist}</div><div>{saveprefsbutton}</div></body></html>');
+
+        $form                = $this->createForm()->createView();
+        $params              = $this->createParams();
+        $params['form']      = $form;
+        $params['startform'] = '<form name="lead_contact_frequency_rules" method="post">';
+
+        $content = $this->dispatchEvent($page, $params, false);
+
+        // Should have exactly one DOCTYPE
+        Assert::assertSame(1, substr_count($content, '<!DOCTYPE'), 'DOCTYPE should not be duplicated');
+    }
+
+    public function testFormDoesNotWrapBodyWhenElementsAreDirectChildren(): void
+    {
+        $page = new Page();
+        $page->setIsPreferenceCenter(true);
+        $page->setCustomHtml('
+            <!DOCTYPE html>
+            <html lang="en">
+            <body>
+                <h1>My Preference Center</h1>
+                <div>{segmentlist}</div>
+                <div>{channelfrequency}</div>
+                <div>{saveprefsbutton}</div>
+                <div>{form=1}</div>
+            </body>
+            </html>
+        ');
+
+        $form                = $this->createForm()->createView();
+        $params              = $this->createParams();
+        $params['form']      = $form;
+        $params['startform'] = '<form name="lead_contact_frequency_rules" method="post">';
+
+        $content = $this->dispatchEvent($page, $params, false);
+
+        // The body should NOT be wrapped in the preference center form
+        Assert::assertStringNotContainsString('<body><form', $content, 'Body should not be wrapped in form');
+        Assert::assertStringNotContainsString('</form></body>', $content, 'Body should not be wrapped in form');
+
+        // A wrapper div should be created instead
+        Assert::assertStringContainsString('preference-center-form-wrapper', $content, 'Wrapper div should be created');
+
+        // The preference center form should still exist
+        Assert::assertStringContainsString('<form name="lead_contact_frequency_rules"', $content, 'Preference center form should exist');
+        Assert::assertStringContainsString('</form>', $content, 'Preference center form should be closed');
+    }
+
     private function createCategory(): Category
     {
         $category = new Category();
@@ -198,12 +251,12 @@ final class PreferencePageTest extends MauticMysqlTestCase
     /**
      * @param mixed[] $params
      */
-    private function dispatchEvent(Page $page, array $params): string
+    private function dispatchEvent(Page $page, array $params, bool $stripTags = true): string
     {
         $event = new PageDisplayEvent($page->getCustomHtml(), $page, $params);
         $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
 
-        return strip_tags($event->getContent());
+        return $stripTags ? strip_tags($event->getContent()) : $event->getContent();
     }
 
     private function assertDefaultLabels(string $content): void


### PR DESCRIPTION
This PR fixes two related issues with custom preference center pages (reported in #16102).

## Problem 1: DOCTYPE duplication / HTML corruption

	handlePreferenceCenterReplacements() was parsing HTML into DOMDocument and immediately calling saveHTML() before doing string replacements. This unnecessary round-trip through DOMDocument corrupted the HTML structure, especially the <!DOCTYPE declaration.

## Problem 2: Entire page wrapped in <form>

	wrapPreferenceCenterInFormTag() recursively walked up the DOM tree until it found a parent containing the save button. When preference center tokens were direct children of <body>, this wrapped the entire <body> in <form>...</form>, breaking nested forms (e.g. {form=1}), JavaScript, and any other form-dependent customization.

## Changes

- **BuilderSubscriber.php**:
  - Removed redundant DOMDocument parse/save in handlePreferenceCenterReplacements() — token replacement now operates directly on the string.
  - When wrapPreferenceCenterInFormTag() would otherwise wrap <body> or <html>, it now creates a <div class="preference-center-form-wrapper"> around the preference center elements and wraps that div instead.

- **PreferencePageTest.php**:
  - Added testDoctypeIsPreserved() — verifies exactly one <!DOCTYPE in output.
  - Added testFormDoesNotWrapBodyWhenElementsAreDirectChildren() — verifies <body> is not wrapped, wrapper div exists, and the preference center form still functions.

## Backward Compatibility

This change is backward compatible for the common case where preference center elements are already grouped inside a container <div>. The wrapper div logic only activates when elements are loose inside <body> or <html> — exactly the scenario that was broken.

Closes #16102