### PR TITLE
Non blocking MOTD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,47 +8,52 @@ Mautic is an open-source marketing automation platform built on **Symfony 7.4** 
 
 ## Essential Commands
 
+### Command Execution Rule
+- Prefer `ddev` wrappers for agent-run PHP, Composer, Symfony console, and PHPUnit commands in this repository.
+- Use forms like `ddev exec php bin/phpunit -c app/phpunit.xml.dist ...`, `ddev exec php bin/console ...`, and `ddev composer ...`.
+- Avoid running `php`, `composer`, `bin/console`, or `bin/phpunit` directly on the host unless the user explicitly asks for that.
+
 ### Development Setup
 ```bash
 # DDEV-based setup (recommended) - auto-installs and configures everything
 ddev start
 
 # Manual setup
-composer install
+ddev composer install
 npm ci && npm run build
-bin/console mautic:install <site-url>
+ddev exec php bin/console mautic:install <site-url>
 ```
 
 ### Testing
 ```bash
 # Run all PHPUnit tests
-composer test
+ddev composer test
 
 # Run specific test file
-bin/phpunit app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
+ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
 
 # Run specific bundle tests
-bin/phpunit app/bundles/CoreBundle/Tests
+ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/CoreBundle/Tests
 
 # Run specific test method
-bin/phpunit --filter testGuessTimezoneFromOffset
+ddev exec php bin/phpunit -c app/phpunit.xml.dist --filter testGuessTimezoneFromOffset
 
 # E2E acceptance tests (Codeception)
-composer run e2e-test
+ddev composer run e2e-test
 ```
 
 ### Code Quality
 ```bash
-composer phpstan          # Static analysis (level 6)
-composer cs               # Check coding standards (dry-run)
-composer fixcs            # Auto-fix coding standards
-composer rector           # Run Rector refactoring (code + tests)
-bin/console lint:twig app plugins  # Lint Twig templates
+ddev composer phpstan                  # Static analysis (level 6)
+ddev composer cs                       # Check coding standards (dry-run)
+ddev composer fixcs                    # Auto-fix coding standards
+ddev composer rector                   # Run Rector refactoring (code + tests)
+ddev exec php bin/console lint:twig app plugins  # Lint Twig templates
 ```
 
 ### Asset Management
 ```bash
-composer generate-assets  # Regenerate compiled assets
+ddev composer generate-assets  # Regenerate compiled assets
 npm run build            # Build frontend with webpack
 ```
 
@@ -103,12 +108,12 @@ MauticExampleBundle/
 
 Before submitting PRs, run:
 ```bash
-composer test      # PHPUnit tests pass
-composer phpstan   # Static analysis passes
-composer cs        # Coding standards check
+ddev composer test      # PHPUnit tests pass
+ddev composer phpstan   # Static analysis passes
+ddev composer cs        # Coding standards check
 ```
 
-For UI changes, also run `composer run e2e-test`.
+For UI changes, also run `ddev composer run e2e-test`.
 
 ## Configuration
 

--- a/app/bundles/CoreBundle/Command/MessageOfTheDayCommand.php
+++ b/app/bundles/CoreBundle/Command/MessageOfTheDayCommand.php
@@ -42,9 +42,9 @@ final class MessageOfTheDayCommand extends Command
 
             $this->renderMessage($output, $selectedMessage);
         } catch (MessageOfTheDayException $e) {
-            $output->writeln('<error>Failed to load MOTD: '.$e->getMessage().'</error>');
+            $output->writeln('<comment>Skipped MOTD: '.$e->getMessage().'</comment>');
 
-            return Command::FAILURE;
+            return Command::SUCCESS;
         }
 
         return Command::SUCCESS;

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
@@ -8,6 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class MessageOfTheDayCommandTest extends MauticMysqlTestCase
 {
@@ -170,7 +173,24 @@ final class MessageOfTheDayCommandTest extends MauticMysqlTestCase
 
         $tester = $this->testSymfonyCommand('mautic:motd');
 
-        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
-        $this->assertStringContainsString('Could not decode MOTD JSON', $tester->getDisplay());
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('Skipped MOTD: Could not decode MOTD JSON', $tester->getDisplay());
+    }
+
+    public function testItSkipsMotdWhenFetchFails(): void
+    {
+        file_put_contents($this->cachePath, 'stale-cache');
+        touch($this->cachePath, time() - 7200);
+
+        $httpClient = static::getContainer()->get(HttpClientInterface::class);
+        self::assertInstanceOf(MockHttpClient::class, $httpClient);
+        $httpClient->setResponseFactory([
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+
+        $tester = $this->testSymfonyCommand('mautic:motd');
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('Skipped MOTD: Could not fetch motd.json', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

[CI](https://github.com/mautic/mautic/actions/runs/27268251673/job/80530785962?pr=16217) is today blocked again:
```
 [OK] All assets were successfully installed.                                   

> bin/console mautic:motd
Failed to load MOTD: Could not fetch motd.json
Script bin/console mautic:motd handling the motd event returned with error code 1
Script @motd was called via post-install-cmd
Error: Process completed with exit code 1.
```
I think this command shouldn't return 1 even if it fails. It's not important to display the message but it is not good to block CI just because it cannot fetch it for whatever reason.

I also got fed up asking my agent to run tests in DDEV so I'm updating Agents.md with that information.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. run `bin/console mautic:motd` and it should succeed no matter if it can or cannot fetch the message.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->