### PR TITLE
Improving automatic reviews for test classes with Rector

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
@@ -7,7 +7,6 @@ namespace Mautic\ApiBundle\Tests\Functional\Controller;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class ClientControllerTest extends MauticMysqlTestCase
 {

--- a/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
@@ -62,7 +62,7 @@ class ClientControllerTest extends MauticMysqlTestCase
     private function assertPaginationDetails(int $pageCount): void
     {
         $content = $this->client->getResponse()->getContent();
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $translator = static::getContainer()->get('translator');
 

--- a/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
@@ -43,8 +43,8 @@ final class Oauth2Test extends MauticMysqlTestCase
         $this->client->followRedirects(true);
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode(), $response->getContent());
-        Assert::assertSame('https://localhost/oauth/v2/authorize_login', $response->headers->get('Location'));
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND, $response->getContent());
+        self::assertResponseRedirects('https://localhost/oauth/v2/authorize_login');
     }
 
     public static function provideMethods(): \Generator

--- a/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
@@ -234,7 +234,7 @@ final class PutOperationTest extends MauticMysqlTestCase
             ])
         );
 
-        Assert::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $response = json_decode($this->client->getResponse()->getContent(), true);
 

--- a/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
@@ -162,7 +162,7 @@ final class PutOperationTest extends MauticMysqlTestCase
             ])
         );
 
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -93,10 +93,10 @@ class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         $content        = $clientResponse->getContent();
 
         if ($isAllowed) {
-            $this->assertSame(201, $clientResponse->getStatusCode(), $content);
+            $this->assertResponseStatusCodeSame(201, $content);
             $this->assertStringNotContainsString($message, $content);
         } else {
-            $this->assertSame(400, $clientResponse->getStatusCode(), $content);
+            $this->assertResponseStatusCodeSame(400, $content);
             $this->assertStringContainsString($message, $content);
         }
     }

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -182,7 +182,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->expectedMimeType, $response->headers->get('Content-Type'));
         $this->assertNotSame($this->expectedContentDisposition.$this->asset->getOriginalFileName(), $response->headers->get('Content-Disposition'));
         $this->assertEquals($this->expectedPngContent, $content);
@@ -200,7 +200,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->expectedContentDisposition.$this->asset->getOriginalFileName(), $response->headers->get('Content-Disposition'));
         $this->assertEquals($this->expectedPngContent, $content);
     }
@@ -217,7 +217,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $content = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode(), $content);
+        $this->assertResponseIsSuccessful($content);
         $this->assertNotEquals($this->expectedPngContent, $content);
         PageControllerTest::assertTrue($response->isOk());
 

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -219,7 +219,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
 
         $this->assertResponseIsSuccessful($content);
         $this->assertNotEquals($this->expectedPngContent, $content);
-        PageControllerTest::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         PageControllerTest::assertStringContainsString(
             '/asset/'.$this->asset->getSlug(),

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -256,7 +256,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
 
         $this->client->request(Request::METHOD_GET, "/s/assets/{$route}/{$asset->getId()}");
 
-        Assert::assertSame($expectedStatusCode, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame($expectedStatusCode);
     }
 
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,6 +19,6 @@ final class AssetDownloadFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returns 404 correctly
         $this->client->request(Request::METHOD_GET, '/asset/unicorn'); // returned 500 but it should return 404
 
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 }

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -125,11 +125,8 @@ class PublicControllerFunctionalTest extends AbstractAssetTestCase
         // Don't follow redirects automatically
         $this->client->followRedirects(false);
         $this->client->request('GET', '/asset/'.$asset->getSlug());
-
-        $response = $this->client->getResponse();
-
         $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
-        $this->assertSame($remotePath, $response->headers->get('Location'));
+        $this->assertResponseRedirects($remotePath);
     }
 
     public function testDownloadActionWithMissingLocalFile(): void

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -142,7 +142,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $this->client->request('GET', '/api/v2/downloads?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
 
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -220,7 +220,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $this->client->request('GET', '/api/v2/downloads?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -65,11 +65,9 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
 
         // Try to access the foreign download - should be forbidden
         $this->client->request('GET', '/api/v2/downloads/'.$foreignDownload->getId());
-        $response = $this->client->getResponse();
 
-        self::assertSame(
+        self::assertResponseStatusCodeSame(
             Response::HTTP_FORBIDDEN,
-            $response->getStatusCode(),
             'User with viewown permission should not be able to access downloads of assets they do not own. '.
             'This validates that ApiPermissionVoter correctly uses getPermissionUser() for Download entities.'
         );

--- a/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
@@ -35,7 +35,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         }
         $this->client->request(Request::METHOD_GET, '/api/campaigns?withContactCounts='.$withContactCounts);
         $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isOk());
+        $this->assertResponseIsSuccessful();
         $response = json_decode($clientResponse->getContent(), true);
         Assert::assertArrayHasKey('campaigns', $response);
         Assert::assertArrayHasKey($campaign->getId(), $response['campaigns']);

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -624,7 +624,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $property = ['removeFrom' => ['this']];
         $event1   = $this->createEvent('Event', $campaign, 'campaign.addremovelead', 'action', $property);
         $property = ['points' => 1];
-        $event2   = $this->createEvent('Event', $campaign, 'lead.changepoints', 'action', $property);
+        $this->createEvent('Event', $campaign, 'lead.changepoints', 'action', $property);
         $this->em->flush();
         $this->em->clear();
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -123,7 +123,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         // Now let's simulate email opens
         foreach ($stats as $stat) {
             $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
-            $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), var_export($this->client->getResponse()->getContent(), true));
+            $this->assertResponseIsSuccessful();
         }
 
         $byEvent = $this->getCampaignEventLogs([3, 4, 5, 10, 14, 15]);
@@ -290,7 +290,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         // Now let's simulate email opens
         foreach ($stats as $stat) {
             $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
-            $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), var_export($this->client->getResponse()->getContent(), true));
+            $this->assertResponseIsSuccessful();
         }
 
         $byEvent = $this->getCampaignEventLogs([3, 4, 5, 10, 14, 15]);
@@ -450,7 +450,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         // Now let's simulate email opens
         foreach ($stats as $stat) {
             $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
-            $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), var_export($this->client->getResponse()->getContent(), true));
+            $this->assertResponseIsSuccessful();
         }
 
         $byEvent = $this->getCampaignEventLogs([3, 4, 5, 10, 14, 15]);

--- a/app/bundles/CampaignBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -53,7 +53,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         /** @var LeadEventLog $log */
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('{"success":1}', $this->client->getResponse()->getContent());
         Assert::assertFalse($log->getIsScheduled());
     }

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -299,7 +299,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testExportCampaignAction(): void
     {
-        $entities = $this->createTestEntities();
+        $this->createTestEntities();
 
         // Create the campaign
         $campaign = new Campaign();

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
@@ -26,7 +26,7 @@ class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTestCas
         // Add the contact to the campaign.
         $this->client->request(Request::METHOD_POST, "/api/campaigns/{$campaign->getId()}/contact/{$contact->getId()}/add");
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('{"success":1}', $clientResponse->getContent());
 
         // Assert that the campaign member was really added.
@@ -39,7 +39,7 @@ class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTestCas
         // Get the contact's campaigns.
         $this->client->request(Request::METHOD_GET, "/api/contacts/{$contact->getId()}/campaigns");
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         $body = json_decode($clientResponse->getContent(), true);
         Assert::assertSame(1, $body['total'], $clientResponse->getContent());
         Assert::assertSame($campaign->getId(), $body['campaigns'][$campaign->getId()]['id'], $clientResponse->getContent());
@@ -51,7 +51,7 @@ class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTestCas
         // Get campaign contacts API endpoint.
         $this->client->request(Request::METHOD_GET, "/api/campaigns/{$campaign->getId()}/contacts");
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         $body = json_decode($clientResponse->getContent(), true);
         Assert::assertSame(3, (int) $body['total']);
         Assert::assertSame($contact->getId(), (int) $body['contacts'][2]['lead_id']);
@@ -59,7 +59,7 @@ class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTestCas
         // Remove the contact from the campaign.
         $this->client->request(Request::METHOD_POST, "/api/campaigns/{$campaign->getId()}/contact/{$contact->getId()}/remove");
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('{"success":1}', $clientResponse->getContent());
 
         // Assert that the campaign member was really removed.

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -14,7 +14,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
 {
@@ -309,7 +308,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $this->client->request(Request::METHOD_POST, '/s/campaigns/delete/'.$campaign->getId());
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful($response->getContent());
 
         $eventLogs = $this->em->getRepository(LeadEventLog::class)->findAll();
         Assert::assertCount(0, $eventLogs);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -364,7 +364,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $campaign = $this->saveSomeCampaignLeadEventLogs();
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns/view/%d', $campaign->getId()));
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
         self::assertStringContainsString('Campaign ABC', $response->getContent());
         self::assertSame('', trim($crawler->filter('#decisions-container')->text()));
         self::assertSame('', trim($crawler->filter('#actions-container')->text()));
@@ -379,7 +379,7 @@ class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $campaign = $this->saveSomeCampaignLeadEventLogs();
         $this->client->request('GET', sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $from, $to));
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
         $body     = json_decode($response->getContent(), true);
         self::assertCount(2, $body);
         self::arrayHasKey('actions');

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
@@ -75,7 +75,7 @@ class CampaignMetricsControllerFunctionalTest extends MauticMysqlTestCase
         $campaign = $testData['campaign'];
 
         $this->client->request(Request::METHOD_GET, "/s/campaign/metrics/email-weekdays/{$campaign->getId()}/2024-12-01/2024-12-12");
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $content      = $this->client->getResponse()->getContent();
         $crawler      = new Crawler($content);
         $daysJson     = $crawler->filter('canvas')->text(null, false);
@@ -103,7 +103,7 @@ class CampaignMetricsControllerFunctionalTest extends MauticMysqlTestCase
         $campaign = $testData['campaign'];
 
         $this->client->request(Request::METHOD_GET, "/s/campaign/metrics/email-hours/{$campaign->getId()}/2024-12-01/2024-12-12");
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $content   = $this->client->getResponse()->getContent();
         $crawler   = new Crawler($content);
         $hourJson  = $crawler->filter('canvas')->text(null, false);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -11,8 +11,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     {
         // Check the message in the Campaign edit page
         $crawler  = $this->client->request('GET', '/s/campaigns/new');
-        $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $attributes = [
             'data-toggle',
@@ -40,8 +39,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
 
         // Check the message in the Campaign edit page
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns/edit/%d', $campaign->getId()));
-        $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $republishBehavior = $translator->trans('mautic.campaignconfig.campaign_republish_behavior.'.$campaign->getRepublishBehavior());
 
@@ -73,8 +71,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
 
         // Check the message in the Campaign listing page
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns'));
-        $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $republishBehavior = $translator->trans('mautic.campaignconfig.campaign_republish_behavior.'.$campaign->getRepublishBehavior());
 
@@ -103,7 +100,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'campaign', 'id' => $campaign->getId()]);
         $response = $this->client->getResponse();
 
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $attributes    = [
             'onclick'               => 'Mautic.confirmationCampaignPublishStatus(mQuery(this));',

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
@@ -90,11 +90,7 @@ class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $contacts = $response['contacts'];
         self::assertCount(150, $contacts);
-        self::assertSame(
-            201,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(201, $this->client->getResponse()->getContent());
 
         return $contacts;
     }

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -82,7 +82,7 @@ class CampaignRotationTest extends MauticMysqlTestCase
 
         $response = $this->client->getResponse();
 
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $withJumpLog    = $this->campaignLeadRepository->getContactRotations([$this->lead->getId()], $this->campaignWithJump->getId());
         $withoutJumpLog = $this->campaignLeadRepository->getContactRotations([$this->lead->getId()], $this->campaignWithoutJump->getId());
@@ -103,7 +103,7 @@ class CampaignRotationTest extends MauticMysqlTestCase
 
         $response = $this->client->getResponse();
 
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $withJumpLog    = $this->campaignLeadRepository->getContactRotations([$this->lead->getId()], $this->campaignWithJump->getId());
         $withoutJumpLog = $this->campaignLeadRepository->getContactRotations([$this->lead->getId()], $this->campaignWithoutJump->getId());

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -80,8 +80,6 @@ class CampaignRotationTest extends MauticMysqlTestCase
 
         $this->client->request('GET', sprintf('/%s', $this->page->getAlias()));
 
-        $response = $this->client->getResponse();
-
         self::assertResponseIsSuccessful();
 
         $withJumpLog    = $this->campaignLeadRepository->getContactRotations([$this->lead->getId()], $this->campaignWithJump->getId());
@@ -100,8 +98,6 @@ class CampaignRotationTest extends MauticMysqlTestCase
         );
 
         $this->client->request('GET', sprintf('/%s', $this->page->getAlias()));
-
-        $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
@@ -53,7 +53,7 @@ final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCa
         ];
 
         $this->client->request(Request::METHOD_POST, sprintf('/s/campaigns/events/edit/%s', $campaignCondition->getId()), $payload, [], $this->createAjaxHeaders());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // version should be incremented as campaign's "modified by user" is updated
         $this->refreshAndSubmitForm($campaign, ++$version);
@@ -95,7 +95,7 @@ final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCa
         $response = $this->client->getResponse();
 
         // This is the core assertion - the request should succeed (no HTTP 500)
-        Assert::assertTrue($response->isOk(), 'EventController should handle scalar to array value conversion without HTTP 500');
+        self::assertResponseIsSuccessful();
 
         // Additional verification: ensure response is valid JSON
         Assert::assertJson($response->getContent());

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTrait.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTrait.php
@@ -20,7 +20,7 @@ trait CampaignControllerTrait
     private function refreshPage(Campaign $campaign): Crawler
     {
         $crawler = $this->client->request('GET', sprintf('/s/campaigns/edit/%s', $campaign->getId()));
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         Assert::assertStringContainsString('Edit Campaign', $crawler->text());
 
         return $crawler;
@@ -38,7 +38,7 @@ trait CampaignControllerTrait
         $form = $crawler->selectButton('Save')->form();
         $form->setValues($formValues);
         $newCrawler = $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->em->clear();
         $campaign = $this->em->find(Campaign::class, $campaign->getId());

--- a/app/bundles/CampaignBundle/Tests/Functional/Validator/OrphanEventsValidationFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Validator/OrphanEventsValidationFunctionalTest.php
@@ -265,7 +265,7 @@ final class OrphanEventsValidationFunctionalTest extends MauticMysqlTestCase
         $form       = $crawler->selectButton('Save')->form();
         $newCrawler = $this->client->submit($form);
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // Verify the validation error message is displayed
         Assert::assertStringContainsString(

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -11,7 +11,6 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -61,7 +60,7 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('TestTitleCategoryController1', $clientResponseContent, 'The return must contain TestTitleCategoryController1');
         $this->assertStringContainsString('TestTitleCategoryController2', $clientResponseContent, 'The return must contain TestTitleCategoryController2');
     }
@@ -75,7 +74,7 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('TestTitleCategoryController1', $clientResponseContent, 'The return must contain TestTitleCategoryController1');
         $this->assertStringNotContainsString('TestTitleCategoryController2', $clientResponseContent, 'The return must not contain TestTitleCategoryController2');
     }
@@ -219,14 +218,14 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $this->client->request(Request::METHOD_GET, 's/categories/category/edit/'.$category->getId());
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $role = $this->createRole(true);
         $user = $this->createUser($role);
         $this->em->flush();
         $this->client->restart();
         $this->loginUser($user);
         $this->client->request(Request::METHOD_GET, 's/categories/category/edit/'.$category->getId());
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString(
             'Category for concurrent edit is currently checked out by',
             $this->client->getResponse()->getContent()
@@ -246,7 +245,7 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->loginUser($user);
         $this->client->request(Request::METHOD_GET, 's/categories/category/edit/'.$category->getId());
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString(
             'You do not have access to the requested area',
             $this->client->getResponse()->getContent()

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -9,7 +9,6 @@ use Mautic\StageBundle\Entity\Stage;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -93,7 +92,7 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $form['category_form[inForm]']->setValue('1');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $clientResponse = $this->client->getResponse();
         $body           = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('categoryId', $body);
@@ -134,9 +133,8 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $form['category_form[inForm]']->setValue('1');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
-        $clientResponse = $this->client->getResponse();
-        $body           = json_decode($clientResponse->getContent(), true);
+        self::assertResponseIsSuccessful();
+
         $this->assertNotEmpty($crawler->filter('select#category_form_bundle')->count(), 'The "Type" (bundle) field should remain visible after validation failure.');
     }
 

--- a/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
@@ -19,7 +19,7 @@ class SysinfoControllerTest extends MauticMysqlTestCase
 
         // Request sysinfo page
         $crawler = $this->client->request(Request::METHOD_GET, '/s/sysinfo');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $dbVersion       = $crawler->filterXPath("//td[@id='dbinfo-version']")->text();
         $dbDriver        = $crawler->filterXPath("//td[@id='dbinfo-driver']")->text();

--- a/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
+++ b/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
@@ -9,6 +9,6 @@ class FunctionalWarmupTest extends MauticMysqlTestCase
     public function testWarmup(): void
     {
         $this->client->request('GET', '/404');
-        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\HttpFoundation\Response;
 
 class AbstractFormControllerTest extends MauticMysqlTestCase
 {
@@ -28,7 +26,7 @@ class AbstractFormControllerTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $payload        = $clientResponse->getContent();
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         $this->assertStringContainsString("Forms\n</h1>", $payload);
     }
 
@@ -50,7 +48,7 @@ class AbstractFormControllerTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
         $payload  = $response->getContent();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Dashboard</h1>', $payload);
     }
 
@@ -72,7 +70,7 @@ class AbstractFormControllerTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
         $payload  = $response->getContent();
 
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Dashboard</h1>', $payload);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -50,7 +50,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content      = \json_decode($response->getContent(), true);
         $expectedLink = rtrim($expectedLink, '/').'/'.$entity->getId();
@@ -284,7 +284,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search=user&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content = \json_decode($response->getContent(), true);
         $this->assertStringContainsString('s/users/edit/'.$user->getId(), $content['newContent']);
@@ -318,7 +318,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
 
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk(), $response->getContent());
+        $this->assertResponseIsSuccessful();
         $content = \json_decode($response->getContent(), true);
         $this->assertArrayHasKey('newContent', $content);
 
@@ -392,7 +392,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $searchString = '';
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content = \json_decode($response->getContent(), true);
         $this->assertGlobalSearchNotResult($content['newContent']);
@@ -400,7 +400,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $searchString = 'random';
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content = \json_decode($response->getContent(), true);
         $this->assertGlobalSearchNotResult($content['newContent']);
@@ -434,7 +434,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $searchString = 'john';
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content = \json_decode($response->getContent(), true);
 
