### PR TITLE
[rector] make use of short *= operations

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -68,8 +68,8 @@ class EventType extends AbstractType
                 $label .= '_inaction';
 
                 unset($choices['immediate']);
-                $choices['interval'] = $choices['interval'].'_inaction';
-                $choices['date']     = $choices['date'].'_inaction';
+                $choices['interval'] .= '_inaction';
+                $choices['date'] .= '_inaction';
             }
             $default = array_key_first($choices);
 

--- a/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
@@ -56,7 +56,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $decisions = [];
         foreach ($channels as $channel) {
             if (isset($channel['campaignDecisionsSupported'])) {
-                $decisions = $decisions + $channel['campaignDecisionsSupported'];
+                $decisions += $channel['campaignDecisionsSupported'];
             }
         }
 

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -68,7 +68,7 @@ class AjaxController extends CommonAjaxController
                 $stats['failed'] += $batchFailedCount;
 
                 foreach ($batchFailedRecipients as $emails) {
-                    $stats['failedRecipients'] = $stats['failedRecipients'] + $emails;
+                    $stats['failedRecipients'] += $emails;
                 }
 
                 $session->set('mautic.email.send.progress', $progress);

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -468,7 +468,7 @@ class SubmissionRepository extends CommonRepository
                 break;
             case 'startsWith':
                 $operatorExpr    = 'like';
-                $value           = $value.'%';
+                $value .= '%';
                 break;
             case 'endsWith':
                 $operatorExpr   = 'like';

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -113,7 +113,7 @@ class LeadController extends FormController
         $orderBy    = $session->get('mautic.lead.orderby', 'l.last_active');
         // Add an id field to orderBy. Prevent Null-value ordering
         $orderById  = 'l.id' !== $orderBy ? ', l.id' : '';
-        $orderBy    = $orderBy.$orderById;
+        $orderBy .= $orderById;
         $orderByDir = $session->get('mautic.lead.orderbydir', 'DESC');
 
         $filter      = ['string' => $search, 'force' => ''];
@@ -2199,7 +2199,7 @@ class LeadController extends FormController
         $orderBy    = $session->get('mautic.lead.orderby', 'l.last_active');
         // Add an id field to orderBy. Prevent Null-value ordering
         $orderById  = 'l.id' !== $orderBy ? ', l.id' : '';
