### PR TITLE
Fixing campaign restart issue

### DIFF
--- a/app/bundles/CampaignBundle/Membership/MembershipBuilder.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipBuilder.php
@@ -72,7 +72,8 @@ class MembershipBuilder
         if ($this->output) {
             $countResult = $this->campaignLeadRepository->getCountsForCampaignContactsBySegment(
                 $this->campaign->getId(),
-                $this->contactLimiter
+                $this->contactLimiter,
+                $this->campaign->allowRestart()
             );
 
             $this->output->writeln(

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRestartFromSegmentTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRestartFromSegmentTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Campaign;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @see https://github.com/mautic/mautic/issues/16026
+ */
+final class CampaignRestartFromSegmentTest extends MauticMysqlTestCase
+{
+    use CampaignEntitiesTrait;
+
+    protected $useCleanupRollback = false;
+
+    public function testCampaignRestartsWhenContactReturnsToSegment(): void
+    {
+        // Arrange: create a segment and a campaign with "Allow contact to restart campaign" enabled
+        $segment = $this->createSegment('restart-test-segment', []);
+
+        $campaign = new Campaign();
+        $campaign->setName('Restart Test Campaign');
+        $campaign->setIsPublished(true);
+        $campaign->setAllowRestart(true);
+        $campaign->addList($segment);
+        $this->em->persist($campaign);
+
+        // Create a contact and add them to the segment
+        $contact  = $this->createLead('RestartTestContact');
+        $listLead = new ListLead();
+        $listLead->setLead($contact);
+        $listLead->setList($segment);
+        $listLead->setDateAdded(new \DateTime());
+        $this->em->persist($listLead);
+
+        // Create a "change points" action in the campaign (simple, observable side-effect)
+        $event = $this->createEvent(
+            'Add 10 points',
+            $campaign,
+            'lead.changepoints',
+            'action',
+            ['points' => 10]
+        );
+
+        $this->em->flush();
+        $this->em->clear();
+
+        // Act (first run): rebuild campaign membership, then trigger campaign events
+        $this->testSymfonyCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+        $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
+
+        // Assert: contact is in the campaign at rotation 1
+        $this->em->clear();
+
+        $campaignLead = $this->em->getRepository(CampaignLead::class)->findOneBy([
+            'lead'     => $contact->getId(),
+            'campaign' => $campaign->getId(),
+        ]);
+
+        Assert::assertNotNull($campaignLead, 'Contact should be in the campaign after first rebuild.');
+        Assert::assertFalse($campaignLead->wasManuallyRemoved(), 'Contact should not be removed after first rebuild.');
+        Assert::assertSame(1, $campaignLead->getRotation(), 'Rotation should be 1 after first run.');
+
+        $logsAfterFirstRun = $this->em->getRepository(LeadEventLog::class)->findBy([
+            'lead'     => $contact->getId(),
+            'campaign' => $campaign->getId(),
+        ]);
+        Assert::assertCount(1, $logsAfterFirstRun, 'Campaign event should have run once after first trigger.');
+
+        // Simulate contact leaving the segment (e.g. campaign removes their tag).
+        // Use DBAL directly to avoid ORM caching complications with composite-PK entities.
+        $connection = $this->em->getConnection();
+        $affected   = $connection->executeStatement(
+            'UPDATE '.MAUTIC_TABLE_PREFIX.'lead_lists_leads SET manually_removed = 1 WHERE lead_id = ? AND leadlist_id = ?',
+            [$contact->getId(), $segment->getId()]
+        );
+        Assert::assertSame(1, $affected, 'Expected exactly one ListLead row to be updated.');
+        $this->em->clear();
+
+        // Rebuild: contact is now orphaned in the campaign (in campaign_leads but no longer in segment)
+        $this->testSymfonyCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+
+        $this->em->clear();
+
+        $campaignLead = $this->em->getRepository(CampaignLead::class)->findOneBy([
+            'lead'     => $contact->getId(),
+            'campaign' => $campaign->getId(),
+        ]);
+
+        Assert::assertNotNull($campaignLead, 'Campaign lead record should still exist after soft-removal.');
+        Assert::assertTrue($campaignLead->wasManuallyRemoved(), 'Contact should be removed from campaign after leaving segment.');
+        Assert::assertNotNull($campaignLead->getDateLastExited(), 'date_last_exited should be set when removed via segment departure.');
+
+        // Simulate contact returning to the segment (e.g. tag is re-applied)
+        $connection->executeStatement(
+            'UPDATE '.MAUTIC_TABLE_PREFIX.'lead_lists_leads SET manually_removed = 0 WHERE lead_id = ? AND leadlist_id = ?',
+            [$contact->getId(), $segment->getId()]
+        );
+        $this->em->clear();
+
+        // Act (second run): rebuild campaign membership — BUG: contact is not re-added
+        $this->testSymfonyCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
+
+        $this->em->clear();
+
+        $campaignLead = $this->em->getRepository(CampaignLead::class)->findOneBy([
+            'lead'     => $contact->getId(),
+            'campaign' => $campaign->getId(),
+        ]);
+
+        Assert::assertNotNull($campaignLead, 'Campaign lead record should exist.');
+        Assert::assertFalse(
+            $campaignLead->wasManuallyRemoved(),
+            'Contact should be re-added to campaign when returning to segment with allowRestart=true.'
+        );
+        Assert::assertSame(2, $campaignLead->getRotation(), 'Rotation should be incremented to 2 for the second run.');
+
+        // Trigger campaign events for the second rotation
+        $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
+
+        $this->em->clear();
+
+        $allEventLogs = $this->em->getRepository(LeadEventLog::class)->findBy([
+            'lead'     => $contact->getId(),
+            'campaign' => $campaign->getId(),
+        ]);
+
+        Assert::assertCount(
+            2,
+            $allEventLogs,
+            'Campaign event should have run twice in total (once per rotation) when the contact returns to the segment.'
+        );
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16026

## Description

When a campaign has **"Allow contact to restart campaign"** enabled and is driven by a segment source, contacts that leave and then re-join the segment are not re-added to the campaign. The campaign therefore never restarts for them, even though the setting explicitly allows it. Manually adding the contact back from the contact detail page works correctly — only the segment-driven path is broken.

### Root cause and history

The bug has a two-commit history and was latent for years before becoming observable.

**2018 — the original oversight.** `MembershipBuilder::addNewlyQualifiedMembers` contains a progress-reporting block guarded by `if ($this->output)`. Inside it, a count query is run to estimate how many contacts are about to be added — both to print a human-readable message and to skip unnecessary work with an early `return 0` if the count is zero. This count query, `getCountsForCampaignContactsBySegment`, accepts an `$allowRestart` flag that changes its exclusion logic, but the call in `MembershipBuilder` never passed that flag, always defaulting to `false`. The actual data query directly below it did pass the flag correctly. For years this mismatch caused no visible harm because the count semantics were close enough that the early exit was never triggered incorrectly.

**September 2022 — the fix that exposed the bug (Mautic 5.0).** Commit `18f2a8b22e` ("Fix campaign looping issue", [#11318](https://github.com/mautic/mautic/pull/11318)) tightened the exclusion logic for restartable campaigns. Previously, a contact with `manually_removed = 1` was simply allowed to be picked up again. The looping fix refined this by also requiring `date_last_exited IS NULL` — meaning only contacts that were manually removed (not exited via a segment departure) should be excluded from re-entry. This was the correct fix for the looping issue, but it made the count query semantics meaningfully stricter than the rebuild query. Now, when a contact returns to the segment after a proper exit (`manually_removed = 1`, `date_last_exited` set), the count query excludes them entirely (it sees them as still "in" the campaign), returns 0, and the early-exit fires — preventing the real rebuild query from ever running.

### The fix

Pass `$this->campaign->allowRestart()` to `getCountsForCampaignContactsBySegment()` in `MembershipBuilder::addNewlyQualifiedMembers`, matching what the actual data query already does. This is a one-line change.

---

### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester)).

2. Create a new **Segment** — for example named `Restart Test`. Leave it with no automatic filters (or add a simple one such as tag = `restart`).

3. Create a new **Campaign** with the following settings:
   - Source: the segment you just created.
   - Check **"Allow contact to restart campaign"**.
   - Add at least one action step (e.g. "Adjust contact points: +10").

4. Create a **Contact** and add them to the segment manually (or apply the tag if you used a filter).

5. Run `php bin/console mautic:campaigns:update --campaign-id=<id>` to rebuild campaign membership, then `php bin/console mautic:campaigns:trigger --campaign-id=<id>` to execute events.

6. **Verify (first run):** The contact appears in the campaign's contact list and the action has executed (e.g. points increased by 10).

7. Remove the contact from the segment (e.g. remove the tag, or manually remove them from the segment). Run `mautic:campaigns:update` again.

8. **Verify:** The contact is now shown as removed from the campaign (grayed out / "Removed" status in the campaign contacts view).

9. Re-add the contact to the segment (e.g. re-apply the tag).

10. Run `mautic:campaigns:update` again.

11. **Verify (this is the key assertion — broken before this fix):** The contact is active in the campaign again and their rotation has incremented. Running `mautic:campaigns:trigger` should execute the action a second time (e.g. points increase by another 10, total +20).

    > **Before this fix:** step 11 fails — the contact stays removed and the campaign does not restart.
    > **After this fix:** step 11 passes as expected.
