### PR TITLE
Fix ExceptionListener fatal when sub-request throws an Error

### DIFF
--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -101,7 +101,7 @@ class ExceptionListener extends ErrorListener
             $response = $event->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, false);
 
             $event->setResponse($response);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logException(
                 $e,
                 sprintf(
@@ -121,7 +121,12 @@ class ExceptionListener extends ErrorListener
                 }
             }
 
-            $prev = new \ReflectionProperty('Exception', 'previous');
+            // \Exception and \Error each declare their own private $previous,
+            // so reflect on whichever base class the wrapper actually extends.
+            // Using a subclass name (e.g. \TypeError) here would throw
+            // "Property X::$previous does not exist" because private props
+            // are not visible through a subclass reflection.
+            $prev = new \ReflectionProperty($wrapper instanceof \Error ? \Error::class : \Exception::class, 'previous');
             $prev->setValue($wrapper, $exception);
 
             throw $e;

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -126,7 +126,8 @@ class ExceptionListener extends ErrorListener
             // Using a subclass name (e.g. \TypeError) here would throw
             // "Property X::$previous does not exist" because private props
             // are not visible through a subclass reflection.
-            $prev = new \ReflectionProperty($wrapper instanceof \Error ? \Error::class : \Exception::class, 'previous');
+            $previousDeclaringClass = $wrapper instanceof \Error ? \Error::class : \Exception::class;
+            $prev                   = new \ReflectionProperty($previousDeclaringClass, 'previous');
             $prev->setValue($wrapper, $exception);
 
             throw $e;

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/ExceptionListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/ExceptionListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\EventListener;
+
+use Mautic\CoreBundle\EventListener\ExceptionListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Router;
+
+class ExceptionListenerTest extends TestCase
+{
+    /**
+     * Regression test for https://github.com/mautic/mautic/issues/15952.
+     *
+     * When the sub-request used to render an error page throws an Error
+     * (e.g. \TypeError, or Symfony's FatalError wrapping a parse error),
+     * the previous catch (\Exception $e) block missed it entirely, so the
+     * Error propagated up. After widening to catch (\Throwable $e), the
+     * Error reaches the chain-traversal + reflection block, which used to
+     * use ReflectionProperty('Exception', 'previous'). Setting that on an
+     * Error instance triggers a fatal:
+     *
+     *   Cannot access private property Error::$previous
+     *
+     * because Error declares its own private $previous, separate from
+     * Exception's. The fix picks Error::class or Exception::class for the
+     * reflection target based on the wrapper's base class so $previous can
+     * be assigned on either branch of the Throwable hierarchy.
+     */
+    public function testErrorFromSubRequestIsRethrownWithoutFatal(): void
+    {
+        $originalException = new \RuntimeException('original kernel exception');
+        $subRequestError   = new \TypeError('sub-request blew up');
+
+        $router = $this->createMock(Router::class);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel->method('handle')->willThrowException($subRequestError);
+
+        $listener = new ExceptionListener($router, null);
+
+        $event = new ExceptionEvent(
+            $kernel,
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $originalException
+        );
+
+        $caught = null;
+        try {
+            $listener->onKernelException($event);
+        } catch (\Throwable $e) {
+            $caught = $e;
+        }
+
+        // Before the fix:
+        //   - catch (\Exception $e) didn't match \TypeError → TypeError leaked
+        //     out unchanged; OR if it did reach the reflection line via the
+        //     chain, "Cannot access private property Error::$previous" surfaced.
+        // After the fix:
+        //   - the TypeError is caught, the original exception is chained as its
+        //     ->previous, and the TypeError is re-thrown.
+        self::assertSame(
+            $subRequestError,
+            $caught,
+            'ExceptionListener must catch the sub-request Throwable and re-throw it.'
+        );
+        self::assertSame(
+            $originalException,
+            $caught->getPrevious(),
+            'The original exception must be chained as ->previous of the rethrown Throwable.'
+        );
+    }
+
+    /**
+     * Companion case: a chained Exception whose deepest ->previous is an
+     * \Error. The traversal walks to the Error, and reflection on
+     * Exception's $previous would fail because Error has its own private
+     * $previous; the fix picks Error::class on this branch.
+     */
+    public function testReflectionWorksWhenDeepestPreviousIsAnError(): void
+    {
+        $originalException   = new \RuntimeException('original');
+        $deepestError        = new \TypeError('deepest');
+        $subRequestException = new \RuntimeException('sub-request', 0, $deepestError);
+
+        $router = $this->createMock(Router::class);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel->method('handle')->willThrowException($subRequestException);
+
+        $listener = new ExceptionListener($router, null);
+
+        $event = new ExceptionEvent(
+            $kernel,
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $originalException
+        );
+
+        try {
+            $listener->onKernelException($event);
+            self::fail('Listener was expected to re-throw the sub-request exception.');
+        } catch (\Throwable $rethrown) {
+            self::assertSame($subRequestException, $rethrown);
+            // The original exception is chained on the deepest Throwable.
+            self::assertSame($originalException, $deepestError->getPrevious());
+        }
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/ExceptionListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/ExceptionListenerTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Router;
 
-class ExceptionListenerTest extends TestCase
+final class ExceptionListenerTest extends TestCase
 {
     /**
      * Regression test for https://github.com/mautic/mautic/issues/15952.


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #15952

## Description

`ExceptionListener::onKernelException()` ran:

```php
try {
    $response = $event->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, false);
    $event->setResponse($response);
} catch (\Exception $e) {
    ...
    $wrapper = $e;
    while ($prev = $wrapper->getPrevious()) {
        if ($exception === $wrapper = $prev) { throw $e; }
    }
    $prev = new \ReflectionProperty('Exception', 'previous');
    $prev->setValue($wrapper, $exception);
    throw $e;
}
```

Two coupled defects when the sub-request raises an `\Error` (or chains into one):

1. **The catch missed `\Error`.** A `\TypeError` from the sub-request handler, or a Symfony `FatalError` wrapping a parse error, is not an `\Exception`, so it bypassed this block entirely and bubbled up unhandled.
2. **Reflection on the wrong base class.** `\Exception` and `\Error` are siblings under `\Throwable`; each declares its own private `$previous`. Once `$wrapper` was walked into an `\Error` via `getPrevious()`, calling `setValue($wrapper, $exception)` through a reflection built from `\Exception::$previous` raised the fatal reported in #15952:

   > Cannot access private property Error::$previous

The fix widens the catch to `\Throwable` so the same logic also handles `\Error` paths, and selects the reflected base class from `$wrapper instanceof \Error`. A subclass name (e.g. `\TypeError`) cannot be used here — `ReflectionProperty` does not see a parent's private property through a subclass and raises `Property X::$previous does not exist`. There are exactly two base classes that declare this private property (`\Exception`, `\Error`), so the branch is exhaustive.

Affected branches: bug exists on 5.x → 7.x. Targeting `7.1` per "lowest *actively maintained* patch branch" — `7.0` had its last patch in April; `7.1` is the branch currently receiving bug fixes.

---
### 📋 Steps to test this PR

A unit-level regression test (`Mautic\CoreBundle\Tests\Unit\EventListener\ExceptionListenerTest`) covers both branches:

- `testErrorFromSubRequestIsRethrownWithoutFatal` — mocks the kernel to throw a `\TypeError` from `handle()`; asserts the listener catches it, chains the original exception as `->previous`, and re-throws the same TypeError. Before the fix, the catch never matched.
- `testReflectionWorksWhenDeepestPreviousIsAnError` — mocks the kernel to throw a `\RuntimeException` whose `->previous` is a `\TypeError`. The chain traversal lands on the TypeError; the reflection must use `\Error::class`. Before the fix, this raised `Cannot access private property Error::$previous`.

```bash
bin/phpunit app/bundles/CoreBundle/Tests/Unit/EventListener/ExceptionListenerTest.php
```

End-to-end reproduction (matches the issue): add an invalid host to `trusted_hosts`, trigger an exception during error-page rendering so the sub-request itself emits a `\TypeError` / `FatalError`. Before the fix the response contains `Cannot access private property Error::$previous`. After the fix the original `\TypeError` is re-thrown with the original exception chained as `->previous`, and the upstream error handler renders it normally.
