### PR TITLE
Implement email and page preview PDF downloads

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/14.content.preview.js
+++ b/app/bundles/CoreBundle/Assets/js/14.content.preview.js
@@ -88,6 +88,11 @@ Mautic.contentPreviewUrlGenerator = {
         mQuery('#content_preview_url').val(previewUrl);
         // Update URL in preview button
         mQuery('#content_preview_url_button').attr('onClick', "window.open('" + previewUrl + "', '_blank');");
+
+        const pdfPreviewUrl = previewUrl + '/download/pdf';
+        if (mQuery('#content_preview_pdf_url_button').length) {
+            mQuery('#content_preview_pdf_url_button').attr('onClick', "window.open('" + pdfPreviewUrl + "', '_blank');");
+        }
     }
 }
 

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -96,6 +96,21 @@ return [
                     'objectType'    => null,
                 ],
             ],
+            'mautic_email_preview_download' => [
+                'path'       => '/email/preview/{objectId}/download/{downloadType}',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::previewDownloadAction',
+                'defaults'   => [
+                    'downloadType' => 'pdf',
+                ],
+            ],
+            'mautic_email_preview_download_draft' => [
+                'path'       => '/email/preview/{objectId}/draft/download/{downloadType}',
+                'controller' => 'Mautic\EmailBundle\Controller\PublicController::previewDownloadAction',
+                'defaults'   => [
+                    'objectType'   => 'draft',
+                    'downloadType' => 'pdf',
+                ],
+            ],
         ],
     ],
     'menu' => [

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Twig\Helper\AnalyticsHelper;
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\EmailBundle\Event\TransportWebhookEvent;
 use Mautic\EmailBundle\Helper\EmailConfig;
@@ -33,6 +34,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -526,6 +528,132 @@ class PublicController extends CommonFormController
         }
 
         return new Response($content);
