### PR TITLE
fix: email domain submission filter

### DIFF
--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -91,10 +91,7 @@ class FormValidationSubscriber implements EventSubscriberInterface
         }
 
         if (!empty($field->getValidation()['donotsubmit'])) {
-            // Check the domains using shell wildcard patterns
-            $donotSubmitFilter  = fn ($doNotSubmitArray): bool => fnmatch($doNotSubmitArray, $value, FNM_CASEFOLD);
-            $notNotSubmitEmails = $this->coreParametersHelper->get('do_not_submit_emails');
-            if (array_filter($notNotSubmitEmails, $donotSubmitFilter)) {
+            if ($this->isDoNotSubmitEmail((string) $value, (array) $this->coreParametersHelper->get('do_not_submit_emails'))) {
                 $validationMsg = $field->getValidation()['donotsubmit_validationmsg'] ?? $this->translator->trans('mautic.form.submission.email.donotsubmit.invalid', [], 'validators');
                 $event->failedValidation($validationMsg);
             }
@@ -108,6 +105,33 @@ class FormValidationSubscriber implements EventSubscriberInterface
                 $event->failedValidation($validationMsg);
             }
         }
+    }
+
+    /**
+     * @param array<int, mixed> $filters
+     */
+    private function isDoNotSubmitEmail(string $email, array $filters): bool
+    {
+        $email  = strtolower(trim($email));
+        $domain = strtolower((string) substr(strrchr($email, '@') ?: '', 1));
+
+        foreach ($filters as $filter) {
+            $filter = strtolower(trim((string) $filter));
+
+            if ('' === $filter) {
+                continue;
+            }
+
+            if (fnmatch($filter, $email, FNM_CASEFOLD)) {
+                return true;
+            }
+
+            if ('' !== $domain && !str_contains($filter, '@') && fnmatch($filter, $domain, FNM_CASEFOLD)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function fieldTelValidation(Events\ValidationEvent $event): void

--- a/app/bundles/FormBundle/Form/Type/FormFieldEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldEmailType.php
@@ -3,6 +3,7 @@
 namespace Mautic\FormBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,6 +16,7 @@ class FormFieldEmailType extends AbstractType
 {
     public function __construct(
         private TranslatorInterface $translator,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 
@@ -25,7 +27,7 @@ class FormFieldEmailType extends AbstractType
             YesNoButtonGroupType::class,
             [
                 'label' => 'mautic.form.field.type.donotsubmit',
-                'data'  => $options['data']['donotsubmit'] ?? false,
+                'data'  => $options['data']['donotsubmit'] ?? !empty($this->coreParametersHelper->get('do_not_submit_emails')),
             ]
         );
 

--- a/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
@@ -200,6 +200,57 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         self::assertSame('Cannot be sent with this email', $event->getInvalidReason());
     }
 
+    public function testEmailDonotSubmitPlainDomainTriggersFailure(): void
+    {
+        $field = new Field();
+        $field->setType('email');
+        $field->setValidation([
+            'donotsubmit'               => 1,
+            'donotsubmit_validationmsg' => 'Cannot be sent with this email',
+        ]);
+
+        $this->coreParametersHelper
+            ->method('get')
+            ->willReturnCallback(function (string $key) {
+                return match ($key) {
+                    'do_not_submit_emails'         => ['blocked.com'],
+                    'blocked_free_email_providers' => [],
+                    default                        => [],
+                };
+            });
+
+        $event = new ValidationEvent($field, 'user@blocked.com');
+        $this->subscriber->onFormValidate($event);
+
+        self::assertFalse($event->isValid());
+        self::assertSame('Cannot be sent with this email', $event->getInvalidReason());
+    }
+
+    public function testEmailDonotSubmitPlainDomainAllowsDifferentDomain(): void
+    {
+        $field = new Field();
+        $field->setType('email');
+        $field->setValidation([
+            'donotsubmit'               => 1,
+            'donotsubmit_validationmsg' => 'Cannot be sent with this email',
+        ]);
+
+        $this->coreParametersHelper
+            ->method('get')
+            ->willReturnCallback(function (string $key) {
+                return match ($key) {
+                    'do_not_submit_emails'         => ['blocked.com'],
+                    'blocked_free_email_providers' => [],
+                    default                        => [],
+                };
+            });
+
+        $event = new ValidationEvent($field, 'user@allowed.com');
+        $this->subscriber->onFormValidate($event);
+
+        self::assertTrue($event->isValid());
+    }
+
     public function testEmailBlockedFreeProviderTriggersFailure(): void
     {
         $field = new Field();

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldEmailTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldEmailTypeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\FormBundle\Tests\Form\Type;
+
+use Mautic\CoreBundle\Form\Type\ButtonGroupType;
+use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\FormBundle\Form\Type\FormFieldEmailType;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class FormFieldEmailTypeTest extends TypeTestCase
+{
+    private MockObject&TranslatorInterface $translator;
+
+    private MockObject&CoreParametersHelper $coreParametersHelper;
+
+    protected function setUp(): void
+    {
+        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+
+        parent::setUp();
+    }
+
+    /**
+     * @return array<FormExtensionInterface>
+     */
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([
+                ButtonGroupType::class      => new ButtonGroupType(),
+                YesNoButtonGroupType::class => new YesNoButtonGroupType(),
+                FormFieldEmailType::class   => new FormFieldEmailType($this->translator, $this->coreParametersHelper),
+            ], []),
+        ];
+    }
+
+    public function testDoNotSubmitDefaultsToTrueWhenConfiguredDomainsExist(): void
+    {
+        $this->coreParametersHelper
+            ->method('get')
+            ->with('do_not_submit_emails')
+            ->willReturn(['blocked.com']);
+
+        $form = $this->factory->create(FormFieldEmailType::class, [], [
+            'data' => $this->getValidationData(),
+        ]);
+
+        self::assertTrue((bool) $form->get('donotsubmit')->getData());
+    }
+
+    public function testDoNotSubmitDefaultsToFalseWhenConfiguredDomainsDoNotExist(): void
+    {
+        $this->coreParametersHelper
+            ->method('get')
+            ->with('do_not_submit_emails')
+            ->willReturn([]);
+
+        $form = $this->factory->create(FormFieldEmailType::class, [], [
+            'data' => $this->getValidationData(),
+        ]);
+
+        self::assertFalse((bool) $form->get('donotsubmit')->getData());
+    }
+
+    public function testDoNotSubmitPreservesSavedFalseWhenConfiguredDomainsExist(): void
+    {
+        $this->coreParametersHelper
+            ->expects(self::never())
+            ->method('get');
+
+        $form = $this->factory->create(FormFieldEmailType::class, [], [
+            'data' => $this->getValidationData([
+                'donotsubmit' => false,
+            ]),
+        ]);
+
+        self::assertFalse((bool) $form->get('donotsubmit')->getData());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function getValidationData(array $data = []): array
+    {
+        return array_merge([
+            'donotsubmit_validationmsg'    => 'Cannot be sent with this email',
+            'blockfreeemail_validationmsg' => 'Please provide a business email address',
+        ], $data);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | <!-- Fixes #... -->

## Description

Fixes the email field domain filter so it works when blocked domains are set in Configuration. New email fields now turn the filter on by default when blocked domains exist, and submissions are blocked when the configured value is a plain domain such as `blocked.com`.

<img width="637" height="300" alt="image" src="https://github.com/user-attachments/assets/9fc342f7-528d-409c-ba1c-fd9bacaf3da2" />


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](mdc:https:/contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Configuration > Form Settings.
3. Add `blocked.com` to "Do not accept submission from these domain names" and save.
4. Create or edit a Mautic form.
5. Add an Email field.
6. Check that "Domain name submission filter" is turned on for the Email field.
7. Save the form and open its public form page.
8. Submit the form with `person@blocked.com`.
9. Check that the form shows the validation message and does not accept the submission.
10. Submit the form with `person@allowed.com`.
11. Check that the form accepts the submission.