### PR TITLE
Bumping the Codecov Action from v5 to v7 as it fails (M7.2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
       with:
         files: ./coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Upload coverage report
       if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         files: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
M7.1 version: https://github.com/mautic/mautic/pull/16210
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | No linked issue. <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This updates the Codecov GitHub Action in the test workflow from `codecov/codecov-action@v5` to `codecov/codecov-action@v7`.

The `v5` wrapper downloads the Codecov CLI verification key from `https://keybase.io/codecovsecurity/pgp_keys.asc`, which now returns `404`. That leaves the action without a public key and causes the coverage upload step to fail during signature verification with:

- `gpg: no valid OpenPGP data found.`
- `gpg: Can't check signature: No public key`

`v7` switches the wrapper to the current `codecovsecops` Keybase endpoint, so the CLI signature verification succeeds again.

This is a workflow-only fix. It does not change application code or test behavior.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. A green CI

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->