### PR TITLE
Fix release packaging on missing media dirs and PHPStan baseline check on non-PR runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -282,7 +282,7 @@ jobs:
             exit 1
           fi
         elif [[ "${{ matrix.commands }}" == "PHPStan baseline changes" ]]; then
-          if [[ "${{ steps.changed-files.outputs.modified_files }}" == *"phpstan-baseline.neon"* ]]; then
+          if [[ -n "${{ github.base_ref }}" ]] && [[ "${{ steps.changed-files.outputs.modified_files }}" == *"phpstan-baseline.neon"* ]]; then
             stat=$(git diff --shortstat "origin/${{ github.base_ref }}" ${{ github.sha }} -- phpstan-baseline.neon)
             echo $stat
             regex="[0-9]+[[:space:]]insertion"

--- a/build/package_release.php
+++ b/build/package_release.php
@@ -89,7 +89,11 @@ if (!isset($args['repackage'])) {
 
     // Ensure the generated media files don't end up in the deleted files by explicitly adding them to the release files.
     foreach (['css', 'js', 'libraries/ckeditor', 'libraries/ckeditor/translations'] as $dir) {
-        $files = array_diff(scandir(__DIR__.'/packaging/media/'.$dir), ['..', '.']);
+        $path = __DIR__.'/packaging/media/'.$dir;
+        if (!is_dir($path)) {
+            continue;
+        }
+        $files = array_diff(scandir($path), ['..', '.']);
         array_walk($files, function (&$item) use ($dir) { $item = 'media/'.$dir.'/'.$item; });
         $releaseFiles = array_merge($releaseFiles, $files);
     }


### PR DESCRIPTION
## Summary
  - Guard `scandir()` in `build/package_release.php` with an `is_dir()` check so the release packager skips missing media subdirs instead of failing.
  - Only run the PHPStan baseline diff in `tests.yml` when `github.base_ref` is set (i.e. pull request events), since it's empty on push/schedule/workflow_dispatch runs.