### PR TITLE
Guard empty monitored bounce addresses

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1787,8 +1787,12 @@ class MailHelper
         $monitoredEmail = false;
 
         if ($settings = $this->isMontoringEnabled('EmailBundle', 'bounces')) {
+            if (!($addressParts = $this->getMonitoredEmailAddressParts($settings))) {
+                return false;
+            }
+
             // Append the bounce notation
-            [$email, $domain] = explode('@', $settings['address']);
+            [$email, $domain] = $addressParts;
             $email .= '+bounce';
             if ($idHash || $this->idHash) {
                 $email .= '_'.($idHash ?: $this->idHash);
@@ -1809,8 +1813,12 @@ class MailHelper
         $monitoredEmail = false;
 
         if ($settings = $this->isMontoringEnabled('EmailBundle', 'unsubscribes')) {
+            if (!($addressParts = $this->getMonitoredEmailAddressParts($settings))) {
+                return false;
+            }
+
             // Append the bounce notation
-            [$email, $domain] = explode('@', $settings['address']);
+            [$email, $domain] = $addressParts;
             $email .= '+unsubscribe';
             if ($idHash || $this->idHash) {
                 $email .= '_'.($idHash ?: $this->idHash);
@@ -1819,6 +1827,20 @@ class MailHelper
         }
 
         return $monitoredEmail;
+    }
+
+    /**
+     * @param mixed[] $settings
+     *
+     * @return array{0: string, 1: string}|false
+     */
+    private function getMonitoredEmailAddressParts(array $settings): array|false
+    {
+        if (empty($settings['address']) || !is_string($settings['address']) || !filter_var($settings['address'], FILTER_VALIDATE_EMAIL)) {
+            return false;
+        }
+
+        return explode('@', $settings['address'], 2);
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperMonitoredAddressTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperMonitoredAddressTest.php
@@ -17,11 +17,11 @@ use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
 class MailHelperMonitoredAddressTest extends TestCase

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperMonitoredAddressTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperMonitoredAddressTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Mautic\EmailBundle\Tests\Helper;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\AssetBundle\Model\AssetModel;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\PathsHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
+use Mautic\EmailBundle\Helper\FromEmailHelper;
+use Mautic\EmailBundle\Helper\MailHashHelper;
+use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Helper\SMimeHelper;
+use Mautic\EmailBundle\Model\EmailStatModel;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+use Mautic\PageBundle\Model\RedirectModel;
+use Mautic\PageBundle\Model\TrackableModel;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+
+class MailHelperMonitoredAddressTest extends TestCase
+{
+    public function testGenerateUnsubscribeEmailUsesConfiguredMonitoringAddress(): void
+    {
+        $mailbox = $this->createMock(Mailbox::class);
+        $mailbox->expects($this->once())
+            ->method('isConfigured')
+            ->with('EmailBundle', 'unsubscribes')
+            ->willReturn(true);
+        $mailbox->expects($this->once())
+            ->method('getMailboxSettings')
+            ->willReturn(['address' => 'list@example.com']);
+
+        $helper = $this->createMailHelper($mailbox);
+
+        $this->assertSame('list+unsubscribe_stat123@example.com', $helper->generateUnsubscribeEmail('stat123'));
+    }
+
+    private function createMailHelper(Mailbox $mailbox): MailHelper
+    {
+        $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $coreParametersHelper->method('get')->willReturnMap(
+            [
+                ['mailer_return_path', false, null],
+                ['mailer_from_email', false, 'nobody@nowhere.com'],
+                ['mailer_reply_to_email', false, null],
+                ['mailer_from_name', false, 'No Body'],
+                ['mailer_address_length_limit', false, 320],
+            ]
+        );
+
+        $sMimeHelper = $this->createMock(SMimeHelper::class);
+        $sMimeHelper->method('sMimeSigningEnabled')->willReturn(false);
+
+        return new MailHelper(
+            new Mailer(new SmtpTransport()),
+            $this->createMock(FromEmailHelper::class),
+            $coreParametersHelper,
+            $mailbox,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(MailHashHelper::class),
+            $this->createMock(RouterInterface::class),
+            $this->createMock(Environment::class),
+            $this->createMock(ThemeHelper::class),
+            $this->createMock(PathsHelper::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(RequestStack::class),
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(AssetModel::class),
+            $this->createMock(TrackableModel::class),
+            $this->createMock(RedirectModel::class),
+            $sMimeHelper,
+            $this->createMock(EmailStatModel::class),
+        );
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -923,6 +923,71 @@ class MailHelperTest extends TestCase
         $this->assertNull($helper::validateEmail($email)); /** @phpstan-ignore-line as it's testing a deprecated method */
     }
 
+    public function testGenerateBounceEmailUsesConfiguredMonitoringAddress(): void
+    {
+        $this->mailbox->expects($this->once())
+            ->method('isConfigured')
+            ->with('EmailBundle', 'bounces')
+            ->willReturn(true);
+        $this->mailbox->expects($this->once())
+            ->method('getMailboxSettings')
+            ->willReturn(['address' => 'bounces@example.com']);
+
+        $helper = $this->mockEmptyMailHelper();
+
+        $this->assertSame('bounces+bounce_stat123@example.com', $helper->generateBounceEmail('stat123'));
+    }
+
+    /**
+     * @param mixed[] $settings
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidMonitoringAddressSettings')]
+    public function testGenerateBounceEmailReturnsFalseForInvalidMonitoringAddress(array $settings): void
+    {
+        $this->mailbox->expects($this->once())
+            ->method('isConfigured')
+            ->with('EmailBundle', 'bounces')
+            ->willReturn(true);
+        $this->mailbox->expects($this->once())
+            ->method('getMailboxSettings')
+            ->willReturn($settings);
+
+        $helper = $this->mockEmptyMailHelper();
+
+        $this->assertFalse($helper->generateBounceEmail('stat123'));
+    }
+
+    /**
+     * @param mixed[] $settings
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideInvalidMonitoringAddressSettings')]
+    public function testGenerateUnsubscribeEmailReturnsFalseForInvalidMonitoringAddress(array $settings): void
+    {
+        $this->mailbox->expects($this->once())
+            ->method('isConfigured')
+            ->with('EmailBundle', 'unsubscribes')
+            ->willReturn(true);
+        $this->mailbox->expects($this->once())
+            ->method('getMailboxSettings')
+            ->willReturn($settings);
+
+        $helper = $this->mockEmptyMailHelper();
+
+        $this->assertFalse($helper->generateUnsubscribeEmail('stat123'));
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed[]}>
+     */
+    public static function provideInvalidMonitoringAddressSettings(): iterable
+    {
+        yield 'blank address' => [['address' => '']];
+        yield 'missing address' => [[]];
+        yield 'missing domain' => [['address' => 'bounces@']];
+        yield 'missing local part' => [['address' => '@example.com']];
+        yield 'not an email address' => [['address' => 'not-an-email-address']];
+    }
+
     public function testValidateValidEmails(): void
     {
         $helper    = $this->mockEmptyMailHelper();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | Yes
| New feature/enhancement? (use the a.x branch) | No
| Deprecations?                          | No
| BC breaks? (use the c.x branch)        | No
| Automated tests included?              | Yes
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16242

## Description

When monitored bounce settings exist but `EmailBundle_bounces.address` is blank or malformed, `MailHelper::generateBounceEmail()` currently splits the address with `explode('@', ...)` and can generate an invalid return path such as `+bounce_<hash>@`. Symfony then rejects that address while sending test mail, producing the HTTP 500 described in #16242.

This change validates monitored mailbox addresses before generating bounce or unsubscribe addresses. If the configured address is missing or invalid, Mautic now behaves as if no monitored return-path address is available instead of creating an invalid RFC 2822 address.

I also added unit coverage for:

- valid bounce address generation
- blank, missing, and malformed monitored bounce addresses
- the same invalid-address guard for unsubscribe monitored addresses, which used the same split pattern

LLM assistance disclosure: implemented with OpenAI Codex assistance and manually reviewed before submission.

---
### Steps to test this PR:

1. Configure email sending normally.
2. Configure `EmailBundle_bounces` so the mailbox settings exist but `address` is blank, matching the issue report.
3. Send a test email.
4. Confirm the email send path no longer throws an undefined array key warning or Symfony RFC compliance exception for a generated `+bounce_...@` return path.
5. Configure a valid bounce address such as `bounces@example.com` and confirm generated bounce addresses still include the `+bounce_<hash>` notation.

## Local validation

- `git diff --check` passed with only Git's Windows line-ending normalization warnings.
- PHP and Composer are not installed in this Windows environment, and this fresh clone has no `vendor/` directory, so I could not run the PHPUnit test locally here.