+    }
+
+    public function previewDownloadAction(
+        ThemeHelper $themeHelper,
+        AssetsHelper $assetsHelper,
+        EmailConfig $emailConfig,
+        EmailModel $model,
+        Request $request,
+        LeadModel $leadModel,
+        FakeContactHelper $fakeLeadHelper,
+        string $objectId,
+        ?string $objectType = null,
+        string $downloadType = 'pdf',
+    ): Response {
+        if ('pdf' !== strtolower($downloadType)) {
+            return $this->notFound();
+        }
+
+        $contactId   = (int) $request->query->get('contactId');
+        $emailEntity = $model->getEntity($objectId);
+
+        if (null === $emailEntity) {
+            return $this->notFound();
+        }
+
+        $publicPreview = $emailEntity->isPublicPreview();
+        $draftEnabled  = $emailConfig->isDraftEnabled();
+        if ('draft' === $objectType && $draftEnabled && $emailEntity->hasDraft()) {
+            $publicPreview = $emailEntity->getDraft()->isPublicPreview();
+        }
+
+        if (
+            ($this->security->isAnonymous() && !$publicPreview)
+            || (!$this->security->isAnonymous()
+                && !$this->security->hasEntityAccess(
+                    'email:emails:viewown',
+                    'email:emails:viewother',
+                    $emailEntity->getCreatedBy()
+                ))
+        ) {
+            return $this->accessDenied();
+        }
+
+        if ($contactId && (
+            !$this->security->isAdmin()
+            && !$this->security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother')
+        )
+        ) {
+            $contactId = null;
+        }
+
+        $idHash = 'xxxxxxxxxxxxxx';
+
+        $BCcontent = $emailEntity->getContent();
+        $content   = $emailEntity->getCustomHtml();
+
+        if ('draft' === $objectType && $draftEnabled && $emailEntity->hasDraft()) {
+            $content = $emailEntity->getDraftContent();
+        }
+
+        if (empty($content) && !empty($BCcontent)) {
+            $template = $emailEntity->getTemplate();
+
+            $assetsHelper->addCustomDeclaration('<meta name="robots" content="noindex">');
+
+            $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/email.html.twig');
+
+            $content = $themeHelper->renderThemeTemplate(
+                $logicalName,
+                [
+                    'inBrowser' => true,
+                    'content'   => $emailEntity->getContent(),
+                    'email'     => $emailEntity,
+                    'lead'      => null,
+                    'template'  => $template,
+                ]
+            );
+        }
+
+        $tokens = ['{tracking_pixel}' => ''];
+
+        if ($contactId) {
+            $contact = $leadModel->getRepository()->getLead($contactId);
+            $contact = $model->enrichedContactWithCompanies($contact);
+        } else {
+            $contact = $fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
+        }
+
+        $event = new EmailSendEvent(
+            null,
+            [
+                'content'      => $content,
+                'email'        => $emailEntity,
+                'idHash'       => $idHash,
+                'tokens'       => $tokens,
+                'internalSend' => true,
+                'lead'         => $contact,
+            ]
+        );
+        $this->dispatcher->dispatch($event, EmailEvents::EMAIL_ON_DISPLAY);
+
+        $content = $event->getContent(true);
+
+        $fileName = strtolower(trim(preg_replace('/[^A-Za-z0-9._-]+/', '-', (string) $emailEntity->getName()) ?? '', '-'));
+        if ('' === $fileName) {
+            $fileName = 'email-preview';
+        }
+        $fileName .= '.pdf';
+
+        $pdfEvent = new EmailPreviewPdfGenerationEvent($content, $emailEntity, $contact, $request, $fileName);
+        $this->dispatcher->dispatch($pdfEvent, EmailEvents::EMAIL_PREVIEW_GENERATE_PDF);
+
+        if (!$pdfEvent->hasPdfContent()) {
+            return new Response('PDF generation failed', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $pdfContent = $pdfEvent->getPdfContent();
+        $response   = new Response($pdfContent);
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Length', (string) strlen($pdfContent));
+        $response->headers->set(
+            'Content-Disposition',
+            sprintf('%s; filename="%s"', ResponseHeaderBag::DISPOSITION_ATTACHMENT, $pdfEvent->getFileName())
+        );
+
+        return $response;
     }
 
     /**

--- a/app/bundles/EmailBundle/EmailEvents.php
+++ b/app/bundles/EmailBundle/EmailEvents.php
@@ -68,6 +68,16 @@ final class EmailEvents
     public const EMAIL_ON_DISPLAY = 'mautic.email_on_display';
 
     /**
+     * The mautic.email_preview_generate_pdf event is dispatched when an email preview is downloaded as PDF.
+     *
+     * The event listener receives a
+     * Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent instance.
+     *
+     * @var string
+     */
+    public const EMAIL_PREVIEW_GENERATE_PDF = 'mautic.email_preview_generate_pdf';
+
+    /**
      * The mautic.email_on_build event is dispatched before displaying the email builder form to allow adding of tokens.
      *
      * The event listener receives a

--- a/app/bundles/EmailBundle/Event/EmailPreviewPdfGenerationEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailPreviewPdfGenerationEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Event;
+
+use Mautic\EmailBundle\Entity\Email;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class EmailPreviewPdfGenerationEvent extends Event
+{
+    private ?string $pdfContent = null;
+
+    /**
+     * @param array<string, mixed>|object|null $contact
+     */
+    public function __construct(
+        private string $htmlContent,
+        private Email $email,
+        private mixed $contact,
+        private Request $request,
+        private string $fileName,
+    ) {
+    }
+
+    public function getHtmlContent(): string
+    {
+        return $this->htmlContent;
+    }
+
+    public function setHtmlContent(string $htmlContent): void
+    {
+        $this->htmlContent = $htmlContent;
+    }
+
+    public function getEmail(): Email
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return array<string, mixed>|object|null
+     */
+    public function getContact(): mixed
+    {
+        return $this->contact;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function setFileName(string $fileName): void
+    {
+        $this->fileName = $fileName;
+    }
+
+    public function hasPdfContent(): bool
+    {
+        return null !== $this->pdfContent;
+    }
+
+    public function getPdfContent(): string
+    {
+        return $this->pdfContent ?? '';
+    }
+
+    public function setPdfContent(string $pdfContent): void
+    {
+        $this->pdfContent = $pdfContent;
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/EmailPreviewPdfSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailPreviewPdfSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent;
+use Mautic\EmailBundle\Pdf\EmailPreviewPdfGenerator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class EmailPreviewPdfSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private EmailPreviewPdfGenerator $pdfGenerator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EmailEvents::EMAIL_PREVIEW_GENERATE_PDF => ['onEmailPreviewGeneratePdf', -255],
+        ];
+    }
+
+    public function onEmailPreviewGeneratePdf(EmailPreviewPdfGenerationEvent $event): void
+    {
+        if ($event->hasPdfContent()) {
+            return;
+        }
+
+        $event->setPdfContent($this->pdfGenerator->generate($event->getHtmlContent()));
+    }
+}

--- a/app/bundles/EmailBundle/Pdf/EmailPreviewPdfGenerator.php
+++ b/app/bundles/EmailBundle/Pdf/EmailPreviewPdfGenerator.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Pdf;
+
+final class EmailPreviewPdfGenerator
+{
+    public function generate(string $htmlContent): string
+    {
+        if (class_exists('Dompdf\\Dompdf')) {
+            return $this->generateWithDompdf($htmlContent);
+        }
+
+        return $this->generateWithStdlib($htmlContent);
+    }
+
+    private function generateWithDompdf(string $htmlContent): string
+    {
+        $dompdfClass  = 'Dompdf\\Dompdf';
+        $optionsClass = 'Dompdf\\Options';
+
+        if (class_exists($optionsClass)) {
+            $options = new $optionsClass();
+            if (method_exists($options, 'set')) {
+                $options->set('isRemoteEnabled', true);
+                $options->set('isHtml5ParserEnabled', true);
+            }
+            $dompdf = new $dompdfClass($options);
+        } else {
+            $dompdf = new $dompdfClass();
+        }
+
+        $dompdf->loadHtml($htmlContent);
+        $dompdf->setPaper('A4', 'portrait');
+        $dompdf->render();
+
+        return $dompdf->output();
+    }
+
+    private function generateWithStdlib(string $htmlContent): string
+    {
+        $text = $this->normalizeTextFromHtml($htmlContent);
+
+        if ('' === $text) {
+            $text = 'No content available';
+        }
+
+        $lines = [];
+        foreach (preg_split('/\R/', $text) ?: [] as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                $lines[] = '';
+                continue;
+            }
+
+            foreach (explode("\n", wordwrap($line, 95, "\n", true)) as $wrappedLine) {
+                $lines[] = $wrappedLine;
+            }
+        }
+
+        $lineLimit = 52;
+        if (count($lines) > $lineLimit) {
+            $lines = array_slice($lines, 0, $lineLimit);
+        }
+
+        $stream = $this->buildTextStream($lines);
+
+        return $this->buildSinglePagePdf($stream);
+    }
+
+    private function normalizeTextFromHtml(string $htmlContent): string
+    {
+        $withLineBreaks = preg_replace('/<\s*br\s*\/?>/i', "\n", $htmlContent) ?? $htmlContent;
+        $withLineBreaks = preg_replace('/<\/(p|div|h[1-6]|li|tr|table)>/i', "\n", $withLineBreaks) ?? $withLineBreaks;
+        $plainText      = html_entity_decode(strip_tags($withLineBreaks), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $plainText      = preg_replace('/\R{3,}/', "\n\n", $plainText) ?? $plainText;
+
+        return trim($plainText);
+    }
+
+    /**
+     * @param array<int, string> $lines
+     */
+    private function buildTextStream(array $lines): string
+    {
+        $commands = [
+            'BT',
+            '/F1 11 Tf',
+            '50 792 Td',
+        ];
+
+        $lineIndex = 0;
+        foreach ($lines as $line) {
+            if (0 !== $lineIndex) {
+                $commands[] = '0 -14 Td';
+            }
+
+            if ('' !== $line) {
+                $commands[] = '('.$this->escapePdfString($line).') Tj';
+            }
+
+            ++$lineIndex;
+        }
+
+        $commands[] = 'ET';
+
+        return implode("\n", $commands)."\n";
+    }
+
+    private function escapePdfString(string $value): string
+    {
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value);
+    }
+
+    private function buildSinglePagePdf(string $stream): string
+    {
+        $objects   = [];
+        $objects[] = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        $objects[] = "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n";
+        $objects[] = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n";
+        $objects[] = "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+        $objects[] = "5 0 obj\n<< /Length ".strlen($stream)." >>\nstream\n".$stream."endstream\nendobj\n";
+
+        $pdf     = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= $object;
+        }
+
+        $xrefOffset = strlen($pdf);
+        $pdf .= "xref\n0 6\n";
+        $pdf .= "0000000000 65535 f \n";
+
+        for ($index = 1; $index <= 5; ++$index) {
+            $pdf .= sprintf('%010d 00000 n '."\n", $offsets[$index]);
+        }
+
+        $pdf .= "trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n".$xrefOffset."\n%%EOF";
+
+        return $pdf;
+    }
+}

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -578,6 +578,17 @@
                                                 'type': 'button'
                                             },
                                             onclick: 'window.open("' ~ previewUrl ~ '", "_blank");'
