### PR TITLE
Fix Campaign builder events tooltips

### DIFF
--- a/app/bundles/CampaignBundle/Assets/js/campaign.js
+++ b/app/bundles/CampaignBundle/Assets/js/campaign.js
@@ -35,10 +35,10 @@ Mautic.campaignOnLoad = function (container, response) {
         // set hover and double click functions for the event buttons
         if (!isCampaignPreview) {
             mQuery('#CampaignCanvas .list-campaign-event, #CampaignCanvas .list-campaign-source').off('.eventbuttons')
-                .on('mouseover.eventbuttons', function() {
+                .on('mouseenter.eventbuttons', function() {
                     mQuery(this).find('.campaign-event-buttons').removeClass('hide');
                 })
-                .on('mouseout.eventbuttons', function() {
+                .on('mouseleave.eventbuttons', function() {
                     mQuery(this).find('.campaign-event-buttons').addClass('hide');
                 })
                 .on('dblclick.eventbuttons', function(event) {
@@ -492,10 +492,10 @@ Mautic.campaignEventOnLoad = function (container, response) {
         mQuery(eventId + " a[data-toggle='ajax-delete']").off("click.ajax").on("click.ajax", Mautic.handleEventDeleteClick);
 
         mQuery(eventId).off('.eventbuttons')
-            .on('mouseover.eventbuttons', function() {
+            .on('mouseenter.eventbuttons', function() {
                 mQuery(this).find('.campaign-event-buttons').removeClass('hide');
             })
-            .on('mouseout.eventbuttons', function() {
+            .on('mouseleave.eventbuttons', function() {
                 mQuery(this).find('.campaign-event-buttons').addClass('hide');
             })
             .on('dblclick.eventbuttons', function(event) {
@@ -682,10 +682,10 @@ Mautic.campaignSourceOnLoad = function (container, response) {
         });
 
         mQuery(eventId).off('.eventbuttons')
-            .on('mouseover.eventbuttons', function() {
+            .on('mouseenter.eventbuttons', function() {
                 mQuery(this).find('.campaign-event-buttons').removeClass('hide');
             })
-            .on('mouseout.eventbuttons', function() {
+            .on('mouseleave.eventbuttons', function() {
                 mQuery(this).find('.campaign-event-buttons').addClass('hide');
             })
             .on('dblclick.eventbuttons', function(event) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | <!-- required for new features -->
| Related developer documentation PR URL | <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

The Clone/Remove buttons on a campaign event used `mouseover`/`mouseout` to toggle their visibility. These events bubble and re-fire whenever the pointer crosses between the event element and any of its descendants. When hovering a button, its tooltip pops up over the button, which triggers `mouseout` on the event element → the `.hide` class is added → the buttons disappear → the pointer is now "back over" the bare element → `mouseover` fires → `.hide` is removed → buttons (and tooltip) reappear → endless flicker loop. This was especially visible on events freshly added via JS.

The fix switches the handlers to `mouseenter`/`mouseleave`, which do not fire when the pointer moves between an element and its descendants, breaking the loop.

https://github.com/user-attachments/assets/38959a75-b92f-4ed7-ad4d-4964d7b34f2a

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open a campaign in the builder and add a new event (e.g. "Send email") so it is rendered via JS.
3. Hover the new event to reveal the Clone/Remove buttons, then move the pointer onto one of the buttons so its tooltip appears.
4. Confirm the buttons and tooltip stay visible and no longer flicker in an endless loop.
