### PR TITLE
Addressing parameter.phpDocType issues in the PHPSTAN Baseline

### DIFF
--- a/app/bundles/AssetBundle/Entity/Download.php
+++ b/app/bundles/AssetBundle/Entity/Download.php
@@ -89,11 +89,8 @@ class Download
     #[Groups(['download:read', 'download:write'])]
     private $sourceId;
 
-    /**
-     * @var Email|null
-     */
     #[Groups(['download:read', 'download:write'])]
-    private $email;
+    private ?Email $email = null;
 
     private ?string $utmCampaign = null;
 
@@ -348,18 +345,12 @@ class Download
         $this->sourceId = (int) $sourceId;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getEmail()
+    public function getEmail(): ?Email
     {
         return $this->email;
     }
 
-    /**
-     * @param mixed $email
-     */
-    public function setEmail(Email $email): void
+    public function setEmail(?Email $email): void
     {
         $this->email = $email;
     }

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -372,8 +372,6 @@ class EventExecutioner
     }
 
     /**
-     * @param Counter|null $counter
-     *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
@@ -394,8 +392,6 @@ class EventExecutioner
     }
 
     /**
-     * @param Counter|null $counter
-     *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -41,10 +41,7 @@ class Stat
      */
     private $list;
 
-    /**
-     * @var IpAddress|null
-     */
-    private $ipAddress;
+    private ?IpAddress $ipAddress = null;
 
     private ?\DateTimeInterface $dateSent = null;
 
@@ -293,18 +290,12 @@ class Stat
         return $this->id;
     }
 
-    /**
-     * @return IpAddress|null
-     */
-    public function getIpAddress()
+    public function getIpAddress(): ?IpAddress
     {
         return $this->ipAddress;
     }
 
-    /**
-     * @param IpAddress|null $ip
-     */
-    public function setIpAddress(IpAddress $ip): void
+    public function setIpAddress(?IpAddress $ip): void
     {
         $this->ipAddress = $ip;
     }

--- a/app/bundles/EmailBundle/Entity/StatDevice.php
+++ b/app/bundles/EmailBundle/Entity/StatDevice.php
@@ -23,10 +23,7 @@ class StatDevice
      */
     private $device;
 
-    /**
-     * @var IpAddress|null
-     */
-    private $ipAddress;
+    private ?IpAddress $ipAddress = null;
 
     /**
      * @var \DateTimeInterface
@@ -80,18 +77,12 @@ class StatDevice
         return (int) $this->id;
     }
 
-    /**
-     * @return IpAddress
-     */
-    public function getIpAddress()
+    public function getIpAddress(): ?IpAddress
     {
         return $this->ipAddress;
     }
 
-    /**
-     * @param mixed $ip
-     */
-    public function setIpAddress(IpAddress $ip): void
+    public function setIpAddress(?IpAddress $ip): void
     {
         $this->ipAddress = $ip;
     }
@@ -130,9 +121,6 @@ class StatDevice
         return $this->device;
     }
 
-    /**
-     * @param mixed $device
-     */
     public function setDevice(LeadDevice $device): void
     {
         $this->device = $device;

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -44,7 +44,7 @@ class InstallController extends CommonController
     /**
      * Controller action for install steps.
      *
-     * @param int $index The step number to process
+     * @param float $index The step number to process
      *
      * @throws \Doctrine\DBAL\Exception
      */

--- a/app/bundles/NotificationBundle/Entity/Stat.php
+++ b/app/bundles/NotificationBundle/Entity/Stat.php
@@ -31,7 +31,7 @@ class Stat
      */
     private $list;
 
-    private ?IpAddress $ipAddress;
+    private ?IpAddress $ipAddress = null;
 
     /**
      * @var \DateTimeInterface

--- a/app/bundles/NotificationBundle/Entity/Stat.php
+++ b/app/bundles/NotificationBundle/Entity/Stat.php
@@ -31,10 +31,7 @@ class Stat
      */
     private $list;
 
-    /**
-     * @var IpAddress|null
-     */
-    private $ipAddress;
+    private ?IpAddress $ipAddress;
 
     /**
      * @var \DateTimeInterface
@@ -246,18 +243,12 @@ class Stat
         return (int) $this->id;
     }
 
-    /**
-     * @return IpAddress|null
-     */
-    public function getIpAddress()
+    public function getIpAddress(): ?IpAddress
     {
         return $this->ipAddress;
     }
 
-    /**
-     * @param mixed $ip
-     */
-    public function setIpAddress(IpAddress $ip): void
+    public function setIpAddress(?IpAddress $ip): void
     {
         $this->ipAddress = $ip;
     }
@@ -286,9 +277,6 @@ class Stat
         return $this->lead;
     }
 
