### PR TITLE
fix(api): return 400 JSON instead of 500 for OAuth redirect_uri_mismatch

### DIFF
--- a/app/bundles/ApiBundle/EventListener/OAuthExceptionListener.php
+++ b/app/bundles/ApiBundle/EventListener/OAuthExceptionListener.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ApiBundle\EventListener;
+
+use OAuth2\OAuth2ServerException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class OAuthExceptionListener implements EventSubscriberInterface
+{
+    private const AUTHORIZE_PATH_PREFIX = '/oauth/v2/authorize';
+    private const REDIRECT_URI_MISMATCH = 'redirect_uri_mismatch';
+
+    public function __construct(private readonly TranslatorInterface $translator)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::EXCEPTION => ['onKernelException', 0]];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (!str_starts_with($event->getRequest()->getPathInfo(), self::AUTHORIZE_PATH_PREFIX)) {
+            return;
+        }
+
+        $exception = $event->getThrowable();
+        if (!$this->isRedirectUriMismatch($exception)) {
+            return;
+        }
+
+        $event->setResponse(new JsonResponse(
+            [
+                'error'             => self::REDIRECT_URI_MISMATCH,
+                'error_description' => $this->translator->trans('mautic.api.oauth.error.redirect_uri_mismatch'),
+                'action'            => $this->translator->trans('mautic.api.oauth.error.redirect_uri_mismatch.action'),
+            ],
+            $this->getStatusCode($exception)
+        ));
+    }
+
+    private function isRedirectUriMismatch(\Throwable $exception): bool
+    {
+        return $exception instanceof OAuth2ServerException
+            && self::REDIRECT_URI_MISMATCH === $exception->getMessage();
+    }
+
+    private function getStatusCode(OAuth2ServerException $exception): int
+    {
+        $statusCode = (int) $exception->getHttpCode();
+
+        return Response::HTTP_INTERNAL_SERVER_ERROR === $statusCode ? Response::HTTP_BAD_REQUEST : $statusCode;
+    }
+}

--- a/app/bundles/ApiBundle/EventListener/OAuthExceptionListener.php
+++ b/app/bundles/ApiBundle/EventListener/OAuthExceptionListener.php
@@ -51,6 +51,7 @@ final class OAuthExceptionListener implements EventSubscriberInterface
         ));
     }
 
