### PR TITLE
Decode company entities in contact list name

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
@@ -7,13 +7,13 @@
                 }) }}
             </div>
         {% endif %}
-        {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : item.primaryIdentifier|purify %}
+        {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : htmlEntityDecode(item.primaryIdentifier)|purify %}
         <div>
             {{ primaryIdentifier }}
         </div>
         {{ customContent('lead.name.after', _context) }}
         {% if 'company' in columns|keys and primaryIdentifier != item.secondaryIdentifier and item.secondaryIdentifier %}
-            <div class="small">{{ item.secondaryIdentifier|purify }}</div>
+            <div class="small">{{ htmlEntityDecode(item.secondaryIdentifier)|purify }}</div>
         {% endif %}
     </a>
 </td>

--- a/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
@@ -7,13 +7,14 @@
                 }) }}
             </div>
         {% endif %}
-        {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : htmlEntityDecode(item.primaryIdentifier)|purify %}
+        {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : htmlEntityDecode(htmlEntityDecode(item.primaryIdentifier))|purify %}
+        {% set secondaryIdentifier = item.secondaryIdentifier ? htmlEntityDecode(htmlEntityDecode(item.secondaryIdentifier))|purify : '' %}
         <div>
             {{ primaryIdentifier }}
         </div>
         {{ customContent('lead.name.after', _context) }}
-        {% if 'company' in columns|keys and primaryIdentifier != item.secondaryIdentifier and item.secondaryIdentifier %}
-            <div class="small">{{ htmlEntityDecode(item.secondaryIdentifier)|purify }}</div>
+        {% if 'company' in columns|keys and primaryIdentifier != secondaryIdentifier and secondaryIdentifier %}
+            <div class="small">{{ secondaryIdentifier }}</div>
         {% endif %}
     </a>
 </td>

--- a/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
@@ -10,11 +10,15 @@
         {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : htmlEntityDecode(htmlEntityDecode(item.primaryIdentifier))|purify %}
         {% set secondaryIdentifier = item.secondaryIdentifier ? htmlEntityDecode(htmlEntityDecode(item.secondaryIdentifier))|purify : '' %}
         <div>
-            {{ primaryIdentifier }}
+            {% if item.isAnonymous %}
+                {{ primaryIdentifier }}
+            {% else %}
+                {{ primaryIdentifier|raw }}
+            {% endif %}
         </div>
         {{ customContent('lead.name.after', _context) }}
         {% if 'company' in columns|keys and primaryIdentifier != secondaryIdentifier and secondaryIdentifier %}
-            <div class="small">{{ secondaryIdentifier }}</div>
+            <div class="small">{{ secondaryIdentifier|raw }}</div>
         {% endif %}
     </a>
 </td>

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
@@ -13,7 +13,9 @@ final class LeadControllerListingPageTest extends MauticMysqlTestCase
 {
     protected function setUp(): void
     {
-        $this->configParams['contact_columns'] = ['name', 'location', 'email'];
+        $this->configParams['contact_columns'] = 'testContactListingDecodesHtmlEntitiesInCompanySecondaryIdentifier' === $this->name()
+            ? ['name', 'company', 'email']
+            : ['name', 'location', 'email'];
 
         parent::setUp();
     }
@@ -87,6 +89,25 @@ final class LeadControllerListingPageTest extends MauticMysqlTestCase
 
         Assert::assertStringContainsString('Acme &amp; Sons', $content);
         Assert::assertStringNotContainsString('Acme &amp;amp; Sons', $content);
+    }
+
+    public function testContactListingDecodesHtmlEntitiesInCompanySecondaryIdentifier(): void
+    {
+        $contact = new Lead();
+        $contact->setFirstname('Jane');
+        $contact->setLastname('Doe');
+        $contact->setEmail('jane@doe.example.com');
+        $contact->setCompany('Acme &amp; Sons');
+
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $crawler        = $this->client->request('GET', 's/contacts');
+        $nameColumnHtml = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr/td[2]")->html();
+
+        Assert::assertStringContainsString('Jane Doe', $nameColumnHtml);
+        Assert::assertStringContainsString('Acme &amp; Sons', $nameColumnHtml);
+        Assert::assertStringNotContainsString('Acme &amp;amp; Sons', $nameColumnHtml);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
@@ -73,6 +73,22 @@ final class LeadControllerListingPageTest extends MauticMysqlTestCase
         ];
     }
 
+    public function testContactListingDecodesHtmlEntitiesInCompanyPrimaryIdentifier(): void
+    {
+        $contact = new Lead();
+        $contact->setEmail('jane@doe.example.com');
+        $contact->setCompany('Acme &amp; Sons');
+
+        $this->em->persist($contact);
+        $this->em->flush();
+
+        $this->client->request('GET', 's/contacts');
+        $content = (string) $this->client->getResponse()->getContent();
+
+        Assert::assertStringContainsString('Acme &amp; Sons', $content);
+        Assert::assertStringNotContainsString('Acme &amp;amp; Sons', $content);
+    }
+
     /**
      * @param string[] $location
      *


### PR DESCRIPTION
## Summary

Fixes #16321.

## Changes

- Decode HTML entities before purifying contact-list primary identifiers.
- Apply the same behavior to secondary identifiers displayed under the name.
- Add a regression test for a company primary identifier containing `&amp;`.

## Testing/Verification

- `git diff --check`
- `docker run --rm -v "${PWD}:/app" -w /app php:8.4-cli php -l app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php`

Not run: targeted PHPUnit, because this local runner does not have PHP/Composer/DDEV dependencies or a Mautic test database available.