@@ -448,7 +448,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $searchString = 'client';
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=globalSearch&global_search='.$searchString.'&tmp=list');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $content = \json_decode($response->getContent(), true);
 

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ConfigControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ConfigControllerTest.php
@@ -31,7 +31,7 @@ final class ConfigControllerTest extends MauticMysqlTestCase
     public function testListOfRemoteDomainsVisibility(bool $enabled): void
     {
         $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $content = $this->client->getResponse()->getContent();
         $label   = 'List of allowed remote domains (one per line)';

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
@@ -10,7 +10,6 @@ use Mautic\ReportBundle\Entity\Report;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
@@ -35,7 +34,7 @@ final class ExportControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/s/contacts');
         $this->assertStringContainsString('Export to CSV', $this->client->getResponse()->getContent());
         $this->client->request(Request::METHOD_GET, '/s/contacts/batchExport?filetype=csv');
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
     }
 
     public function testFormExportAction(): void
@@ -51,7 +50,7 @@ final class ExportControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/s/forms/results/'.$formId);
         $this->assertStringContainsString('Export to CSV', $this->client->getResponse()->getContent());
         $this->client->request(Request::METHOD_GET, '/s/forms/results/'.$formId.'/export');
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     public function testReportExportAction(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 final class ThemeControllerTest extends MauticMysqlTestCase
 {
@@ -65,7 +64,7 @@ final class ThemeControllerTest extends MauticMysqlTestCase
     public function testBatchDeleteActionValidation(): void
     {
         $this->client->request(Request::METHOD_POST, 's/themes/batchDelete?ids=[%22aurora%22,%22brienz%22]');
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('aurora is the default theme and therefore cannot be removed.', $this->client->getResponse()->getContent());
         $this->assertStringContainsString('brienz is the default theme and therefore cannot be removed.', $this->client->getResponse()->getContent());
     }
@@ -83,7 +82,7 @@ final class ThemeControllerTest extends MauticMysqlTestCase
         $themesProperty->setValue($themeHelper, []);
 
         $this->client->request(Request::METHOD_POST, '/s/themes/batchDelete?ids=[%22blanktest%22,%22auroratest%22]');
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('2 themes have been deleted!', $this->client->getResponse()->getContent(), $this->client->getResponse()->getContent());
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
@@ -11,7 +11,7 @@ class CommonRepositoryTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', 's/contacts?search=is:mine');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:mine', $this->client->getResponse()->getContent());
     }
 
@@ -19,7 +19,7 @@ class CommonRepositoryTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', 's/companies?search=is:mine');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:mine', $this->client->getResponse()->getContent());
     }
 
@@ -27,7 +27,7 @@ class CommonRepositoryTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', 's/emails?search=is:published');
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:published', $this->client->getResponse()->getContent());
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
@@ -165,7 +165,7 @@ class ConfigSubscriberTest extends MauticMysqlTestCase
         );
 
         $crawler = $this->client->submit($form);
-        Assert::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         return $crawler;
     }

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
@@ -150,7 +150,7 @@ class ConfigSubscriberTest extends MauticMysqlTestCase
     private function setImagePathRequest(string $value): Crawler
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // Find save & close button
         $buttonCrawler = $crawler->selectButton('config[buttons][save]');

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/EditorFontsSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/EditorFontsSubscriberTest.php
@@ -33,7 +33,7 @@ class EditorFontsSubscriberTest extends MauticMysqlTestCase
         $crawler  = $this->client->request(Request::METHOD_GET, '/');
         $response = $crawler->html();
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         Assert::assertStringContainsString(
             'var mauticEditorFonts               = [{"name":"Arial","font":"Arial, Helvetica, sans-serif","url":"https:\/\/custom-font.test\/arial.css"},{"name":"Courier New","font":"Courier New, Courier, monospace","url":"https:\/\/custom-font.test\/courier.css"}];',

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -83,7 +83,7 @@ class SamlTest extends MauticMysqlTestCase
         ]);
         $this->client->submit($configForm);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         $content = $clientResponse->getContent();
         Assert::assertNotFalse($content);
         Assert::assertStringContainsString('Configuration successfully updated', $content);
@@ -130,7 +130,7 @@ class SamlTest extends MauticMysqlTestCase
         // Get the form for authentication.
         $response = $guzzleClient->request(Request::METHOD_GET, $url);
         \assert($response instanceof \GuzzleHttp\Psr7\Response);
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $body    = (string) $response->getBody();
         $crawler = new Crawler($body, $url);
@@ -150,7 +150,7 @@ class SamlTest extends MauticMysqlTestCase
         );
         \assert($response instanceof \GuzzleHttp\Psr7\Response);
         // Because guzzle does not support javascript the answer is a form.
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $body        = (string) $response->getBody();
         $crawler     = new Crawler($body, $url);
@@ -174,7 +174,7 @@ class SamlTest extends MauticMysqlTestCase
 
         $this->client->followRedirect();
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         $content = $clientResponse->getContent();
         Assert::assertNotFalse($content);
         Assert::assertStringContainsString('user1@example.com user1@example.com', $content);

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -83,7 +83,7 @@ class SamlTest extends MauticMysqlTestCase
         ]);
         $this->client->submit($configForm);
         $clientResponse = $this->client->getResponse();
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
         $content = $clientResponse->getContent();
         Assert::assertNotFalse($content);
         Assert::assertStringContainsString('Configuration successfully updated', $content);
@@ -130,7 +130,7 @@ class SamlTest extends MauticMysqlTestCase
         // Get the form for authentication.
         $response = $guzzleClient->request(Request::METHOD_GET, $url);
         \assert($response instanceof \GuzzleHttp\Psr7\Response);
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $body    = (string) $response->getBody();
         $crawler = new Crawler($body, $url);
@@ -150,7 +150,7 @@ class SamlTest extends MauticMysqlTestCase
         );
         \assert($response instanceof \GuzzleHttp\Psr7\Response);
         // Because guzzle does not support javascript the answer is a form.
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $body        = (string) $response->getBody();
         $crawler     = new Crawler($body, $url);
@@ -174,7 +174,7 @@ class SamlTest extends MauticMysqlTestCase
 
         $this->client->followRedirect();
         $clientResponse = $this->client->getResponse();
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
         $content = $clientResponse->getContent();
         Assert::assertNotFalse($content);
         Assert::assertStringContainsString('user1@example.com user1@example.com', $content);

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -102,16 +102,16 @@ class SamlTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         // The request is going straight to discovery, thus sparing one redirect, that otherwise would be done anyway.
         // @see \LightSaml\SpBundle\Controller\DefaultController::loginAction if 'idp' is empty.
-        Assert::assertSame('/saml/discovery', $clientResponse->headers->get('Location'));
+        self::assertResponseRedirects('/saml/discovery');
         $this->client->followRedirect();
 
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        Assert::assertSame('/s/saml/login?idp=http://'.$host.':'.$port.'/simplesaml/saml2/idp/metadata.php', $clientResponse->headers->get('Location'));
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND, $clientResponse->getContent());
+        self::assertResponseRedirects('/s/saml/login?idp=http://'.$host.':'.$port.'/simplesaml/saml2/idp/metadata.php');
         $this->client->followRedirect();
 
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND, $clientResponse->getContent());
         Assert::assertStringContainsString('http://'.$host.':'.$port.'/simplesaml/saml2/idp/SSOService.php?SAMLRequest=', $clientResponse->headers->get('Location'));
 
         // Here need to replicate the browser. The default client will not work, because the test must request an external service.
@@ -164,13 +164,13 @@ class SamlTest extends MauticMysqlTestCase
             $form->getPhpValues(),
         );
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        Assert::assertSame('https://localhost/s/dashboard', $clientResponse->headers->get('Location'));
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND, $clientResponse->getContent());
+        self::assertResponseRedirects('https://localhost/s/dashboard');
 
         $this->client->followRedirect();
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        Assert::assertSame('/s/dashboard', $clientResponse->headers->get('Location'));
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND, $clientResponse->getContent());
+        self::assertResponseRedirects('/s/dashboard');
 
         $this->client->followRedirect();
         $clientResponse = $this->client->getResponse();

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -62,7 +62,6 @@ class LocalFileAdapterServiceTest extends MauticMysqlTestCase
             Request::METHOD_POST,
             "efconnect?cmd=mkdir&name=$this->folderName&target=fls1_Lw"
         );
-        $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         /** @var PathsHelper $pathsHelper */
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -63,7 +63,7 @@ class LocalFileAdapterServiceTest extends MauticMysqlTestCase
             "efconnect?cmd=mkdir&name=$this->folderName&target=fls1_Lw"
         );
         $response = $this->client->getResponse();
-        self::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         /** @var PathsHelper $pathsHelper */
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');
         $folderPath  = "{$pathsHelper->getImagePath()}/$this->folderName";

--- a/app/bundles/CoreBundle/Tests/Traits/ControllerTrait.php
+++ b/app/bundles/CoreBundle/Tests/Traits/ControllerTrait.php
@@ -18,7 +18,7 @@ trait ControllerTrait
         $crawler         = $this->client->request('GET', '/s/'.$urlAlias);
         $clientResponse  = $this->client->getResponse();
         $responseContent = $clientResponse->getContent();
-        PageControllerTest::assertTrue($clientResponse->isOk());
+        $this->assertResponseIsSuccessful();
 
         PageControllerTest::assertStringContainsString(
             'col-'.$routeAlias.'-dateAdded',

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -34,7 +34,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $this->createAndLoginUser(self::PERMISSION_CREATE);
         $this->client->request(Request::METHOD_GET, '/s/dwc/new');
 
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
     }
 
     public function testNoNestingValidationNewAction(): void
@@ -78,7 +78,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $this->createAndLoginUser(self::PERMISSION_DELETE_OWN);
         $this->client->request(Request::METHOD_POST, '/s/dwc/delete');
 
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
     }
 
     public function testForbiddenDeleteAction(): void

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -40,7 +40,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
     public function testNoNestingValidationNewAction(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/dwc/new');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $this->submitFormAndAssertNoNestingValidation($crawler);
     }
@@ -56,7 +56,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
     public function testNoNestingValidationEditAction(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/dwc/new');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $buttonCrawler = $crawler->selectButton('Save');
         $form          = $buttonCrawler->form();
@@ -66,7 +66,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         ]);
         $crawler = $this->client->submit($form);
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertStringNotContainsString(self::NO_NESTING_VALIDATION_MESSAGE, $crawler->text());
         Assert::assertStringContainsString('Edit Dynamic Content', $crawler->text());
 
@@ -227,7 +227,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         ]);
         $crawler = $this->client->submit($form);
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString(self::NO_NESTING_VALIDATION_MESSAGE, $crawler->text());
     }
 }

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -50,7 +50,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request(Request::METHOD_GET, '/s/dwc/new');
 
-        Assert::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testNoNestingValidationEditAction(): void
@@ -86,7 +86,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request('GET', '/s/dwc/delete');
 
-        Assert::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testDwcWithProject(): void

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -78,7 +78,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $parameters = self::getContainer()->get('mautic.helper.core_parameters');
 
         $this->client->request(Request::METHOD_POST, '/s/ajax?action=email:sendTestEmail');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $this->assertQueuedEmailCount(0, message: 'Test emails should never be queued.');
         $this->assertEmailCount(1);
@@ -126,7 +126,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, "/s/ajax?action=email:getEmailDeliveredCount&id={$email->getId()}");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertSame([
             'success'         => 1,
             'delivered'       => 1,
@@ -181,7 +181,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, "/s/ajax?action=email:getEmailDeliveredCount&id={$emailEn->getId()}");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertSame([
             'success'         => 1,
             'delivered'       => 1,
@@ -224,7 +224,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, "/s/ajax?action=email:heatmap&id={$email->getId()}");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $content = json_decode($response->getContent(), true);
         $this->assertSame('Test html', $content['content']);
         $this->assertSame([
@@ -288,7 +288,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     public function testGetBuilderTokensAction(): void
     {
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=email:getBuilderTokens');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $response = json_decode($this->client->getResponse()->getContent(), true);
         Assert::assertArrayHasKey('tokens', $response);
         Assert::assertArrayHasKey('{contactfield=email}', $response['tokens']);

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -280,7 +280,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertNotEmpty($response);
         $this->assertEquals($emailName.' ('.$email->getId().')', $response[0]['items'][$email->getId()]);
     }

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -215,7 +215,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($emailId, $response['email']['id']);
         $this->assertTrue($response['email']['sendToDnc']);
         $this->assertEquals('API email renamed', $response['email']['name']);
@@ -235,7 +235,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($emailId, $response['email']['id']);
         $this->assertEquals($payload['name'], $response['email']['name']);
         $this->assertEquals('Email created via API test renamed', $response['email']['subject']);
@@ -252,7 +252,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($emailId, $response['email']['id']);
         $this->assertEquals($payload['name'], $response['email']['name']);
         $this->assertEquals($payload['subject'], $response['email']['subject']);
@@ -265,7 +265,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertNull($response['email']['id']);
         $this->assertEquals($payload['name'], $response['email']['name']);
         $this->assertEquals($payload['subject'], $response['email']['subject']);
@@ -288,7 +288,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Response should include the two entities that we just deleted
         $this->assertSame(2, count($response['lists']));
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testReplyActionIfNotFound(): void
@@ -599,7 +599,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $sendResponse   = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertEquals($sendResponse, ['success' => true, 'sentCount' => 1, 'failedRecipients' => 0], $clientResponse->getContent());
 
         $testEmail = function (string $customToken): void {
@@ -623,7 +623,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $sendResponse = json_decode($clientResponse->getContent(), true);
 
@@ -642,7 +642,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $sendResponse   = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertEquals($sendResponse, ['success' => true, 'sentCount' => 1, 'failedRecipients' => 0], $clientResponse->getContent());
 
         $testEmailOwnerAsMailer = function (): void {
@@ -667,7 +667,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', "/api/emails/{$emailId}/contact/{$contactId}/send");
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $sendResponse = json_decode($clientResponse->getContent(), true);
 
@@ -685,7 +685,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', "/api/emails/{$emailId}/contact/{$contactId}/send");
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $sendResponse = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -147,7 +147,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $response = $response['email'];
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
         Assert::assertSame($payload['name'], $response['name']);
         Assert::assertSame($payload['subject'], $response['subject']);
         Assert::assertSame($payload['customHtml'], $response['customHtml']);
@@ -176,7 +176,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $segmentAId      = $segmentResponse['lists'][0]['id'];
         $segmentBId      = $segmentResponse['lists'][1]['id'];
 
-        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(201);
         $this->assertGreaterThan(0, $segmentAId);
 
         // Create email with the new segment:
@@ -193,7 +193,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $emailId        = $response['email']['id'];
 
-        $this->assertSame(201, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(201);
         $this->assertGreaterThan(0, $emailId);
         $this->assertEquals($payload['name'], $response['email']['name']);
         $this->assertEquals($payload['subject'], $response['email']['subject']);
@@ -278,7 +278,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(404, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(404);
         $this->assertSame(404, $response['errors'][0]['code']);
 
         // Delete also testing segments:
@@ -300,7 +300,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $response     = $this->client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertSame('Email Stat with tracking hash tracking_hash_123 was not found', $responseData['errors'][0]['message']);
     }
 
@@ -329,11 +329,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
 
-        Assert::assertSame(
-            Response::HTTP_CREATED,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $createdEmail = json_decode($this->client->getResponse()->getContent(), true)['email'];
         Assert::assertSame($expectedIsPublished, $createdEmail['isPublished']);
@@ -496,7 +492,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
         $response = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame(['success' => true], json_decode($response->getContent(), true));
 
         // Get the email reply that was just created from the stat API.

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiDefaultsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiDefaultsFunctionalTest.php
@@ -59,7 +59,7 @@ final class EmailApiDefaultsFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true)['email'];
 
@@ -94,7 +94,7 @@ final class EmailApiDefaultsFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true)['email'];
 

--- a/app/bundles/EmailBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -24,7 +24,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
 
         // request config edit page
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // set form data
         $form   = $crawler->selectButton('config[buttons][save]')->form();
@@ -42,7 +42,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         $values['config']['emailconfig']['mailer_dsn']['options']['list']['0']['value']  = $data['type'];
 
         $this->client->request($form->getMethod(), $form->getUri(), $values);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // check the DSN is escaped properly in the config file (both using double percent signs and URL encoded)
         $configParameters = $this->getConfigParameters();
@@ -58,7 +58,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
 
         // check values are unescaped properly in the edit form
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('config[buttons][save]')->form();
         Assert::assertEquals($data['scheme'], $form['config[emailconfig][mailer_dsn][scheme]']->getValue());
@@ -78,7 +78,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
     {
         // request config edit page
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // set form data
         $form = $crawler->selectButton('config[buttons][save]')->form();
@@ -89,7 +89,7 @@ class ConfigControllerFunctionalTest extends MauticMysqlTestCase
 
         // check if there is the given validation error
         $crawler = $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString($expectedMessage, $crawler->text());
     }
 

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -86,8 +86,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     public function testIndexActionWhenFiltering(): void
     {
         $this->client->request('GET', '/s/emails?search=has%3Aresults&tmpl=list');
-        $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful('Return code must be 200.');
+        $this->assertResponseIsSuccessful();
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -511,7 +511,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $form['emailform[isPublished]']->setValue('1');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $emails = $this->em->getRepository(Email::class)->findBy([], ['id' => 'ASC']);
         Assert::assertCount(2, $emails);
@@ -667,7 +667,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $form['emailform[isPublished]']->setValue('1');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $emails = $this->em->getRepository(Email::class)->findBy([], ['id' => 'ASC']);
         Assert::assertCount(2, $emails);
@@ -703,7 +703,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $form['emailform[isPublished]']->setValue('1');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $errString = sprintf('The Dynamic Content slot &#039;%s&#039; is not of type &#039;text&#039;.', $dwc->getSlotName());
         if (TypeList::TEXT === $type) {
             $this->assertStringNotContainsString($errString, $this->client->getResponse()->getContent());
@@ -807,7 +807,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
             'batchLimit' => $batchLimit,
         ]);
 
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertSame('{"success":1,"percent":100,"progress":[2,2],"stats":{"sent":2,"failed":0,"failedRecipients":[]}}', $this->client->getResponse()->getContent());
         $this->assertQueuedEmailCount(2);
     }
@@ -815,7 +815,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
     public function testPublishPermissionOnNewEmailForAdminUser(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $isUnpublishedInput = $crawler->filter('input[name="emailform[isPublished]"][value="0"]:not([disabled="disabled"][checked])');
         $isPublishedInput   = $crawler->filter('input[name="emailform[isPublished]"][value="1"][checked]:not([disabled="disabled"])');
         $publishUpInput     = $crawler->filter('input[name="emailform[publishUp]"]:not([disabled="disabled"])');
@@ -832,7 +832,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $form['emailform[template]']->setValue('blank');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $email = $this->em->getRepository(Email::class)->findOneBy(['name' => 'Email publish test']);
         Assert::assertTrue($email->getIsPublished());
@@ -913,7 +913,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $email = $this->createEmail('Email A', 'Email A Subject', 'template', 'blank', 'Test html');
         $this->em->flush();
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $isUnpublishedInput = $crawler->filter('input[name="emailform[isPublished]"][value="0"]:not([disabled="disabled"][checked])');
         $isPublishedInput   = $crawler->filter('input[name="emailform[isPublished]"][value="1"][checked]:not([disabled="disabled"])');
         $publishUpInput     = $crawler->filter('input[name="emailform[publishUp]"]:not([disabled="disabled"])');
@@ -1046,7 +1046,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->xmlHttpRequest('GET', '/s/ajax', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -1276,7 +1276,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
         $form['emailform[name]']->setValue($longName);
@@ -1383,7 +1383,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $longSubject = str_repeat('b', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
         $form['emailform[name]']->setValue('Valid Name');
@@ -1406,7 +1406,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $longName = str_repeat('a', Email::MAX_NAME_SUBJECT_LENGTH + 1); // 191 characters
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('emailform[buttons][save]')->form();
         $form['emailform[name]']->setValue($longName);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailDraftFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailDraftFunctionalTest.php
@@ -86,7 +86,7 @@ final class EmailDraftFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
         $form    = $crawler->selectButton('Apply Draft')->form();
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $emailDraft = $this->em->getRepository(EmailDraft::class)->findOneBy(['email' => $email]);
 
@@ -100,7 +100,7 @@ final class EmailDraftFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
         $form    = $crawler->selectButton('Discard Draft')->form();
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $emailDraft = $this->em->getRepository(EmailDraft::class)->findOneBy(['email' => $email]);
 
@@ -115,7 +115,7 @@ final class EmailDraftFunctionalTest extends MauticMysqlTestCase
         $form                          = $crawler->selectButton('Save as Draft')->form();
         $form['emailform[customHtml]'] = 'Test html Draft';
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $emailDraft = $this->em->getRepository(EmailDraft::class)->findOneBy(['email' => $email]);
         Assert::assertEquals('Test html Draft', $emailDraft->getHtml());

--- a/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
@@ -35,14 +35,14 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
         $form = $crawler->selectButton(self::SAVE_AND_CLOSE)->form();
 
         // change lists/excludedLists and submit the form
         $form['emailform[excludedLists]']->setValue([$listOne->getId(), $listThree->getId()]); // @phpstan-ignore-line
         $crawler = $this->client->submit($form);
 
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('The same segment cannot be excluded and included in the same time.', $crawler->html());
     }
 
@@ -63,7 +63,7 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
 
         $form = $crawler->selectButton(self::SAVE_AND_CLOSE)->form();
 
@@ -86,7 +86,7 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $excludedListsField->setValue([$listTwo->getId(), $listThree->getId()]);
         $this->client->submit($form);
 
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
 
         $email = $this->em->find(Email::class, $email->getId());
 
@@ -139,7 +139,7 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/edit/{$email->getId()}");
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
 
         $form = $crawler->selectButton(self::SAVE_AND_CLOSE)->form();
 
@@ -149,7 +149,7 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $preferenceCenterField->setValue((string) $preferenceCenterTwo->getId());
         $this->client->submit($form);
 
-        $this->assertResponseOk();
+        self::assertResponseIsSuccessful();
 
         $email = $this->em->find(Email::class, $email->getId());
 
@@ -247,10 +247,5 @@ class EmailFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($page);
 
         return $page;
-    }
-
-    private function assertResponseOk(): void
-    {
-        Assert::assertTrue($this->client->getResponse()->isOk());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\LeadList;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 class EmailGraphStatsControllerFunctionalTest extends MauticMysqlTestCase
@@ -18,7 +17,7 @@ class EmailGraphStatsControllerFunctionalTest extends MauticMysqlTestCase
         $email = $this->createAndPersistEmail('Email A');
 
         $this->client->request(Request::METHOD_GET, "/s/emails-graph-stats/{$email->getId()}/0/2022-08-21/2022-09-21");
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     public function testSegmentViewAction(): void
@@ -27,7 +26,7 @@ class EmailGraphStatsControllerFunctionalTest extends MauticMysqlTestCase
         $email   = $this->createAndPersistEmail('Email B', $segment);
 
         $this->client->request(Request::METHOD_GET, "/s/emails-graph-stats/{$email->getId()}/0/2022-08-21/2022-09-21");
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     private function createAndPersistEmail(string $name, ?LeadList $segment = null): Email

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -94,10 +94,9 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), var_export($this->client->getResponse()->getContent(), true));
+        $this->assertResponseIsSuccessful();
 
         self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), $crawler->filter('form')->eq(0)->attr('action'));
-        $this->assertTrue($this->client->getResponse()->isOk());
     }
 
     public function testContactPreferencesLandingPageTracking(): void
@@ -125,7 +124,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         $form = $crawler->filter('form')->form();
 
         // Unsubscribe from email.
@@ -134,12 +133,12 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertStringContainsString('/email/unsubscribe/tracking_hash_unsubscribe_form_email', $form->getUri());
         $crawler = $this->client->submit($form);
 
-        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $this->assertEquals(1, $crawler->filter('#success-message-text')->count(), $this->client->getResponse()->getContent());
         $expectedMessage = static::getContainer()->get('translator')->trans('mautic.email.preferences_center_success_message.text');
         $this->assertEquals($expectedMessage, trim($crawler->filter('#success-message-text')->text(null, false)));
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         // Assert that the contact has the DNC record now.
         $dncRepository = $this->em->getRepository(DoNotContact::class);
@@ -162,7 +161,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
         self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), $crawler->filter('form')->eq(0)->attr('action'));
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testUnsubscribeFormActionWithThemeWithFormSupport(): void
@@ -176,7 +175,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
         self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), $crawler->filter('form')->eq(0)->attr('action'));
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testWithoutUnsubscribeFormAction(): void
@@ -190,7 +189,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
         self::assertStringNotContainsString('form/submit?formId=', $crawler->html());
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testOneClickUnsubscribeAction(): void
@@ -201,7 +200,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/email/unsubscribe/'.$stat->getTrackingHash(), [
             'List-Unsubscribe' => 'One-Click',
         ]);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $dncCollection = $stat->getLead()->getDoNotContact();
         $this->assertEquals(1, $dncCollection->count());
         $this->assertEquals(DoNotContact::UNSUBSCRIBED, $dncCollection->first()->getReason());
