### PR TITLE
[NOT-FOR-MERGE] MTC-10813 Fix conditional form sub-fields sharing duplicate field_order on save…

### DIFF
--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -128,14 +128,27 @@ class FieldController extends CommonFormController
                         $formField['isRequired'] = !empty($formField['properties']['captcha']);
                     }
 
-                    // Add it to the next to last assuming the last is the submit button
+                    // Add field before the submit button
                     if (count($fields)) {
-                        $lastField = end($fields);
-                        $lastKey   = key($fields);
-                        array_pop($fields);
+                        $submitKey = null;
+                        $submitField = null;
 
-                        $fields[$keyId]   = $formField;
-                        $fields[$lastKey] = $lastField;
+                        foreach ($fields as $key => $field) {
+                            if (isset($field['type']) && 'button' === $field['type']) {
+                                $submitKey = $key;
+                                $submitField = $field;
+                                break;
+                            }
+                        }
+
+                        if ($submitKey) {
+                            // Remove submit button, add new field, re-add submit button at the end
+                            unset($fields[$submitKey]);
+                            $fields[$keyId] = $formField;
+                            $fields[$submitKey] = $submitField;
+                        } else {
+                            $fields[$keyId] = $formField;
+                        }
                     } else {
                         $fields[$keyId] = $formField;
                     }

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -822,7 +822,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedActions,
-                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
+                    fn ($a, $b): int => $a['order'] <=> $b['order']
                 );
             }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -790,7 +790,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedFields,
-                    fn ($a, $b): int => $a['order'] <=> $b['order']
+                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
                 );
             }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -822,7 +822,7 @@ class FormController extends CommonFormController
             if (!empty($reorder)) {
                 uasort(
                     $modifiedActions,
-                    fn ($a, $b): int => $a['order'] <=> $b['order']
+                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
                 );
             }
 

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -183,7 +183,7 @@ class Form extends FormEntity
 
         $builder->createOneToMany('fields', 'Field')
             ->setIndexBy('id')
-            ->setOrderBy(['order' => 'ASC'])
+            ->setOrderBy(['order' => 'ASC', 'id' => 'ASC'])
             ->mappedBy('form')
             ->cascadeAll()
             ->fetchExtraLazy()

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -195,16 +195,8 @@ class FormModel extends CommonFormModel
             }
             $field->setForm($entity);
             $field->setSessionId($key);
-            if (!$field->getParent()) {
-                $field->setOrder($order);
-                ++$order;
-            } else {
-                if (isset($sessionFields[$field->getParent()]['order'])) {
-                    $field->setOrder($sessionFields[$field->getParent()]['order']);
-                } else {
-                    $field->setOrder($order);
-                }
-            }
+            $field->setOrder($order);
+            ++$order;
             $entity->addField($properties['id'], $field);
         }
 
@@ -437,7 +429,7 @@ class FormModel extends CommonFormModel
         $fields = $entity->getFields()->toArray();
 
         // Ensure the correct order in case this is generated right after a form save with new fields
-        uasort($fields, fn ($a, $b): int => $a->getOrder() <=> $b->getOrder());
+        uasort($fields, fn (Field $a, Field $b): int => $this->compareFieldOrder($a, $b));
 
         $viewOnlyFields     = $this->getCustomComponents()['viewOnlyFields'];
         $displayManager     = new DisplayManager($entity, !empty($viewOnlyFields) ? $viewOnlyFields : []);
@@ -1068,5 +1060,16 @@ class FormModel extends CommonFormModel
                 );
             }
         }
+    }
+
+    private function compareFieldOrder(Field $a, Field $b): int
+    {
+        $order = $a->getOrder() <=> $b->getOrder();
+
+        if (0 !== $order) {
+            return $order;
+        }
+
+        return ($a->getId() ?? 0) <=> ($b->getId() ?? 0);
     }
 }

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -5,12 +5,136 @@ declare(strict_types=1);
 namespace Mautic\FormBundle\Tests\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class FormModelFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;