-    /**
-     * @param mixed $lead
-     */
     public function setLead(?Lead $lead = null): void
     {
         $this->lead = $lead;

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -37,10 +37,7 @@ class Hit
      */
     private $redirect;
 
-    /**
-     * @var Email|null
-     */
-    private $email;
+    private ?Email $email = null;
 
     /**
      * @var Lead|null
@@ -795,18 +792,12 @@ class Hit
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getEmail()
+    public function getEmail(): ?Email
     {
         return $this->email;
     }
 
-    /**
-     * @param mixed $email
-     */
-    public function setEmail(Email $email): void
+    public function setEmail(?Email $email): void
     {
         $this->email = $email;
     }

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -136,10 +136,10 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     private $activePermissions;
 
     /**
-     * @var array
+     * @var mixed[]
      */
     #[Groups(['user:read', 'user:write'])]
-    private $preferences = [];
+    private array $preferences = [];
 
     /**
      * @var string|null
@@ -779,15 +779,15 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     }
 
     /**
-     * @return mixed
+     * @return mixed[]
      */
-    public function getPreferences()
+    public function getPreferences(): array
     {
         return $this->preferences;
     }
 
     /**
-     * @param mixed $preferences
+     * @param mixed[] $preferences
      */
     public function setPreferences(array $preferences): void
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -709,12 +709,6 @@ parameters:
 			path: app/bundles/AssetBundle/Entity/Download.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$email with type mixed is not subtype of native type Mautic\\EmailBundle\\Entity\\Email\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/AssetBundle/Entity/Download.php
-
-		-
 			message: '#^Property Mautic\\AssetBundle\\Entity\\Download\:\:\$trackingId \(string\) does not accept int\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -3079,12 +3073,6 @@ parameters:
 			message: '#^Method Mautic\\CampaignBundle\\Executioner\\EventExecutioner\:\:recordLogsAsFailedForEvent\(\) has parameter \$reason with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$counter with type Mautic\\CampaignBundle\\Executioner\\Result\\Counter\|null is not subtype of native type Mautic\\CampaignBundle\\Executioner\\Result\\Counter\.$#'
-			identifier: parameter.phpDocType
-			count: 2
 			path: app/bundles/CampaignBundle/Executioner/EventExecutioner.php
 
 		-
@@ -11836,12 +11824,6 @@ parameters:
 			path: app/bundles/EmailBundle/Entity/Stat.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$ip with type Mautic\\CoreBundle\\Entity\\IpAddress\|null is not subtype of native type Mautic\\CoreBundle\\Entity\\IpAddress\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/EmailBundle/Entity/Stat.php
-
-		-
 			message: '#^Property Mautic\\EmailBundle\\Entity\\Stat\:\:\$openDetails type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -11852,18 +11834,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/bundles/EmailBundle/Entity/Stat.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$device with type mixed is not subtype of native type Mautic\\LeadBundle\\Entity\\LeadDevice\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatDevice.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$ip with type mixed is not subtype of native type Mautic\\CoreBundle\\Entity\\IpAddress\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/EmailBundle/Entity/StatDevice.php
 
 		-
 			message: '#^Method Mautic\\EmailBundle\\Entity\\StatDeviceRepository\:\:getDeviceStats\(\) has parameter \$emailIds with no type specified\.$#'
@@ -16560,12 +16530,6 @@ parameters:
 		-
 			message: '#^Method Mautic\\InstallBundle\\Controller\\InstallController\:\:handleInstallerErrors\(\) has parameter \$messages with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/bundles/InstallBundle/Controller/InstallController.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$index with type int is incompatible with native type float\.$#'
-			identifier: parameter.phpDocType
 			count: 1
 			path: app/bundles/InstallBundle/Controller/InstallController.php
 
@@ -26777,18 +26741,6 @@ parameters:
 			path: app/bundles/NotificationBundle/Entity/Stat.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$ip with type mixed is not subtype of native type Mautic\\CoreBundle\\Entity\\IpAddress\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/NotificationBundle/Entity/Stat.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$lead with type mixed is not subtype of native type Mautic\\LeadBundle\\Entity\\Lead\|null\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/NotificationBundle/Entity/Stat.php
-
-		-
 			message: '#^Property Mautic\\NotificationBundle\\Entity\\Stat\:\:\$clickDetails type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -27115,12 +27067,6 @@ parameters:
 		-
 			message: '#^Method Mautic\\PageBundle\\Entity\\Hit\:\:setQuery\(\) has parameter \$query with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: app/bundles/PageBundle/Entity/Hit.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$email with type mixed is not subtype of native type Mautic\\EmailBundle\\Entity\\Email\.$#'
-			identifier: parameter.phpDocType
 			count: 1
 			path: app/bundles/PageBundle/Entity/Hit.php
 
@@ -33377,12 +33323,6 @@ parameters:
 			path: app/bundles/UserBundle/Entity/User.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$preferences with type mixed is not subtype of native type array\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: app/bundles/UserBundle/Entity/User.php
-
-		-
 			message: '#^Property Mautic\\UserBundle\\Entity\\User\:\:\$activePermissions has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -34293,12 +34233,6 @@ parameters:
 			identifier: return.type
 			count: 2
 			path: plugins/MauticClearbitBundle/Controller/ClearbitController.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$user with type Mautic\\UserBundle\\Entity\\User\|null is not subtype of native type Mautic\\UserBundle\\Entity\\User\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: plugins/MauticClearbitBundle/Controller/PublicController.php
 
 		-
 			message: '#^PHPDoc tag @var for variable \$result has no value type specified in iterable type array\.$#'
@@ -39548,12 +39482,6 @@ parameters:
 			path: plugins/MauticFullContactBundle/Controller/PublicController.php
 
 		-
-			message: '#^PHPDoc tag @param for parameter \$user with type Mautic\\UserBundle\\Entity\\User\|null is not subtype of native type Mautic\\UserBundle\\Entity\\User\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: plugins/MauticFullContactBundle/Controller/PublicController.php
-
-		-
 			message: '#^PHPDoc tag @var for variable \$organizations has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -40369,18 +40297,6 @@ parameters:
 				Use addContact instead; existing implementations will need a migration to rename lead_id to contact_id$#
 			'''
 			identifier: method.deprecated
-			count: 1
-			path: plugins/MauticSocialBundle/Entity/TweetStat.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$lead with type mixed is not subtype of native type Mautic\\LeadBundle\\Entity\\Lead\|null\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: plugins/MauticSocialBundle/Entity/TweetStat.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$tweet with type mixed is not subtype of native type MauticPlugin\\MauticSocialBundle\\Entity\\Tweet\|null\.$#'
-			identifier: parameter.phpDocType
 			count: 1
 			path: plugins/MauticSocialBundle/Entity/TweetStat.php
 

--- a/plugins/MauticClearbitBundle/Controller/PublicController.php
+++ b/plugins/MauticClearbitBundle/Controller/PublicController.php
@@ -17,10 +17,10 @@ class PublicController extends FormController
     /**
      * Write a notification.
      *
-     * @param string    $message   Message of the notification
-     * @param string    $header    Header for message
-     * @param string    $iconClass CSS class for the icon (e.g. ri-eye-line)
-     * @param User|null $user      User object; defaults to current user
+     * @param string $message   Message of the notification
+     * @param string $header    Header for message
+     * @param string $iconClass CSS class for the icon (e.g. ri-eye-line)
+     * @param User   $user      User object; defaults to current user
      */
     public function addNewNotification($message, $header, $iconClass, User $user): void
     {

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -17,10 +17,10 @@ class PublicController extends FormController
     /**
      * Write a notification.
      *
-     * @param string    $message   Message of the notification
-     * @param string    $header    Header for message
-     * @param string    $iconClass CSS class for the icon (e.g. ri-eye-line)
-     * @param User|null $user      User object; defaults to current user
+     * @param string $message   Message of the notification
+     * @param string $header    Header for message
+     * @param string $iconClass CSS class for the icon (e.g. ri-eye-line)
+     * @param User   $user      User object; defaults to current user
      */
     public function addNewNotification($message, $header, $iconClass, User $user): void
     {

--- a/plugins/MauticSocialBundle/Entity/TweetStat.php
+++ b/plugins/MauticSocialBundle/Entity/TweetStat.php
@@ -22,10 +22,7 @@ class TweetStat
      */
     private $twitterTweetId;
 
-    /**
-     * @var Tweet|null
-     */
-    private $tweet;
+    private ?Tweet $tweet = null;
 
     /**
      * @var TheLead|null
@@ -196,17 +193,11 @@ class TweetStat
         $this->dateSent = $dateSent;
     }
 
-    /**
-     * @return Tweet
-     */
-    public function getTweet()
+    public function getTweet(): ?Tweet
     {
         return $this->tweet;
     }
 
-    /**
-     * @param mixed $tweet
-     */
     public function setTweet(?Tweet $tweet = null): void
     {
         $this->tweet = $tweet;
@@ -220,9 +211,6 @@ class TweetStat
         return $this->lead;
     }
 
-    /**
-     * @param mixed $lead
-     */
     public function setLead(?TheLead $lead = null): void
     {
         $this->lead = $lead;


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ Code quality fix
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ No tests required (code quality improvement)
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Resolves PHPStan baseline errors

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR fixes 15 PHPStan `parameter.phpDocType` errors across the codebase by updating PHPDoc annotations to match native type declarations.

**Changes made:**
- Fixed parameter type mismatches in entity setter methods where PHPDoc types didn't match the native type hints
- Updated `@param` annotations for better type accuracy:
  - Changed `@param mixed` to specific class types (`Email`, `IpAddress`, `LeadDevice`, etc.)
  - Updated nullable parameter types (`|null`) in PHPDoc to match actual function signatures
  - Fixed parameter type `int` to `float` in `InstallController::stepAction()`

All errors are now resolved with PHPStan passing without errors.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:


1. Review the changed files to ensure PHPDoc annotations match native type declarations
2. Verify no regressions in PHPStan analysis

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->