@@ -242,7 +241,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Save preferences', $crawler->html());
     }
 
@@ -310,7 +309,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $translator = static::getContainer()->get('translator');
         $needle     = $translator->trans('mautic.page.form.saveprefs', [], null, $expectedLocale);
@@ -425,7 +424,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $this->client->request('GET', '/email/preview/'.$email->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testPreviewForExpiredEmailForAnonymousUser(): void
@@ -446,7 +445,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $this->client->request('GET', '/email/preview/'.$email->getId());
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -618,8 +617,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         // Get the unsubscribe page
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        // Assert that the response is OK
-        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         // Assert that the link for unsubscribe all exists
         $unsubscribeAllLink = $crawler->filter('a[href^="/email/dnc/"]')->first();
@@ -629,8 +627,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         // Click the link for unsubscribe all
         $this->client->request('GET', $href);
 
-        // Assert that the response is OK
-        self::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         // Assert that the response contains the expected string
         $this->assertStringContainsString(

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -81,7 +81,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         self::getContainer()->get('event_dispatcher')->addListener(EmailEvents::ON_TRANSPORT_WEBHOOK, fn (TransportWebhookEvent $event) => $event->setResponse(new Response('OK')));
         $this->client->request('POST', '/mailer/callback');
 
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('OK', $this->client->getResponse()->getContent());
     }
 
@@ -565,7 +565,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
             'Record not found.',
             strip_tags((string) $this->client->getResponse()->getContent())
         );
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     public function testUnsubscribeWithEmailStat(): void
@@ -593,7 +593,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
             'We are sorry to see you go! john@doe.email will no longer receive emails from us. If this was by mistake, click here to re-subscribe.',
             strip_tags((string) $this->client->getResponse()->getContent())
         );
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         /** @var DoNotContactRepository $dncRepository */
         $dncRepository = $this->em->getRepository(DoNotContact::class);

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -63,7 +63,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request('POST', '/mailer/callback');
 
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         Assert::assertSame('No email transport that could process this callback was found', $this->client->getResponse()->getContent());
     }
 
@@ -72,7 +72,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
         self::getContainer()->get('event_dispatcher')->addListener(EmailEvents::ON_TRANSPORT_WEBHOOK, fn () => null /* exists but does nothing */);
         $this->client->request('POST', '/mailer/callback');
 
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         Assert::assertSame('No email transport that could process this callback was found', $this->client->getResponse()->getContent());
     }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -42,7 +42,7 @@ class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
         $this->em->flush();
 
         $crawler      = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $crawlerTable = $crawler->filterXPath('//*[contains(@href,"example.com")]')->closest('table');
 
         // convert html table to php array
@@ -99,7 +99,7 @@ class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
         $this->em->flush();
 
         $crawler            = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
         $crawlerGraphTable  = $crawler->filterXPath('//*[contains(@href,"example.com")]')->closest('table');
 
@@ -253,7 +253,7 @@ class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 
         // -- test report table in mautic panel
         $crawler            = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
 
         // convert html table to php array

--- a/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
@@ -7,7 +7,6 @@ namespace Mautic\EmailBundle\Tests\Functional\ApiPlatform;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Tests\Functional\ApiPlatform\OwnershipScopedApiAuthorizationTestBase;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\HttpFoundation\Response;
 
 final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
@@ -56,7 +55,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->client->request('GET', '/api/v2/emails?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -118,7 +117,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->client->request('GET', '/api/v2/emails?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 

--- a/app/bundles/EmailBundle/Tests/Functional/BotRatioHelperFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/BotRatioHelperFunctionalTest.php
@@ -56,7 +56,7 @@ final class BotRatioHelperFunctionalTest extends MauticMysqlTestCase
             'REMOTE_ADDR'     => $ipAddress,
         ];
         $this->client->request(Request::METHOD_GET, '/email/'.$stat->getTrackingHash().'.gif', [], [], $server);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $updatedStat = $this->em->getRepository(Stat::class)->findOneBy(['id'=>$statId]);
         $this->assertSame($isRead, $updatedStat->getIsRead());

--- a/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
@@ -150,7 +150,7 @@ class EmailTypeTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
         Assert::assertSame(Response::HTTP_CREATED, $response['statusCodes'][0], $clientResponse->getContent());
         Assert::assertSame(Response::HTTP_CREATED, $response['statusCodes'][1], $clientResponse->getContent());
         Assert::assertSame(Response::HTTP_CREATED, $response['statusCodes'][2], $clientResponse->getContent());

--- a/app/bundles/EmailBundle/Tests/Functional/Security/Permissions/EmailPermissionsTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Security/Permissions/EmailPermissionsTest.php
@@ -14,7 +14,7 @@ class EmailPermissionsTest extends MauticMysqlTestCase
     public function testEmailSendToDncPermissionIsAvailable(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/roles/new');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         Assert::assertStringContainsString('Send to unsubscribed contacts', $this->client->getResponse()->getContent());
 
@@ -28,7 +28,7 @@ class EmailPermissionsTest extends MauticMysqlTestCase
     public function testUserCanSaveSendToDncPermission(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/roles/new');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $submit = $crawler->selectButton('Save & Close');
         $form   = $submit->form();
@@ -37,7 +37,7 @@ class EmailPermissionsTest extends MauticMysqlTestCase
         $form['role[description]']->setValue('This is to send emails with "Send to DNC" permission');
         $form['role[permissions][email:emails][8]']->setValue('sendtodnc');
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $role               = $this->em->getRepository(Role::class)->findOneBy(['name' => 'Send To DNC Permission']);
         $readablePermission = $role->getRawPermissions();

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -581,7 +581,6 @@ class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 
         $this->fromEmaiHelper->method('getFromAddressConsideringOwner')->willReturn(new AddressDTO('someone@somewhere.com'));
         $routerMock = $this->createMock(Router::class);
-        $twig       = $this->createMock(Environment::class);
 
         $themeHelper = $this->createMock(ThemeHelper::class);
         $themeHelper->expects(self::never())

--- a/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
@@ -32,7 +32,7 @@ final class FieldCollectorTest extends \PHPUnit\Framework\TestCase
         $fieldCollector->getFields('contact');
 
         // Calling for the second time to ensure it's cached and the dispatcher is called only once.
-        $fieldCollection = $fieldCollector->getFields('contact');
+        $fieldCollector->getFields('contact');
 
         Assert::assertEquals(1, $dispatcher->dispatchMethodCallCounter);
     }

--- a/app/bundles/FormBundle/Tests/Collector/ObjectCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/ObjectCollectorTest.php
@@ -31,7 +31,7 @@ final class ObjectCollectorTest extends \PHPUnit\Framework\TestCase
         $objectCollector->getObjects();
 
         // Calling for the second time to ensure it's cached and the dispatcher is called only once.
-        $objectCollection = $objectCollector->getObjects();
+        $objectCollector->getObjects();
 
         Assert::assertEquals(1, $dispatcher->dispatchMethodCallCounter);
     }

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
@@ -26,7 +26,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertSame($expectedStatusCode, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
         $this->assertResponseIsSuccessful();
 
         $responseData = json_decode($response->getContent(), true);
@@ -64,7 +64,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
      * @param array<string, mixed> $updateData
      */
     #[DataProvider('updateFormDataProvider')]
-    public function testUpdateFormWithFieldsAndActions(array $initialFormData, array $updateData, int $expectedStatusCode): void
+    public function testUpdateFormWithFieldsAndActions(array $initialFormData, array $updateData): void
     {
         $form = $this->createForm($initialFormData);
 
@@ -75,7 +75,6 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertSame($expectedStatusCode, $response->getStatusCode());
         $this->assertResponseIsSuccessful();
 
         $responseData = json_decode($response->getContent(), true);
@@ -122,7 +121,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
 
         // The form creation should be rejected due to duplicate aliases
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $responseData = json_decode($response->getContent(), true);
 
         // Check for error response - could be either 'error' or 'errors' key depending on API format
@@ -157,8 +156,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
             $formData,
         );
 
-        $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
     }
 
     public function testUpdateFormRemovesUnspecifiedFieldsOnPut(): void
@@ -245,7 +243,6 @@ final class FormApiControllerTest extends MauticMysqlTestCase
             'update name only' => [
                 ['name' => 'Original Form'],
                 ['name' => 'Updated Form Name'],
-                Response::HTTP_OK,
             ],
             'add fields to existing form' => [
                 ['name' => 'Form without fields'],
@@ -258,7 +255,6 @@ final class FormApiControllerTest extends MauticMysqlTestCase
                         ],
                     ],
                 ],
-                Response::HTTP_OK,
             ],
         ];
     }

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -96,7 +96,7 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
             '/s/forms/field/new?type=companyLookup&tmpl=field&formId='.$form->getId().'&inBuilder=1'
         );
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -186,7 +186,6 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), json_encode($languageHelper->getLanguageChoices()));
         $form     = $response['form'];
-        $formId   = $form['id'];
 
         $crawler = $this->client->request('GET', '/form/'.$form['id']);
         $this->assertStringContainsString('Merci de patienter...', $crawler->html());
