### PR TITLE
Add dependabot configuration for composer and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-sync-scaffolding.yml
+++ b/.github/workflows/dependabot-sync-scaffolding.yml
@@ -13,10 +13,16 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.DEPENDABOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Copy lockfile to scaffolding
         run: cp package-lock.json app/assets/scaffold/files/package-lock.json

--- a/.github/workflows/dependabot-sync-scaffolding.yml
+++ b/.github/workflows/dependabot-sync-scaffolding.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync-scaffolding:
-    if: startsWith(github.head_ref, 'dependabot/') && github.repository == 'mautic/mautic'
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/') && github.repository == 'mautic/mautic'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependabot-sync-scaffolding.yml
+++ b/.github/workflows/dependabot-sync-scaffolding.yml
@@ -1,0 +1,34 @@
+name: Sync Dependabot updates to scaffolding
+
+on:
+  pull_request:
+    paths:
+      - 'package-lock.json'
+
+jobs:
+  sync-scaffolding:
+    if: startsWith(github.head_ref, 'dependabot/') && github.repository == 'mautic/mautic'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy lockfile to scaffolding
+        run: cp package-lock.json app/assets/scaffold/files/package-lock.json
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app/assets/scaffold/files/package-lock.json
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: sync dependabot update to scaffolding"
+            git push
+          fi


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Dependabot was creating individual PRs for every dependency bump, which was noisy. This config groups all composer updates into one weekly PR and all npm updates into another, reducing PR churn significantly.

Also adds a workflow that automatically syncs Dependabot's root `package-lock.json` updates to `app/assets/scaffold/files/package-lock.json`, removing the need to do it manually.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. No test needed

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->