### PR TITLE
[NOT-FOR-MERGE] Fix tracking links with special characters in URL fragment result in 404

### DIFF
--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -267,11 +267,21 @@ class UrlHelper
      */
     public static function isValidUrl($url): bool
     {
-        $path         = parse_url($url, PHP_URL_PATH);
-        $encodedPath  = array_map('urlencode', explode('/', $path));
-        $url          = str_replace($path, implode('/', $encodedPath), $url);
+        $urlToValidate = $url;
 
-        return (bool) filter_var($url, FILTER_VALIDATE_URL);
+        // RFC 3986 allows non-ASCII characters in the fragment that filter_var rejects.
+        $fragment = parse_url($url, PHP_URL_FRAGMENT);
+        if (null !== $fragment) {
+            $urlToValidate = substr($url, 0, -(\strlen($fragment) + 1));
+        }
+
+        $path = parse_url($urlToValidate, PHP_URL_PATH);
+        if (null !== $path && '' !== $path) {
+            $encodedPath   = array_map('urlencode', explode('/', $path));
+            $urlToValidate = str_replace($path, implode('/', $encodedPath), $urlToValidate);
+        }
+
+        return (bool) filter_var($urlToValidate, FILTER_VALIDATE_URL);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -184,6 +184,8 @@ STRING
     {
         $this->assertTrue(UrlHelper::isValidUrl('https://domain.tld/e'));
         $this->assertTrue(UrlHelper::isValidUrl('https://domain.tld/é'));
+        $this->assertTrue(UrlHelper::isValidUrl('https://www.example.com/page#color=grün'));
+        $this->assertTrue(UrlHelper::isValidUrl('https://www.example.com/page?foo=bar#section=äöü'));
         $this->assertFalse(UrlHelper::isValidUrl('notvalidurl'));
         $this->assertFalse(UrlHelper::isValidUrl('notvalidurlé'));
     }


### PR DESCRIPTION
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ 
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | 

## Description

Summary
When an email link contains a URL fragment with special characters (e.g. #grün), Mautic's tracking redirect returns a 404 instead of taking the user to the correct page. Works fine without the fragment, and does not occur in M7.

Steps to reproduce

Add a link to an email in Mautic where the URL has a fragment with a special character — e.g. [https://www.your-mautic-instance.example/url-path/#color=grün](https://www.your-mautic-instance.example/url-path//#color=gr%C3%BCn) 

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Send the email — Mautic wraps the link in a tracking URL
3. Click the tracking link
4. See 404 error. The redirect fails.

Expected behaviour The user is redirected to the destination page.
 