### PR TITLE
[rector] inline logger dependency, as only set and read, no extra var

### DIFF
--- a/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
+++ b/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
@@ -16,12 +16,9 @@ class CacheClearSubscriber implements CacheClearerInterface
      */
     private AdapterInterface $cacheProvider;
 
-    private LoggerInterface $logger;
-
-    public function __construct(AdapterInterface $cacheProvider, LoggerInterface $logger)
+    public function __construct(AdapterInterface $cacheProvider, private readonly LoggerInterface $logger)
     {
         $this->cacheProvider = $cacheProvider;
-        $this->logger        = $logger;
     }
 
     /**


### PR DESCRIPTION
Hello to Mautic :wave: ,

Tomas from @rectorphp here.  Past week I went through popular repositories on Github and looked for ways people use Rector. Here I've notice few errors ignored in `rector.php`, most of them caused by a bug on our side. Those skips are valuable, as rule + path gives us testable fixture. 

So I've fixed couple of them and want to contribute back (new Rector release coming).

This is first fix, to kick it of :+1:  



(Let me know if target branch is correct)