### PR TITLE
[NOT-FOR-MERGE] MTC-10813 Prevent re-shuffling of conditional form fields

### DIFF
--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -128,14 +128,27 @@ class FieldController extends CommonFormController
                         $formField['isRequired'] = !empty($formField['properties']['captcha']);
                     }
 
-                    // Add it to the next to last assuming the last is the submit button
+                    // Add field before the submit button
                     if (count($fields)) {
-                        $lastField = end($fields);
-                        $lastKey   = key($fields);
-                        array_pop($fields);
+                        $submitKey = null;
+                        $submitField = null;
 
-                        $fields[$keyId]   = $formField;
-                        $fields[$lastKey] = $lastField;
+                        foreach ($fields as $key => $field) {
+                            if (isset($field['type']) && 'button' === $field['type']) {
+                                $submitKey = $key;
+                                $submitField = $field;
+                                break;
+                            }
+                        }
+
+                        if ($submitKey) {
+                            // Remove submit button, add new field, re-add submit button at the end
+                            unset($fields[$submitKey]);
+                            $fields[$keyId] = $formField;
+                            $fields[$submitKey] = $submitField;
+                        } else {
+                            $fields[$keyId] = $formField;
+                        }
                     } else {
                         $fields[$keyId] = $formField;
                     }

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -822,7 +822,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedActions,
-                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
+                    fn ($a, $b): int => $a['order'] <=> $b['order']
                 );
             }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -790,7 +790,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedFields,
-                    fn ($a, $b): int => $a['order'] <=> $b['order']
+                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
                 );
             }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -822,7 +822,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedActions,
-                    fn ($a, $b): int => $a['order'] <=> $b['order']
+                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
                 );
             }
 


### PR DESCRIPTION
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
The app/bundles/FormBundle/Controller/FieldController.php assumes that the last value in $fields is always the submit button. So when adding a new field, it's added as the second last field.
However, when adding multiple conditional values at a time, it can happen that the submit isn't the last in $fields because somehow in the session the values got reordered. 
The new logic doesn't assume that the submit field is the last value of the $fields array but searches for the submit field in the array instead, removes it, adds the new field and then adds the submit in the end.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. 

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->