+    /** @phpstan-assert-if-true OAuth2ServerException $exception */
     private function isRedirectUriMismatch(\Throwable $exception): bool
     {
         return $exception instanceof OAuth2ServerException

--- a/app/bundles/ApiBundle/Tests/EventListener/OAuthExceptionListenerTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/OAuthExceptionListenerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ApiBundle\Tests\EventListener;
+
+use Mautic\ApiBundle\EventListener\OAuthExceptionListener;
+use OAuth2\OAuth2ServerException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class OAuthExceptionListenerTest extends TestCase
+{
+    public function testSubscribesToKernelException(): void
+    {
+        self::assertSame(
+            [KernelEvents::EXCEPTION => ['onKernelException', 0]],
+            OAuthExceptionListener::getSubscribedEvents()
+        );
+    }
+
+    public function testReturnsBadRequestWithActionForRedirectUriMismatch(): void
+    {
+        $event = $this->createExceptionEvent(
+            Request::create('/oauth/v2/authorize', 'GET'),
+            new OAuth2ServerException(
+                Response::HTTP_BAD_REQUEST,
+                'redirect_uri_mismatch',
+                'The redirect URI provided does not match registered URI(s).'
+            )
+        );
+
+        (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
+
+        self::assertNotNull($event->getResponse());
+        self::assertSame(Response::HTTP_BAD_REQUEST, $event->getResponse()->getStatusCode());
+
+        $payload = json_decode((string) $event->getResponse()->getContent(), true);
+
+        self::assertSame('redirect_uri_mismatch', $payload['error']);
+        self::assertSame(
+            'The OAuth redirect URI does not match the API credentials configuration.',
+            $payload['error_description']
+        );
+        self::assertSame('Change it in the settings.', $payload['action']);
+    }
+
+    public function testConverts500TooBadRequestForRedirectUriMismatch(): void
+    {
+        $event = $this->createExceptionEvent(
+            Request::create('/oauth/v2/authorize', 'GET'),
+            new OAuth2ServerException(
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                'redirect_uri_mismatch',
+                'The redirect URI provided does not match registered URI(s).'
+            )
+        );
+
+        (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
+
+        self::assertNotNull($event->getResponse());
+        self::assertSame(Response::HTTP_BAD_REQUEST, $event->getResponse()->getStatusCode());
+    }
+
+    public function testIgnoresNonAuthorizeRoutes(): void
+    {
+        $event = $this->createExceptionEvent(
+            Request::create('/api/contacts', 'GET'),
+            new OAuth2ServerException(Response::HTTP_BAD_REQUEST, 'redirect_uri_mismatch')
+        );
+
+        (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testIgnoresOtherOauthErrors(): void
+    {
+        $event = $this->createExceptionEvent(
+            Request::create('/oauth/v2/authorize', 'GET'),
+            new OAuth2ServerException(Response::HTTP_BAD_REQUEST, 'invalid_request')
+        );
+
+        (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    public function testIgnoresNonOauthExceptions(): void
+    {
+        $event = $this->createExceptionEvent(
+            Request::create('/oauth/v2/authorize', 'GET'),
+            new \RuntimeException('Something went wrong')
+        );
+
+        (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    private function createExceptionEvent(Request $request, \Throwable $exception): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $exception
+        );
+    }
+
+    private function createTranslator(): TranslatorInterface
+    {
+        return new class implements TranslatorInterface {
+            /**
+             * @var array<string, string>
+             */
+            private const TRANSLATIONS = [
+                'mautic.api.oauth.error.redirect_uri_mismatch'        => 'The OAuth redirect URI does not match the API credentials configuration.',
+                'mautic.api.oauth.error.redirect_uri_mismatch.action' => 'Change it in the settings.',
+            ];
+
+            public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return self::TRANSLATIONS[$id] ?? $id;
+            }
+
+            public function getLocale(): string
+            {
+                return 'en_US';
+            }
+        };
+    }
+}

--- a/app/bundles/ApiBundle/Tests/EventListener/OAuthExceptionListenerTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/OAuthExceptionListenerTest.php
@@ -29,7 +29,7 @@ final class OAuthExceptionListenerTest extends TestCase
         $event = $this->createExceptionEvent(
             Request::create('/oauth/v2/authorize', 'GET'),
             new OAuth2ServerException(
-                Response::HTTP_BAD_REQUEST,
+                (string) Response::HTTP_BAD_REQUEST,
                 'redirect_uri_mismatch',
                 'The redirect URI provided does not match registered URI(s).'
             )
@@ -50,12 +50,12 @@ final class OAuthExceptionListenerTest extends TestCase
         self::assertSame('Change it in the settings.', $payload['action']);
     }
 
-    public function testConverts500TooBadRequestForRedirectUriMismatch(): void
+    public function testConverts500ToBadRequestForRedirectUriMismatch(): void
     {
         $event = $this->createExceptionEvent(
             Request::create('/oauth/v2/authorize', 'GET'),
             new OAuth2ServerException(
-                Response::HTTP_INTERNAL_SERVER_ERROR,
+                (string) Response::HTTP_INTERNAL_SERVER_ERROR,
                 'redirect_uri_mismatch',
                 'The redirect URI provided does not match registered URI(s).'
             )
@@ -71,7 +71,7 @@ final class OAuthExceptionListenerTest extends TestCase
     {
         $event = $this->createExceptionEvent(
             Request::create('/api/contacts', 'GET'),
-            new OAuth2ServerException(Response::HTTP_BAD_REQUEST, 'redirect_uri_mismatch')
+            new OAuth2ServerException((string) Response::HTTP_BAD_REQUEST, 'redirect_uri_mismatch')
         );
 
         (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
@@ -83,7 +83,7 @@ final class OAuthExceptionListenerTest extends TestCase
     {
         $event = $this->createExceptionEvent(
             Request::create('/oauth/v2/authorize', 'GET'),
-            new OAuth2ServerException(Response::HTTP_BAD_REQUEST, 'invalid_request')
+            new OAuth2ServerException((string) Response::HTTP_BAD_REQUEST, 'invalid_request')
         );
 
         (new OAuthExceptionListener($this->createTranslator()))->onKernelException($event);
@@ -124,6 +124,9 @@ final class OAuthExceptionListenerTest extends TestCase
                 'mautic.api.oauth.error.redirect_uri_mismatch.action' => 'Change it in the settings.',
             ];
 
+            /**
+             * @param array<string, string> $parameters
+             */
             public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
             {
                 return self::TRANSLATIONS[$id] ?? $id;

--- a/app/bundles/ApiBundle/Translations/en_US/messages.ini
+++ b/app/bundles/ApiBundle/Translations/en_US/messages.ini
@@ -60,3 +60,5 @@ mautic.api.error.api.disabled="API disabled. You need to enable the API in the A
 mautic.api.error.basic.auth.disabled="Basic Auth disabled. You need to enable HTTP basic auth in the API settings of Mautic's Configuration."
 mautic.api.error.basic.auth.invalid.credentials="Authorization denied, invalid credentials."
 mautic.api.error.entity.locked="%name% is currently checked out by %user% (on %date% at %time%)."
+mautic.api.oauth.error.redirect_uri_mismatch="The OAuth redirect URI does not match the API credentials configuration."
+mautic.api.oauth.error.redirect_uri_mismatch.action="Change it in the settings."


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️

## Description

When the redirect URI in an OAuth2 API credential does not match the one sent during the `/oauth/v2/authorize` flow, the underlying `klapaudius/oauth2-php` library throws an `OAuth2ServerException` with error code `redirect_uri_mismatch`.  The exception is uncaught, Symfony converts it to a 500 Internal Server Error, and it surfaces in logs as CRITICAL — misleading operators into thinking there is a server-side fault when the real cause is a misconfigured API credential the user can fix themselves.

**Root cause:** no exception handler was converting this known, actionable OAuth error into a proper HTTP response.

**Fix:** Add `OAuthExceptionListener`, a `kernel.exception` subscriber scoped to the `/oauth/v2/authorize` path.  It:
- Intercepts `OAuth2ServerException` with the `redirect_uri_mismatch` error code only.
- Downgrades any 5xx status code to `400 Bad Request` (the library sometimes reports 500; the correct RFC 6749 response for a bad redirect URI is a 4xx).
- Returns a structured JSON body with `error`, `error_description`, and `action` fields so the API consumer knows exactly what to reconfigure without reading server logs.

The listener is auto-wired and auto-configured — no manual service definition is required.

---
### 📋 Steps to test this PR:

1. Enable the API under **Settings → Configuration → API Settings**.
2. Create an OAuth2 API credential with **Redirect URI** set to `https://example.com/callback`.
3. Visit `/oauth/v2/authorize?client_id=<your_client_id>&redirect_uri=https://wrong.example.com/callback&response_type=code` in your browser or via curl.
4. **Before this fix:** you get a 500 Internal Server Error page / JSON with no actionable message.
5. **After this fix:** you get HTTP 400 with:
   ```json
   {
     "error": "redirect_uri_mismatch",
     "error_description": "The OAuth redirect URI does not match the API credentials configuration.",
     "action": "Change it in the settings."
   }
   ```
6. Verify that other OAuth errors (e.g. `invalid_client`) are **not** affected and still follow the normal error path.
7. Verify that exceptions on non-OAuth paths (e.g. `/api/contacts`) are **not** intercepted by this listener.