@@ -288,7 +287,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         // Visit the form preview page
-        $crawler = $this->client->request('GET', sprintf('/s/forms/preview/%d', $form->getId()));
+        $this->client->request('GET', sprintf('/s/forms/preview/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('First Option', $this->client->getResponse()->getContent());
         $this->assertStringContainsString('Second Option', $this->client->getResponse()->getContent());

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -39,7 +39,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testIndexActionWhenNotFiltered(): void
     {
         $this->client->request('GET', '/s/forms');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -48,7 +48,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testIndexActionWhenFiltering(): void
     {
         $this->client->request('GET', '/s/forms?search=has%3Aresults&tmpl=list');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -57,7 +57,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testNewActionForm(): void
     {
         $this->client->request('GET', '/s/forms/new/');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -66,7 +66,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testSaveActionForm(): void
     {
         $crawler = $this->client->request('GET', '/s/forms/new/');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $form->setValues(
@@ -76,7 +76,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $crawler = $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $form->setValues(
@@ -87,14 +87,14 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
 
         // The form failed to save when saved for the second time with renderStyle=No.
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertStringNotContainsString('Internal Server Error - Expected argument of type "null or string", "boolean" given', $this->client->getResponse()->getContent());
     }
 
     public function testNewActionCheckDisplayMessageOptionsForm(): void
     {
         $this->client->request('GET', '/s/forms/new');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $clientResponse = $this->client->getResponse();
         self::assertResponseStatusCodeSame(Response::HTTP_OK, $clientResponse->getContent());
         $this->assertStringContainsString('Hide form', $clientResponse->getContent(), $clientResponse->getContent());
@@ -105,7 +105,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testErrorValidationWithHideFormTypeWithoutMessage(): void
     {
         $crawler = $this->client->request('GET', '/s/forms/new/');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $selectedValue = $crawler->filter('#mauticform_postAction option:selected')->attr('value');
 
@@ -121,7 +121,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $crawler = $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $divClass = $crawler->filter('#mauticform_postActionProperty')->ancestors()->first()->attr('class');
         $this->assertStringContainsString('has-error', $divClass, $crawler->html());
     }
@@ -129,7 +129,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
     public function testSuccessWithHideForm(): void
     {
         $crawler = $this->client->request('GET', '/s/forms/new/');
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $selectedValue = $crawler->filter('#mauticform_postAction option:selected')->attr('value');
 
@@ -145,7 +145,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $crawler = $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $divClass = $crawler->filter('#mauticform_postActionProperty')->ancestors()->first()->attr('class');
         $this->assertStringNotContainsString('has-error', $divClass, $crawler->html());
     }
@@ -209,12 +209,12 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $this->client->submit($formElement);
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertStringNotContainsString('contact: Email', $response->getContent(), 'Email field should not be marked as mapped.');
     }
 
@@ -232,15 +232,15 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $this->client->submit($formElement);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->client->xmlHttpRequest('GET', sprintf('/s/forms/field/edit/%d?formId=%d', $field->getId(), $form->getId()));
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertJson($response->getContent());
 
         $content = json_decode($response->getContent())->newContent;
@@ -283,7 +283,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Verify form creation
-        $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         // Visit the form preview page
@@ -652,7 +652,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($mauticform);
 
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $forms = $this->em->getRepository(Form::class)->findBy([], ['id' => 'ASC']);
         Assert::assertCount(2, $forms);

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -184,7 +184,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), json_encode($languageHelper->getLanguageChoices()));
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, json_encode($languageHelper->getLanguageChoices()));
         $form     = $response['form'];
 
         $crawler = $this->client->request('GET', '/form/'.$form['id']);

--- a/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -53,7 +53,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->makeRequest(['search' => 'Company', 'formId' => $form->getId()]);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertSame(
             [
                 [

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -59,10 +59,10 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
             'mauticform[file_field]' => $file,
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->client->request(Request::METHOD_GET, "/forms/results/file/{$fieldId}/filename/{$fileName}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $field = $fieldModel->getEntity($fieldId);
         unlink($fileName);

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -45,7 +45,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($clientResponse->getContent(), true);
         $form     = $response['form'];
         $formId   = $form['id'];
@@ -97,7 +97,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($clientResponse->getContent(), true);
         $form     = $response['form'];
         $formId   = $form['id'];
@@ -139,17 +139,12 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($clientResponse->getContent(), true);
         $form     = $response['form'];
         $formId   = $form['id'];
-
         $crawler  = $this->client->request(Request::METHOD_GET, "/s/forms/results/{$formId}");
-        $response = $this->client->getResponse();
-
-        if (!$response->isOk()) {
-            $this->fail('Response is not OK. Status: '.$response->getStatusCode().', Content: '.$response->getContent());
-        }
+        self::assertResponseIsSuccessful();
 
         $editButton = $crawler->filter('a[href*="/s/forms/edit/'.$formId.'"]');
         $this->assertCount(1, $editButton, 'Edit button should be present on form results page');
@@ -159,9 +154,9 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
     {
         $data = 'data:image/png;base64,AAAFBfj42Pj4';
 
-        [$type, $data]     = explode(';', $data);
-        [, $data]          = explode(',', $data);
-        $data              = base64_decode($data);
+        [, $data] = explode(';', $data);
+        [, $data] = explode(',', $data);
+        $data     = base64_decode($data);
 
         file_put_contents($filename, $data);
     }

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -67,7 +67,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
@@ -86,7 +86,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Check the redirect
         $currentUrl = $this->client->getRequest()->getUri();
@@ -127,7 +127,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
@@ -229,7 +229,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Add conditional state field dependent on the country field:
         $patchPayload = [
@@ -320,7 +320,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Add conditional state field dependent on the country field:
         $patchPayload = [
@@ -459,7 +459,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         $campaignSources = ['forms' => [$formId => $formId]];
 
@@ -528,7 +528,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -567,7 +567,9 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             'PHP_AUTH_USER' => $user->getUserIdentifier(),
             'PHP_AUTH_PW'   => $this->getUserPlainPassword(),
         ]);
-        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode(), $clientResponse->getContent());
     }
 
     private function createUser(): User
@@ -699,7 +701,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -832,7 +834,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Submit the form
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -1065,7 +1067,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Submit the form
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -1250,7 +1252,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $formId         = json_decode($clientResponse->getContent(), true)['form']['id'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode());
 
         // Submit the form directly via POST
         $this->client->request(
@@ -1316,7 +1318,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         $responseData = json_decode($clientResponse->getContent(), true);
         $formId       = $responseData['form']['id'];
@@ -1359,7 +1361,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         );
 
         $secondResponse = $this->client->getResponse();
-        $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
+        $this->assertSame(Response::HTTP_FOUND, $secondResponse->getStatusCode());
 
         $redirectUrl = $secondResponse->headers->get('Location');
         $this->assertNotNull($redirectUrl);
@@ -1436,7 +1438,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $formId         = $response['form']['id'];
         $formAlias      = $response['form']['alias'];
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -1361,7 +1361,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $submissionsResponse = $this->client->getResponse();
         $submissionsData     = json_decode($submissionsResponse->getContent(), true);
 
-        $this->assertSame(Response::HTTP_OK, $submissionsResponse->getStatusCode(), $submissionsResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertArrayHasKey('submissions', $submissionsData);
         $this->assertCount(1, $submissionsData['submissions']);
 
@@ -1397,7 +1397,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $finalSubmissionsResponse = $this->client->getResponse();
         $finalSubmissionsData     = json_decode($finalSubmissionsResponse->getContent(), true);
 
-        $this->assertSame(Response::HTTP_OK, $finalSubmissionsResponse->getStatusCode(), $finalSubmissionsResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertArrayHasKey('submissions', $finalSubmissionsData);
         $this->assertCount(1, $finalSubmissionsData['submissions']);
 

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -67,7 +67,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
@@ -86,7 +86,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Check the redirect
         $currentUrl = $this->client->getRequest()->getUri();
@@ -127,7 +127,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
@@ -155,9 +155,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             ],
         ];
         $this->client->request(Request::METHOD_PATCH, "/api/forms/{$formId}/edit", $patchPayload);
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -171,9 +170,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         ]);
         $this->client->submit($form);
 
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         /** @var SubmissionRepository $submissionRepository */
         $submissionRepository = $this->em->getRepository(Submission::class);
@@ -200,9 +197,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->setUpSymfony($this->configParams);
         // Cleanup:
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testRequiredConditionalFieldIfAllFieldsEmpty(): void
@@ -233,7 +229,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Add conditional state field dependent on the country field:
         $patchPayload = [
@@ -258,9 +254,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             ],
         ];
         $this->client->request(Request::METHOD_PATCH, "/api/forms/{$formId}/edit", $patchPayload);
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -294,9 +289,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup:
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testRequiredConditionalFieldIfRequiredStateShouldKickIn(): void
@@ -327,7 +320,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Add conditional state field dependent on the country field:
         $patchPayload = [
@@ -352,9 +345,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             ],
         ];
         $this->client->request(Request::METHOD_PATCH, "/api/forms/{$formId}/edit", $patchPayload);
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -378,9 +369,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup:
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testProgressiveFormsWithMaximumFieldsDisplayedAtTime(): void
@@ -470,7 +459,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $campaignSources = ['forms' => [$formId => $formId]];
 
@@ -539,7 +528,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -566,7 +555,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $submission     = $response['submissions'][0];
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         Assert::assertSame($formId, $submission['form']['id']);
         Assert::assertGreaterThanOrEqual(1, $response['total']);
 
@@ -578,9 +567,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             'PHP_AUTH_USER' => $user->getUserIdentifier(),
             'PHP_AUTH_PW'   => $this->getUserPlainPassword(),
         ]);
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertSame(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     private function createUser(): User
@@ -681,9 +668,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup:
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$form->getId()}/delete");
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testSendSubmissionWhenFieldHaveMysqlReservedWords(): void
@@ -714,7 +699,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -751,9 +736,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup:
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     private function getUserPlainPassword(): string
@@ -849,7 +832,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -868,7 +851,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         // Get form submissions via API
         $this->client->request(Request::METHOD_GET, "/api/forms/{$formId}/submissions");
         $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $submissionsData = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('total', $submissionsData);
@@ -901,7 +884,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         // Get contact companies
         $this->client->request(Request::METHOD_GET, "/api/contacts/{$contact['id']}/companies");
         $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $contactCompanies = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('total', $contactCompanies);
         $this->assertArrayHasKey('companies', $contactCompanies);
@@ -914,8 +897,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -1083,7 +1065,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -1102,7 +1084,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         // Get form submissions via API
         $this->client->request(Request::METHOD_GET, "/api/forms/{$formId}/submissions");
         $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $submissionsData = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('total', $submissionsData);
@@ -1125,7 +1107,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         // Get contact
         $this->client->request(Request::METHOD_GET, "/api/contacts/{$submissionContact['id']}");
         $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $contactResponse = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('contact', $contactResponse);
         $contact = $contactResponse['contact'];
@@ -1136,12 +1118,10 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Cleanup
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $this->client->request(Request::METHOD_DELETE, "/api/fields/contact/{$contactCustomField['id']}/delete");
-        $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
     }
 
     /**
@@ -1270,7 +1250,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $formId         = json_decode($clientResponse->getContent(), true)['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form directly via POST
         $this->client->request(
@@ -1336,7 +1316,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $responseData = json_decode($clientResponse->getContent(), true);
         $formId       = $responseData['form']['id'];
@@ -1379,7 +1359,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         );
 
         $secondResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_FOUND, $secondResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
 
         $redirectUrl = $secondResponse->headers->get('Location');
         $this->assertNotNull($redirectUrl);
@@ -1456,7 +1436,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $formId         = $response['form']['id'];
         $formAlias      = $response['form']['alias'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         // Submit the form:
         $crawler     = $this->client->request(Request::METHOD_GET, "/form/{$formId}");
@@ -1467,10 +1447,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             'mauticform[name]' => 'Name',
         ]);
         $this->client->submit($form);
-
-        $clientResponse = $this->client->getResponse();
-
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         /** @var SubmissionRepository $submissionRepository */
         $submissionRepository = $this->em->getRepository(Submission::class);
@@ -1484,9 +1461,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->setUpSymfony($this->configParams);
 
         $this->client->request(Request::METHOD_DELETE, "/api/forms/{$formId}/delete");
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
 
@@ -1517,9 +1493,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $submissionId = $submissions[0]->getId();
 
         $this->client->request(Request::METHOD_POST, "/s/forms/results/{$form['id']}/delete/{$submissionId}");
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $conn        = $this->em->getConnection();
         $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
@@ -1561,9 +1536,8 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->restart();
 
         $this->client->request(Request::METHOD_POST, "s/forms/results/{$form['id']}/batchDelete?ids={$submissionIdsEncoded}");
-        $clientResponse = $this->client->getResponse();
 
-        $this->assertResponseIsSuccessful($clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -75,7 +75,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $form['mauticform[email]']->setValue('testing@ampersand.select');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         // Create some necessary entities.
         $campaignEvent = new Event();

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -63,7 +63,7 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
 

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -167,7 +167,7 @@ class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
         $response       = json_decode($clientResponse->getContent(), true);
         $formId         = (int) $response['form']['id'];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         return $formId;
     }

--- a/app/bundles/FormBundle/Tests/Functional/Model/SubmissionOwnerAndStageFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/Model/SubmissionOwnerAndStageFunctionalTest.php
@@ -77,7 +77,7 @@ class SubmissionOwnerAndStageFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
 

--- a/app/bundles/FormBundle/Tests/Functional/UpdateLeadFormActionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/UpdateLeadFormActionFunctionalTest.php
@@ -195,8 +195,7 @@ class UpdateLeadFormActionFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
-        $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $formId   = $response['form']['id'];
 

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
@@ -202,6 +202,6 @@ final class SubmissionModelFunctionalTest extends MauticMysqlTestCase
         $form = $formCrawler->form();
         $form->setValues($values);
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
     }
 }

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
@@ -159,11 +159,10 @@ final class SubmissionModelFunctionalTest extends MauticMysqlTestCase
     private function createForm(array $payload): array
     {
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
-        $clientResponse = $this->client->getResponse();
-        $response       = json_decode($clientResponse->getContent(), true);
-        $formId         = $response['form']['id'];
-        $formAlias      = $response['form']['alias'];
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $response  = json_decode($this->client->getResponse()->getContent(), true);
+        $formId    = $response['form']['id'];
+        $formAlias = $response['form']['alias'];
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         return [$formId, $formAlias];
     }

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
@@ -30,7 +30,7 @@ final class UIContactIntegrationsTabSubscriberTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $this->client->request('GET', "/s/contacts/view/{$contact->getId()}");
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('<dt>Object</dt><dd>testobject</dd>', $this->client->getResponse()->getContent());
         Assert::assertStringContainsString('<dt>Object ID</dt><dd>testid</dd>', $this->client->getResponse()->getContent());
         Assert::assertStringContainsString('testintegration', $this->client->getResponse()->getContent());

--- a/app/bundles/IntegrationsBundle/Tests/Unit/DTO/NoteTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/DTO/NoteTest.php
@@ -25,6 +25,6 @@ final class NoteTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Type value can be either "%s" or "%s".', Note::TYPE_INFO, Note::TYPE_WARNING));
 
-        $noteObject = new Note('Notes', 'randomType');
+        new Note('Notes', 'randomType');
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -423,7 +423,6 @@ class LeadSubscriberTest extends TestCase
         $fieldNames = [];
         $values     = [];
         $valueDAOs  = [];
-        $i          = 0;
 
         foreach ($fieldChanges as $fieldName => [$oldValue, $newValue]) {
             $values[]     = [$newValue];

--- a/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
@@ -42,7 +42,7 @@ final class CleanupExportedFilesCommandFunctionalTest extends MauticMysqlTestCas
             's/contacts/batchExport',
             ['filetype' => 'csv']
         );
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $contactExportSchedulerRows = $this->checkContactExportScheduler(1);
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler     = $contactExportSchedulerRows[0];

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -37,7 +37,6 @@ class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         // Delete 1 contact.
         $contact = $contacts[0];
         $this->client->request(Request::METHOD_POST, '/s/contacts/delete/'.$contact->getId());
-        $clientResponse = $this->client->getResponse();
         self::assertResponseIsSuccessful();
 
         // Run segment count cache command again.

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
 {
@@ -39,7 +38,7 @@ class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         $contact = $contacts[0];
         $this->client->request(Request::METHOD_POST, '/s/contacts/delete/'.$contact->getId());
         $clientResponse = $this->client->getResponse();
-        self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         // Run segment count cache command again.
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -267,7 +267,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/s/ajax?action=lead:getSegmentDependencyTree&id={$segmentA->getId()}");
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         Assert::assertSame(
             [
@@ -387,7 +387,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/s/ajax?action=lead:getSegmentDependencyTree&id={$segmentA->getId()}");
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         $responseData = json_decode($response->getContent(), true);
 
@@ -520,7 +520,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         // Check suggestions for admin user.
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:contactList&field=undefined&filter=user');
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         $data       = json_decode($response->getContent(), true);
         $foundNames = array_column($data, 'value');
@@ -604,7 +604,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->setServerParameter('PHP_AUTH_PW', $passwordNonAdmin);
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:contactList&field=undefined&filter=user');
         $response = $this->client->getResponse();
-        self::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         $data       = json_decode($response->getContent(), true);
         $foundNames = array_column($data, 'value');
@@ -630,11 +630,10 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->xmlHttpRequest(Request::METHOD_POST, '/s/ajax', $payload);
 
         // Get the response HTML
-        $response    = $this->client->getResponse();
-        $htmlContent = $response->getContent();
+        $htmlContent = $this->client->getResponse()->getContent();
 
         // Assert the response is successful
-        $this->assertTrue($response->isOk(), "Response was not OK for object: $object, group: $group");
+        $this->assertResponseIsSuccessful();
         $this->assertStringNotContainsString('<form', $htmlContent, 'Response contains a form instead of just field order.');
         $this->assertStringContainsString('<select', $htmlContent, 'Response contains select tag.');
 

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -76,7 +76,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         // Ensure the contact 1 was removed as a member of campaign 1 member now.
         $this->assertSame([['lead_id' => (string) $contact->getId(), 'manually_added' => '0', 'manually_removed' => '1']], $this->getMembersForCampaign($campaign->getId()));
 
-        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
         $this->assertTrue(isset($response['success']), 'The response does not contain the `success` param.');
         $this->assertSame(1, $response['success']);
     }
@@ -477,8 +477,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         ]);
         $clientResponse = $this->client->getResponse();
 
-        $response = json_decode($clientResponse->getContent(), true);
-        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful($clientResponse->getContent());
 
         // Assert the tag is removed from the lead
         $updatedLead = $this->em->getRepository(Lead::class)->find($lead->getId());

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -135,7 +135,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:getLookupChoiceList&searchKey=lead.company&lead.company=unicorn');
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('[]', $response->getContent());
     }
 
@@ -148,7 +148,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:getLookupChoiceList&searchKey=lead.company&lead.company=sa');
         $response = $this->client->getResponse();
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertSame('[{"text":"SaaS Company","value":"'.$company->getId().'"}]', $response->getContent());
     }
 
@@ -177,7 +177,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
         $content  = json_decode($response->getContent(), true);
 
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertIsArray($content);
         Assert::assertCount(1, $content, 'The result should contain only one element');
         Assert::assertSame('Company 1', $content[0]['text']);
@@ -187,7 +187,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
         $content  = json_decode($response->getContent(), true);
 
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertIsArray($content);
         Assert::assertCount(1, $content, 'The result should contain only one element');
         Assert::assertSame('Company 2', $content[0]['text']);

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -127,7 +127,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=lead:getSegmentDependencyTree&id=9999');
         $response = $this->client->getResponse();
-        Assert::assertSame(404, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(404);
         Assert::assertSame('{"message":"Segment 9999 could not be found."}', $response->getContent());
     }
 
@@ -156,7 +156,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax?action=lead:getLookupChoiceList&lead.company=unicorn');
         $response = $this->client->getResponse();
-        Assert::assertSame(400, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(400);
         Assert::assertStringContainsString('Bad Request - The searchKey parameter is required', $response->getContent());
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -54,7 +54,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -79,7 +79,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -100,7 +100,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -164,7 +164,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertSame($expectedStatusCode, $response->getStatusCode(), $response->getContent());
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
 
         if (Response::HTTP_CREATED === $expectedStatusCode) {
             $responseData = json_decode($response->getContent(), true);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -216,7 +216,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         // Call endpoint
         $this->client->request('GET', '/api/contacts/'.(string) $contact->getId());
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertArrayHasKey('contact', $responseJson);
@@ -328,7 +328,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         // Call endpoint
         $this->client->request('GET', '/api/contacts/'.(string) $contact->getId());
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertArrayHasKey('contact', $responseJson);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -131,7 +131,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $errorResponse  = json_decode($clientResponse->getContent(), true);
 
         Assert::assertArrayHasKey('errors', $errorResponse);
-        Assert::assertSame($errorResponse['errors'][0]['code'], $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame($errorResponse['errors'][0]['code']);
         Assert::assertSame($expectedMessage, $errorResponse['errors'][0]['message']);
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -62,7 +62,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testActivityApi(): void
     {
         $this->client->request('GET', '/api/contacts/activity');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertArrayHasKey('events', json_decode($this->client->getResponse()->getContent(), true));
         Assert::assertArrayHasKey('filters', json_decode($this->client->getResponse()->getContent(), true));
         Assert::assertArrayHasKey('order', json_decode($this->client->getResponse()->getContent(), true));
@@ -505,7 +505,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', '/api/contacts?where[0][val]=unicorn&where[0][col]=email&where[0][expr]=eq');
         $clientResponse = $this->client->getResponse();
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertEquals('{"total":"0","contacts":{}}', $clientResponse->getContent());
     }
 
@@ -575,7 +575,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ]
         );
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($this->client->getResponse()->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         $payload = json_decode($clientResponse->getContent(), true);
         Assert::assertEquals(1, $payload['total']);
         $contactFromApi = $payload['contacts'][$contact->getId()];

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -264,7 +264,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $response = json_decode($clientResponse->getContent(), true);
 
@@ -1274,7 +1274,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Call endpoint
         $this->client->request('GET', '/api/contacts/activity');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseJson = json_decode($clientResponse->getContent());
         $this->assertSame($expectedActivites, $responseJson->total);
     }
@@ -1302,7 +1302,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Call endpoint
         $this->client->request('GET', '/api/contacts/'.(string) $contact->getId().'/activity');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseJson = json_decode($clientResponse->getContent());
         $resultOrder  = [];
         foreach ($responseJson->events as $event) {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -807,7 +807,6 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Remove contact
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
-        $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
     }
 
@@ -1091,7 +1090,6 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Remove contact
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
-        $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
     }
 
@@ -1191,7 +1189,6 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Remove the contact.
         $this->client->request(Request::METHOD_DELETE, "/api/contacts/$contactId/delete");
-        $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -178,7 +178,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request($method, $route, $payload);
 
-        $this->assertSame($expectedStatusCode, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
         $assertResponse($this->client->getResponse(), $contact1->getId(), $contact2->deletedId);
     }
 
@@ -211,7 +211,7 @@ class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
 
         $response = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
