### PR TITLE
[rector] Remove always true  $cleanSlate variable, always set to true

### DIFF
--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -521,7 +521,6 @@ class FormController extends CommonFormController
         }
 
         $session    = $request->getSession();
-        $cleanSlate = true;
 
         // set the page we came from
         $page = $request->getSession()->get('mautic.form.page', 1);
@@ -692,7 +691,6 @@ class FormController extends CommonFormController
                 );
             } elseif ($valid && $form->get('buttons')->get('apply')->isClicked()) {
                 // Rebuild everything to include new ids
-                $cleanSlate = true;
                 $reorder    = true;
 
                 // Rebuild the form with new action so that apply doesn't keep creating a clone
@@ -700,8 +698,6 @@ class FormController extends CommonFormController
                 $form   = $model->createForm($entity, $this->formFactory, $action);
             }
         } else {
-            $cleanSlate = true;
-
             // lock the entity
             $model->lockEntity($entity);
         }
@@ -713,7 +709,6 @@ class FormController extends CommonFormController
         // Get field and action settings
         $availableFields = $this->fieldHelper->getChoiceList($customComponents['fields']);
 
-        if ($cleanSlate) {
             // clean slate
             $this->clearSessionComponents($request, $objectId);
             $this->alreadyMappedFieldCollector->removeAllForForm($objectId);
@@ -818,7 +813,6 @@ class FormController extends CommonFormController
 
             $session->set('mautic.form.'.$objectId.'.actions.modified', $modifiedActions);
             $deletedActions = [];
-        }
 
         return $this->delegateView(
             [

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -709,110 +709,110 @@ class FormController extends CommonFormController
         // Get field and action settings
         $availableFields = $this->fieldHelper->getChoiceList($customComponents['fields']);
 
-            // clean slate
-            $this->clearSessionComponents($request, $objectId);
-            $this->alreadyMappedFieldCollector->removeAllForForm($objectId);
+        // clean slate
+        $this->clearSessionComponents($request, $objectId);
+        $this->alreadyMappedFieldCollector->removeAllForForm($objectId);
 
-            // load existing fields into session
-            $modifiedFields   = [];
-            $existingFields   = $entity->getFields()->toArray();
-            $fieldMap         = [];
-            $submitButton     = false;
+        // load existing fields into session
+        $modifiedFields   = [];
+        $existingFields   = $entity->getFields()->toArray();
+        $fieldMap         = [];
+        $submitButton     = false;
 
-            foreach ($existingFields as $fieldId => $formField) {
-                // Check to see if the field still exists
+        foreach ($existingFields as $fieldId => $formField) {
+            // Check to see if the field still exists
 
-                if ('button' == $formField->getType()) {
-                    // submit button found
-                    $submitButton = true;
-                }
-                if ('button' !== $formField->getType() && !in_array($formField->getType(), $availableFields)) {
-                    continue;
-                }
+            if ('button' == $formField->getType()) {
+                // submit button found
+                $submitButton = true;
+            }
+            if ('button' !== $formField->getType() && !in_array($formField->getType(), $availableFields)) {
+                continue;
+            }
 
-                $id    = $formField->getId();
-                $field = $formField->convertToArray();
+            $id    = $formField->getId();
+            $field = $formField->convertToArray();
 
-                if (!$id) {
-                    // Cloned entity
-                    $id = $field['id'] = $field['sessionId'] = $fieldMap[$fieldId] = 'new'.hash('sha1', uniqid(mt_rand()));
-                    if (isset($field['parent'])) {
-                        $field['parent'] = $fieldMap[$field['parent']];
-                    }
-                }
-
-                unset($field['form']);
-
-                if (isset($customComponents['fields'][$field['type']])) {
-                    // Set the custom parameters
-                    $field['customParameters'] = $customComponents['fields'][$field['type']];
-                }
-
-                $field['formId']     = $objectId;
-                $modifiedFields[$id] = $field;
-
-                if (!empty($field['mappedObject']) && !empty($field['mappedField']) && empty($field['parent'])) {
-                    $this->alreadyMappedFieldCollector->addField($objectId, $field['mappedObject'], $field['mappedField']);
+            if (!$id) {
+                // Cloned entity
+                $id = $field['id'] = $field['sessionId'] = $fieldMap[$fieldId] = 'new'.hash('sha1', uniqid(mt_rand()));
+                if (isset($field['parent'])) {
+                    $field['parent'] = $fieldMap[$field['parent']];
                 }
             }
 
-            if (!$submitButton) { // means something deleted the submit button from the form
-                // add a submit button
-                $keyId = 'new'.hash('sha1', uniqid(mt_rand()));
-                $field = new Field();
+            unset($field['form']);
 
-                $modifiedFields[$keyId]                    = $field->convertToArray();
-                $modifiedFields[$keyId]['label']           = $this->translator->trans('mautic.core.form.submit');
-                $modifiedFields[$keyId]['alias']           = 'submit';
-                $modifiedFields[$keyId]['showLabel']       = 1;
-                $modifiedFields[$keyId]['type']            = 'button';
-                $modifiedFields[$keyId]['id']              = $keyId;
-                $modifiedFields[$keyId]['inputAttributes'] = 'class="btn btn-ghost"';
-                $modifiedFields[$keyId]['formId']          = $objectId;
-                unset($modifiedFields[$keyId]['form']);
+            if (isset($customComponents['fields'][$field['type']])) {
+                // Set the custom parameters
+                $field['customParameters'] = $customComponents['fields'][$field['type']];
             }
 
-            if (!empty($reorder)) {
-                uasort(
-                    $modifiedFields,
-                    fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
-                );
+            $field['formId']     = $objectId;
+            $modifiedFields[$id] = $field;
+
+            if (!empty($field['mappedObject']) && !empty($field['mappedField']) && empty($field['parent'])) {
+                $this->alreadyMappedFieldCollector->addField($objectId, $field['mappedObject'], $field['mappedField']);
+            }
+        }
+
+        if (!$submitButton) { // means something deleted the submit button from the form
+            // add a submit button
+            $keyId = 'new'.hash('sha1', uniqid(mt_rand()));
+            $field = new Field();
+
+            $modifiedFields[$keyId]                    = $field->convertToArray();
+            $modifiedFields[$keyId]['label']           = $this->translator->trans('mautic.core.form.submit');
+            $modifiedFields[$keyId]['alias']           = 'submit';
+            $modifiedFields[$keyId]['showLabel']       = 1;
+            $modifiedFields[$keyId]['type']            = 'button';
+            $modifiedFields[$keyId]['id']              = $keyId;
+            $modifiedFields[$keyId]['inputAttributes'] = 'class="btn btn-ghost"';
+            $modifiedFields[$keyId]['formId']          = $objectId;
+            unset($modifiedFields[$keyId]['form']);
+        }
+
+        if (!empty($reorder)) {
+            uasort(
+                $modifiedFields,
+                fn ($a, $b): int => $a['order'] <=> $b['order'] ?: $a['id'] <=> $b['id']
+            );
+        }
+
+        $session->set('mautic.form.'.$objectId.'.fields.modified', $modifiedFields);
+        $deletedFields = [];
+
+        // Load existing actions into session
+        $modifiedActions = [];
+        $existingActions = $entity->getActions()->toArray();
+
+        foreach ($existingActions as $formAction) {
+            // Check to see if the action still exists
+            if (!isset($customComponents['actions'][$formAction->getType()])) {
+                continue;
             }
 
-            $session->set('mautic.form.'.$objectId.'.fields.modified', $modifiedFields);
-            $deletedFields = [];
+            $id     = $formAction->getId();
+            $action = $formAction->convertToArray();
 
-            // Load existing actions into session
-            $modifiedActions = [];
-            $existingActions = $entity->getActions()->toArray();
-
-            foreach ($existingActions as $formAction) {
-                // Check to see if the action still exists
-                if (!isset($customComponents['actions'][$formAction->getType()])) {
-                    continue;
-                }
-
-                $id     = $formAction->getId();
-                $action = $formAction->convertToArray();
-
-                if (!$id) {
-                    // Cloned entity so use a random Id instead
-                    $action['id'] = $id = 'new'.hash('sha1', uniqid(mt_rand()));
-                }
-                unset($action['form']);
-
-                $modifiedActions[$id] = $action;
+            if (!$id) {
+                // Cloned entity so use a random Id instead
+                $action['id'] = $id = 'new'.hash('sha1', uniqid(mt_rand()));
             }
+            unset($action['form']);
 
-            if (!empty($reorder)) {
-                uasort(
-                    $modifiedActions,
-                    fn ($a, $b): int => $a['order'] <=> $b['order']
-                );
-            }
+            $modifiedActions[$id] = $action;
+        }
 
-            $session->set('mautic.form.'.$objectId.'.actions.modified', $modifiedActions);
-            $deletedActions = [];
+        if (!empty($reorder)) {
+            uasort(
+                $modifiedActions,
+                fn ($a, $b): int => $a['order'] <=> $b['order']
+            );
+        }
+
+        $session->set('mautic.form.'.$objectId.'.actions.modified', $modifiedActions);
+        $deletedActions = [];
 
         return $this->delegateView(
             [


### PR DESCRIPTION
Without indent changes on purpose, that's why CS report fails. This way it's easier to read the code and review.
Once approved, I'll update the indents :+1: 

We have 2 options:

* remove always true condition
* fix a bug


<br>

## 1. Remove always true condition

Verified with Github search in the file for "cleanSlate": https://github.com/search?q=repo%3Amautic%2Fmautic+%22cleanSlate%22+path%3Aapp%2Fbundles%2FFormBundle%2FController%2FFormController.php&type=code

If there would be some magic `${$name}` override, there would be at least a string `'cleanSlate'` somewhere. But it's not:

<img width="1378" height="814" alt="image" src="https://github.com/user-attachments/assets/0aac55b3-c05c-4573-9431-584a68a520a9" />


---

Backed by PHPStan ignored in baseline:

<img width="1460" height="408" alt="image" src="https://github.com/user-attachments/assets/9911f972-a967-4061-ad3a-03e46aa6a062" />


---

## 2. Fix a bug

When we search "cleanSlate" in a whole repository, wë́'ll find another use in a controller:
https://github.com/search?q=repo%3Amautic%2Fmautic+%22cleanSlate%22+path%3Aapp%2Fbundles%2F&type=code

<img width="1264" height="546" alt="image" src="https://github.com/user-attachments/assets/ed9d44bd-b39a-47c9-851e-7d98e350754b" />


See the condition? **It sets value to `false` in here**:

https://github.com/mautic/mautic/blob/c08d408d061ba1fe62751522f10ac2a7dcf4b006/app/bundles/PointBundle/Controller/TriggerController.php#L405-L408

**If we look for the same button click condition in `FormController`, it sets value to `true`:**

<img width="1172" height="212" alt="Screenshot From 2026-06-21 11-50-16" src="https://github.com/user-attachments/assets/f9e591e3-185c-4e56-be36-d632767ea009" />

Seems like a bad copy-paste from older controller. The `FormController` was added in 2014 in this commit: https://github.com/mautic/mautic/commit/ee8ef6cd6523ab404ffb6518cd88127443918e11#diff-b87fff3fca6eeed7bff8fd7b878969243241501370e62be6e76219e2b060f0e8, with already `true` used everywhere.

<br>

I don't know much more about the controller. Can you verify if it's a bug?