### PR TITLE
Fixing publish dates for API

### DIFF
--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -69,7 +69,10 @@ class CampaignEventSubscriber implements EventSubscriberInterface
             && $campaign->getIsPublished()
             && !$campaign->getPublishUp()
         ) {
-            $campaign->setPublishUp(new \DateTime());
+            // Publish up date should be in format 'yyyy-MM-dd HH:mm'
+            $publishUp = new \DateTime();
+            $publishUp->setTime((int) $publishUp->format('H'), (int) $publishUp->format('i'));
+            $campaign->setPublishUp($publishUp);
         }
 
         if (array_key_exists('isPublished', $changes)) {

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -517,6 +517,33 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertStringContainsString('No JSON content found, and exactly one ZIP file must be uploaded.', $response->getContent());
     }
 
+    public function testEditCampaignAcceptsRoundTrippedIso8601PublishUp(): void
+    {
+        $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
+        $this->loginUser($user);
+
+        $campaign = new Campaign();
+        $campaign->setName('Campaign with ISO publish up');
+        $campaign->setPublishUp(new \DateTime('2026-01-15 12:30:00'));
+
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        $this->client->request(Request::METHOD_GET, sprintf('/api/campaigns/%d', $campaign->getId()));
+        $getResponse = $this->client->getResponse();
+        $this->assertResponseIsSuccessful($getResponse->getContent());
+
+        $campaignData = json_decode($getResponse->getContent(), true)['campaign'];
+        Assert::assertIsString($campaignData['publishUp']);
+
+        $this->client->request(Request::METHOD_PATCH, sprintf('/api/campaigns/%d/edit', $campaign->getId()), [
+            'publishUp' => $campaignData['publishUp'],
+        ]);
+
+        $editResponse = $this->client->getResponse();
+        $this->assertResponseIsSuccessful($editResponse->getContent());
+    }
+
     private function createTemporaryFile(string $extension): string
     {
         $filePath = tempnam(sys_get_temp_dir(), 'mautic_test_').'.'.$extension;

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -101,6 +101,17 @@ class CampaignEventSubscriberTest extends TestCase
         $this->fixture->onCampaignPreSave(new CampaignEvent($campaign));
     }
 
+    public function testNewPublishedCampaignGetsPublishUpWithoutSeconds(): void
+    {
+        $campaign = new Campaign();
+        $campaign->setIsPublished(true);
+
+        $this->fixture->onCampaignPreSave(new CampaignEvent($campaign));
+
+        self::assertNotNull($campaign->getPublishUp());
+        self::assertSame('00', $campaign->getPublishUp()->format('s'));
+    }
+
     public function testFailedEventGeneratesANotification(): void
     {
         $this->leadEventLogRepositoryMock->expects($this->once())

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -6,6 +6,8 @@ use Mautic\CoreBundle\Form\Type\BooleanType;
 use Mautic\CoreBundle\Form\Type\CountryType;
 use Mautic\CoreBundle\Form\Type\LocaleType;
 use Mautic\CoreBundle\Form\Type\MultiselectType;
+use Mautic\CoreBundle\Form\Type\PublishDownDateType;
+use Mautic\CoreBundle\Form\Type\PublishUpDateType;
 use Mautic\CoreBundle\Form\Type\RegionType;
 use Mautic\CoreBundle\Form\Type\SelectType;
 use Mautic\CoreBundle\Form\Type\TimezoneType;
@@ -113,6 +115,8 @@ trait RequestTrait
                 case DateTimeType::class:
                 case DateType::class:
                 case TimeType::class:
+                case PublishUpDateType::class:
+                case PublishDownDateType::class:
                     // Prevent zero based date placeholders
                     $dateTest = (int) str_replace(['/', '-', ' '], '', $params[$name]);
 
@@ -133,6 +137,8 @@ trait RequestTrait
 
                     switch ($type::class) {
                         case DateTimeType::class:
+                        case PublishUpDateType::class:
+                        case PublishDownDateType::class:
                             $params[$name] = (new \DateTime(date('Y-m-d H:i:s', $timestamp)))->format('Y-m-d H:i:s');
                             break;
                         case DateType::class:


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | N/A (bug reproduced from API Library round-trip test) <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This was discovered by the API Library tests:
```
1) Mautic\Tests\Api\CampaignsTest::testEditPatch
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"publishUp: Please enter a valid date and time.","details":{"publishUp":["Please enter a valid date and time."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:244

2) Mautic\Tests\Api\CampaignsTest::testEventAndSourceDeleteViaPut
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"publishUp: Please enter a valid date and time.","details":{"publishUp":["Please enter a valid date and time."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:349
```

This PR fixes a campaign API round-trip regression where Mautic returns publishUp in ISO 8601 format, but then rejects that same value on edit with: publishUp: Please enter a valid date and time.

Root cause timeline:

1. Change that introduced the format mismatch risk:
https://github.com/mautic/mautic/commit/7aa67f335c4759cbf07a72e9ae572b783da3a10c

This switched campaign publish fields to custom form types. Request parameter normalization matched core DateTimeType directly and did not normalize values for these custom publish date types.

2. Change that made the API Library test fail consistently:
https://github.com/mautic/mautic/commit/0be0a038dc79f3bf61f4295081fafa5838fe5ceb

This auto-populates publishUp for newly published campaigns, so API create responses now contain non-null publishUp values that get round-tripped back into edit and trigger the validation error.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. In Mautic, generate API credentials for an API user and prepare an API client (Postman, Insomnia, or curl).
3. Create a campaign via legacy API endpoint as published (`POST /api/campaigns/new`) with minimal required payload (`name`, `isPublished`, one source, one event).
4. Fetch the created campaign (`GET /api/campaigns/{id}`) and copy the returned `publishUp` value (ISO 8601 string).
5. Edit the same campaign via legacy endpoint (`PATCH /api/campaigns/{id}/edit`) and send that exact copied `publishUp` value back in payload.
6. Verify expected result:
  - Response is `200 OK`.
  - No validation error `publishUp: Please enter a valid date and time.`.
7. Regression guard check (optional):
  - Repeat step 5 with `publishUp` removed from payload.
  - Confirm request still succeeds (control case).

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->