### PR TITLE
security: add allowed_classes => false to unserialize() calls in LeadBundle and migrations

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -105,7 +105,7 @@ trait CustomFieldsApiControllerTrait
                 if (!isset($fieldDefinition['properties'])) {
                     $fieldDefinition['properties'] = [];
                 }
-                $properties = is_string($fieldDefinition['properties']) ? unserialize($fieldDefinition['properties']) : $fieldDefinition['properties'];
+                $properties = is_string($fieldDefinition['properties']) ? unserialize($fieldDefinition['properties'], ['allowed_classes' => false]) : $fieldDefinition['properties'];
 
                 $fields[$group][$field]['value']           = empty($properties['scale']) ? (int) $fields[$group][$field]['value']
                     : (float) $fields[$group][$field]['value'];

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -772,7 +772,7 @@ SQL;
 
         $segmentIds = [];
         foreach ($query->getResult() as $property) {
-            $property       = unserialize($property['properties']);
+            $property       = unserialize($property['properties'], ['allowed_classes' => false]);
             $segmentIds     = array_merge($property['addToLists'], $property['removeFromLists'], $segmentIds);
         }
 
@@ -795,7 +795,7 @@ SQL;
 
         foreach ($query->getResult() as $rowFilters) {
             $segmentMembershipFilters = array_filter(
-                unserialize($rowFilters['filters']),
+                unserialize($rowFilters['filters'], ['allowed_classes' => false]),
                 fn (array $filter) => 'leadlist' === $filter['type']
             );
 
@@ -874,7 +874,7 @@ SQL;
 
         $segmentIds = [];
         foreach ($query->getResult() as $property) {
-            $property       = unserialize($property['properties']);
+            $property       = unserialize($property['properties'], ['allowed_classes' => false]);
             $segmentIds     = array_merge($property['addToLists'], $property['removeFromLists'], $segmentIds);
         }
 

--- a/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
@@ -132,7 +132,7 @@ class ReportDevicesSubscriber implements EventSubscriberInterface
         $data = $event->getData();
         if (isset($data[0]['client_info'])) {
             foreach ($data as &$row) {
-                $clientInfo         = unserialize($row['client_info']);
+                $clientInfo         = unserialize($row['client_info'], ['allowed_classes' => false]);
                 $row['client_info'] = (is_array($clientInfo) && isset($clientInfo['name'])) ? $clientInfo['name'] : '';
             }
             $event->setData($data);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2496,7 +2496,7 @@ class LeadModel extends FormModel
                 }
                 $allowedValues = is_array($field['properties'])
                     ? $field['properties']
-                    : unserialize($field['properties']);
+                    : unserialize($field['properties'], ['allowed_classes' => false]);
 
                 $flattenedAllowedValues = array_map(fn ($item): string => html_entity_decode($item['value'], ENT_QUOTES), $allowedValues['list']);
 

--- a/app/migrations/Version20230606111852.php
+++ b/app/migrations/Version20230606111852.php
@@ -31,7 +31,7 @@ final class Version20230606111852 extends PreUpAssertionMigration
         $results        = $this->connection->executeQuery($sql)->fetchAllAssociative();
         $updatedRecords = 0;
         foreach ($results as $row) {
-            $propertiesArray                            = unserialize($row['properties']);
+            $propertiesArray                            = unserialize($row['properties'], ['allowed_classes' => false]);
             $propertiesArray['settings']['description'] = str_replace(self::OLD_STRING, self::NEW_STRING, $propertiesArray['settings']['description']);
             $propertiesString                           = serialize($propertiesArray);
 

--- a/app/migrations/Version20231110103625.php
+++ b/app/migrations/Version20231110103625.php
@@ -19,7 +19,7 @@ final class Version20231110103625 extends AbstractMauticMigration
 
         $addPermissions = [];
         foreach ($results as $row) {
-            $permissionsArray = unserialize($row['readable_permissions']);
+            $permissionsArray = unserialize($row['readable_permissions'], ['allowed_classes' => false]);
             // Add permissions if not exists
             $permissionsToAdd = ['lead:export', 'form:export', 'report:export'];
 


### PR DESCRIPTION
## Summary

Mautic has a `Serializer::decode()` helper (`CoreBundle/Helper/Serializer.php`) that already defaults to `allowed_classes => false`. However, several call sites in LeadBundle and database migrations use raw `unserialize()` directly, bypassing the helper.

When `unserialize()` runs without `allowed_classes`, PHP will instantiate any class in the autoloader that appears in the serialized payload. An attacker who can write to the relevant database columns (via SQL injection or a compromised admin session) can craft a PHP Object Injection payload.

## Affected call sites

| File | Column/value | Risk |
|------|-------------|------|
| `LeadModel.php` | `field['properties']` from DB | Requires write to custom field table |
| `LeadListRepository.php` (×2) | `properties` and `filters` from DB | Segment filter definitions |
| `CustomFieldsApiControllerTrait.php` | `fieldDefinition['properties']` from DB | Via API |
| `ReportDevicesSubscriber.php` | `client_info` from DB | Device tracking data |
| `Version20231110103625.php` | `readable_permissions` migration | Migration-time only |
| `Version20230606111852.php` | `properties` migration | Migration-time only |

## Fix

Added `['allowed_classes' => false]` to all call sites. All the serialized values here are expected to be plain PHP arrays of scalars — no objects. This is consistent with how `Serializer::decode()` already works. Zero behavior change for valid data.