+                                        },
+                                        {
+                                            label: 'mautic.core.download',
+                                            variant: 'ghost',
+                                            icon_only: true,
+                                            icon: 'ri-download-line',
+                                            attributes: {
+                                                'id': 'content_preview_pdf_url_button',
+                                                'type': 'button'
+                                            },
+                                            onclick: 'window.open("' ~ previewUrl ~ '/download/pdf", "_blank");'
                                         }
                                     ]
                                 } %}
@@ -609,9 +620,12 @@
                              readonly
                              value="{{ draftPreviewUrl|escape }}"/>
                       <span class="input-group-btn">
-                        <button class="btn btn-default btn-nospin" onclick="window.open('{{ draftPreviewUrl }}', '_blank');">
+                                                <button class="btn btn-default btn-nospin" onclick="window.open('{{ draftPreviewUrl }}', '_blank');">
                             <i class="fa fa-external-link"></i>
                         </button>
+                                                <button class="btn btn-default btn-nospin" onclick="window.open('{{ draftPreviewUrl }}/download/pdf', '_blank');">
+                                                        <i class="fa fa-download"></i>
+                                                </button>
                     </span>
                   </div>
               </div>

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -237,6 +237,22 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         self::assertStringContainsString('404 Not Found - Requested URL not found: /email/preview/5009', $crawler->text());
     }
 
