### PR TITLE
fix: handle deleted contact in ContactTracker device tracking

### DIFF
--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -46,11 +46,12 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->clear();
 
-        // A returning visitor whose cookie still references the deleted contact ID
-        // should be treated as a new anonymous visitor instead of throwing EntityNotFoundException
+        // A returning visitor whose cookie still references the deleted contact ID must NOT
+        // throw EntityNotFoundException; they are handled as a brand-new anonymous visitor.
         $result = $this->trackContactByDevice($device);
 
-        Assert::assertNull($result, 'Expected null (new anonymous visitor) when tracked device references a deleted contact.');
+        Assert::assertInstanceOf(Lead::class, $result, 'Expected a fresh anonymous visitor contact when the tracked device references a deleted contact.');
+        Assert::assertNotSame($contactId, $result->getId(), 'A deleted contact must not be re-tracked.');
     }
 
     public function testReset(): void

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Tracker;
 
+use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
@@ -35,9 +36,15 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
         $device  = $this->createDevice($contact, 'track-deleted-contact');
         $this->em->flush();
 
-        // Delete the contact but leave the device record pointing to the deleted ID
-        $this->em->remove($contact);
-        $this->em->flush();
+        $contactId = $contact->getId();
+
+        // Simulate the race condition: delete the lead row directly via DBAL, bypassing
+        // Doctrine's ON DELETE CASCADE so the device record remains orphaned.
+        // This replicates the window where a request has already loaded the lead_id
+        // from the device table but the lead is deleted before it can be fetched.
+        static::getContainer()->get(Connection::class)
+            ->executeStatement('DELETE FROM leads WHERE id = :id', ['id' => $contactId]);
+
         $this->em->clear();
 
         // A returning visitor whose cookie still references the deleted contact ID

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -26,6 +26,27 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
         $this->requestStack   = static::getContainer()->get(RequestStack::class);
     }
 
+    public function testDeletedContactTrackedDeviceDoesNotThrow(): void
+    {
+        static::getContainer()->get(TokenStorageInterface::class)->setToken(null);
+        $this->contactTracker->setUseSystemContact(false);
+
+        $contact = $this->createContact('deleted-contact@domain.tld');
+        $device  = $this->createDevice($contact, 'track-deleted-contact');
+        $this->em->flush();
+
+        // Delete the contact but leave the device record pointing to the deleted ID
+        $this->em->remove($contact);
+        $this->em->flush();
+        $this->em->clear();
+
+        // A returning visitor whose cookie still references the deleted contact ID
+        // should be treated as a new anonymous visitor instead of throwing EntityNotFoundException
+        $result = $this->trackContactByDevice($device);
+
+        Assert::assertNull($result, 'Expected null (new anonymous visitor) when tracked device references a deleted contact.');
+    }
+
     public function testReset(): void
     {
         static::getContainer()->get(TokenStorageInterface::class)->setToken(null);

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Tracker;
 
-use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
@@ -42,7 +41,7 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
         // Doctrine's ON DELETE CASCADE so the device record remains orphaned.
         // This replicates the window where a request has already loaded the lead_id
         // from the device table but the lead is deleted before it can be fetched.
-        static::getContainer()->get(Connection::class)
+        $this->em->getConnection()
             ->executeStatement('DELETE FROM leads WHERE id = :id', ['id' => $contactId]);
 
         $this->em->clear();

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -42,7 +42,7 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
         // This replicates the window where a request has already loaded the lead_id
         // from the device table but the lead is deleted before it can be fetched.
         $this->em->getConnection()
-            ->executeStatement('DELETE FROM leads WHERE id = :id', ['id' => $contactId]);
+            ->executeStatement('DELETE FROM '.MAUTIC_TABLE_PREFIX.'leads WHERE id = :id', ['id' => $contactId]);
 
         $this->em->clear();
 

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -227,11 +227,18 @@ class ContactTracker
             try {
                 $lead = $trackedDevice->getLead();
 
+                if ($lead instanceof \Doctrine\Persistence\Proxy && !$lead->__isInitialized()) {
+                    // Force the proxy to initialize so a deleted contact throws here,
+                    // inside the guard, instead of later in unguarded code
+                    $lead->__load();
+                }
+
                 // Lead associations are not hydrated with custom field values by default
                 $this->hydrateCustomFieldData($lead);
             } catch (EntityNotFoundException) {
                 // The contact was deleted but the device tracking record still references
                 // the old ID. Treat as a new anonymous visitor.
+                $lead = null;
                 $this->logger->debug('CONTACT: Tracked device references a deleted contact, treating as new visitor.');
             }
         }

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\LeadBundle\Tracker;
 
