### PR TITLE
Replacing JS Cookie lib with native JS

### DIFF
--- a/app/assets/scaffold/files/package-lock.json
+++ b/app/assets/scaffold/files/package-lock.json
@@ -58,7 +58,6 @@
         "jquery.caret": "^0.3.1",
         "jquery.cookie": "^1.4.1",
         "jquery.quicksearch": "^2.4.0",
-        "js-cookie": "^2.2.1",
         "jsplumb": "^2.15.6",
         "jvectormap-next": "^3.1.1",
         "moment": "^2.29.4",
@@ -6037,12 +6036,6 @@
       "dependencies": {
         "jquery": ">=1.8"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/app/assets/scaffold/files/package.json
+++ b/app/assets/scaffold/files/package.json
@@ -59,7 +59,6 @@
     "jquery.caret": "^0.3.1",
     "jquery.cookie": "^1.4.1",
     "jquery.quicksearch": "^2.4.0",
-    "js-cookie": "^2.2.1",
     "jsplumb": "^2.15.6",
     "jvectormap-next": "^3.1.1",
     "moment": "^2.29.4",

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -12,7 +12,6 @@ class AssetGenerationHelper
     private const NODE_MODULES = [
         'mousetrap/mousetrap.js', // Needed for keyboard shortcuts
         'jquery/dist/jquery.js', // Needed for everything. It's the underlying framework.
-        'js-cookie/src/js.cookie.js', // Needed for cookies.
         'bootstrap/dist/js/bootstrap.js', // Needed for the UI components like bodal boxes.
         'jquery-form/src/jquery.form.js', // Needed for ajax forms with file attachments.
         'moment/min/moment.min.js', // Needed for date/time formatting.

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -117,7 +117,7 @@ Mautic.leadOnLoad = function (container, response) {
         mQuery('.lead-avatar-panel .avatar-collapser a.arrow').on('click', function() {
             setTimeout(function() {
                 var status = (mQuery('#lead-avatar-block').hasClass('in') ? 'expanded' : 'collapsed');
-                Cookies.set('mautic_lead_avatar_panel', status, {expires: 30});
+                document.cookie = 'mautic_lead_avatar_panel=' + status + '; path=/; max-age=' + (30 * 24 * 60 * 60) + '; SameSite=Strict';
             }, 500);
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "jquery.caret": "^0.3.1",
         "jquery.cookie": "^1.4.1",
         "jquery.quicksearch": "^2.4.0",
-        "js-cookie": "^2.2.1",
         "jsplumb": "^2.15.6",
         "jvectormap-next": "^3.1.1",
         "moment": "^2.29.4",
@@ -6037,12 +6036,6 @@
       "dependencies": {
         "jquery": ">=1.8"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "jquery.caret": "^0.3.1",
     "jquery.cookie": "^1.4.1",
     "jquery.quicksearch": "^2.4.0",
-    "js-cookie": "^2.2.1",
     "jsplumb": "^2.15.6",
     "jvectormap-next": "^3.1.1",
     "moment": "^2.29.4",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Removes the `js-cookie` npm dependency (previously used only in one place) and replaces it with a native `document.cookie` write.

Previously I only wanted to update the library as https://github.com/mautic/mautic/pull/16148 suggested. However, that comes with a BC break because they moved the JS file to a different location and caused Mautic installation to break. Since we had an option to either live with a vulnerable library or BC break I chose to go with the BC break and remove it completely. I doubt any plugin is using this library so it shouldn't cause any troubles. If so the replacement for native JS is simple. Or there is still the jQuery Cookie library available which we should remove in Mautic 8.

**Why:** The single usage was `Cookies.set('mautic_lead_avatar_panel', status, {expires: 30})` in `LeadBundle` — a UI preference cookie storing whether the contact avatar panel is expanded or collapsed. Loading a 800-byte library for one cookie write is unnecessary; the native API handles this without any encoding concerns because the value is always either `expanded` or `collapsed`.

**Changes:**
- `app/bundles/LeadBundle/Assets/js/lead.js` — replaced `Cookies.set(...)` with a native `document.cookie` assignment using `max-age` and `SameSite=Strict`
- `app/bundles/CoreBundle/Helper/AssetGenerationHelper.php` — removed `js-cookie` from the `NODE_MODULES` asset list
- `package.json` / `app/assets/scaffold/files/package.json` — removed `js-cookie` dependency
- `package-lock.json` — regenerated without `js-cookie`

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `npm install && composer generate-assets` and confirm it completes without errors
3. Navigate to any contact detail page (`/s/contacts/view/{id}`)
4. Collapse the avatar panel using the arrow toggle — navigate away and return; the panel should remain collapsed
5. Expand it again — navigate away and return; the panel should remain expanded
6. Verify no JS console errors related to `Cookies` or cookies