+    public function testPreviewEmailCanBeDownloadedAsPdf(): void
+    {
+        $email = $this->createEmail();
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, sprintf('/email/preview/%d/download/pdf', $email->getId()));
+        self::assertResponseIsSuccessful();
+
+        $response    = $this->client->getResponse();
+        $contentType = (string) $response->headers->get('Content-Type');
+
+        self::assertStringStartsWith('application/pdf', $contentType);
+        self::assertStringContainsString('attachment;', (string) $response->headers->get('Content-Disposition'));
+        self::assertStringStartsWith('%PDF', (string) $response->getContent());
+    }
+
     private function createSegment(string $name = 'Segment 1'): LeadList
     {
         $segment = new LeadList();

--- a/app/bundles/EmailBundle/Tests/Pdf/EmailPreviewPdfGeneratorTest.php
+++ b/app/bundles/EmailBundle/Tests/Pdf/EmailPreviewPdfGeneratorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Pdf;
+
+use Mautic\EmailBundle\Pdf\EmailPreviewPdfGenerator;
+use PHPUnit\Framework\TestCase;
+
+final class EmailPreviewPdfGeneratorTest extends TestCase
+{
+    public function testGenerateReturnsPdfContent(): void
+    {
+        $generator = new EmailPreviewPdfGenerator();
+        $pdf       = $generator->generate('<html><body><h1>Email preview</h1><p>This is a PDF export test.</p></body></html>');
+
+        self::assertStringStartsWith('%PDF', $pdf);
+        self::assertStringContainsString('%%EOF', $pdf);
+    }
+}

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -49,6 +49,21 @@ return [
                 'controller' => 'Mautic\PageBundle\Controller\PublicController::previewAction',
                 'defaults'   => ['objectType' => null],
             ],
+            'mautic_page_preview_download' => [
+                'path'       => '/page/preview/{id}/download/{downloadType}',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::previewDownloadAction',
+                'defaults'   => [
+                    'downloadType' => 'pdf',
+                ],
+            ],
+            'mautic_page_preview_download_draft' => [
+                'path'       => '/page/preview/{id}/draft/download/{downloadType}',
+                'controller' => 'Mautic\PageBundle\Controller\PublicController::previewDownloadAction',
+                'defaults'   => [
+                    'objectType'   => 'draft',
+                    'downloadType' => 'pdf',
+                ],
+            ],
         ],
         'api' => [
             'mautic_api_pagesstandard' => [

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -22,6 +22,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
+use Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent;
 use Mautic\PageBundle\Event\TrackingEvent;
 use Mautic\PageBundle\Event\UrlTokenReplaceEvent;
 use Mautic\PageBundle\Helper\PageConfig;
@@ -37,6 +38,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -393,6 +395,119 @@ class PublicController extends AbstractFormController
         }
 
         return new Response($content);
+    }
+
+    public function previewDownloadAction(
+        Request $request,
+        PageConfig $pageConfig,
+        CorePermissions $security,
+        AnalyticsHelper $analyticsHelper,
+        AssetsHelper $assetsHelper,
+        ThemeHelper $themeHelper,
+        PageModel $model,
+        LeadModel $leadModel,
+        int $id,
+        ?string $objectType = null,
+        string $downloadType = 'pdf',
+    ): Response {
+        if ('pdf' !== strtolower($downloadType)) {
+            return $this->notFound();
+        }
+
+        $page = $model->getEntity($id);
+        if (!$page || !$page->getId()) {
+            return $this->notFound();
+        }
+
+        $contact   = null;
+        $contactId = (int) $request->query->get('contactId');
+        if ($contactId) {
+            $contact = $leadModel->getEntity($contactId);
+        }
+
+        $draftEnabled = $pageConfig->isDraftEnabled();
+        $analytics    = $analyticsHelper->getCode();
+
+        $BCcontent     = $page->getContent();
+        $content       = $page->getCustomHtml();
+        $publicPreview = $page->isPublicPreview();
+
+        if ('draft' === $objectType && $draftEnabled && $page->hasDraft()) {
+            $content       = $page->getDraftContent();
+            $publicPreview = $page->getDraft()->isPublicPreview();
+        }
+
+        if (($security->isAnonymous() && (!$page->isPublished() || !$publicPreview)) || (!$security->isAnonymous(
+        ) && !$security->hasEntityAccess(
+            'page:pages:viewown',
+            'page:pages:viewother',
+            $page->getCreatedBy()
+        ))) {
+            return $this->accessDenied();
+        }
+
+        if ($contactId && (!$security->isAdmin() || !$security->hasEntityAccess(
+            'lead:leads:viewown',
+            'lead:leads:viewother'
+        ))) {
+            return $this->accessDenied();
+        }
+
+        if (empty($content) && !empty($BCcontent)) {
+            $template = $page->getTemplate();
+            $content  = $page->getContent();
+
+            if (!empty($analytics)) {
+                $assetsHelper->addCustomDeclaration($analytics);
+            }
+
+            $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/page.html.twig');
+
+            $content = $themeHelper->renderThemeTemplate(
+                $logicalName,
+                [
+                    'content'  => $content,
+                    'page'     => $page,
+                    'template' => $template,
+                    'public'   => true, // @deprecated Remove in 2.0
+                ]
+            );
+        } else {
+            $content = str_replace('</head>', $analytics."\n</head>", $content);
+        }
+
+        if ($this->dispatcher->hasListeners(PageEvents::PAGE_ON_DISPLAY)) {
+            $event = new PageDisplayEvent($content, $page, $this->getPreferenceCenterConfig());
+            if (isset($contact) && $contact instanceof Lead) {
+                $event->setLead($contact);
+            }
+            $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+            $content = $event->getContent();
+        }
+
+        $fileName = strtolower(trim(preg_replace('/[^A-Za-z0-9._-]+/', '-', (string) $page->getTitle()) ?? '', '-'));
+        if ('' === $fileName) {
+            $fileName = 'page-preview';
+        }
+        $fileName .= '.pdf';
+
+        $pdfEvent = new PagePreviewPdfGenerationEvent($content, $page, $contact, $request, $fileName);
+        $this->dispatcher->dispatch($pdfEvent, PageEvents::PAGE_PREVIEW_GENERATE_PDF);
+
+        if (!$pdfEvent->hasPdfContent()) {
+            return new Response('PDF generation failed', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        $pdfContent = $pdfEvent->getPdfContent();
+        $response   = new Response($pdfContent);
+        $response->headers->set('Content-Type', 'application/pdf');
+        $response->headers->set('Content-Length', (string) strlen($pdfContent));
+        $response->headers->set(
+            'Content-Disposition',
+            sprintf('%s; filename="%s"', ResponseHeaderBag::DISPOSITION_ATTACHMENT, $pdfEvent->getFileName())
+        );
+
+        return $response;
     }
 
     public function trackingImageAction(Request $request, PageModel $model): Response

--- a/app/bundles/PageBundle/Event/PagePreviewPdfGenerationEvent.php
+++ b/app/bundles/PageBundle/Event/PagePreviewPdfGenerationEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Event;
+
+use Mautic\PageBundle\Entity\Page;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class PagePreviewPdfGenerationEvent extends Event
+{
+    private ?string $pdfContent = null;
+
+    /**
+     * @param array<string, mixed>|object|null $contact
+     */
+    public function __construct(
+        private string $htmlContent,
+        private Page $page,
+        private mixed $contact,
+        private Request $request,
+        private string $fileName,
+    ) {
+    }
+
+    public function getHtmlContent(): string
+    {
+        return $this->htmlContent;
+    }
+
+    public function setHtmlContent(string $htmlContent): void
+    {
+        $this->htmlContent = $htmlContent;
+    }
+
+    public function getPage(): Page
+    {
+        return $this->page;
+    }
+
+    /**
+     * @return array<string, mixed>|object|null
+     */
+    public function getContact(): mixed
+    {
+        return $this->contact;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function setFileName(string $fileName): void
+    {
+        $this->fileName = $fileName;
+    }
+
+    public function hasPdfContent(): bool
+    {
+        return null !== $this->pdfContent;
+    }
+
+    public function getPdfContent(): string
+    {
+        return $this->pdfContent ?? '';
+    }
+
+    public function setPdfContent(string $pdfContent): void
+    {
+        $this->pdfContent = $pdfContent;
+    }
+}

--- a/app/bundles/PageBundle/EventListener/PagePreviewPdfSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PagePreviewPdfSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\EventListener;
+
+use Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent;
+use Mautic\PageBundle\PageEvents;
+use Mautic\PageBundle\Pdf\PagePreviewPdfGenerator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class PagePreviewPdfSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private PagePreviewPdfGenerator $pdfGenerator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PageEvents::PAGE_PREVIEW_GENERATE_PDF => ['onPagePreviewGeneratePdf', -255],
+        ];
+    }
+
+    public function onPagePreviewGeneratePdf(PagePreviewPdfGenerationEvent $event): void
+    {
+        if ($event->hasPdfContent()) {
+            return;
+        }
+
+        $event->setPdfContent($this->pdfGenerator->generate($event->getHtmlContent()));
+    }
+}