-        $orderBy    = $orderBy.$orderById;
+        $orderBy .= $orderById;
         $orderByDir = $session->get('mautic.lead.orderbydir', 'DESC');
         $ids        = $request->get('ids');
 

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -339,7 +339,7 @@ class LeadFieldRepository extends CommonRepository
                 switch ($operatorExpr) {
                     case 'startsWith':
                         $operatorExpr    = 'like';
-                        $value           = $value.'%';
+                        $value .= '%';
                         break;
                     case 'endsWith':
                         $operatorExpr   = 'like';

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -531,7 +531,7 @@ class FieldType extends AbstractType
 
         if ($options['data']->getColumnIsNotRemoved()) {
             if (array_key_exists('tooltip', $attr)) {
-                $attr['tooltip'] = $attr['tooltip'].' mautic.lead.field.being_removed_in_background';
+                $attr['tooltip'] .= ' mautic.lead.field.being_removed_in_background';
             } else {
                 $attr['tooltip'] = 'mautic.lead.field.being_removed_in_background';
             }

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -432,7 +432,7 @@ class ImportModel extends FormModel
             if ($diffCount > 0) {
                 // Fill in the data with empty string
                 $fill = array_fill($dataCount, $diffCount, '');
-                $data = $data + $fill;
+                $data += $fill;
             } else {
                 return true;
             }

--- a/app/bundles/LeadBundle/Services/ContactColumnsDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactColumnsDictionary.php
@@ -47,7 +47,7 @@ class ContactColumnsDictionary
             $this->fieldList['points']      = $this->translator->trans('mautic.lead.points');
             $this->fieldList['last_active'] = $this->translator->trans('mautic.lead.lastactive');
             $this->fieldList['id']          = $this->translator->trans('mautic.core.id');
-            $this->fieldList                = $this->fieldList + $this->fieldModel->getFieldList(false);
+            $this->fieldList += $this->fieldModel->getFieldList(false);
         }
 
         return $this->fieldList;

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -235,7 +235,7 @@ class IntegrationHelper
             $integrationsWithFeatures = [];
             foreach ($withFeatures as $feature) {
                 if (isset($this->byFeatureList[$feature])) {
-                    $integrationsWithFeatures = $integrationsWithFeatures + $this->byFeatureList[$feature];
+                    $integrationsWithFeatures += $this->byFeatureList[$feature];
                 }
             }
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -148,7 +148,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
                         switch ($condition) {
                             case 'startsWith':
-                                $value = $value.'%';
+                                $value .= '%';
                                 break;
                             case 'endsWith':
                                 $value = '%'.$value;
@@ -444,7 +444,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
                                         break;
                                     case 'startsWith':
                                         $exprFunction    = 'like';
-                                        $filter['value'] = $filter['value'].'%';
+                                        $filter['value'] .= '%';
                                         break;
                                     case 'endsWith':
                                         $exprFunction    = 'like';

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -400,9 +400,9 @@ class HubspotIntegration extends CrmAbstractIntegration
                             $contactData = $this->amendLeadDataBeforeMauticPopulate($contact, 'Lead');
                             $contact     = $this->getMauticLead($contactData);
                             if ($contact && !$contact->isNewlyCreated()) { // updated
-                                $executed[0] = $executed[0] + 1;
+                                $executed[0] += 1;
                             } elseif ($contact && $contact->isNewlyCreated()) { // newly created
-                                $executed[1] = $executed[1] + 1;
+                                $executed[1] += 1;
                             }
 
                             if ($contact) {

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -400,9 +400,9 @@ class HubspotIntegration extends CrmAbstractIntegration
                             $contactData = $this->amendLeadDataBeforeMauticPopulate($contact, 'Lead');
                             $contact     = $this->getMauticLead($contactData);
                             if ($contact && !$contact->isNewlyCreated()) { // updated
-                                $executed[0] += 1;
+                                ++$executed[0];
                             } elseif ($contact && $contact->isNewlyCreated()) { // newly created
-                                $executed[1] += 1;
+                                ++$executed[1];
                             }
 
                             if ($contact) {

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2827,7 +2827,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $totalIgnored = $totalToProcess - ($totalUpdated + $totalCreated + $totalErrors);
 
         if ($totalIgnored < 0) { // this could have been marked as deleted so it was not pushed
-            $totalIgnored = $totalIgnored * -1;
+            $totalIgnored *= -1;
         }
 
         return [$totalUpdated, $totalCreated, $totalErrors, $totalIgnored];

--- a/rector.php
+++ b/rector.php
@@ -44,14 +44,10 @@ return RectorConfig::configure()
         UnserializeToSerializerDecodeRector::class,
     ])
     ->reportUnusedSkips()
-<<<<<<< HEAD
     ->withTypeCoverageLevel(15)
-=======
-    ->withTypeCoverageLevel(6)
     ->withCodeQualityLevel(2)
->>>>>>> 1ec1d82bc3 ([php] make use of *= operations)
     ->withSkip([
-        \Rector\Renaming\Rector\FuncCall\RenameFunctionRector::class,
+        Rector\Renaming\Rector\FuncCall\RenameFunctionRector::class,
         '*/Test/*',
         '*/Tests/*',
 

--- a/rector.php
+++ b/rector.php
@@ -44,8 +44,14 @@ return RectorConfig::configure()
         UnserializeToSerializerDecodeRector::class,
     ])
     ->reportUnusedSkips()
+<<<<<<< HEAD
     ->withTypeCoverageLevel(15)
+=======
+    ->withTypeCoverageLevel(6)
+    ->withCodeQualityLevel(2)
+>>>>>>> 1ec1d82bc3 ([php] make use of *= operations)
     ->withSkip([
+        \Rector\Renaming\Rector\FuncCall\RenameFunctionRector::class,
         '*/Test/*',
         '*/Tests/*',
 


### PR DESCRIPTION
These structures make it more smooth to read and avoid typos on the middle part. There is already heavy use of `.=`, `+=` etc. in this codebase, so this is a way to standardize the syntax.

Let me know if you're interested in these changes :+1: 