@@ -76,7 +76,7 @@ final class LeadApiControllerProfilerTest extends MauticMysqlTestCase
         $counter->setValue($leadRepository, 0);
 
         $this->client->request(Request::METHOD_GET, '/api/contacts', $queryParams);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $response = json_decode($this->client->getResponse()->getContent(), true);
         Assert::assertSame($expectedCount, (int) $response['total']);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -582,7 +582,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertTrue($clientResponse->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertEquals($segmentPayload['category'], $response['list']['category']['id']);
 
         // Search segments by category:
@@ -590,7 +590,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertTrue($clientResponse->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertCount(1, $response['lists']);
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -227,7 +227,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($segmentId, $response['list']['id'], 'ID of the created segment does not match with the edited one.');
         $this->assertEquals('API segment renamed', $response['list']['name']);
         $this->assertEquals($payload['description'], $response['list']['description']);
@@ -237,7 +237,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame($segmentId, $response['list']['id'], 'ID of the created segment does not match with the fetched one.');
         $this->assertEquals('API segment renamed', $response['list']['name']);
         $this->assertEquals($payload['description'], $response['list']['description']);
@@ -247,7 +247,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertNull($response['list']['id']);
         $this->assertEquals('API segment renamed', $response['list']['name']);
         $this->assertEquals($payload['description'], $response['list']['description']);
@@ -430,7 +430,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertArrayNotHasKey('errors', $response);
     }
 
@@ -642,7 +642,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertArrayHasKey('lists', $response);
         Assert::assertArrayHasKey($segment->getId(), $response['lists']);
         Assert::assertArrayNotHasKey(
@@ -655,7 +655,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertArrayHasKey('lists', $response);
         Assert::assertArrayHasKey($segment->getId(), $response['lists']);
         Assert::assertArrayHasKey(
@@ -680,7 +680,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertSame(
             2,
             $response['lists'][$segment->getId()]['contactCount'],
@@ -763,7 +763,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful($clientResponse->getContent());
         Assert::assertArrayHasKey('errors', $response);
 
         $expectedErrorMessage1 = $this->translator->trans(

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -85,7 +85,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             ]
         );
 
-        Assert::assertSame($expectedResponseCode, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame($expectedResponseCode);
 
         if ($expectedErrorMessage) {
             Assert::assertStringContainsString(
@@ -165,7 +165,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $segmentId = $response['list']['id'];
 
-        $this->assertSame(201, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(201);
         $this->assertGreaterThan(0, $segmentId);
         $this->assertEquals($payload['name'], $response['list']['name']);
         $this->assertEquals($payload['description'], $response['list']['description']);
@@ -257,7 +257,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        $this->assertSame(404, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(404);
         $this->assertSame(404, $response['errors'][0]['code']);
     }
 
@@ -397,7 +397,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        Assert::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         Assert::assertArrayHasKey('errors', $response);
         $errorMessage = $this->translator->trans(
             'mautic.lead.lists.used_in_campaigns.unpublish',
@@ -464,7 +464,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedErrorMessage, $response['errors'][0]['message']);
     }
 
@@ -537,7 +537,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/segments/{$list1->getId()}/edit", ['isPublished' => false]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
-        Assert::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         Assert::assertArrayHasKey('errors', $response);
 
         $expectedErrorMessage = sprintf(
@@ -710,7 +710,7 @@ class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
-        Assert::assertSame(Response::HTTP_CONFLICT, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
         Assert::assertArrayHasKey('errors', $response);
 
         $expectedErrorMessage = $this->translator->trans(

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -112,7 +112,6 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         // Sending an empty payload should return a 500 server error
         // TODO ensure that the server sends back a 400 status code instead
         $this->client->request('POST', '/api/tags/new', []);
-        $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(500);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -111,18 +111,18 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $buttonCrawler = $crawler->selectButton('Save & Close');
         $form          = $buttonCrawler->form();
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertMatchesRegularExpression('/\/s\/companies\/view\/'.$this->company1Id.'/', $this->client->getRequest()->getUri());
     }
 
     public function testEditAndCancelActionCompany(): void
     {
         $crawler = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $buttonCrawler = $crawler->selectButton('Cancel');
         $form          = $buttonCrawler->form();
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertMatchesRegularExpression('/\/s\/companies\/view\/'.$this->company1Id.'/', $this->client->getRequest()->getUri());
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
@@ -34,7 +34,7 @@ class FieldControllerTest extends MauticMysqlTestCase
         $form  = $crawler->selectButton('Save & Close')->form();
         $label = 'Test value for custom field 4';
         $form['leadfield[label]']->setValue($label);
-        $crawler = $this->client->submit($form);
+        $this->client->submit($form);
 
         $field = $this->em->getRepository(LeadField::class)->findOneBy(['label' => $label]);
         $this->assertNotNull($field);

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -43,7 +43,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
 
@@ -54,7 +54,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
 
         $text = strip_tags($this->client->getResponse()->getContent());
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $text);
+        self::assertResponseIsSuccessful();
         Assert::assertStringNotContainsString('New Custom Field', $text);
         Assert::assertStringNotContainsString('This form should not contain extra fields.', $text);
         Assert::assertStringContainsString('Edit Custom Field - Best Date Ever', $text);
@@ -115,7 +115,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $domDocument = $crawler->getNode(0)->ownerDocument;
         $inputLabel  = $domDocument->createElement('input');
@@ -139,7 +139,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
 
         $text = strip_tags($this->client->getResponse()->getContent());
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $text);
+        self::assertResponseIsSuccessful();
         Assert::assertStringNotContainsString('New Custom Field', $text);
         Assert::assertStringNotContainsString('This form should not contain extra fields.', $text);
         Assert::assertStringContainsString('Edit Custom Field - Test select field', $text);
@@ -153,7 +153,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
 
         $domDocument = $crawler->getNode(0)->ownerDocument;
         $yesLabel    = $domDocument->createElement('input');
@@ -177,7 +177,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
         $form['leadfield[properties][no]']->setValue($properties['no'] ?? '');
 
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $text = strip_tags($this->client->getResponse()->getContent());
         Assert::assertStringNotContainsString($expectedMessage, $text);
@@ -212,7 +212,7 @@ class FieldFunctionalTest extends MauticMysqlTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/fields/new');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         // Check if the radio button with value 0 is checked and value 1 is not
         Assert::assertNotNull(

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -469,7 +469,7 @@ class LeadControllerTest extends MauticMysqlTestCase
     {
         $contactA = $this->createContact('contact@a.email');
         $contactB = $this->createContact('contact@b.email');
-        $contactC = $this->createContact('contact@c.email');
+        $this->createContact('contact@c.email');
 
         $companyName = 'Doe Corp';
         $company     = new Company();
@@ -506,7 +506,7 @@ class LeadControllerTest extends MauticMysqlTestCase
                 'lead_quickemail[replyToAddress]' => $replyTo,
             ]
         );
-        $crawler = $this->client->submit($form);
+        $this->client->submit($form);
         $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
         $this->assertQueuedEmailCount(1);
 
@@ -556,7 +556,7 @@ class LeadControllerTest extends MauticMysqlTestCase
                 'lead_quickemail[replyToAddress]' => $replyTo,
             ]
         );
-        $crawler = $this->client->submit($form);
+        $this->client->submit($form);
         $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
         $this->assertQueuedEmailCount(1);
 
@@ -991,7 +991,7 @@ EMAIL;
         $this->setCsrfHeader();
         $this->client->xmlHttpRequest($form->getMethod(), $form->getUri(), $form->getPhpValues());
         $this->assertResponseIsSuccessful();
-        $response = $this->client->getResponse();
+        $this->client->getResponse();
 
         $scores = $contact->getGroupScores();
         $this->assertCount(2, $scores);
@@ -1056,7 +1056,7 @@ EMAIL;
                 'lead_batch_dnc[ids]'    => json_encode([$contact->getId()]),
             ]
         );
-        $crawler = $this->client->submit($form);
+        $this->client->submit($form);
         $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
 
         $clientResponse = $this->client->getResponse();

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -267,7 +267,7 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
 
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
 
         /** @var Lead $contact */
         $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'john_23657@doe.com']);
@@ -297,7 +297,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $this->loadFixtures([LoadLeadData::class]);
         $this->client->request(Request::METHOD_GET, '/s/contacts/batchExport?filetype=csv');
         $clientResponse = $this->client->getResponse();
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString(
             'Contact export scheduled for CSV file type.',
             $clientResponse->getContent()
@@ -496,7 +496,7 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/s/contacts/email/{$contact->getId()}");
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $crawler = new Crawler(json_decode($this->client->getResponse()->getContent(), true)['newContent'], $this->client->getInternalRequest()->getUri());
         $form    = $crawler->selectButton('Send')->form();
         $form->setValues(
@@ -507,7 +507,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             ]
         );
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         $this->assertQueuedEmailCount(1);
 
         $email = $this->getMailerMessage();
@@ -546,7 +546,7 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/s/contacts/email/{$contact->getId()}");
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $crawler = new Crawler(json_decode($this->client->getResponse()->getContent(), true)['newContent'], $this->client->getInternalRequest()->getUri());
         $form    = $crawler->selectButton('Send')->form();
         $form->setValues(
@@ -557,7 +557,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             ]
         );
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         $this->assertQueuedEmailCount(1);
 
         $email = $this->getMailerMessage();
@@ -820,9 +820,9 @@ EMAIL;
 
         $this->client->submit($form);
 
-        $clientResponse = $this->client->getResponse();
+        $this->client->submit($form);
 
-        Assert::assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
 
         /** @var Lead $contact */
         $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'john_23657@doe.com']);
@@ -1030,7 +1030,7 @@ EMAIL;
         $this->client->request(Request::METHOD_GET, '/s/companies/merge/'.$companyA->getId());
         $response = $this->client->getResponse();
 
-        Assert::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         $content = $response->getContent();
 
@@ -1047,7 +1047,7 @@ EMAIL;
         $this->em->clear();
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/contacts/batchDnc');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $crawler = new Crawler(json_decode($this->client->getResponse()->getContent(), true)['newContent'], $this->client->getInternalRequest()->getUri());
         $form    = $crawler->selectButton('Save')->form();
         $form->setValues(
@@ -1057,7 +1057,7 @@ EMAIL;
             ]
         );
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $clientResponse = $this->client->getResponse();
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -265,8 +265,6 @@ class LeadControllerTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $clientResponse = $this->client->getResponse();
-
         self::assertResponseIsSuccessful();
 
         /** @var Lead $contact */

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -312,7 +312,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Remove 1 contact from segment.
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contact/'.$contact1Id.'/remove');
         self::assertSame('{"success":1}', $this->client->getResponse()->getContent());
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
 
@@ -325,7 +325,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $parameters = ['ids' => [$contact1Id]];
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contacts/add', $parameters);
         self::assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
-        self::assertSame(200, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
 
@@ -558,7 +558,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', 's/segments/batchDelete?'.$parameters, [], [], $this->createAjaxHeaders());
 
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $clientResponseBody = json_decode($clientResponse->getContent(), true);
 
         $this->assertStringContainsString($expectedErrorMessage, $clientResponseBody['flashes']);
@@ -790,7 +790,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('1 segments have been deleted!', $clientResponse->getContent());
 
         $this->em->clear();

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -76,7 +76,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$segment->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertGreaterThan(0, $crawler->filter('#leadlist_filters_0_operator option')->count());
     }
 
@@ -380,15 +380,15 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $segmentsCountBefore = $this->em->getRepository(LeadList::class)->count([]);
         // Go to clone segment action
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/clone/'.$segmentId);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         // First submit
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $crawler = $this->client->submit($form);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), 'Correct Apply');
+        $this->assertResponseIsSuccessful();
         // Second submit
         $form = $crawler->selectButton('leadlist_buttons_apply')->form();
         $this->client->submit($form);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), 'Correct Apply');
+        $this->assertResponseIsSuccessful();
         // Number of segments after clone
         $segmentsCountAfter = $this->em->getRepository(LeadList::class)->count([]);
         // Check that just one segment was created
@@ -411,11 +411,11 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
     private function getAliasWhenCloneSegment(int $segmentId): string
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/clone/'.$segmentId);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         // Save cloned segment
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $crawler = $this->client->submit($form);
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), 'Correct Apply');
+        $this->assertResponseIsSuccessful();
 
         return $crawler->filter('#leadlist_alias')->attr('value');
     }
@@ -464,7 +464,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $form['leadlist[isPublished]']->setValue('0');
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString($expectedErrorMessage, $this->client->getResponse()->getContent());
     }
 
@@ -475,13 +475,13 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'lead.list', 'id' => $list1->getId()]);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$list2->getId());
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $form['leadlist[isPublished]']->setValue('0');
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $rows = $this->listRepo->findAll();
         $this->assertCount(2, $rows);
@@ -826,7 +826,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
 
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         if ($shouldContainError) {
             $this->assertStringContainsString('Date field filter value &quot;'.$filter.'&quot; is invalid', $this->client->getResponse()->getContent());

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -458,7 +458,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $expectedErrorMessage = sprintf('The segment %s is used in %s, please go back and check segments before unpublishing', $list1->getName(), $list2->getName());
 
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'lead.list', 'id' => $list1->getId()]);
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertStringContainsString($expectedErrorMessage, $this->client->getResponse()->getContent());
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$list1->getId());
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
@@ -629,7 +629,7 @@ final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
             ]
         );
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $this->em->refresh($segment);
         $this->assertFalse($segment->isPublished());

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -51,7 +51,7 @@ class ListControllerTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/s/segments');
         $clientResponse = $this->client->getResponse();
-        $this->assertResponseIsSuccessful('Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('February 7, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('March 21, 2020', $clientResponse->getContent());
         $this->assertStringContainsString('Test User', $clientResponse->getContent());
@@ -63,7 +63,6 @@ class ListControllerTest extends MauticMysqlTestCase
     public function testIndexActionWhenFiltering(): void
     {
         $this->client->request('GET', '/s/segments?search=has%3Aresults&tmpl=list');
-        $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -213,7 +213,7 @@ class ListControllerTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/api/segments?search=filters_field:custom_field_test');
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Segment filter', $clientResponse->getContent());
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
@@ -29,7 +29,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $contact = (new Lead())->setFirstname('Test');
         static::getContainer()->get('mautic.lead.model.lead')->saveEntity($contact);
 
-        $crawler = $this->client->request('GET', '/s/contacts/notes/'.$contact->getId());
+        $this->client->request('GET', '/s/contacts/notes/'.$contact->getId());
         $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
     }
 
@@ -41,7 +41,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $contact = (new Lead())->setFirstname('Test');
         static::getContainer()->get('mautic.lead.model.lead')->saveEntity($contact);
 
-        $crawler = $this->client->request('GET', '/s/contacts/notes/'.$contact->getId().'/new');
+        $this->client->request('GET', '/s/contacts/notes/'.$contact->getId().'/new');
         $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
@@ -74,7 +74,7 @@ class CompanyTest extends MauticMysqlTestCase
         $errorMessage = 'This value should be between 0 and 2147483647.';
 
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->em->clear();
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -57,9 +57,8 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testCategoriesOnContactPreferences(): void
     {
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/contacts/contactFrequency/'.$this->lead->getId());
-        $response   = $this->client->getResponse();
 
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $subscribedCats = $crawler->filter('select[id="lead_contact_frequency_rules_global_categories"]')->filter('option[selected="selected"]');
 
@@ -73,9 +72,8 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 
         // Request the preference on Lead detail page.
         $crawler  = $this->client->request(Request::METHOD_GET, '/s/contacts/contactFrequency/'.$this->lead->getId());
-        $response = $this->client->getResponse();
 
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $subscribedCats = $crawler->filter('select[id="lead_contact_frequency_rules_global_categories"]')->filter('option[selected="selected"]');
 
@@ -199,10 +197,9 @@ class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
     private function getContactFrequencyCrawler(Lead $lead): Crawler
     {
         // Request the preference on Lead detail page.
-        $crawler  = $this->client->request(Request::METHOD_GET, '/s/contacts/contactFrequency/'.$lead->getId());
-        $response = $this->client->getResponse();
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/contacts/contactFrequency/'.$lead->getId());
 
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         return $crawler;
     }

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 {
@@ -125,7 +124,7 @@ class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/ajax', $payload);
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), print_r(json_decode($this->client->getResponse()->getContent(), true), true));
+        $this->assertResponseIsSuccessful();
         $contentArray = json_decode($this->client->getResponse()->getContent(), true);
 
         $this->assertCount($expectedCount, $contentArray['items']);

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -270,7 +270,6 @@ class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     {
         $application = new Application(self::$kernel);
         $application->setAutoExit(false);
-        $applicationTester = new ApplicationTester($application);
 
         $contactIds = $this->createContacts();
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -52,7 +52,7 @@ class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $crawler            = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
 
         // convert html table to php array

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
 use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Model\CampaignModel;
@@ -948,11 +947,6 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->companyModelMock->expects($this->once())
             ->method('getRepository')
             ->willReturn($this->companyRepositoryMock);
-
-        $mockStmt = $this->getMockBuilder(Result::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['fetchAllAssociative'])
-            ->getMock();
 
         $this->reportGraphEventMock->expects($this->once())
             ->method('getQueryBuilder')

--- a/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
@@ -25,7 +25,7 @@ final class EmailTypeFunctionalTest extends MauticMysqlTestCase
 
         // Fetch the form
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$lead->getId());
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
@@ -42,7 +42,7 @@ final class EmailTypeFunctionalTest extends MauticMysqlTestCase
             'lead_quickemail[list]'     => 0,
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         // Check the email has correct text
         $copy = $this->em->getRepository(Copy::class)->findOneBy(['subject' => 'Test Jap Mautic']);

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Tests\Functional\ApiPlatform;
 
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\HttpFoundation\Response;
 
 final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
@@ -55,7 +54,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -117,7 +116,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -177,7 +176,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertCount(
@@ -197,7 +196,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertCount(

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -116,7 +116,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         $this->client->request('GET', '/api/contacts?limit=100');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($legacyCollection);
@@ -132,7 +132,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertNotContains((int) $foreignContact->getId(), $legacyIds);
 
         $this->client->request('GET', '/api/v2/contacts?page=1');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $v2Collection = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($v2Collection);
@@ -183,7 +183,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=2');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $firstPage = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($firstPage);
@@ -202,7 +202,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         }
 
         $this->client->request('GET', '/api/v2/contacts?page=2&itemsPerPage=2');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        self::assertResponseIsSuccessful();
 
         $secondPage = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($secondPage);
@@ -267,7 +267,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         $this->client->request('GET', '/api/contacts?start=0&limit=10');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($legacyCollection);
@@ -283,7 +283,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertContains((int) $foreignContact->getId(), $legacyIds);
 
         $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $collection = json_decode($this->client->getResponse()->getContent(), true);
         self::assertIsArray($collection);
@@ -347,7 +347,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertCount(
@@ -367,7 +367,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), $response->getContent());
+        self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         self::assertCount(

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -52,11 +52,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $endpoint = sprintf($endpointTemplate, (int) $foreignContact->getId());
         $this->client->request('GET', $endpoint);
 
-        self::assertSame(
-            Response::HTTP_FORBIDDEN,
-            $this->client->getResponse()->getStatusCode(),
-            $this->client->getResponse()->getContent()
-        );
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
@@ -37,7 +37,7 @@ class ContactExportLimitFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
 
         // Assert response code is 400 (Bad Request)
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         // Decode the JSON response
         $responseData = json_decode($clientResponse->getContent(), true);

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -14,8 +14,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
     public function testMergeAction(): void
     {
         $this->client->request('GET', '/s/companies/merge/1');
-        $clientResponse         = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testMergeActionWithoutPermission(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -47,7 +47,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             's/contacts/batchExport',
             ['filetype' => 'csv']
         );
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $contactExportSchedulerRows = $this->checkContactExportScheduler(1);
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler     = $contactExportSchedulerRows[0];
@@ -66,7 +66,7 @@ class LeadControllerTest extends MauticMysqlTestCase
             UrlGeneratorInterface::ABSOLUTE_URL
         );
         $this->client->request(Request::METHOD_GET, $link);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $notFoundLink = $this->router->generate(
             'mautic_contact_export_download',

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
@@ -55,7 +55,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
 
         // Fetch the form
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$contact->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
@@ -72,7 +72,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
             'lead_quickemail[list]'     => 0,
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $email = self::getMailerMessages()[0]->toString();
         Assert::assertStringContainsString('Hey John...', $email);
@@ -104,7 +104,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
 
         // Fetch the form
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$contact->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
@@ -121,7 +121,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
             'lead_quickemail[list]'     => 0,
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $email = self::getMailerMessages()[0]->toString();
         Assert::assertStringContainsString('Hey John...', $email);
@@ -141,7 +141,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
 
         // Fetch the form
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$contact->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
@@ -158,7 +158,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
             'lead_quickemail[list]'     => 0,
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $email = self::getMailerMessages()[0]->toString();
         Assert::assertStringContainsString('Hey John...', $email);
@@ -188,7 +188,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
 
         // Fetch the form
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$contact->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
         $content     = $this->client->getResponse()->getContent();
         $content     = json_decode($content)->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());
@@ -206,7 +206,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
             'lead_quickemail[templates]' => $emailEntity->getId(),
         ]);
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $messages = self::getMailerMessages();
         Assert::assertCount(1, $messages, 'Expected exactly one email message to be sent');