--- a/app/bundles/PageBundle/PageEvents.php
+++ b/app/bundles/PageBundle/PageEvents.php
@@ -154,4 +154,12 @@ final class PageEvents
      * @var string
      */
     public const ON_URL_TOKEN_REPLACE = 'mautic.page.on_url_token_replace';
+
+    /**
+     * The mautic.page_preview_generate_pdf event is dispatched to generate a PDF from page preview HTML.
+     *
+     * The event listener receives a
+     * Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent
+     */
+    public const PAGE_PREVIEW_GENERATE_PDF = 'mautic.page_preview_generate_pdf';
 }

--- a/app/bundles/PageBundle/Pdf/PagePreviewPdfGenerator.php
+++ b/app/bundles/PageBundle/Pdf/PagePreviewPdfGenerator.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Pdf;
+
+final class PagePreviewPdfGenerator
+{
+    public function generate(string $htmlContent): string
+    {
+        if (class_exists('Dompdf\\Dompdf')) {
+            return $this->generateWithDompdf($htmlContent);
+        }
+
+        return $this->generateWithStdlib($htmlContent);
+    }
+
+    private function generateWithDompdf(string $htmlContent): string
+    {
+        $dompdfClass  = 'Dompdf\\Dompdf';
+        $optionsClass = 'Dompdf\\Options';
+
+        if (class_exists($optionsClass)) {
+            $options = new $optionsClass();
+            if (method_exists($options, 'set')) {
+                $options->set('isRemoteEnabled', true);
+                $options->set('isHtml5ParserEnabled', true);
+            }
+            $dompdf = new $dompdfClass($options);
+        } else {
+            $dompdf = new $dompdfClass();
+        }
+
+        $dompdf->loadHtml($htmlContent);
+        $dompdf->setPaper('A4', 'portrait');
+        $dompdf->render();
+
+        return $dompdf->output();
+    }
+
+    private function generateWithStdlib(string $htmlContent): string
+    {
+        $text = $this->normalizeTextFromHtml($htmlContent);
+
+        if ('' === $text) {
+            $text = 'No content available';
+        }
+
+        $lines = [];
+        foreach (preg_split('/\R/', $text) ?: [] as $line) {
+            $line = trim($line);
+            if ('' === $line) {
+                $lines[] = '';
+                continue;
+            }
+
+            foreach (explode("\n", wordwrap($line, 95, "\n", true)) as $wrappedLine) {
+                $lines[] = $wrappedLine;
+            }
+        }
+
+        $lineLimit = 52;
+        if (count($lines) > $lineLimit) {
+            $lines = array_slice($lines, 0, $lineLimit);
+        }
+
+        $stream = $this->buildTextStream($lines);
+
+        return $this->buildSinglePagePdf($stream);
+    }
+
+    private function normalizeTextFromHtml(string $htmlContent): string
+    {
+        $withLineBreaks = preg_replace('/<\s*br\s*\/?>/i', "\n", $htmlContent) ?? $htmlContent;
+        $withLineBreaks = preg_replace('/<\/(p|div|h[1-6]|li|tr|table)>/i', "\n", $withLineBreaks) ?? $withLineBreaks;
+        $plainText      = html_entity_decode(strip_tags($withLineBreaks), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $plainText      = preg_replace('/\R{3,}/', "\n\n", $plainText) ?? $plainText;
+
+        return trim($plainText);
+    }
+
+    /**
+     * @param array<int, string> $lines
+     */
+    private function buildTextStream(array $lines): string
+    {
+        $commands = [
+            'BT',
+            '/F1 11 Tf',
+            '50 792 Td',
+        ];
+
+        $lineIndex = 0;
+        foreach ($lines as $line) {
+            if (0 !== $lineIndex) {
+                $commands[] = '0 -14 Td';
+            }
+
+            if ('' !== $line) {
+                $commands[] = '('.$this->escapePdfString($line).') Tj';
+            }
+
+            ++$lineIndex;
+        }
+
+        $commands[] = 'ET';
+
+        return implode("\n", $commands)."\n";
+    }
+
+    private function escapePdfString(string $value): string
+    {
+        return str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value);
+    }
+
+    private function buildSinglePagePdf(string $stream): string
+    {
+        $objects   = [];
+        $objects[] = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        $objects[] = "2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n";
+        $objects[] = "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n";
+        $objects[] = "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+        $objects[] = "5 0 obj\n<< /Length ".strlen($stream)." >>\nstream\n".$stream."endstream\nendobj\n";
+
+        $pdf     = "%PDF-1.4\n";
+        $offsets = [0];
+        foreach ($objects as $object) {
+            $offsets[] = strlen($pdf);
+            $pdf .= $object;
+        }
+
+        $xrefOffset = strlen($pdf);
+        $pdf .= "xref\n0 6\n";
+        $pdf .= "0000000000 65535 f \n";
+
+        for ($index = 1; $index <= 5; ++$index) {
+            $pdf .= sprintf('%010d 00000 n '."\n", $offsets[$index]);
+        }
+
+        $pdf .= "trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n".$xrefOffset."\n%%EOF";
+
+        return $pdf;
+    }
+}