+use Doctrine\ORM\EntityNotFoundException;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -223,10 +224,16 @@ class ContactTracker
 
         // Is there a device being tracked?
         if ($trackedDevice = $this->deviceTracker->getTrackedDevice()) {
-            $lead = $trackedDevice->getLead();
+            try {
+                $lead = $trackedDevice->getLead();
 
-            // Lead associations are not hydrated with custom field values by default
-            $this->hydrateCustomFieldData($lead);
+                // Lead associations are not hydrated with custom field values by default
+                $this->hydrateCustomFieldData($lead);
+            } catch (EntityNotFoundException) {
+                // The contact was deleted but the device tracking record still references
+                // the old ID. Treat as a new anonymous visitor.
+                $this->logger->debug('CONTACT: Tracked device references a deleted contact, treating as new visitor.');
+            }
         }
 
         if (null === $lead) {


### PR DESCRIPTION
 | Q                         | A
  | ------------------------- | ---                                                                                                                                                                                   
  | Bug fix?                  | ✔️ 
  | New feature?              | ❌                                                                                                                                                                                    
  | Deprecations?             | ❌
  | BC breaks?                | ❌                                                                                                                                                                                    
  | Automated tests included? | ❌                                                                                                                                                                                    
  | Issue(s) addressed        | Fixes #8712, Fixes #10044
                                                                                                                                                                                                                      
  ## Description  
                                                                                                                                                                                                                      
  When a contact is deleted from Mautic, any browser that previously                                                                                                                                                  
  visited a tracked page retains a device tracking cookie referencing the
  old contact ID. On the next visit, `ContactTracker::getContactByTrackedDevice()`                                                                                                                                    
  calls `$trackedDevice->getLead()`, which returns an uninitialized Doctrine                                                                                                                                          
  proxy. The subsequent call to `hydrateCustomFieldData()` initializes that                                                                                                                                           
  proxy and throws an uncaught `EntityNotFoundException` because the contact                                                                                                                                          
  row no longer exists.                                                                                                                                                                                               
                                                                                                                                                                                                                      
  This causes a `CRITICAL` log error on every visit from an affected browser                                                                                                                                          
  and can break page responses for those visitors.
                                                                                                                                                                                                                      
  **Root cause confirmed on a live Mautic 7.1.1 production instance** — the                                                                                                                                           
  error appeared repeatedly in `var/logs/mautic_prod-*.php`:
                                                                                                                                                                                                                      
  mautic.CRITICAL: Uncaught PHP Exception Doctrine\ORM\EntityNotFoundException:                                                                                                                                       
  "Entity of type 'Mautic\LeadBundle\Entity\Lead' for IDs id(X) was not found"                                                                                                                                        
                                                                                                                                                                                                                      
  **Fix:** Wrap the device lead lookup and hydration in a `try/catch` for
  `EntityNotFoundException`. When caught, `$lead` remains `null` and execution                                                                                                                                        
  falls through to `getTrackedLead()` and ultimately creates a new anonymous                                                                                                                                          
  contact — the same graceful path already used by the legacy cookie method.                                                                                                                                          
                                                                                                                                                                                                                      
  This pattern is identical to the approach taken in #16073, which was                                                                                                                                                
  recently merged for the same exception in `PointSubscriber`.                                                                                                                                                        
                                                                                                                                                                                                                      
  ## Steps to test
                                                                                                                                                                                                                      
  1. Create a contact and visit a Mautic-tracked landing page (sets device tracking cookie)                                                                                                                           
  2. Delete that contact from Mautic
  3. Visit the tracked page again in the same browser                                                                                                                                                                 
  4. **Before fix:** `CRITICAL` error in `mautic_prod-*.php`, broken page response                                                                                                                                    
  5. **After fix:** Page loads normally, visitor treated as a new anonymous contact, no errors logged                                                                                                                 
                                                                                                                                                                                                                      
  Note I changed Automated tests included? to ❌ — we should be honest since we haven't written a PHPUnit test yet. The maintainers may ask for one before merging, and that's fine — it's normal back-and-forth on a 
  first PR.                                                                                                                                                                                                           
                                                                                                                                                                                     