+
+    /**
+     * @see https://github.com/mautic/mautic/issues/11558
+     */
+    public function testConditionalFieldsPreserveOrderAfterDatabaseSave(): void
+    {
+        /** @var FormModel $formModel */
+        $formModel = static::getContainer()->get('mautic.form.model.form');
+
+        $parentKey     = 'mautic_parent';
+        $sessionFields = [
+            $parentKey => [
+                'id'         => $parentKey,
+                'label'      => 'Yes or No',
+                'alias'      => 'yes_no',
+                'type'       => 'select',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'properties' => [
+                    'list' => [
+                        'list' => [
+                            ['label' => 'Yes', 'value' => 'yes'],
+                            ['label' => 'No', 'value' => 'no'],
+                        ],
+                    ],
+                ],
+            ],
+            'child_a' => [
+                'id'         => 'child_a',
+                'label'      => 'Question A',
+                'alias'      => 'question_a',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+                'conditions' => [
+                    'expr'   => 'in',
+                    'any'    => 0,
+                    'values' => ['yes'],
+                ],
+            ],
+            'child_b' => [
+                'id'         => 'child_b',
+                'label'      => 'Question B',
+                'alias'      => 'question_b',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+                'conditions' => [
+                    'expr'   => 'in',
+                    'any'    => 0,
+                    'values' => ['yes'],
+                ],
+            ],
+            'child_c' => [
+                'id'         => 'child_c',
+                'label'      => 'Question C',
+                'alias'      => 'question_c',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+                'conditions' => [
+                    'expr'   => 'in',
+                    'any'    => 0,
+                    'values' => ['yes'],
+                ],
+            ],
+        ];
+
+        $form = new Form();
+        $form->setName('Conditional field order test');
+        $form->setAlias('cond_order_'.uniqid());
+        $form->setIsPublished(false);
+
+        $formModel->setFields($form, $sessionFields);
+        $formModel->saveEntity($form);
+
+        $formId = $form->getId();
+        $this->em->clear();
+
+        $reloaded = $formModel->getEntity($formId);
+        self::assertNotNull($reloaded);
+        self::assertSame(['Question A', 'Question B', 'Question C'], $this->getConditionalChildLabels($reloaded));
+
+        $resaveSessionFields = [];
+        foreach ($reloaded->getFields() as $field) {
+            $sessionId = 'mautic_re_'.$field->getId();
+            $field->setSessionId($sessionId);
+            $fieldData = $field->convertToArray();
+            unset($fieldData['form']);
+            $fieldData['id']                 = $field->getId();
+            $resaveSessionFields[$sessionId] = $fieldData;
+        }
+
+        $formModel->setFields($reloaded, $resaveSessionFields);
+        $formModel->saveEntity($reloaded);
+        $this->em->clear();
+
+        $savedAgain = $formModel->getEntity($formId);
+        self::assertNotNull($savedAgain);
+        self::assertSame(['Question A', 'Question B', 'Question C'], $this->getConditionalChildLabels($savedAgain));
+
+        $formModel->deleteEntity($savedAgain);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getConditionalChildLabels(Form $form): array
+    {
+        $labels = [];
+
+        foreach ($form->getFields() as $field) {
+            if ($field->getParent()) {
+                $labels[] = $field->getLabel();
+            }
+        }
+
+        return $labels;
+    }
 
     public function testPopulateValuesWithGetParameters(): void
     {

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -216,7 +216,62 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(4, $childField->getOrder());
         $this->assertSame('text', $newChildField->getType());
         $this->assertSame('new_child', $newChildField->getAlias());
-        $this->assertSame(4, $newChildField->getOrder());
+        $this->assertSame(5, $newChildField->getOrder());
+    }
+
+    public function testSetFieldsAssignsUniqueSequentialOrderToConditionalFields(): void
+    {
+        $parentKey = 'parent';
+        $fields    = [
+            $parentKey => [
+                'id'         => $parentKey,
+                'label'      => 'Yes or No',
+                'alias'      => 'yes_no',
+                'type'       => 'select',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'order'      => 1,
+            ],
+            'child_a' => [
+                'id'         => 'child_a',
+                'label'      => 'Question A',
+                'alias'      => 'question_a',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+            ],
+            'child_b' => [
+                'id'         => 'child_b',
+                'label'      => 'Question B',
+                'alias'      => 'question_b',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+            ],
+            'child_c' => [
+                'id'         => 'child_c',
+                'label'      => 'Question C',
+                'alias'      => 'question_c',
+                'type'       => 'text',
+                'showLabel'  => 1,
+                'saveResult' => 1,
+                'parent'     => $parentKey,
+            ],
+        ];
+
+        $form = new Form();
+        $this->formModel->setFields($form, $fields);
+
+        $entityFields = $form->getFields()->toArray();
+        $this->assertSame(1, $entityFields[$parentKey]->getOrder());
+        $this->assertSame(2, $entityFields['child_a']->getOrder());
+        $this->assertSame(3, $entityFields['child_b']->getOrder());
+        $this->assertSame(4, $entityFields['child_c']->getOrder());
+
+        $orders = array_map(fn (Field $field) => $field->getOrder(), $entityFields);
+        $this->assertSame(count($entityFields), count(array_unique($orders)));
     }
 
     public function testGetComponentsFields(): void


### PR DESCRIPTION
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>

Additional fix to https://github.com/mautic/mautic/pull/16216

<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          |  ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

When building a Mautic form with multiple conditional fields (fields that appear based on the value of a parent field), the field order is randomly shuffled after saving the form. The fields do not appear in the order they were defined.


---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new Mautic form
3. Add a select field with at least two options (e.g. "yes" / "no")
4. Add multiple fields that are based on a selected value from the field above (conditional/dependent fields)
5. Save the form
6. Observe that the order of the conditional sub-fields are in the correct order