--- a/app/bundles/PageBundle/Resources/views/Page/details.html.twig
+++ b/app/bundles/PageBundle/Resources/views/Page/details.html.twig
@@ -333,6 +333,17 @@
                                                 'id': 'content_preview_url_button',
                                                 'class': 'btn-nospin'
                                             }
+                                        },
+                                        {
+                                            label: 'mautic.core.download',
+                                            variant: 'ghost',
+                                            icon_only: true,
+                                            icon: 'ri-download-line',
+                                            onclick: 'window.open("' ~ previewUrl ~ '/download/pdf", "_blank");',
+                                            attributes: {
+                                                'id': 'content_preview_pdf_url_button',
+                                                'class': 'btn-nospin'
+                                            }
                                         }
                                     ]
                                 } %}
@@ -358,6 +369,10 @@
                     <button class="btn btn-default btn-nospin"
                             onclick="window.open('{{ draftPreviewUrl }}', '_blank');">
                         <i class="fa fa-external-link"></i>
+                    </button>
+                    <button class="btn btn-default btn-nospin"
+                            onclick="window.open('{{ draftPreviewUrl }}/download/pdf', '_blank');">
+                        <i class="fa fa-download"></i>
                     </button>
                 </span>
                       </div>

--- a/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
@@ -7,6 +7,7 @@ namespace Mautic\PageBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional test ensuring that malicious Twig constructs in theme templates
@@ -92,6 +93,28 @@ final class ThemeHelperSandboxTest extends MauticMysqlTestCase
             'Hello Mautic',
             (string) $response->getContent()
         );
