### PR TITLE
Export config preserves null values.

### DIFF
--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -99,6 +99,57 @@ final class ConfigControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame($googleAnalytics, $form['config[pageconfig][google_analytics]']->getValue());
     }
 
+    public function testEmptyValuesArePreservedAsNull(): void
+    {
+        // request config edit page
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
+        self::assertResponseIsSuccessful();
+
+        // Find save & close button
+        $buttonCrawler = $crawler->selectButton('config[buttons][save]');
+        $form          = $buttonCrawler->form();
+        $form->setValues(
+            [
+                'config[emailconfig][monitored_email][EmailBundle_bounces][override_settings]' => '1',
+                // Do not set address, so the \Mautic\EmailBundle\EventListener\ConfigSubscriber::onConfigBeforeSave will revert config to defaults
+                'config[emailconfig][monitored_email][EmailBundle_bounces][address]' => '',
+                'config[emailconfig][monitored_email][EmailBundle_bounces][port]'    => '789',
+
+                // Some fields are not transferred into request.
+                'config[coreconfig][site_url]'           => 'https://mautic-community.local', // required
+                'config[leadconfig][contact_columns]'    => ['name', 'email', 'id'],
+                'config[companyconfig][company_columns]' => ['companyname', 'companyemail', 'companywebsite', 'score', 'leadcount', 'id'],
+            ]
+        );
+
+        $crawler = $this->client->submit($form);
+        self::assertResponseIsSuccessful();
+
+        // Check for a flash error
+        $response = $this->client->getResponse()->getContent();
+        $message  = $crawler->filterXPath("//div[@id='flashes']//span")->count()
+            ?
+            $crawler->filterXPath("//div[@id='flashes']//span")->first()->text()
+            :
+            '';
+        $this->assertStringNotContainsString('Could not save updated configuration:', (string) $response, $message);
+
+        // Check values are escaped properly in the config file
+        $configParameters = $this->getConfigParameters();
+        $this->assertArrayHasKey('monitored_email', $configParameters);
+        $this->assertArrayHasKey('EmailBundle_bounces', $configParameters['monitored_email']);
+        $this->assertSame([
+            'address'           => null,
+            'host'              => null,
+            'port'              => '993',
+            'encryption'        => '/ssl',
+            'user'              => null,
+            'password'          => null,
+            'override_settings' => 0,
+            'folder'            => null,
+        ], $configParameters['monitored_email']['EmailBundle_bounces']);
+    }
+
     private function getConfigPath(): string
     {
         /** @var \AppKernel $kernel */

--- a/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
@@ -173,7 +173,7 @@ final class ConfigMapperTest extends \PHPUnit\Framework\TestCase
 
         $processedForms = $mapper->bindFormConfigsWithRealValues($this->forms);
 
-        $this->assertEquals($this->forms, $processedForms);
+        $this->assertSame($this->forms, $processedForms);
     }
 
     #[TestDox('Defaults should be merged with local config values')]
@@ -233,7 +233,7 @@ final class ConfigMapperTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $this->assertEquals($forms, $processedForms);
+        $this->assertSame($forms, $processedForms);
     }
 
     #[TestDox('Defaults should be merged with local config values but restricted fields should be removed')]
@@ -254,6 +254,6 @@ final class ConfigMapperTest extends \PHPUnit\Framework\TestCase
         // Expected should have had monitored_email unset due to it being restricted
         unset($forms['emailconfig']['parameters']['monitored_email']);
 
-        $this->assertEquals($forms, $processedForms);
+        $this->assertSame($forms, $processedForms);
     }
 }

--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -193,30 +193,18 @@ class Configurator
     public function render(): string
     {
         $string = "<?php\n";
-        $string .= "\$parameters = array(\n";
+        $string .= '$parameters = ';
 
-        foreach ($this->parameters as $key => $value) {
-            if ('' !== $value) {
-                if (is_string($value)) {
-                    $value = "'".addcslashes($value, '\\\'')."'";
-                } elseif (is_bool($value)) {
-                    $value = ($value) ? 'true' : 'false';
-                } elseif (null === $value) {
-                    $value = 'null';
-                } elseif (is_array($value)) {
-                    $value = $this->renderArray($value);
-                }
+        $string .= var_export($this->parameters, true);
 
-                $string .= "\t'{$key}' => {$value},\n";
-            }
-        }
-
-        return $string.");\n";
+        return $string.";\n";
     }
 
     /**
      * @param array<mixed> $array
      * @param int          $level
+     *
+     * @deprecated use \var_export instead
      */
     protected function renderArray($array, $level = 1): string
     {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ✔️
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Use `var_export` instead of a custom exporter to write config.

Deprecation: deprecate a `protected function renderArray` as not needed anymore.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Make sure the "EmailBundle_bounces" "address" is `null` in local.config.
3. Open configuration -> "Email settings".
4. Check the "Bounces" "Use custom connection settings?"
5. Leave the "Bounces" "Monitored address" as an empty string.
6. Save configuration.
7. Check the local.php config still have the "EmailBundle_bounces" "address" as `null`.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->