@@ -238,7 +238,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $this->client->request(Request::METHOD_GET, '/s/contacts/email/'.$lead->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $content     = json_decode($this->client->getResponse()->getContent())->newContent;
         $crawler     = new Crawler($content, $this->client->getInternalRequest()->getUri());

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
@@ -178,7 +178,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
     {
         $this->client->request('POST', "/api/emails/{$emailId}/send");
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(200, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertResponseIsSuccessful();
         Assert::assertSame(
             json_decode($clientResponse->getContent(), true, 512, JSON_THROW_ON_ERROR),
             [

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
@@ -39,8 +39,6 @@ final class LeadRepositoryTest extends MauticMysqlTestCase
     {
         $contactRepo = $this->em->getRepository(Lead::class);
 
-        $ipRepo = $this->em->getRepository(IpAddress::class);
-
         $ip      = new IpAddress('127.0.0.1');
         $contact = new Lead();
         $contact->addIpAddress($ip);

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -10,7 +10,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\ListModel;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -33,7 +32,7 @@ class SegmentSubscriberTest extends MauticMysqlTestCase
     {
         $segment   = $this->saveSegment('Segment D', 'segment-d', $filters);
         $crawler   = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$segment->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         /** @var TranslatorInterface $translator */
         $translator = $this->getContainer()->get('translator');
 

--- a/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
@@ -34,7 +34,7 @@ class LeadModelSelectFieldTrimTest extends MauticMysqlTestCase
 
         $campaign = $this->createCampaign('Industry Campaign');
 
-        $event = $this->createEvent(
+        $this->createEvent(
             'Update Industry',
             $campaign,
             'lead.update.field',

--- a/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
@@ -54,8 +54,6 @@ class IpAddressModelTest extends TestCase
         $contact      = $this->createMock(Lead::class);
         $ipAddress    = $this->createMock(IpAddress::class);
         $ipAddresses  = new ArrayCollection(['1.2.3.4' => $ipAddress]);
-        $connection   = $this->createMock(Connection::class);
-        $queryBuilder = $this->createMock(QueryBuilder::class);
 
         $contact->expects($this->exactly(1))
             ->method('getIpAddresses')

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -116,7 +116,7 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
 
         $segmentId = $response['list']['id'];
 
-        $this->assertSame(201, $clientResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(201);
         $this->assertGreaterThan(0, $segmentId);
 
         return $this->em->getRepository(LeadList::class)->find($segmentId);

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -57,7 +57,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->installPackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     public function testRemovePackageAction(): void
@@ -75,7 +75,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->removePackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        Assert::assertSame(200, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     private function generateController(bool $isPackageInstalled): AjaxController

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -57,7 +57,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->installPackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(200, $response->getStatusCode());
     }
 
     public function testRemovePackageAction(): void
@@ -75,7 +75,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->removePackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(200, $response->getStatusCode());
     }
 
     private function generateController(bool $isPackageInstalled): AjaxController

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 
 final class AjaxControllerTest extends AbstractMauticTestCase
 {
@@ -57,7 +58,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->installPackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testRemovePackageAction(): void
@@ -75,7 +76,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->removePackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        self::assertResponseIsSuccessful();
+        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     private function generateController(bool $isPackageInstalled): AjaxController

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -24,7 +24,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Response;
 
 final class AjaxControllerTest extends AbstractMauticTestCase
 {
@@ -58,7 +57,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->installPackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     public function testRemovePackageAction(): void
@@ -76,7 +75,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->removePackageAction($request);
 
         Assert::assertSame('{"success":true}', $response->getContent());
-        Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        self::assertResponseIsSuccessful();
     }
 
     private function generateController(bool $isPackageInstalled): AjaxController

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -34,7 +34,7 @@ final class DetailControllerTest extends MauticMysqlTestCase
 
         $responseContent = $this->client->getResponse()->getContent();
 
-        Assert::assertSame($responseCode, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseStatusCodeSame($responseCode);
         Assert::assertStringContainsString($foundPackageDesc, $responseContent);
         Assert::assertStringContainsString($foundPackageName, $responseContent);
         Assert::assertStringContainsString($latestVersion, $responseContent);

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
@@ -40,7 +40,7 @@ final class ListControllerTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', 's/marketplace');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
 
         Assert::assertSame(
             [
@@ -75,7 +75,7 @@ final class ListControllerTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', 's/marketplace');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         Assert::assertSame(
             [

--- a/app/bundles/PageBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -13,7 +13,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     public function testGetBuilderTokensAction(): void
     {
         $this->client->request(Request::METHOD_GET, '/s/ajax?action=page:getBuilderTokens');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $response = json_decode($this->client->getResponse()->getContent(), true);
         Assert::assertArrayHasKey('tokens', $response);
         Assert::assertArrayHasKey('{pagetitle}', $response['tokens']);

--- a/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
@@ -31,7 +31,7 @@ final class NotFoundFunctionalTest extends MauticMysqlTestCase
 
         // Test the custom 404 page:
         $crawler = $this->client->request(Request::METHOD_GET, '/page-that-does-not-exist');
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         Assert::assertStringContainsString('Custom 404 Not Found Page', $crawler->text());
         Assert::assertFalse($this->client->getResponse()->isRedirection(), 'The response should not be a redirect.');
         Assert::assertSame('/page-that-does-not-exist', $this->client->getRequest()->getRequestUri(), 'The request URI should be the same as the original URI.');

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
@@ -35,7 +35,7 @@ class PageControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, sprintf('/%s', $page->getAlias()));
         $response = $this->client->getResponse();
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Test Html', $response->getContent());
     }
 

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -218,8 +218,7 @@ class PageControllerTest extends MauticMysqlTestCase
     public function testNewActionPage(): void
     {
         $this->client->request('GET', '/s/pages/new/');
-        $clientResponse         = $this->client->getResponse();
-        $clientResponseContent  = $clientResponse->getContent();
+        $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
 
@@ -228,9 +227,7 @@ class PageControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', 's/pages/results/'.$this->id);
         $clientResponse         = $this->client->getResponse();
-        $clientResponseContent  = $clientResponse->getContent();
-        $model                  = static::getContainer()->get('mautic.page.model.page');
-        $page                   = $model->getEntity($this->id);
+
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
 
@@ -241,10 +238,7 @@ class PageControllerTest extends MauticMysqlTestCase
     {
         $this->loadFixtures([LoadPageCategoryData::class, LoadPageData::class]);
 
-        ob_start();
         $this->client->request(Request::METHOD_GET, '/s/pages/results/'.$this->id.'/export');
-        $content = ob_get_contents();
-        ob_end_clean();
 
         $clientResponse = $this->client->getResponse();
 
@@ -259,10 +253,7 @@ class PageControllerTest extends MauticMysqlTestCase
     {
         $this->loadFixtures([LoadPageCategoryData::class, LoadPageData::class]);
 
-        ob_start();
         $this->client->request(Request::METHOD_GET, '/s/pages/results/'.$this->id.'/export/xlsx');
-        $content = ob_get_contents();
-        ob_end_clean();
 
         $clientResponse = $this->client->getResponse();
 
@@ -277,10 +268,7 @@ class PageControllerTest extends MauticMysqlTestCase
     {
         $this->loadFixtures([LoadPageCategoryData::class, LoadPageData::class]);
 
-        ob_start();
         $this->client->request(Request::METHOD_GET, '/s/pages/results/'.$this->id.'/export/html');
-        $content = ob_get_contents();
-        ob_end_clean();
 
         $clientResponse = $this->client->getResponse();
 

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -9,7 +9,6 @@ use Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData;
 use Mautic\PageBundle\DataFixtures\ORM\LoadPageData;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Model\PageModel;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -83,7 +82,7 @@ class PageControllerTest extends MauticMysqlTestCase
         $leadsBeforeTest   = $this->connection->fetchAllAssociative('SELECT `id` FROM `'.$this->prefix.'leads`;');
         $leadIdsBeforeTest = array_column($leadsBeforeTest, 'id');
         $this->client->request('GET', '/page-page-landingPageTracking');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
         if (!empty($leadIdsBeforeTest)) {
@@ -122,7 +121,7 @@ class PageControllerTest extends MauticMysqlTestCase
         $leadsBeforeTest   = $this->connection->fetchAllAssociative('SELECT `id` FROM `'.$this->prefix.'leads`;');
         $leadIdsBeforeTest = array_column($leadsBeforeTest, 'id');
         $this->client->request('GET', '/page-page-landingPageTrackingSecondVisit');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
         if (!empty($leadIdsBeforeTest)) {
             $sql .= ' WHERE `id` NOT IN ('.implode(',', $leadIdsBeforeTest).');';
@@ -139,7 +138,7 @@ class PageControllerTest extends MauticMysqlTestCase
         $this->assertCount(1, $eventLogsAfterFirstVisit);
         $this->assertSame('created_contact', reset($eventLogsAfterFirstVisit)['action']);
         $this->client->request('GET', '/page-page-landingPageTrackingSecondVisit');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $eventLogsAfterSecondVisit = $this->connection->fetchAllAssociative('
           SELECT `id`, `action`
           FROM `'.$this->prefix.'lead_event_log`
@@ -289,7 +288,6 @@ class PageControllerTest extends MauticMysqlTestCase
         $pageModel->saveEntity($parentPage);
 
         $this->client->request(Request::METHOD_GET, '/this_is_my_page');
-        $response = $this->client->getResponse();
-        Assert::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
@@ -78,7 +78,7 @@ final class PageDraftFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/pages/edit/{$page->getId()}");
         $form    = $crawler->selectButton('Apply Draft')->form();
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $pageDraft = $this->em->getRepository(PageDraft::class)->findOneBy(['page' => $page]);
 
@@ -91,7 +91,7 @@ final class PageDraftFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/pages/edit/{$page->getId()}");
         $form    = $crawler->selectButton('Discard Draft')->form();
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $pageDraft = $this->em->getRepository(PageDraft::class)->findOneBy(['page' => $page]);
 
@@ -106,7 +106,7 @@ final class PageDraftFunctionalTest extends MauticMysqlTestCase
         $form                          = $crawler->selectButton('Save as Draft')->form();
         $form['page[customHtml]']      = 'Test html Draft';
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $pageDraft = $this->em->getRepository(PageDraft::class)->findOneBy(['page' => $page]);
         Assert::assertEquals('Test html Draft', $pageDraft->getHtml());

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -235,7 +235,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
     private function assertPageContent(string $url, string $expectedContent): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         self::assertSame($expectedContent, $crawler->filter('body')->text());
     }
 

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -32,7 +32,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
         // Anonymous visitor is not allowed to access preview if not public
         $this->logoutUser();
         $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
 
         $this->loginUser($user);
 
@@ -49,7 +49,7 @@ class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Anonymous visitor is not allowed to access preview
         $this->client->request(Request::METHOD_GET, $url);
-        self::assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testPreviewPageUrlIsValid(): void

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -35,7 +35,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $encodedPayload = urlencode($payload);
         $this->client->request(Request::METHOD_GET, "/xss-test?tags={$encodedPayload}");
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $tagRepository = $this->em->getRepository(Tag::class);
         $tags          = $tagRepository->findAll();

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -58,7 +58,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, '/page-a');
 
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('redirectUrlProvider')]
@@ -75,7 +75,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $response = $this->client->getResponse();
         \assert($response instanceof RedirectResponse);
-        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
         Assert::assertSame($url, $response->getTargetUrl());
     }
 
@@ -122,7 +122,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $response = $this->client->getResponse();
         \assert($response instanceof RedirectResponse);
-        Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
         Assert::assertSame($url, $response->getTargetUrl(), 'The dots in the query part must be preserved.');
 
         $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);

--- a/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOffFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOffFunctionalTest.php
@@ -37,7 +37,7 @@ class VisitPageWitIpAnonymizationOffFunctionalTest extends MauticMysqlTestCase
         $this->logoutUser();
         $pageContent = $this->client->request(Request::METHOD_GET, '/page-page-anonymizaiton-off');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $pageContent->text());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('Test Html', $pageContent->text());
 
         /** @var HitRepository $hitRepository */

--- a/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOnFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOnFunctionalTest.php
@@ -37,7 +37,7 @@ class VisitPageWitIpAnonymizationOnFunctionalTest extends MauticMysqlTestCase
         $this->logoutUser();
         $pageContent = $this->client->request(Request::METHOD_GET, '/page-page-anonymizaiton-on');
 
-        Assert::assertTrue($this->client->getResponse()->isOk(), $pageContent->text());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('Test Html', $pageContent->text());
 
         /** @var HitRepository $hitRepository */

--- a/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
+++ b/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
@@ -26,7 +26,7 @@ class PluginControllerTest extends MauticMysqlTestCase
         ]);
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     public function testConfigurePluginValidationError(): void
@@ -54,7 +54,7 @@ class PluginControllerTest extends MauticMysqlTestCase
         $this->client->xmlHttpRequest(Request::METHOD_GET, '/s/plugins/info/MauticFocusBundle');
 
         $response = $this->client->getResponse();
-        Assert::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         $content = $response->getContent();
         Assert::assertJson($content);

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
@@ -38,7 +38,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/api/points/groups');
         $getAllResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_OK, $getAllResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($getAllResponse->getContent(), true);
         $this->assertArrayHasKey('pointGroups', $responseData);
         $this->assertEquals(1, $responseData['total']);
@@ -56,7 +56,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->client->request('PATCH', "/api/points/groups/{$createdData['id']}/edit", $updatePayload);
         $updateResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_OK, $updateResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($updateResponse->getContent(), true);
         $this->assertArrayHasKey('pointGroup', $responseData);
         $updatedData = $responseData['pointGroup'];
@@ -67,7 +67,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->client->request('DELETE', "/api/points/groups/{$createdData['id']}/delete");
         $deleteResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_OK, $deleteResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($deleteResponse->getContent(), true);
         $this->assertArrayHasKey('pointGroup', $responseData);
         $deleteData = $responseData['pointGroup'];
@@ -160,7 +160,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('POST', "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}/$operator/{$value}");
         $adjustResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $adjustResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($adjustResponse->getContent(), true);
         $this->assertSame($expectedScore, $responseData['groupScore']['score']);
     }
@@ -172,7 +172,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups");
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
         $this->assertSame(count($expectedGroups), $responseData['total']);
         $this->assertSame($expectedGroups, $responseData['groupScores']);
@@ -182,7 +182,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
     {
         $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}");
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
         $this->assertSame($expectedScore, $responseData['groupScore']['score']);
     }

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
@@ -26,7 +26,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
 
         $createResponse = $this->client->getResponse();
 
-        $this->assertSame(Response::HTTP_CREATED, $createResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $responseData = json_decode($createResponse->getContent(), true);
         $this->assertArrayHasKey('pointGroup', $responseData);
         $createdData = $responseData['pointGroup'];
@@ -77,7 +77,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         // Try to GET the group that should no longer exist
         $this->client->request('GET', "/api/points/groups/{$createdData['id']}");
         $getResponse = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_FOUND, $getResponse->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($getResponse->getContent(), true);
         $this->assertArrayHasKey('errors', $responseData);
         $this->assertCount(1, $responseData['errors']);
@@ -138,7 +138,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         // Try to GET the group points that should not exist
         $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups/0");
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($response->getContent(), true);
         $this->assertArrayHasKey('errors', $responseData);
         $this->assertCount(1, $responseData['errors']);
@@ -148,7 +148,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         // Try to GET the group points for a contact that should not exist
         $this->client->request('GET', '/api/contacts/0/points/groups/0');
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($response->getContent(), true);
         $this->assertArrayHasKey('errors', $responseData);
         $this->assertCount(1, $responseData['errors']);

--- a/app/bundles/PointBundle/Tests/Controller/TriggerControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/TriggerControllerTest.php
@@ -47,7 +47,7 @@ final class TriggerControllerTest extends MauticMysqlTestCase
         $this->assertCount(2, $triggerEventRepo->findAll());
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/points/triggers/clone/'.$trigger->getId());
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $form    = $crawler->selectButton('Save')->form();
         $this->client->submit($form);

--- a/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
+++ b/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
@@ -102,7 +102,7 @@ class PointEntityValidationTest extends MauticMysqlTestCase
         $form['point[type]']->setValue('form.submit');
 
         $this->client->submit($form);
-        self::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $response = $this->client->getResponse()->getContent();
         self::assertStringContainsString($errorMessage, (string) $response);

--- a/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
@@ -67,7 +67,7 @@ class SegmentFilterFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/api/contacts?search=segment:group-a-points-gte1');
         $clientResponse = $this->client->getResponse();
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $response = json_decode($clientResponse->getContent(), true);
         $this->assertEquals(1, (int) $response['total']);
         $contactIds = array_column($response['contacts'], 'id');

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
@@ -154,7 +154,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
 
     public function testAddEntityActionWithoutPermission(): void
     {
-        $user = $this->createAndLoginUser();
+        $this->createAndLoginUser();
 
         $url = '/s/projects/addEntity/'.$this->testProject->getId().'?entityType=email';
         $this->client->request('GET', $url);

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
@@ -56,9 +56,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     {
         $this->client->followRedirects(false);
         $this->client->request('GET', '/s/projects/selectEntityType/99999');
-        $response = $this->client->getResponse();
-
-        $this->assertSame(404, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testAddEntityActionGetRequest(): void
@@ -147,9 +145,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     {
         $this->client->followRedirects(false);
         $this->client->request('GET', '/s/projects/addEntity/99999?entityType=email');
-        $response = $this->client->getResponse();
-
-        $this->assertSame(404, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(404);
     }
 
     public function testAddEntityActionWithoutPermission(): void

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
@@ -123,7 +123,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
         $crawler                = $this->client->request('GET', '/s/projects/edit/'.$project->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Edit project: '.$project->getName(), $clientResponseContent, 'The return must contain \'Edit project\' text');
 
         $form = $crawler->selectButton('Save & Close')->form();

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
@@ -51,7 +51,7 @@ final class ProjectEntityLookupLimitTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $decoded = json_decode($response->getContent(), true);

--- a/app/bundles/ProjectBundle/Tests/Functional/Validator/UniqueNameValidatorFunctionalTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Validator/UniqueNameValidatorFunctionalTest.php
@@ -24,7 +24,7 @@ final class UniqueNameValidatorFunctionalTest extends MauticMysqlTestCase
         $form          = $buttonCrawler->form();
         $form['project_entity[name]']->setValue('QWERTY');
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString(
             'A project with this name already exists.',

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -26,14 +26,14 @@ class ReportApiControllerTest extends MauticMysqlTestCase
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', [], false, true);
         $this->client->request('GET', '/api/reports/'.$reportId);
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testGetReportSuccessByNoCorrectAccessToViewOther(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewother']]);
         $this->client->request('GET', '/api/reports/'.$reportId);
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testReportFailByNoCorrectAccessToViewOwn(): void
@@ -47,7 +47,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewown']], true);
         $this->client->request('GET', '/api/reports/'.$reportId);
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     /**

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -19,7 +19,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', []);
         $this->client->request('GET', '/api/reports/'.$reportId);
-        $this->assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testGetReportSuccessByCorrectAccessIsAdmin(): void
@@ -40,7 +40,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewown']]);
         $this->client->request('GET', '/api/reports/'.$reportId);
-        $this->assertSame(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testReportSuccessViewOwnBySameUser(): void

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -58,7 +58,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         // Check the details page
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
 
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     public function testReportTableOrderColumn(): void
@@ -101,25 +101,25 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
     public function testCreatingNewReportAndClone(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/reports/new/');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $saveButton = $crawler->selectButton('Save');
         $form       = $saveButton->form();
         $form['report[name]']->setValue('Report ABC');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         $report = $this->em->getRepository(Report::class)->findOneBy(['name' => 'Report ABC']);
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/reports/clone/{$report->getId()}");
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $saveButton = $crawler->selectButton('Save');
         $form       = $saveButton->form();
         $form['report[name]']->setValue('Report ABC - cloned');
 
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
         $reportClone = $this->em->getRepository(Report::class)->findOneBy(['name' => 'Report ABC - cloned']);
 
         Assert::assertSame($report->getId() + 1, $reportClone->getId());
@@ -154,7 +154,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSqlInjectionNotWork('/s/reports/view/'.$report->getId().'\'?tmpl=list&name=report.'.$report->getId().'&orderby=a_id');
 
         $this->client->request('GET', '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId().'&orderby=a_id');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     public function testContactReportwithComanyDateAddedColumn(): void
@@ -173,7 +173,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         // Check the details page
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     public function testEmailReportWithAggregatedColumnsAndTotals(): void
@@ -273,7 +273,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         // Get report view
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
         $response = $this->client->getResponse();
-        Assert::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         // Load view content as HTML and convert the report table to result array
         $result  = $this->parseReportTable($response->getContent());
@@ -326,7 +326,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         // Check the details page
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $response = $this->client->getResponse();
 
         $result = $this->parseReportTable($response->getContent());
@@ -355,7 +355,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         // Check the details page
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
     }
 
     /**
@@ -401,8 +401,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         }
 
         $this->client->submit($form);
-        $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $report   = $this->em->getRepository(Report::class)->find($report->getId());
         $schedule = $report->getSchedule();
@@ -506,15 +505,14 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $form           = $buttonCrawler->form();
         $form['report[scheduleUnit]']->setValue(SchedulerEnum::UNIT_NOW);
         $this->client->submit($form);
-        $response = $this->client->getResponse();
-        self::assertTrue($response->isOk());
+        self::assertResponseIsSuccessful();
 
         $schedulerRepository = self::getContainer()->get(SchedulerRepository::class);
         \assert($schedulerRepository instanceof SchedulerRepository);
         $scheduler = $schedulerRepository->getSchedulerByReport($report);
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
-        self::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         // Find save & close button
         $buttonCrawler = $crawler->selectButton('config[buttons][save]');
@@ -527,7 +525,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $this->client->submit($form);
-        self::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         while ($scheduler->getScheduleDate() > new \DateTime()) {
             // This ugly thing is needed, because \Mautic\ReportBundle\Scheduler\Model\SchedulerPlanner::computeScheduler
@@ -662,7 +660,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->getContainer()->get('mautic.report.model.report')->saveEntity($report);
 
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $content  = $this->client->getResponse()->getcontent();
         Assert::assertStringContainsString(self::TEST_EMAIL, $content);
@@ -707,7 +705,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         static::getContainer()->set('mautic.report.model.report', $reportModel);
 
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $content = $this->client->getResponse()->getContent();
         Assert::assertStringContainsString(self::DEFAULT_TEST_EMAIL, $content);

--- a/app/bundles/ReportBundle/Tests/Functional/AbstractReportSubscriberTestCase.php
+++ b/app/bundles/ReportBundle/Tests/Functional/AbstractReportSubscriberTestCase.php
@@ -50,7 +50,7 @@ abstract class AbstractReportSubscriberTestCase extends MauticMysqlTestCase
     public function verifyReport(int $reportId, array $expected): void
     {
         $crawler            = $this->client->request(Request::METHOD_GET, "/s/reports/view/$reportId");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
 
         // convert HTML table to php array

--- a/app/bundles/SmsBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\SmsBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 class AjaxControllerFunctionalTest extends MauticMysqlTestCase
@@ -13,7 +12,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
     public function testGetBuilderTokensAction(): void
     {
         $this->client->request(Request::METHOD_POST, '/s/ajax?action=sms:getBuilderTokens');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         $tokens = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertArrayHasKey('tokens', $tokens);
         $this->assertArrayHasKey('{contactfield=email}', $tokens['tokens']);

--- a/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
@@ -15,7 +15,7 @@ class StageControllerFunctionalTest extends MauticMysqlTestCase
     public function testStageMenuString(): void
     {
         $stage = $this->client->request(Request::METHOD_GET, '/s/stages');
-        Assert::assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
         $stageMenuString = $stage->filterXPath('//a[@id="mautic_stage_index"]');
         Assert::assertStringContainsString('Stages', $stageMenuString->text());
     }

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -83,7 +83,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('"username":"'.$user->getUserIdentifier().'"', $clientResponse->getContent());
     }
 
@@ -104,7 +104,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('"username":"'.$user->getUserIdentifier().'"', $clientResponse->getContent());
     }
 

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -20,7 +20,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         // Assuming user with id 99999 does not exist
         $this->client->request(Request::METHOD_PATCH, '/api/users/99999/edit', ['role' => 1]);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_NOT_FOUND, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         Assert::assertStringContainsString('"message":"Item was not found."', $clientResponse->getContent());
     }
 
@@ -29,7 +29,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         // Assuming role with id 99999 does not exist
         $this->client->request(Request::METHOD_PATCH, '/api/users/1/edit', ['role' => 99999]);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         Assert::assertStringContainsString('"message":"role: The selected choice is invalid."', $clientResponse->getContent());
     }
 
@@ -38,7 +38,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         // Correct request format is ['role' => 2]
         $this->client->request(Request::METHOD_PATCH, '/api/users/1/edit', ['role' => ['id' => 2]]);
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         Assert::assertStringContainsString('"message":"role: The selected choice is invalid."', $clientResponse->getContent());
     }
 
@@ -59,11 +59,10 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
-        $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         Assert::assertStringContainsString(
             '"message":"You do not have access to the requested area\/action."',
-            $clientResponse->getContent()
+            $this->client->getResponse()->getContent()
         );
     }
 
@@ -125,8 +124,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->setServerParameter('PHP_AUTH_PW', $weakPassword);
 
         $this->client->request(Request::METHOD_PATCH, "/api/users/{$user->getId()}/edit", ['role' => $role->getId()]);
-        $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_UNAUTHORIZED, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('passwordProvider')]
@@ -142,8 +140,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(Request::METHOD_POST, '/api/users/new', $userPayload);
-        $clientResponse = $this->client->getResponse();
-        Assert::assertSame($responseCode, $clientResponse->getStatusCode());
+        self::assertResponseStatusCodeSame($responseCode);
     }
 
     /**

--- a/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
@@ -32,7 +32,7 @@ class ProfileControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, 's/account');
 
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringNotContainsString('user[plainPassword][password]', $clientResponse->getContent());
         $this->assertStringNotContainsString('user[plainPassword][confirm]', $clientResponse->getContent());
     }
@@ -47,7 +47,7 @@ class ProfileControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, 's/account');
 
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('user[plainPassword][password]', $clientResponse->getContent());
         $this->assertStringContainsString('user[plainPassword][confirm]', $clientResponse->getContent());
     }

--- a/app/bundles/UserBundle/Tests/Controller/SecurityControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/SecurityControllerTest.php
@@ -25,7 +25,7 @@ class SecurityControllerTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
 
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $validationError = self::getContainer()->get('translator')->trans('mautic.user.security.saml.clearsession', [], 'flashes');
         $this->assertStringContainsString($validationError, $clientResponse->getContent());
@@ -36,7 +36,7 @@ class SecurityControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, '/saml/login_retry');
 
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         $validationError = self::getContainer()->get('translator')->trans('mautic.user.security.saml.clearsession', [], 'flashes');
         $this->assertStringNotContainsString($validationError, $clientResponse->getContent());

--- a/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
@@ -33,7 +33,7 @@ class UserControllerTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, 's/users/edit/'.$user1->getId());
 
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringNotContainsString('user[plainPassword][password]', $clientResponse->getContent());
         $this->assertStringNotContainsString('user[plainPassword][confirm]', $clientResponse->getContent());
     }

--- a/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
@@ -26,7 +26,7 @@ class PublicControllerTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, self::PASSWORD_RESET_URI.'?bundle=%27-alert("XSS%20TEST%20Mautic")-%27');
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $responseData = $clientResponse->getContent();
         // Tests that actual string is not present.
         $this->assertStringNotContainsString('-alert("xss test mautic")-', $responseData, 'XSS injection attempt is filtered.');
@@ -38,7 +38,7 @@ class PublicControllerTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, self::PASSWORD_RESET_URI);
         $clientResponse = $this->client->getResponse();
-        $this->assertSame(200, $clientResponse->getStatusCode(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $responseData = $clientResponse->getContent();
         $this->assertStringContainsString('Enter either your username or email to reset your password. Instructions to reset your password will be sent to the email in your profile.', $responseData);
     }

--- a/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
@@ -52,7 +52,7 @@ class PublicControllerTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
         $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());
+        $this->assertResponseIsSuccessful();
 
         $responseData = $clientResponse->getContent();
         $this->assertStringContainsString('A new password has been generated and will be emailed to you, if this user exists. If you do not receive it within a few minutes, check your spam box and/or contact the system administrator.', $responseData);
@@ -71,7 +71,7 @@ class PublicControllerTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('A new password has been generated and will be emailed to you, if this user exists. If you do not receive it within a few minutes, check your spam box and/or contact the system administrator.', $clientResponse->getContent());
     }
 }

--- a/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
@@ -24,7 +24,7 @@ class RoleControllerFunctionalTest extends MauticMysqlTestCase
         $form['role[description]']->setValue($desc);
 
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());
+        $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString($name, $this->client->getResponse()->getContent());
         $this->assertStringContainsString($desc, $this->client->getResponse()->getContent());
@@ -48,7 +48,7 @@ class RoleControllerFunctionalTest extends MauticMysqlTestCase
         $form['role[name]']->setValue($updatedName);
 
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString($updatedName, $this->client->getResponse()->getContent());
     }

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\HttpFoundation\Response;
 
 class UserControllerFunctionalTest extends MauticMysqlTestCase
 {
@@ -23,13 +22,13 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
     public function testEditGetPage(): void
     {
         $this->client->request('GET', '/s/users/edit/1');
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testRedirectNonExistingUser(): void
     {
         $crawler = $this->client->request('GET', '/s/users/edit/00000');
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Users', $crawler->filter('h1')->text());
         $this->assertStringContainsString('User not found with', $crawler->filter('#flashes')->text());
     }
@@ -43,7 +42,7 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('has been updated!', $response->getContent());
     }
 
@@ -60,7 +59,7 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('The email entered is invalid.', $this->client->getResponse()->getContent());
     }
 
@@ -82,7 +81,7 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString($message, $this->client->getResponse()->getContent());
     }
 
@@ -135,7 +134,7 @@ class UserControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->submit($form);
 
-        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString($message, $this->client->getResponse()->getContent());
     }
 

--- a/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
@@ -9,7 +9,6 @@ use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class UserLogoutFunctionalTest extends MauticMysqlTestCase
@@ -42,7 +41,7 @@ class UserLogoutFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, '/s/logout');
         $clientResponse = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString(
             'login',
             $clientResponse->getContent()

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/TimingSafeFormLoginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/TimingSafeFormLoginAuthenticatorTest.php
@@ -41,8 +41,6 @@ class TimingSafeFormLoginAuthenticatorTest extends TestCase
             ->method('loadUserByIdentifier')
             ->with('testuser')
             ->willReturn($user);
-
-        $passwordHasher = $this->createMock(PasswordHasherInterface::class);
         /** @var PasswordHasherFactoryInterface|\PHPUnit\Framework\MockObject\MockObject $passwordHasherFactory */
         $passwordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
         $passwordHasherFactory->expects($this->never())

--- a/app/bundles/UserBundle/Tests/Security/UserLoginTest.php
+++ b/app/bundles/UserBundle/Tests/Security/UserLoginTest.php
@@ -42,8 +42,7 @@ class UserLoginTest extends MauticMysqlTestCase
         ]);
         $crawler = $this->client->submit($form);
 
-        $clientResponse = $this->client->getResponse();
-        $this->assertEquals(200, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         // user has logged in
         $title = $crawler->filterXPath('//head/title')->text();

--- a/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -27,7 +27,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         $content = json_decode($response->getContent(), true);
         Assert::assertIsArray($content);
@@ -51,7 +51,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         $content = json_decode($response->getContent(), true);
         Assert::assertIsArray($content);
@@ -75,7 +75,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         $content = json_decode($response->getContent(), true);
         Assert::assertIsArray($content);
@@ -100,7 +100,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         $content = json_decode($response->getContent(), true);
         Assert::assertIsArray($content);
@@ -141,7 +141,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $response = $this->client->getResponse();
-        Assert::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
 
         $content = json_decode($response->getContent(), true);
         Assert::assertIsArray($content);

--- a/app/bundles/WebhookBundle/Tests/Functional/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Controller/WebhookControllerTest.php
@@ -10,7 +10,6 @@ use Mautic\WebhookBundle\Entity\Log;
 use Mautic\WebhookBundle\Entity\Webhook;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 final class WebhookControllerTest extends MauticMysqlTestCase
 {
@@ -24,7 +23,7 @@ final class WebhookControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
         $crawler = $this->client->request(Request::METHOD_GET, '/s/webhooks/view/'.$webhook->getId());
-        Assert::assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
+        self::assertResponseIsSuccessful();
 
         $logList = $crawler->filter('.table.table-responsive > tbody > tr')->count();
         Assert::assertSame(Webhook::LOGS_DISPLAY_LIMIT, $logList);

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
@@ -277,7 +277,7 @@ final class FileManagerControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->client->request($method, $endpoint, $parameters, $files);
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
 
         return $response;
     }

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
@@ -32,7 +32,7 @@ class FocusAjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, "/s/ajax?action=plugin:focus:getViewsCount&focusId={$focus->getId()}");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertSame([
             'success'     => 1,
             'views'       => 3,
@@ -56,7 +56,7 @@ class FocusAjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->xmlHttpRequest(Request::METHOD_GET, "/s/ajax?action=plugin:focus:getClickThroughCount&focusId={$focus->getId()}");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertSame([
             'success'      => 1,
             'clickThrough' => 2,

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
@@ -20,7 +20,7 @@ class FocusPublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_GET, "/focus/{$focus->getId()}.js");
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
         $this->assertNotEmpty($response->getContent());
     }
 

--- a/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -35,7 +35,7 @@ final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler      = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
         // get table with id=reportTable
         $crawlerTable = $crawler->filter('#reportTable');
         // remove first line of table (column names)
@@ -74,7 +74,7 @@ final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $crawler      = $this->client->request(Request::METHOD_GET, "/s/reports/view/{$report->getId()}");
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         // get table with id=reportTable
         $crawlerTable = $crawler->filter('#reportTable');

--- a/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -99,7 +99,7 @@ final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
 
         $focus1 = $this->createFocusItem('FocusItem1', 'doesAbc', 'link', 'modal');
         $focus2 = $this->createFocusItem('FocusItem2', 'doesAbcd', 'link', 'modal');
-        $focus3 = $this->createFocusItem('FocusItem3', 'doesAbcde', 'link', 'modal');
+        $this->createFocusItem('FocusItem3', 'doesAbcde', 'link', 'modal');
         $this->em->flush();
 
         $date = new \DateTime();

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -14,22 +14,19 @@ class MonitoringControllerTest extends MauticMysqlTestCase
     public function testIndex(): void
     {
         $this->client->request('GET', '/s/monitoring');
-        $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testNew(): void
     {
         $this->client->request('GET', '/s/monitoring/new');
-        $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testEdit(): void
     {
         $this->client->request('GET', '/s/monitoring/edit/1');
-        $response = $this->client->getResponse();
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     public function testIndexWithoutPermission(): void

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
@@ -33,7 +33,7 @@ class TweetControllerTest extends MauticMysqlTestCase
     {
         $this->client->request(Request::METHOD_GET, '/s/tweets');
         $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString('Tweet One', $response->getContent());
     }
@@ -48,8 +48,7 @@ class TweetControllerTest extends MauticMysqlTestCase
         $form['twitter_tweet[text]']->setValue('Here is the first tweet');
 
         $this->client->submit($form);
-        $response = $this->client->getResponse();
-        $this->assertTrue($response->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->assertSame(1, $this->tweetsRepo->count(['name' => $name]));
     }
@@ -61,7 +60,7 @@ class TweetControllerTest extends MauticMysqlTestCase
         $crawler               = $this->client->request('GET', '/s/tweets/edit/'.$tweet->getId());
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Edit tweet '.$tweet->getName(), $clientResponseContent, 'The return must contain \'Edit tweet\' text');
 
         $form = $crawler->selectButton('Save & Close')->form();

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
@@ -47,7 +47,7 @@ class TweetControllerTest extends MauticMysqlTestCase
         $form['twitter_tweet[name]']->setValue($name);
         $form['twitter_tweet[text]']->setValue('Here is the first tweet');
 
-        $crawler  = $this->client->submit($form);
+        $this->client->submit($form);
         $response = $this->client->getResponse();
         $this->assertTrue($response->isOk());
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -39,7 +39,7 @@ class BatchControllerTest extends MauticMysqlTestCase
     public function testBatchViewAction(): void
     {
         $this->client->request('GET', '/s/tags/batch/view');
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Add tags', $this->client->getResponse()->getContent());
         $this->assertStringContainsString('Remove tags', $this->client->getResponse()->getContent());
     }
@@ -55,7 +55,7 @@ class BatchControllerTest extends MauticMysqlTestCase
         $form->setValues($values);
         $this->client->submit($form);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('3 contacts affected', $this->client->getResponse()->getContent());
 
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
@@ -80,7 +80,7 @@ class BatchControllerTest extends MauticMysqlTestCase
         $form->setValues($values);
         $this->client->submit($form);
 
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('1 contact affected', $this->client->getResponse()->getContent());
         $lead1 = $leadModel->getEntity($this->leads[0]->getId());
         $this->assertNotContains($this->tags[1], $lead1->getTags()->toArray());

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -54,7 +54,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('tag1', $clientResponseContent, 'The return must contain tag1');
         $this->assertStringContainsString('tag2', $clientResponseContent, 'The return must contain tag2');
     }
@@ -68,7 +68,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('tag1', $clientResponseContent, 'The return must contain tag1');
         $this->assertStringNotContainsString('tag2', $clientResponseContent, 'The return must not contain tag2');
     }
@@ -89,7 +89,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
 
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('tag1', $clientResponseContent, 'The return must contain the tag whose description matches.');
         $this->assertStringNotContainsString('tag2', $clientResponseContent, 'The return must not contain unrelated tags.');
     }
@@ -98,9 +98,9 @@ class TagControllerTest extends MauticMysqlTestCase
     {
         $tagId = $this->tagRepository->findOneBy([])->getId();
         $this->client->request('POST', '/s/tags/delete/'.$tagId);
-        $clientResponse = $this->client->getResponse();
+        $this->client->getResponse();
 
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->tagRepository->find($tagId), null, 'Assert that tag is deleted');
     }
 
@@ -120,9 +120,9 @@ class TagControllerTest extends MauticMysqlTestCase
         Assert::assertSame(1, $this->countLeadTagAssociations($tagId));
 
         $this->client->request('POST', '/s/tags/delete/'.$tagId);
-        $clientResponse = $this->client->getResponse();
+        $this->client->getResponse();
 
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertSame($this->tagRepository->find($tagId), null, 'Assert that tag is deleted');
         Assert::assertSame(0, $this->countLeadTagAssociations($tagId));
     }
@@ -137,7 +137,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/s/tags/view/'.$tag->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString($tag->getTag(), $clientResponseContent, 'The return must contain tag');
     }
 
@@ -171,7 +171,7 @@ class TagControllerTest extends MauticMysqlTestCase
         $crawler                = $this->client->request('GET', '/s/tags/edit/'.$tag->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Edit tag: '.$tag->getTag(), $clientResponseContent, 'The return must contain \'Edit tag\' text');
 
         $form = $crawler->selectButton('Save & Close')->form();
@@ -196,8 +196,7 @@ class TagControllerTest extends MauticMysqlTestCase
     {
         $TagName        = 'Test tag';
         $crawler        = $this->client->request('GET', '/s/tags/new');
-        $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
         $form['tag_entity[tag]']->setValue($TagName);
@@ -210,8 +209,7 @@ class TagControllerTest extends MauticMysqlTestCase
     {
         $TagName        = $this->tagRepository->findOneBy([])->getTag();
         $crawler        = $this->client->request('GET', '/s/tags/new');
-        $clientResponse = $this->client->getResponse();
-        $this->assertTrue($clientResponse->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
         $form['tag_entity[tag]']->setValue($TagName);
@@ -225,20 +223,20 @@ class TagControllerTest extends MauticMysqlTestCase
         $tags   = $this->tagRepository->findAll();
         $tagsId = array_map(fn (Tag $tag) => $tag->getId(), $tags);
         $this->client->request('POST', '/s/tags/batchDelete?ids='.json_encode($tagsId));
-        $this->assertTrue($this->client->getResponse()->isOk(), 'Return code must be 200.');
+        $this->assertResponseIsSuccessful();
         $this->assertEmpty($this->tagRepository->count([]), 'All tags must be deleted.');
     }
 
     public function testEmptyTagShouldThrowValidationError(): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/s/tags/new');
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
 
         $buttonCrawler  = $crawler->selectButton('Save & Close');
         $form           = $buttonCrawler->form();
         $form->setValues(['tag_entity[tag]' => '']);
         $this->client->submit($form);
-        Assert::assertTrue($this->client->getResponse()->isOk());
+        self::assertResponseIsSuccessful();
         Assert::assertStringContainsString('A value is required.', $this->client->getResponse()->getContent());
     }
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -98,8 +98,6 @@ class TagControllerTest extends MauticMysqlTestCase
     {
         $tagId = $this->tagRepository->findOneBy([])->getId();
         $this->client->request('POST', '/s/tags/delete/'.$tagId);
-        $this->client->getResponse();
-
         $this->assertResponseIsSuccessful();
         $this->assertSame($this->tagRepository->find($tagId), null, 'Assert that tag is deleted');
     }
@@ -120,8 +118,6 @@ class TagControllerTest extends MauticMysqlTestCase
         Assert::assertSame(1, $this->countLeadTagAssociations($tagId));
 
         $this->client->request('POST', '/s/tags/delete/'.$tagId);
-        $this->client->getResponse();
-
         $this->assertResponseIsSuccessful();
         $this->assertSame($this->tagRepository->find($tagId), null, 'Assert that tag is deleted');
         Assert::assertSame(0, $this->countLeadTagAssociations($tagId));

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
@@ -16,7 +16,6 @@ use Mautic\LeadBundle\Entity\Tag;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\ReportBundle\Entity\Report;
-use Symfony\Component\HttpFoundation\Response;
 
 final class TagDependenciesTest extends MauticMysqlTestCase
 {
@@ -107,7 +106,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
         $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         // check that the page loads without errors
-        $this->assertSame(Response::HTTP_OK, $clientResponse->getStatusCode());
+        $this->assertResponseIsSuccessful();
     }
 
     private function createTag(string $tagName): Tag

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
@@ -104,8 +104,6 @@ final class TagDependenciesTest extends MauticMysqlTestCase
         $tag         = $this->createTag('TagA');
         $this->createReportWithTagEmpty();
         $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
-        $clientResponse = $this->client->getResponse();
-        // check that the page loads without errors
         $this->assertResponseIsSuccessful();
     }
 

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
 use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
 use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
@@ -26,6 +27,7 @@ return RectorConfig::configure()
     ->withRules([
         SpecificAssertContainsRector::class,
         GetMockBuilderGetMockToCreateMockRector::class,
+        RemoveUnusedVariableAssignRector::class,
         WebTestCaseAssertIsSuccessfulRector::class,
     ])
     ->withSkip([

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -37,7 +37,12 @@ return RectorConfig::configure()
     ->withSkip([
         AddDoesNotPerformAssertionToNonAssertingTestRector::class, // Adds annotation where it does not belong to.
         ParentTestClassConstructorRector::class, // Adds unnecessary constructors to test classes without custom logic.
+        WebTestCaseAssertResponseCodeRector::class => [
+            __DIR__.'/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php',
+            __DIR__.'/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php',
+        ],
         WebTestCaseAssertIsSuccessfulRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Tests/Functional/SamlTest.php',
+            __DIR__.'/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php',
         ],
     ]);

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -31,4 +31,8 @@ return RectorConfig::configure()
     ->withSkip([
         AddDoesNotPerformAssertionToNonAssertingTestRector::class, // Adds annotation where it does not belong to.
         ParentTestClassConstructorRector::class, // Adds unnecessary constructors to test classes without custom logic.
+        WebTestCaseAssertIsSuccessfulRector::class => [
+            __DIR__.'/app/bundles/CoreBundle/Tests/Functional/SamlTest.php',
+            __DIR__.'/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php',
+        ],
     ]);

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use MauticRector\AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\ParentTestClassConstructorRector;
@@ -27,6 +28,7 @@ return RectorConfig::configure()
     ->withRules([
         SpecificAssertContainsRector::class,
         GetMockBuilderGetMockToCreateMockRector::class,
+        AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
         RemoveUnusedVariableAssignRector::class,
         WebTestCaseAssertIsSuccessfulRector::class,
     ])

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -11,6 +11,7 @@ use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMock
 use Rector\PHPUnit\PHPUnit80\Rector\MethodCall\SpecificAssertContainsRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Symfony\Symfony43\Rector\MethodCall\WebTestCaseAssertIsSuccessfulRector;
+use Rector\Symfony\Symfony43\Rector\MethodCall\WebTestCaseAssertResponseCodeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -30,6 +31,7 @@ return RectorConfig::configure()
         GetMockBuilderGetMockToCreateMockRector::class,
         AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
         RemoveUnusedVariableAssignRector::class,
+        WebTestCaseAssertResponseCodeRector::class,
         WebTestCaseAssertIsSuccessfulRector::class,
     ])
     ->withSkip([

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -37,6 +37,5 @@ return RectorConfig::configure()
         ParentTestClassConstructorRector::class, // Adds unnecessary constructors to test classes without custom logic.
         WebTestCaseAssertIsSuccessfulRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Tests/Functional/SamlTest.php',
-            __DIR__.'/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php',
         ],
     ]);

--- a/rector-tests.php
+++ b/rector-tests.php
@@ -8,6 +8,7 @@ use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonA
 use Rector\PHPUnit\PHPUnit60\Rector\MethodCall\GetMockBuilderGetMockToCreateMockRector;
 use Rector\PHPUnit\PHPUnit80\Rector\MethodCall\SpecificAssertContainsRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Symfony\Symfony43\Rector\MethodCall\WebTestCaseAssertIsSuccessfulRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -25,6 +26,7 @@ return RectorConfig::configure()
     ->withRules([
         SpecificAssertContainsRector::class,
         GetMockBuilderGetMockToCreateMockRector::class,
+        WebTestCaseAssertIsSuccessfulRector::class,
     ])
     ->withSkip([
         AddDoesNotPerformAssertionToNonAssertingTestRector::class, // Adds annotation where it does not belong to.

--- a/rector.php
+++ b/rector.php
@@ -10,7 +10,6 @@ use Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector;
-use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\Class_\ReturnTypeFromStrictTernaryRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
@@ -47,8 +46,6 @@ return RectorConfig::configure()
         AddVoidReturnTypeWhereNoReturnRector::class,
         TypedPropertyFromStrictConstructorRector::class,
         TypedPropertyFromStrictSetUpRector::class,
-        RemoveUnusedVariableAssignRector::class,
-        RemoveUselessVarTagRector::class,
         SimplifyUselessVariableRector::class,
         ReturnTypeFromStrictConstantReturnRector::class,
         ReturnTypeFromReturnDirectArrayRector::class,

--- a/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
+++ b/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
@@ -184,8 +184,7 @@ final class AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector extends Abs
             return false;
         }
 
-        // Common functional-test conventions for BrowserKit responses.
-        if ('clientResponse' === $node->name || 'response' === $node->name) {
+        if ('clientResponse' === $node->name) {
             return true;
         }
 

--- a/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
+++ b/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticRector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace BrowserKit success assertions with assertResponseIsSuccessful()',
+            [
+                new CodeSample(
+                    'Assert::assertTrue($this->client->getResponse()->isOk());',
+                    'self::assertResponseIsSuccessful();'
+                ),
+                new CodeSample(
+                    '$this->assertTrue($this->client->getResponse()->isOk(), $this->client->getResponse()->getContent());',
+                    '$this->assertResponseIsSuccessful($this->client->getResponse()->getContent());'
+                ),
+                new CodeSample(
+                    '$clientResponse = $this->client->getResponse();'."\n".'$this->assertTrue($clientResponse->isOk(), $clientResponse->getContent());',
+                    '$clientResponse = $this->client->getResponse();'."\n".'$this->assertResponseIsSuccessful($clientResponse->getContent());'
+                ),
+                new CodeSample(
+                    '$clientResponse = $this->client->getResponse();'."\n".'$this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());',
+                    '$clientResponse = $this->client->getResponse();'."\n".'$this->assertResponseIsSuccessful();'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, StaticCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return null;
+        }
+
+        $assertionType = $this->resolveAssertionType($node);
+        if (null === $assertionType) {
+            return null;
+        }
+
+        $args = $this->resolveReplacementArgs($node, $assertionType);
+        if (null === $args) {
+            return null;
+        }
+
+        if ($node instanceof MethodCall) {
+            return new MethodCall($node->var, new Identifier('assertResponseIsSuccessful'), $args);
+        }
+
+        return new StaticCall(new Name('self'), 'assertResponseIsSuccessful', $args);
+    }
+
+    private function resolveAssertionType(Node $node): ?string
+    {
+        if ($this->isName($node->name, 'assertTrue')) {
+            return 'assertTrue';
+        }
+
+        if ($this->isName($node->name, 'assertEquals') || $this->isName($node->name, 'assertSame')) {
+            return 'statusCode';
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Arg[]|null
+     */
+    private function resolveReplacementArgs(Node $node, string $assertionType): ?array
+    {
+        if ('assertTrue' === $assertionType) {
+            if (!isset($node->args[0]) || !$this->isBrowserKitResponseOkCheck($node->args[0], $node)) {
+                return null;
+            }
+
+            return isset($node->args[1]) && $node->args[1] instanceof Arg
+                ? [$node->args[1]]
+                : [];
+        }
+
+        if (!isset($node->args[0], $node->args[1])) {
+            return null;
+        }
+
+        if (!$this->isHttpOkValue($node->args[0]) || !$this->isBrowserKitStatusCodeCheck($node->args[1], $node)) {
+            return null;
+        }
+
+        return isset($node->args[2]) && $node->args[2] instanceof Arg
+            ? [$node->args[2]]
+            : [];
+    }
+
+    private function isBrowserKitResponseOkCheck(Arg $arg, Node $assertNode): bool
+    {
+        $value = $arg->value;
+
+        if (!$value instanceof MethodCall || !$this->isName($value->name, 'isOk')) {
+            return false;
+        }
+
+        return $this->isBrowserKitResponseFetch($value->var)
+            || $this->isVariableAssignedFromBrowserKitResponse($value->var, $assertNode);
+    }
+
+    private function isBrowserKitStatusCodeCheck(Arg $arg, Node $assertNode): bool
+    {
+        $value = $arg->value;
+
+        if (!$value instanceof MethodCall || !$this->isName($value->name, 'getStatusCode')) {
+            return false;
+        }
+
+        return $this->isBrowserKitResponseFetch($value->var)
+            || $this->isVariableAssignedFromBrowserKitResponse($value->var, $assertNode);
+    }
+
+    private function isHttpOkValue(Arg $arg): bool
+    {
+        $value = $arg->value;
+
+        if ($value instanceof Int_) {
+            return 200 === $value->value;
+        }
+
+        if (!$value instanceof ClassConstFetch) {
+            return false;
+        }
+
+        return $this->isName($value->class, 'Response')
+            && $this->isName($value->name, 'HTTP_OK');
+    }
+
+    private function isBrowserKitResponseFetch(Node $node): bool
+    {
+        if (!$node instanceof MethodCall || !$this->isName($node->name, 'getResponse')) {
+            return false;
+        }
+
+        $clientFetch = $node->var;
+
+        return $clientFetch instanceof PropertyFetch
+            && $this->isName($clientFetch->var, 'this')
+            && $this->isName($clientFetch->name, 'client');
+    }
+
+    private function isVariableAssignedFromBrowserKitResponse(Node $node, Node $assertNode): bool
+    {
+        if (!$node instanceof Variable || !is_string($node->name)) {
+            return false;
+        }
+
+        // Common functional-test conventions for BrowserKit responses.
+        if ('clientResponse' === $node->name || 'response' === $node->name) {
+            return true;
+        }
+
+        $currentStmt = $this->findCurrentStatement($assertNode);
+        if (!$currentStmt instanceof Stmt) {
+            return false;
+        }
+
+        $parentNode = $currentStmt->getAttribute('parent');
+        if (!$parentNode instanceof Node || !property_exists($parentNode, 'stmts') || !is_array($parentNode->stmts)) {
+            return false;
+        }
+
+        $stmtKey = $this->resolveStatementKey($parentNode->stmts, $currentStmt);
+        if (0 === $stmtKey) {
+            return false;
+        }
+
+        for ($currentKey = $stmtKey - 1; $currentKey >= 0; --$currentKey) {
+            $previousStmt = $parentNode->stmts[$currentKey] ?? null;
+            if (!$previousStmt instanceof Expression || !$previousStmt->expr instanceof Assign) {
+                continue;
+            }
+
+            $assign = $previousStmt->expr;
+            if (!$assign->var instanceof Variable || !is_string($assign->var->name) || $assign->var->name !== $node->name) {
+                continue;
+            }
+
+            return $this->isBrowserKitResponseFetch($assign->expr);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Stmt[] $stmts
+     */
+    private function resolveStatementKey(array $stmts, Stmt $currentStmt): ?int
+    {
+        foreach ($stmts as $key => $stmt) {
+            if ($stmt === $currentStmt) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+
+    private function findCurrentStatement(Node $node): ?Stmt
+    {
+        $currentNode = $node;
+
+        while (!$currentNode instanceof Stmt) {
+            $currentNode = $currentNode->getAttribute('parent');
+            if (!$currentNode instanceof Node) {
+                return null;
+            }
+        }
+
+        return $currentNode;
+    }
+}

--- a/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
+++ b/rector/AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -59,6 +60,10 @@ final class AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector extends Abs
     public function refactor(Node $node): ?Node
     {
         if (!$node instanceof MethodCall && !$node instanceof StaticCall) {
+            return null;
+        }
+
+        if (!$this->isInWebTestCase($node)) {
             return null;
         }
 
@@ -242,5 +247,13 @@ final class AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector extends Abs
         }
 
         return $currentNode;
+    }
+
+    private function isInWebTestCase(Node $node): bool
+    {
+        $classReflection = ScopeFetcher::fetch($node)->getClassReflection();
+
+        return null !== $classReflection
+            && $classReflection->is('Symfony\Bundle\FrameworkBundle\Test\WebTestCase');
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR is adding the https://getrector.com/rule-detail/web-test-case-assert-is-successful-rector to the test Rector config. I find this issue in every other PR and I got tired of pointing it out every time. I noticed this stock rule didn't catch nearly all the ways how to write the same 200 response assert so I added a new custom rule to address that.

Martin uncovered another repeating issue which is that we have unused variables in the tests caused not only by this refactoring. So we added https://getrector.com/rule-detail/remove-unused-variable-assign-rector as well. It already executes for the prod code in the DeadCode set.

Also adding https://getrector.com/rule-detail/web-test-case-assert-response-code-rector when in it.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. No production code affected. Just Rector config and tests. So no testing needed. The green CI checkmark is all we need.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->