### PR TITLE
[UXUI-238] Move report date filter above table

### DIFF
--- a/app/bundles/ReportBundle/Resources/views/Report/_details_content_header.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/_details_content_header.html.twig
@@ -1,5 +1,5 @@
 {%- set showDynamicFilters = (report.settings.showDynamicFilters is defined and report.settings.showDynamicFilters) -%}
-{%- set hideDateRangeFilter = (report.settings.hideDateRangeFilter is defined and report.settings.hideDateRangeFilter) -%}
+{%- set dynamicFilterFields = dynamicFilterForm.children|filter(v => 'hidden' != v.vars.block_prefixes[1]) -%}
 
 <!-- report detail header -->
 {% include '@MauticCore/Helper/description--expanded.html.twig' with {'description': report.description} %}
@@ -17,15 +17,13 @@
             </div>
         </div>
     </div>
+    {% if dynamicFilterFields is not empty %}
     <div class="collapse {% if showDynamicFilters %}in{% endif %}" id="report-filters">
         <div class="pr-md pl-md pb-md">
             <div class="panel shd-none mb-0 pa-lg">
                 <div class="row">
-                    <div class="col-sm-12 mb-10 {% if hideDateRangeFilter %}hide{% endif %}">
-                        {{ include('@MauticCore/Helper/graph_dateselect.html.twig', {'dateRangeForm': dateRangeForm}) }}
-                    </div>
                     {{ form_start(dynamicFilterForm) }}
-                    {% for child in dynamicFilterForm.children|filter(v => 'hidden' != v.vars.block_prefixes[1]) %}
+                    {% for child in dynamicFilterFields %}
                       <div class="col-sm-4">
                           {{ form_row(child) }}
                       </div>
@@ -35,6 +33,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
     <!--/ report detail collapseable -->
 
     <div>
@@ -43,9 +42,11 @@
             <a href="#report-details" class="arrow text-secondary collapsed" data-toggle="collapse" aria-expanded="false" aria-controls="report-details">
                 <span class="caret"></span> {{ 'mautic.core.details'|trans }}
             </a>
+            {% if dynamicFilterFields is not empty %}
             <a href="#report-filters" class="arrow text-secondary {% if not showDynamicFilters %}collapsed{% endif %}" data-toggle="collapse" aria-expanded="false" aria-controls="report-filters">
                 <span class="caret"></span> {{ 'mautic.core.filters'|trans }}
             </a>
+            {% endif %}
         </div>
         <!--/ report detail collapseable toggler -->
     </div>

--- a/app/bundles/ReportBundle/Resources/views/Report/_details_report_content.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/_details_report_content.html.twig
@@ -16,7 +16,7 @@
     {% if not hideDateRangeFilter %}
         <div class="col-xs-12">
             <div class="report-date-range-filter clearfix mb-md">
-                {{ include('@MauticCore/Helper/graph_dateselect.html.twig', {'dateRangeForm': dateRangeForm, 'class': 'pull-right'}) }}
+                {{ include('@MauticCore/Helper/graph_dateselect.html.twig', {'dateRangeForm': dateRangeForm, 'class': 'mt-16'}) }}
             </div>
         </div>
     {% endif %}

--- a/app/bundles/ReportBundle/Resources/views/Report/_details_report_content.html.twig
+++ b/app/bundles/ReportBundle/Resources/views/Report/_details_report_content.html.twig
@@ -6,12 +6,21 @@
 {%- set aggregatorCount = report.aggregators|length -%}
 {%- set groupBy = report.groupBy -%}
 {%- set groupByCount = report.groupBy|length -%}
+{%- set hideDateRangeFilter = (report.settings.hideDateRangeFilter is defined and report.settings.hideDateRangeFilter) -%}
 {%- set startCount = totalResults > limit ? (reportPage * limit) - limit + 1 : 1 -%}
 {%- set graphContent = include('@MauticReport/Report/details_data_graphs.html.twig', {'graphOrder': graphOrder, 'graphs': graphs, 'report': report}, with_context=false) -%}
 
 {% if showGraphsAboveTable %}{{ graphContent|raw }}{% endif %}
 
 {% if columnOrder is not empty or aggregatorOrder is not empty %}
+    {% if not hideDateRangeFilter %}
+        <div class="col-xs-12">
+            <div class="report-date-range-filter clearfix mb-md">
+                {{ include('@MauticCore/Helper/graph_dateselect.html.twig', {'dateRangeForm': dateRangeForm, 'class': 'pull-right'}) }}
+            </div>
+        </div>
+    {% endif %}
+
     <!-- table section -->
     <div class="col-xs-12">
         <div id="page-list-wrapper" class="panel panel-default">


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ❌
| New feature/enhancement?      | ✔️
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | UXUI-238

## Description

Moves the report date range filter out of the Filters shelf and places it above the report table. It makes the UX pattern the same seen on the dashboard.

<img width="1213" height="569" alt="image" src="https://github.com/user-attachments/assets/68bbb149-694c-4f0e-aa22-e502c7c6f3d6" />


---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](mdc:https:/contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Reports and open a report that shows table data.
3. Check that the date range filter is shown above the table.
4. Open the Filters shelf and check that the date range filter is no longer shown there.
5. Apply a new date range and check that the report table refreshes for the selected dates.
6. Open a report with dynamic filters and check that those filters still appear in the Filters shelf.