### PR TITLE
Adding new ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP event

### DIFF
--- a/app/bundles/CampaignBundle/CampaignEvents.php
+++ b/app/bundles/CampaignBundle/CampaignEvents.php
@@ -228,6 +228,15 @@ final class CampaignEvents
     public const ON_EVENT_DECISION_TRIGGER = 'mautic.campaign_on_event_decision_trigger';
 
     /**
+     * The mautic.lead.on_after_campaign_action_change_membership event is dispatched after campaign action to change a contact's membership is executed.
+     *
+     * The event listener receives a Mautic\CampaignBundle\Event\CampaignEvent
+     *
+     * @var string
+     */
+    public const ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP = 'mautic.lead.on_after_campaign_action_change_membership';
+
+    /**
      * The mautic.campaign_failure_notify event is dispatched after campaign event is failed for a contact.
      *
      * The event listener receives a Mautic\CampaignBundle\Event\NotifyOfFailureEvent

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
@@ -6,6 +6,7 @@ use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
+use Mautic\CampaignBundle\Event\CampaignEvent;
 use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\Form\Type\CampaignEventAddRemoveLeadType;
 use Mautic\CampaignBundle\Form\Validator\Constraints\InfiniteLoopValidator;
@@ -13,6 +14,7 @@ use Mautic\CampaignBundle\Membership\MembershipManager;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Event\EntityValidateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterface
 {
@@ -20,6 +22,7 @@ class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterfa
         private MembershipManager $membershipManager,
         private CampaignModel $campaignModel,
         private InfiniteLoopValidator $infiniteLoopValidator,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -79,6 +82,11 @@ class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterfa
                     $event->getContactsKeyedById(),
                     $campaign,
                     true
+                );
+
+                $this->eventDispatcher->dispatch(
+                    new CampaignEvent($campaign),
+                    CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP
                 );
             }
         }

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionChangeMembershipSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionChangeMembershipSubscriberFunctionalTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\EventListener;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Event\CampaignEvent;
+use Mautic\CampaignBundle\Event\PendingEvent;
+use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class CampaignActionChangeMembershipSubscriberFunctionalTest extends MauticMysqlTestCase
+{
+    public function testDispatchesAfterEventWhenContactIsRemovedFromCampaign(): void
+    {
+        $contact           = $this->createContact();
+        $executingCampaign = $this->createCampaign('Executing campaign');
+        $targetCampaign    = $this->createCampaign('Target campaign');
+
+        $targetMembership = new CampaignLead();
+        $targetMembership->setCampaign($targetCampaign);
+        $targetMembership->setLead($contact);
+        $targetMembership->setDateAdded(new \DateTime());
+
+        $this->em->persist($targetMembership);
+        $this->em->flush();
+
+        $campaignAction = new Event();
+        $campaignAction->setCampaign($executingCampaign);
+        $campaignAction->setName('Remove from campaign');
+        $campaignAction->setType('campaign.addremovelead');
+        $campaignAction->setEventType(Event::TYPE_ACTION);
+        $campaignAction->setTriggerMode(Event::TRIGGER_MODE_IMMEDIATE);
+        $campaignAction->setProperties([
+            'removeFrom' => [$targetCampaign->getId()],
+        ]);
+
+        $leadEventLog = new LeadEventLog();
+        $leadEventLog->setCampaign($executingCampaign);
+        $leadEventLog->setEvent($campaignAction);
+        $leadEventLog->setLead($contact);
+
+        $pendingEvent = new PendingEvent(new ActionAccessor([]), $campaignAction, new ArrayCollection([$leadEventLog]));
+
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        \assert($dispatcher instanceof EventDispatcherInterface);
+
+        $dispatchedCampaignIds = [];
+        $listener              = static function (CampaignEvent $event) use (&$dispatchedCampaignIds): void {
+            $dispatchedCampaignIds[] = $event->getCampaign()->getId();
+        };
+
+        $dispatcher->addListener(CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP, $listener);
+
+        try {
+            $dispatcher->dispatch($pendingEvent, CampaignEvents::ON_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP);
+        } finally {
+            $dispatcher->removeListener(CampaignEvents::ON_AFTER_CAMPAIGN_ACTION_CHANGE_MEMBERSHIP, $listener);
+        }
+
+        $this->em->clear();
+
+        /** @var CampaignLead|null $updatedMembership */
+        $updatedMembership = $this->em->getRepository(CampaignLead::class)->findOneBy([
+            'campaign' => $targetCampaign->getId(),
+            'lead'     => $contact->getId(),
+        ]);
+
+        Assert::assertNotNull($updatedMembership);
+        Assert::assertTrue($updatedMembership->getManuallyRemoved());
+        Assert::assertSame([$targetCampaign->getId()], $dispatchedCampaignIds);
+    }
+
+    private function createContact(): Lead
+    {
+        $contact = new Lead();
+        $contact->setEmail('change-membership-test@example.com');
+
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function createCampaign(string $name): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName($name);
+        $campaign->setIsPublished(true);
+
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+}


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR adds a new listener that plugins can use for their work. We needed that in our internal plugin. Great for Mautic's extendability.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. This PR cannot be tested, but it has an automated functional test that acts like a plugin and confirms that the new event works correctly.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->