### PR TITLE
Fix bulk tag creation on Enter

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -94,6 +94,10 @@ Mautic.ajaxifyForm = function (formName) {
     // Handle Enter key for jumping to the next input
     mQuery(form + ' input, ' + form + ' select').off('keydown.ajaxform');
     mQuery(form + ' input, ' + form + ' select').on('keydown.ajaxform', function (e) {
+        if (mQuery(e.target).hasClass('chosen-search-input')) {
+            return;
+        }
+
         if (e.keyCode == 13 && mQuery(e.target).is(':input')) {
             var inputs = mQuery(this).parents('form').eq(0).find(':input');
             if (inputs[inputs.index(this) + 1] != null) {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?          | ✔️
| New feature/enhancement?      | ❌
| Deprecations?                          | ❌
| BC breaks?        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      |
| Related developer documentation PR URL |
| Issue(s) addressed                     | Fixes #16200

## Description

The bulk Change Tags modal now lets Chosen handle Enter in its search field, so a typed tag is created and selected when the no-results message is shown.


https://github.com/user-attachments/assets/69d7b221-5ab8-4deb-ba9a-f6ba06c6647a



---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](mdc:https:/contribute.mautic.org/contributing-to-mautic/tester))
2. Open the Contacts page.
3. Select one or more contacts.
4. Open the bulk actions menu and choose Change Tags.
5. In the Add tags field, type a tag name that does not already exist.
6. When the no-results message says to press Enter, press Enter.
7. Confirm the new tag is created and selected in the field.
8. Save the modal and confirm the selected contact has the new tag.