+    }
+
+    public function testPreviewPageCanBeDownloadedAsPdf(): void
+    {
+        $page = new Page();
+        $page->setTitle('PDF Test Page');
+        $page->setAlias('pdf-test-'.uniqid());
+        $page->setIsPublished(true);
+        $page->setPublicPreview(true);
+        $page->setCustomHtml('<html><body>Page PDF content</body></html>');
+
+        $this->em->persist($page);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, '/page/preview/'.$page->getId().'/download/pdf');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseIsSuccessful();
+        $this->assertStringStartsWith('application/pdf', (string) $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('attachment;', (string) $response->headers->get('Content-Disposition'));
+        $this->assertStringStartsWith('%PDF', (string) $response->getContent());
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     private function createMaliciousTheme(string $pageContent): string


### PR DESCRIPTION
| Q                                      | A |
| -------------------------------------- | --- |
| Bug fix? (use the a.b branch)          | ❌ |
| New feature/enhancement? (use the a.x branch)      | ✔️ |
| Deprecations?                          | ❌ |
| BC breaks? (use the c.x branch)        | ❌ |
| Automated tests included?              | ✔️ |
| Related user documentation PR URL      | Pending |
| Related developer documentation PR URL | Pending |
| Issue(s) addressed                     | N/A (internal ticket: MAUT-10379) |

## Description

This PR adds PDF download support for preview content in both EmailBundle and PageBundle using an event-driven implementation that can be overridden by downstream distributions.

What was implemented:

- Added email preview PDF download endpoint and page preview PDF download endpoint.
- Added new events for PDF generation dispatch:
  - mautic.email_preview_generate_pdf
  - mautic.page_preview_generate_pdf
- Added default community listeners/subscribers that generate PDF content.
- Added default PDF generators that:
  - use Dompdf when available
  - fall back to a stdlib-based PDF generator when Dompdf is not installed
- Added preview UI download buttons in Email and Page details views.
- Refactored download route shape to remove redundant objectType for email/page typing:
  - Standard preview download routes now use explicit bundle routes
  - Draft preview downloads are handled via dedicated draft download routes
- Kept implementation compatible with draft preview behavior.

Routing summary:

- Email:
  - /email/preview/{objectId}/download/{downloadType}
  - /email/preview/{objectId}/draft/download/{downloadType}
- Page:
  - /page/preview/{id}/download/{downloadType}
  - /page/preview/{id}/draft/download/{downloadType}

Automated tests:

- Added/updated functional coverage for email and page PDF preview downloads.
- Verified filtered test runs in DDEV for both bundles.

---

### 📋 Steps to test this PR:

1. Check out this branch in your local environment.
2. Clear test cache:
   - ddev exec rm -rf var/cache/test
3. Run focused email PDF download test:
   - ddev composer test -- --filter=testPreviewEmailCanBeDownloadedAsPdf PreviewFunctionalTest.php
4. Run focused page PDF download test:
   - ddev composer test -- --filter=testPreviewPageCanBeDownloadedAsPdf ThemeHelperSandboxTest.php
5. In the UI, open an Email detail page with preview URL controls:
   - Confirm Open Preview works.
   - Confirm Download button opens a PDF file.
6. In the UI, open a Page detail page with preview URL controls:
   - Confirm Open Preview works.
   - Confirm Download button opens a PDF file.
7. If draft exists for email/page:
   - Use draft preview URL section.
   - Confirm draft download button opens draft content as PDF.
8. Optional verification with contact context:
   - Select a contact in preview settings.
   - Confirm preview URL updates and PDF download still returns a valid PDF.

No deprecations and no backward compatibility breaks are introduced in this change.

## Developer Docs (will link separate PR, but capturing here)

# MAUT-10379 Developer Guide: Custom PDF Generation via Events

## Purpose

PDF generation for preview downloads is event-driven so distributions/plugins can provide their own renderer without changing controller logic.

Default community subscribers generate PDF content and can be replaced or overridden.

## Events

### Email preview PDF event

- Event name: `mautic.email_preview_generate_pdf`
- Constant: `Mautic\EmailBundle\EmailEvents::EMAIL_PREVIEW_GENERATE_PDF`
- Event class: `Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent`

### Page preview PDF event

- Event name: `mautic.page_preview_generate_pdf`
- Constant: `Mautic\PageBundle\PageEvents::PAGE_PREVIEW_GENERATE_PDF`
- Event class: `Mautic\PageBundle\Event\PagePreviewPdfGenerationEvent`

## Event payload and contract

Both event classes expose:

- HTML preview content
- Entity (`Email` or `Page`)
- Contact context (if selected)
- Request
- Output file name

To provide a PDF:

1. Listen to the event.
2. Generate binary PDF bytes from `getHtmlContent()`.
3. Call `setPdfContent($bytes)`.
4. Optionally call `setFileName()` to customize file name.

If no listener sets PDF content, the controller returns a 500 error.

## Default implementation

Default subscribers:

- `Mautic\EmailBundle\EventListener\EmailPreviewPdfSubscriber`
- `Mautic\PageBundle\EventListener\PagePreviewPdfSubscriber`

Default generators:

- `Mautic\EmailBundle\Pdf\EmailPreviewPdfGenerator`
- `Mautic\PageBundle\Pdf\PagePreviewPdfGenerator`

Behavior:

- Uses Dompdf if available.
- Falls back to a stdlib-based minimal PDF generator otherwise.

## How to override in a plugin/distribution

Register your own subscriber for the same event and set PDF content before/after default handlers based on priority.

Example (email):

```php
<?php

declare(strict_types=1);

namespace Acme\Bundle\EventListener;

use Mautic\EmailBundle\EmailEvents;
use Mautic\EmailBundle\Event\EmailPreviewPdfGenerationEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

final class CustomEmailPreviewPdfSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            EmailEvents::EMAIL_PREVIEW_GENERATE_PDF => ['onGenerate', 100],
        ];
    }

    public function onGenerate(EmailPreviewPdfGenerationEvent $event): void
    {
        // Optional: skip if another subscriber already provided a PDF
        if ($event->hasPdfContent()) {
            return;
        }

        $html = $event->getHtmlContent();

        // Convert HTML to PDF using your renderer.
        $pdfBytes = $this->convertHtmlToPdf($html);

        $event->setFileName('custom-email-preview.pdf');
        $event->setPdfContent($pdfBytes);
    }

    private function convertHtmlToPdf(string $html): string
    {
        // Replace with your implementation.
        return '%PDF-1.4\n%...';
    }
}
```

Apply the same pattern for page previews using `PagePreviewPdfGenerationEvent` and `PageEvents::PAGE_PREVIEW_GENERATE_PDF`.

## Routes (for reference)

Email:

- `/email/preview/{objectId}/download/{downloadType}`
- `/email/preview/{objectId}/draft/download/{downloadType}`

Page:

- `/page/preview/{id}/download/{downloadType}`
- `/page/preview/{id}/draft/download/{downloadType}`

`downloadType` defaults to `pdf`.


## User Docs (will create a separate PR for this as well, but capturing usage)

# MAUT-10379 User Guide: Download Email and Page Previews as PDF

## Summary

Mautic now supports downloading **preview content** as PDF for both emails and pages.

This is available from the preview URL controls in:

- Email detail view
- Page detail view

## How to use it

### Email preview PDF

1. Go to **Channels > Emails**.
2. Open an email.
3. In the **Preview URL** panel, click the **Download** icon.
4. A PDF file is downloaded for the current preview.

Optional:

- Select a contact in preview settings before downloading to render contact-specific tokens.
- If a draft exists, use the draft preview panel and click Download there to get draft content as PDF.

### Page preview PDF

1. Go to **Components > Landing Pages**.
2. Open a page.
3. In the **Preview URL** panel, click the **Download** icon.
4. A PDF file is downloaded for the current preview.

Optional:

- Select a contact in preview settings before downloading to render contact-specific tokens.
- If a draft exists, use the draft preview panel and click Download there to get draft content as PDF.

## Notes

- The file format is `application/pdf`.
- The PDF content reflects the same preview content shown in browser preview.
- Access and preview permissions still apply.
