### PR TITLE
[rector] Add return type declarations to event classes

### DIFF
--- a/app/bundles/ApiBundle/Event/ApiEntityEvent.php
+++ b/app/bundles/ApiBundle/Event/ApiEntityEvent.php
@@ -25,18 +25,12 @@ class ApiEntityEvent extends CommonEvent
         return $this->entity;
     }
 
-    /**
-     * @return array
-     */
-    public function getEntityRequestParameters()
+    public function getEntityRequestParameters(): array
     {
         return $this->entityRequestParameters;
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }

--- a/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
@@ -188,10 +188,7 @@ class CampaignExecutionEvent extends Event
         return $this;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLogEntry()
+    public function getLogEntry(): ?LeadEventLog
     {
         return $this->log;
     }

--- a/app/bundles/CampaignBundle/Event/CampaignLeadChangeEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignLeadChangeEvent.php
@@ -36,10 +36,8 @@ class CampaignLeadChangeEvent extends Event
 
     /**
      * Returns the Campaign entity.
-     *
-     * @return Campaign
      */
-    public function getCampaign()
+    public function getCampaign(): Campaign
     {
         return $this->campaign;
     }
@@ -57,9 +55,9 @@ class CampaignLeadChangeEvent extends Event
     /**
      * If this is a batch event, return array of leads.
      *
-     * @return Lead[]|null
+     * @return Lead[]
      */
-    public function getLeads()
+    public function getLeads(): array
     {
         return $this->leads;
     }

--- a/app/bundles/CampaignBundle/Event/CampaignScheduledEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignScheduledEvent.php
@@ -110,10 +110,7 @@ class CampaignScheduledEvent extends Event
         return $this->eventSettings;
     }
 
-    /**
-     * @return LeadEventLog|null
-     */
-    public function getLog()
+    public function getLog(): ?LeadEventLog
     {
         return $this->log;
     }

--- a/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
@@ -19,10 +19,8 @@ class CampaignTriggerEvent extends Event
 
     /**
      * Returns the Campaign entity.
-     *
-     * @return Campaign
      */
-    public function getCampaign()
+    public function getCampaign(): Campaign
     {
         return $this->campaign;
     }

--- a/app/bundles/CampaignBundle/Event/ConditionEvent.php
+++ b/app/bundles/CampaignBundle/Event/ConditionEvent.php
@@ -29,18 +29,12 @@ class ConditionEvent extends CampaignExecutionEvent
         );
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getEventConfig()
+    public function getEventConfig(): AbstractEventAccessor
     {
         return $this->eventConfig;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLog()
+    public function getLog(): LeadEventLog
     {
         return $this->eventLog;
     }

--- a/app/bundles/CampaignBundle/Event/DecisionEvent.php
+++ b/app/bundles/CampaignBundle/Event/DecisionEvent.php
@@ -34,18 +34,12 @@ class DecisionEvent extends CampaignExecutionEvent
         );
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getEventConfig()
+    public function getEventConfig(): AbstractEventAccessor
     {
         return $this->eventConfig;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLog()
+    public function getLog(): LeadEventLog
     {
         return $this->eventLog;
     }

--- a/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
+++ b/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
@@ -20,10 +20,7 @@ class DecisionResultsEvent extends Event
     ) {
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getEventConfig()
+    public function getEventConfig(): AbstractEventAccessor
     {
         return $this->eventConfig;
     }
@@ -31,15 +28,12 @@ class DecisionResultsEvent extends Event
     /**
      * @return ArrayCollection|LeadEventLog[]
      */
-    public function getLogs()
+    public function getLogs(): ArrayCollection
     {
         return $this->eventLogs;
     }
 
-    /**
-     * @return EvaluatedContacts
-     */
-    public function getEvaluatedContacts()
+    public function getEvaluatedContacts(): EvaluatedContacts
     {
         return $this->evaluatedContacts;
     }

--- a/app/bundles/CampaignBundle/Event/ExecutedEvent.php
+++ b/app/bundles/CampaignBundle/Event/ExecutedEvent.php
@@ -13,18 +13,12 @@ class ExecutedEvent extends \Symfony\Contracts\EventDispatcher\Event
     ) {
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getConfig()
+    public function getConfig(): AbstractEventAccessor
     {
         return $this->config;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLog()
+    public function getLog(): LeadEventLog
     {
         return $this->log;
     }

--- a/app/bundles/CampaignBundle/Event/FailedEvent.php
+++ b/app/bundles/CampaignBundle/Event/FailedEvent.php
@@ -13,18 +13,12 @@ class FailedEvent extends \Symfony\Contracts\EventDispatcher\Event
     ) {
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getConfig()
+    public function getConfig(): AbstractEventAccessor
     {
         return $this->config;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLog()
+    public function getLog(): LeadEventLog
     {
         return $this->log;
     }

--- a/app/bundles/CampaignBundle/Event/PendingEvent.php
+++ b/app/bundles/CampaignBundle/Event/PendingEvent.php
@@ -214,7 +214,7 @@ class PendingEvent extends AbstractLogCollectionEvent
     /**
      * @return LeadEventLog[]|ArrayCollection
      */
-    public function getFailures()
+    public function getFailures(): ArrayCollection
     {
         return $this->failures;
     }
@@ -222,7 +222,7 @@ class PendingEvent extends AbstractLogCollectionEvent
     /**
      * @return LeadEventLog[]|ArrayCollection
      */
-    public function getSuccessful()
+    public function getSuccessful(): ArrayCollection
     {
         return $this->successful;
     }

--- a/app/bundles/CampaignBundle/Event/ScheduledEvent.php
+++ b/app/bundles/CampaignBundle/Event/ScheduledEvent.php
@@ -31,18 +31,12 @@ class ScheduledEvent extends CampaignScheduledEvent
         );
     }
 
-    /**
-     * @return AbstractEventAccessor
-     */
-    public function getEventConfig()
+    public function getEventConfig(): AbstractEventAccessor
     {
         return $this->eventConfig;
     }
 
-    /**
-     * @return LeadEventLog
-     */
-    public function getLog()
+    public function getLog(): LeadEventLog
     {
         return $this->eventLog;
     }

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
@@ -47,13 +47,8 @@ class ActionDispatcher
 
             $this->validateProcessedLogs($logs, $success, $failed);
 
-            if ($success) {
-                $this->dispatchExecutedEvent($config, $event, $success);
-            }
-
-            if ($failed) {
-                $this->dispatchFailedEvent($config, $failed);
-            }
+            $this->dispatchExecutedEvent($config, $event, $success);
+            $this->dispatchFailedEvent($config, $failed);
 
             // Dispatch legacy ON_EVENT_EXECUTION event for BC
             $this->legacyDispatcher->dispatchExecutionEvents($config, $success, $failed);

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
@@ -47,8 +47,13 @@ class ActionDispatcher
 
             $this->validateProcessedLogs($logs, $success, $failed);
 
-            $this->dispatchExecutedEvent($config, $event, $success);
-            $this->dispatchFailedEvent($config, $failed);
+            if ($success->count()) {
+                $this->dispatchExecutedEvent($config, $event, $success);
+            }
+
+            if ($failed->count()) {
+                $this->dispatchFailedEvent($config, $failed);
+            }
 
             // Dispatch legacy ON_EVENT_EXECUTION event for BC
             $this->legacyDispatcher->dispatchExecutionEvents($config, $success, $failed);

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -55,18 +55,12 @@ class ChannelBroadcastEvent extends Event
     ) {
     }
 
-    /**
-     * @return mixed
-     */
-    public function getChannel()
+    public function getChannel(): ?string
     {
         return $this->channel;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getId()
+    public function getId(): string|int|null
     {
         return $this->id;
     }
@@ -102,10 +96,7 @@ class ChannelBroadcastEvent extends Event
         return true;
     }
 
-    /**
-     * @return OutputInterface
-     */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }

--- a/app/bundles/ChannelBundle/Event/MessageQueueBatchProcessEvent.php
+++ b/app/bundles/ChannelBundle/Event/MessageQueueBatchProcessEvent.php
@@ -22,10 +22,7 @@ class MessageQueueBatchProcessEvent extends Event
         return $channel === $this->channel;
     }
 
-    /**
-     * @return array
-     */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->messages;
     }

--- a/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
+++ b/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
@@ -64,20 +64,16 @@ class ConfigBuilderEvent extends Event
 
     /**
      * Returns the forms array.
-     *
-     * @return array
      */
-    public function getForms()
+    public function getForms(): array
     {
         return $this->forms;
     }
 
     /**
      * Returns the formThemes array.
-     *
-     * @return array
      */
-    public function getFormThemes()
+    public function getFormThemes(): array
     {
         return $this->formThemes;
     }
@@ -112,10 +108,7 @@ class ConfigBuilderEvent extends Event
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getFileFields()
+    public function getFileFields(): array
     {
         return $this->encodedFields;
     }

--- a/app/bundles/ConfigBundle/Event/ConfigEvent.php
+++ b/app/bundles/ConfigBundle/Event/ConfigEvent.php
@@ -97,10 +97,8 @@ class ConfigEvent extends CommonEvent
     /**
      * Return array of fields to unset if empty so that existing values are not
      * overwritten if empty.
-     *
-     * @return array
      */
-    public function getPreservedFields()
+    public function getPreservedFields(): array
     {
         return $this->preserve;
     }
@@ -137,18 +135,13 @@ class ConfigEvent extends CommonEvent
 
     /**
      * Get error messages.
-     *
-     * @return array
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }
 
-    /**
-     * @return array
-     */
-    public function getFieldErrors()
+    public function getFieldErrors(): array
     {
         return $this->fieldErrors;
     }
@@ -167,10 +160,7 @@ class ConfigEvent extends CommonEvent
         return base64_encode($content);
     }
 
-    /**
-     * @return array
-     */
-    public function getOriginalNormData()
+    public function getOriginalNormData(): ?array
     {
         return $this->originalNormData;
     }

--- a/app/bundles/CoreBundle/Event/CustomContentEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomContentEvent.php
@@ -73,10 +73,7 @@ class CustomContentEvent extends Event
         return $this->context;
     }
 
-    /**
-     * @return array
-     */
-    public function getVars()
+    public function getVars(): array
     {
         return $this->vars;
     }

--- a/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
+++ b/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
@@ -36,7 +36,7 @@ class DetermineWinnerEvent extends Event
      *                email?: \Mautic\EmailBundle\Entity\Email
      *                }
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -48,7 +48,7 @@ class DetermineWinnerEvent extends Event
      *                supportTemplate?:string
      *                }
      */
-    public function getAbTestResults()
+    public function getAbTestResults(): ?array
     {
         return $this->abTestResults;
     }

--- a/app/bundles/CoreBundle/Event/IconEvent.php
+++ b/app/bundles/CoreBundle/Event/IconEvent.php
@@ -17,10 +17,7 @@ class IconEvent extends Event
     ) {
     }
 
-    /**
-     * @return CorePermissions
-     */
-    public function getSecurity()
+    public function getSecurity(): CorePermissions
     {
         return $this->security;
     }

--- a/app/bundles/CoreBundle/Event/MaintenanceEvent.php
+++ b/app/bundles/CoreBundle/Event/MaintenanceEvent.php
@@ -46,10 +46,8 @@ class MaintenanceEvent extends Event
 
     /**
      * Returns a DateTime in UTC for the date to delete records older than the given date.
-     *
-     * @return \DateTimeInterface
      */
-    public function getDate()
+    public function getDate(): \DateTimeInterface
     {
         return $this->date;
     }

--- a/app/bundles/CoreBundle/Event/RouteEvent.php
+++ b/app/bundles/CoreBundle/Event/RouteEvent.php
@@ -28,10 +28,7 @@ class RouteEvent extends Event
         $this->collection->addCollection($this->loader->import($path));
     }
 
-    /**
-     * @return RouteCollection
-     */
-    public function getCollection()
+    public function getCollection(): RouteCollection
     {
         return $this->collection;
     }

--- a/app/bundles/CoreBundle/Event/StatsEvent.php
+++ b/app/bundles/CoreBundle/Event/StatsEvent.php
@@ -166,10 +166,8 @@ class StatsEvent extends Event
 
     /**
      * Returns the order.
-     *
-     * @return array
      */
-    public function getOrder()
+    public function getOrder(): array
     {
         return $this->order;
     }
@@ -247,10 +245,7 @@ class StatsEvent extends Event
         return $this->hasResults;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser()
+    public function getUser(): User
     {
         return $this->user;
     }

--- a/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
+++ b/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
@@ -71,7 +71,7 @@ class TokenReplacementEvent extends CommonEvent
     /**
      * @return mixed[]
      */
-    public function getClickthrough()
+    public function getClickthrough(): array
     {
         if (!in_array('lead', $this->clickthrough)) {
             if (is_array($this->lead) && !empty($this->lead['id'])) {

--- a/app/bundles/CoreBundle/Event/UpgradeEvent.php
+++ b/app/bundles/CoreBundle/Event/UpgradeEvent.php
@@ -11,10 +11,7 @@ class UpgradeEvent extends Event
     ) {
     }
 
-    /**
-     * @return array
-     */
-    public function getStatus()
+    public function getStatus(): array
     {
         return $this->status;
     }

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -167,7 +167,7 @@ class WidgetDetailEvent extends CommonEvent
      *
      * @return Widget $widget
      */
-    public function getWidget()
+    public function getWidget(): Widget
     {
         return $this->widget;
     }
@@ -320,10 +320,8 @@ class WidgetDetailEvent extends CommonEvent
 
     /**
      * Get the Translator object.
-     *
-     * @return TranslatorInterface
      */
-    public function getTranslator()
+    public function getTranslator(): TranslatorInterface
     {
         return $this->translator;
     }

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -164,8 +164,6 @@ class WidgetDetailEvent extends CommonEvent
 
     /**
      * Returns the widget entity.
-     *
-     * @return Widget $widget
      */
     public function getWidget(): Widget
     {

--- a/app/bundles/EmailBundle/Event/EmailOpenEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailOpenEvent.php
@@ -26,10 +26,8 @@ class EmailOpenEvent extends CommonEvent
 
     /**
      * Returns the Email entity.
-     *
-     * @return Email
      */
-    public function getEmail()
+    public function getEmail(): ?Email
     {
         return $this->email;
     }

--- a/app/bundles/EmailBundle/Event/EmailReplyEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailReplyEvent.php
@@ -18,18 +18,13 @@ class EmailReplyEvent extends Event
 
     /**
      * Returns the Email entity.
-     *
-     * @return Email
      */
-    public function getEmail()
+    public function getEmail(): ?Email
     {
         return $this->email;
     }
 
-    /**
-     * @return Stat
-     */
-    public function getStat()
+    public function getStat(): Stat
     {
         return $this->stat;
     }

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -209,10 +209,8 @@ class EmailSendEvent extends CommonEvent
 
     /**
      * Get the MailHelper object.
-     *
-     * @return MailHelper
      */
-    public function getHelper()
+    public function getHelper(): ?MailHelper
     {
         return $this->helper;
     }

--- a/app/bundles/EmailBundle/Event/MonitoredEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/MonitoredEmailEvent.php
@@ -17,10 +17,8 @@ class MonitoredEmailEvent extends Event
 
     /**
      * Get the FormBuilder for monitored_mailboxes FormType.
-     *
-     * @return FormBuilderInterface
      */
-    public function getFormBuilder()
+    public function getFormBuilder(): FormBuilderInterface
     {
         return $this->formBuilder;
     }
@@ -54,10 +52,8 @@ class MonitoredEmailEvent extends Event
 
     /**
      * Get array of folders.
-     *
-     * @return array
      */
-    public function getFolders()
+    public function getFolders(): array
     {
         return $this->folders;
     }

--- a/app/bundles/EmailBundle/Event/ParseEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/ParseEmailEvent.php
@@ -30,7 +30,7 @@ class ParseEmailEvent extends Event
      *
      * @return \Mautic\EmailBundle\MonitoredEmail\Message[]
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->messages;
     }
@@ -45,10 +45,7 @@ class ParseEmailEvent extends Event
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getKeys()
+    public function getKeys(): array
     {
         return $this->keys;
     }
@@ -107,18 +104,12 @@ class ParseEmailEvent extends Event
         }
     }
 
-    /**
-     * @return array
-     */
-    public function getCriteriaRequests()
+    public function getCriteriaRequests(): array
     {
         return $this->criteriaRequests;
     }
 
-    /**
-     * @return array
-     */
-    public function getMarkAsSeenInstructions()
+    public function getMarkAsSeenInstructions(): array
     {
         return $this->markAsSeen;
     }

--- a/app/bundles/EmailBundle/Event/QueueEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/QueueEmailEvent.php
@@ -14,10 +14,7 @@ class QueueEmailEvent extends Event
     ) {
     }
 
-    /**
-     * @return MauticMessage
-     */
-    public function getMessage()
+    public function getMessage(): MauticMessage
     {
         return $this->message;
     }

--- a/app/bundles/FormBundle/Event/FormBuilderEvent.php
+++ b/app/bundles/FormBundle/Event/FormBuilderEvent.php
@@ -62,10 +62,8 @@ class FormBuilderEvent extends Event
 
     /**
      * Get submit actions.
-     *
-     * @return array
      */
-    public function getSubmitActions()
+    public function getSubmitActions(): array
     {
         uasort(
             $this->actions,
@@ -145,9 +143,9 @@ class FormBuilderEvent extends Event
     /**
      * Get form fields.
      *
-     * @return mixed
+     * @return array<string, mixed>
      */
-    public function getFormFields()
+    public function getFormFields(): array
     {
         return $this->fields;
     }

--- a/app/bundles/FormBundle/Event/Service/FieldValueTransformer.php
+++ b/app/bundles/FormBundle/Event/Service/FieldValueTransformer.php
@@ -63,18 +63,12 @@ class FieldValueTransformer
         $this->isTransformed = true;
     }
 
-    /**
-     * @return array
-     */
-    public function getContactFieldsToUpdate()
+    public function getContactFieldsToUpdate(): array
     {
         return $this->contactFieldsToUpdate;
     }
 
-    /**
-     * @return array
-     */
-    public function getTokensToUpdate()
+    public function getTokensToUpdate(): array
     {
         return $this->tokensToUpdate;
     }

--- a/app/bundles/FormBundle/Event/SubmissionEvent.php
+++ b/app/bundles/FormBundle/Event/SubmissionEvent.php
@@ -98,10 +98,7 @@ class SubmissionEvent extends CommonEvent
         return $this->server;
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }
@@ -114,10 +111,7 @@ class SubmissionEvent extends CommonEvent
         return $this->entity->getForm();
     }
 
-    /**
-     * @return array
-     */
-    public function getResults()
+    public function getResults(): array
     {
         return $this->results;
     }
@@ -134,10 +128,7 @@ class SubmissionEvent extends CommonEvent
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getFields()
+    public function getFields(): array
     {
         return $this->fields;
     }
@@ -154,10 +145,7 @@ class SubmissionEvent extends CommonEvent
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getTokens()
+    public function getTokens(): array
     {
         return $this->tokens;
     }
@@ -174,10 +162,7 @@ class SubmissionEvent extends CommonEvent
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getContactFieldMatches()
+    public function getContactFieldMatches(): array
     {
         return $this->contactFieldMatches;
     }

--- a/app/bundles/FormBundle/Event/ValidationEvent.php
+++ b/app/bundles/FormBundle/Event/ValidationEvent.php
@@ -20,10 +20,7 @@ class ValidationEvent extends CommonEvent
     ) {
     }
 
-    /**
-     * @return Field
-     */
-    public function getField()
+    public function getField(): Field
     {
         return $this->field;
     }

--- a/app/bundles/IntegrationsBundle/Event/MappedIntegrationObjectTokenEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/MappedIntegrationObjectTokenEvent.php
@@ -40,10 +40,7 @@ class MappedIntegrationObjectTokenEvent extends CommonEvent
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getTokens()
+    public function getTokens(): array
     {
         return $this->tokens;
     }

--- a/app/bundles/LeadBundle/Event/CategoryChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/CategoryChangeEvent.php
@@ -30,28 +30,20 @@ class CategoryChangeEvent extends Event
         }
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): ?Lead
     {
         return $this->lead;
     }
 
     /**
      * Returns batch array of leads.
-     *
-     * @return array
      */
-    public function getLeads()
+    public function getLeads(): ?array
     {
         return $this->leads;
     }
 
-    /**
-     * @return Category
-     */
-    public function getCategory()
+    public function getCategory(): Category
     {
         return $this->category;
     }

--- a/app/bundles/LeadBundle/Event/ChannelSubscriptionChange.php
+++ b/app/bundles/LeadBundle/Event/ChannelSubscriptionChange.php
@@ -19,10 +19,7 @@ class ChannelSubscriptionChange extends Event
     ) {
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }

--- a/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
@@ -19,10 +19,7 @@ class ContactIdentificationEvent extends Event
     ) {
     }
 
-    /**
-     * @return array
-     */
-    public function getClickthrough()
+    public function getClickthrough(): array
     {
         return $this->clickthrough;
     }
@@ -46,10 +43,7 @@ class ContactIdentificationEvent extends Event
         return $this->identifiedByChannel;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getIdentifiedContact()
+    public function getIdentifiedContact(): ?Lead
     {
         return $this->identifiedContact;
     }

--- a/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
@@ -65,10 +65,7 @@ class LeadBuildSearchEvent extends CommonEvent
         return $this->negate;
     }
 
-    /**
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return $this->queryBuilder;
     }
@@ -135,10 +132,7 @@ class LeadBuildSearchEvent extends CommonEvent
         $this->returnParameters = $val;
     }
 
-    /**
-     * @return array
-     */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }

--- a/app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
@@ -32,20 +32,16 @@ class LeadChangeCompanyEvent extends Event
 
     /**
      * Returns the Lead entity.
-     *
-     * @return Lead
      */
-    public function getLead()
+    public function getLead(): ?Lead
     {
         return $this->lead;
     }
 
     /**
      * Returns batch array of leads.
-     *
-     * @return array
      */
-    public function getLeads()
+    public function getLeads(): ?array
     {
         return $this->leads;
     }

--- a/app/bundles/LeadBundle/Event/LeadChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadChangeEvent.php
@@ -15,10 +15,7 @@ class LeadChangeEvent extends Event
     ) {
     }
 
-    /**
-     * @return Lead
-     */
-    public function getOldLead()
+    public function getOldLead(): Lead
     {
         return $this->oldLead;
     }
@@ -31,10 +28,7 @@ class LeadChangeEvent extends Event
         return $this->oldTrackingId;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getNewLead()
+    public function getNewLead(): Lead
     {
         return $this->newLead;
     }

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -40,10 +40,7 @@ class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
         return $this->operators;
     }
 
-    /**
-     * @return TranslatorInterface
-     */
-    public function getTranslator()
+    public function getTranslator(): TranslatorInterface
     {
         return $this->translator;
     }

--- a/app/bundles/LeadBundle/Event/LeadListQueryBuilderGeneratedEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListQueryBuilderGeneratedEvent.php
@@ -14,18 +14,12 @@ class LeadListQueryBuilderGeneratedEvent extends Event
     ) {
     }
 
-    /**
-     * @return LeadList
-     */
-    public function getSegment()
+    public function getSegment(): LeadList
     {
         return $this->segment;
     }
 
-    /**
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return $this->queryBuilder;
     }

--- a/app/bundles/LeadBundle/Event/LeadMergeEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadMergeEvent.php
@@ -15,10 +15,8 @@ class LeadMergeEvent extends Event
 
     /**
      * Returns the victor (loser merges into the victor).
-     *
-     * @return Lead
      */
-    public function getVictor()
+    public function getVictor(): Lead
     {
         return $this->victor;
     }
@@ -26,7 +24,7 @@ class LeadMergeEvent extends Event
     /**
      * Returns the loser (loser merges into the victor).
      */
-    public function getLoser()
+    public function getLoser(): Lead
     {
         return $this->loser;
     }

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -303,10 +303,8 @@ class LeadTimelineEvent extends Event
 
     /**
      * Fetch the order for queries.
-     *
-     * @return array|null
      */
-    public function getEventOrder()
+    public function getEventOrder(): ?array
     {
         return $this->orderBy;
     }
@@ -342,10 +340,8 @@ class LeadTimelineEvent extends Event
 
     /**
      * Fetches the lead being acted on.
-     *
-     * @return Lead
      */
-    public function getLead()
+    public function getLead(): ?Lead
     {
         return $this->lead;
     }

--- a/app/bundles/LeadBundle/Event/ListChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/ListChangeEvent.php
@@ -33,28 +33,21 @@ class ListChangeEvent extends Event
 
     /**
      * Returns the Lead entity.
-     *
-     * @return Lead
      */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }
 
-    /**
-     * @return LeadList
-     */
-    public function getList()
+    public function getList(): LeadList
     {
         return $this->list;
     }
 
     /**
      * Returns batch array of leads.
-     *
-     * @return array|null
      */
-    public function getLeads()
+    public function getLeads(): ?array
     {
         return $this->leads;
     }

--- a/app/bundles/LeadBundle/Event/ListChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/ListChangeEvent.php
@@ -8,7 +8,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class ListChangeEvent extends Event
 {
-    private Lead $lead;
+    private ?Lead $lead = null;
 
     /**
      * @var Lead[]|null
@@ -34,7 +34,7 @@ class ListChangeEvent extends Event
     /**
      * Returns the Lead entity.
      */
-    public function getLead(): Lead
+    public function getLead(): ?Lead
     {
         return $this->lead;
     }

--- a/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
+++ b/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
@@ -20,10 +20,8 @@ class ListPreProcessListEvent extends CommonEvent
 
     /**
      * Returns the List entity.
-     *
-     * @return array
      */
-    public function getList()
+    public function getList(): array
     {
         return $this->list;
     }

--- a/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
@@ -37,7 +37,7 @@ class SegmentDictionaryGenerationEvent extends CommonEvent
     /**
      * @return array<string,mixed[]>
      */
-    public function getTranslations()
+    public function getTranslations(): array
     {
         return $this->translations;
     }

--- a/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
@@ -19,7 +19,7 @@ class ContactSegmentFilterDictionary
     /**
      * @var mixed[]
      */
-    private $filters = [];
+    private array $filters = [];
 
     public function __construct(
         private EventDispatcherInterface $dispatcher,

--- a/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
+++ b/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
@@ -53,10 +53,7 @@ class NotificationSendEvent extends CommonEvent
         return $this;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }

--- a/app/bundles/PageBundle/Event/PageDisplayEvent.php
+++ b/app/bundles/PageBundle/Event/PageDisplayEvent.php
@@ -22,10 +22,8 @@ class PageDisplayEvent extends Event
 
     /**
      * Returns the Page entity.
-     *
-     * @return Page
      */
-    public function getPage()
+    public function getPage(): Page
     {
         return $this->page;
     }
@@ -50,10 +48,8 @@ class PageDisplayEvent extends Event
 
     /**
      * Get params.
-     *
-     * @return array
      */
-    public function getParams()
+    public function getParams(): array
     {
         return $this->params;
     }

--- a/app/bundles/PageBundle/Event/PageHitEvent.php
+++ b/app/bundles/PageBundle/Event/PageHitEvent.php
@@ -27,10 +27,8 @@ class PageHitEvent extends CommonEvent
 
     /**
      * Returns the Page entity.
-     *
-     * @return Page
      */
-    public function getPage()
+    public function getPage(): ?Page
     {
         return $this->page;
     }

--- a/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
+++ b/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
@@ -26,20 +26,16 @@ class RedirectGenerationEvent extends CommonEvent
 
     /**
      * Get the redirect from the event.
-     *
-     * @return Redirect
      */
-    public function getRedirect()
+    public function getRedirect(): Redirect
     {
         return $this->redirect;
     }
 
     /**
      * Get the modified clickthrough from the event.
-     *
-     * @return array
      */
-    public function getClickthrough()
+    public function getClickthrough(): array
     {
         return $this->clickthrough;
     }

--- a/app/bundles/PluginBundle/Event/PluginIntegrationFormBuildEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationFormBuildEvent.php
@@ -15,18 +15,12 @@ class PluginIntegrationFormBuildEvent extends AbstractPluginIntegrationEvent
         $this->integration = $integration;
     }
 
-    /**
-     * @return FormBuilderInterface
-     */
-    public function getFormBuilder()
+    public function getFormBuilder(): FormBuilderInterface
     {
         return $this->builder;
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/app/bundles/PluginBundle/Event/PluginIntegrationFormDisplayEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationFormDisplayEvent.php
@@ -16,10 +16,7 @@ class PluginIntegrationFormDisplayEvent extends AbstractPluginIntegrationEvent
         $this->integration = $integration;
     }
 
-    /**
-     * @return array
-     */
-    public function getSettings()
+    public function getSettings(): array
     {
         return $this->settings;
     }

--- a/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
@@ -15,8 +15,10 @@ class PluginIntegrationKeyEvent extends AbstractPluginIntegrationEvent
 
     /**
      * Get the keys array.
+     *
+     * @return mixed[]|null
      */
-    public function getKeys()
+    public function getKeys(): ?array
     {
         return $this->keys;
     }

--- a/app/bundles/PointBundle/Event/PointActionEvent.php
+++ b/app/bundles/PointBundle/Event/PointActionEvent.php
@@ -14,10 +14,7 @@ class PointActionEvent extends CommonEvent
     ) {
     }
 
-    /**
-     * @return Point
-     */
-    public function getPoint()
+    public function getPoint(): Point
     {
         return $this->point;
     }
@@ -27,10 +24,7 @@ class PointActionEvent extends CommonEvent
         $this->point = $point;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }

--- a/app/bundles/PointBundle/Event/PointBuilderEvent.php
+++ b/app/bundles/PointBundle/Event/PointBuilderEvent.php
@@ -60,10 +60,7 @@ class PointBuilderEvent extends Event
         $this->actions[$key] = $action;
     }
 
-    /**
-     * @return array
-     */
-    public function getActions()
+    public function getActions(): array
     {
         uasort($this->actions, fn ($a, $b): int => strnatcasecmp(
             $a['label'], $b['label']));

--- a/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
@@ -59,10 +59,7 @@ class TriggerBuilderEvent extends Event
         $this->events[$key] = $event;
     }
 
-    /**
-     * @return array
-     */
-    public function getEvents()
+    public function getEvents(): array
     {
         uasort($this->events, fn ($a, $b): int => strnatcasecmp(
             $a['label'], $b['label']));

--- a/app/bundles/PointBundle/Event/TriggerExecutedEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerExecutedEvent.php
@@ -16,26 +16,17 @@ class TriggerExecutedEvent extends Event
     ) {
     }
 
-    /**
-     * @return TriggerEventEntity
-     */
-    public function getTriggerEvent()
+    public function getTriggerEvent(): TriggerEventEntity
     {
         return $this->triggerEvent;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }
 
-    /**
-     * @return bool
-     */
-    public function getResult()
+    public function getResult(): ?bool
     {
         return $this->result;
     }

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -40,7 +40,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @var array<string, mixed[]>
      */
-    private $cachedEvents = [];
+    private array $cachedEvents = [];
 
     public function __construct(
         protected IpLookupHelper $ipLookupHelper,

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -98,10 +98,8 @@ class ReportBuilderEvent extends AbstractReportEvent
 
     /**
      * Fetch the tables in the lookup array.
-     *
-     * @return array
      */
-    public function getTables()
+    public function getTables(): array
     {
         return $this->tableArray;
     }
@@ -290,10 +288,8 @@ class ReportBuilderEvent extends AbstractReportEvent
 
     /**
      * Get graphs.
-     *
-     * @return array
      */
-    public function getGraphs()
+    public function getGraphs(): array
     {
         return $this->graphArray;
     }

--- a/app/bundles/ReportBundle/Event/ReportDataEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportDataEvent.php
@@ -19,10 +19,7 @@ class ReportDataEvent extends AbstractReportEvent
         $this->totalResults = (int) $totalResults;
     }
 
-    /**
-     * @return array
-     */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
@@ -35,10 +32,7 @@ class ReportDataEvent extends AbstractReportEvent
         $this->data = $data;
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -67,10 +67,7 @@ class ReportGeneratorEvent extends AbstractReportEvent
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getSelectColumns()
+    public function getSelectColumns(): array
     {
         return $this->selectColumns;
     }
@@ -85,10 +82,7 @@ class ReportGeneratorEvent extends AbstractReportEvent
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/app/bundles/ReportBundle/Event/ReportGraphEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGraphEvent.php
@@ -21,10 +21,8 @@ class ReportGraphEvent extends AbstractReportEvent
 
     /**
      * Fetch the graphs.
-     *
-     * @return array
      */
-    public function getGraphs()
+    public function getGraphs(): array
     {
         return $this->requestedGraphs;
     }
@@ -87,10 +85,7 @@ class ReportGraphEvent extends AbstractReportEvent
         return array_keys($this->requestedGraphs);
     }
 
-    /**
-     * @return QueryBuilder
-     */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): QueryBuilder
     {
         return $this->queryBuilder;
     }

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -20,10 +20,7 @@ class ReportQueryEvent extends AbstractReportEvent
         $this->totalResults = (int) $totalResults;
     }
 
-    /**
-     * @return QueryBuilder
-     */
-    public function getQuery()
+    public function getQuery(): QueryBuilder
     {
         return $this->query;
     }
@@ -36,10 +33,7 @@ class ReportQueryEvent extends AbstractReportEvent
         $this->query = $query;
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }

--- a/app/bundles/ReportBundle/Event/ReportScheduleSendEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportScheduleSendEvent.php
@@ -16,10 +16,7 @@ class ReportScheduleSendEvent extends Event
     ) {
     }
 
-    /**
-     * @return Scheduler
-     */
-    public function getScheduler()
+    public function getScheduler(): Scheduler
     {
         return $this->scheduler;
     }

--- a/app/bundles/SmsBundle/Event/ReplyEvent.php
+++ b/app/bundles/SmsBundle/Event/ReplyEvent.php
@@ -23,10 +23,7 @@ class ReplyEvent extends \Symfony\Contracts\EventDispatcher\Event
     ) {
     }
 
-    /**
-     * @return Lead
-     */
-    public function getContact()
+    public function getContact(): Lead
     {
         return $this->contact;
     }
@@ -44,10 +41,7 @@ class ReplyEvent extends \Symfony\Contracts\EventDispatcher\Event
         $this->response = $response;
     }
 
-    /**
-     * @return Response|null
-     */
-    public function getResponse()
+    public function getResponse(): ?Response
     {
         return $this->response;
     }

--- a/app/bundles/SmsBundle/Event/SmsSendEvent.php
+++ b/app/bundles/SmsBundle/Event/SmsSendEvent.php
@@ -37,10 +37,7 @@ class SmsSendEvent extends CommonEvent
         $this->content = $content;
     }
 
-    /**
-     * @return Lead
-     */
-    public function getLead()
+    public function getLead(): Lead
     {
         return $this->lead;
     }

--- a/app/bundles/StageBundle/Event/StageBuilderEvent.php
+++ b/app/bundles/StageBundle/Event/StageBuilderEvent.php
@@ -62,10 +62,8 @@ class StageBuilderEvent extends Event
 
     /**
      * Get actions.
-     *
-     * @return array
      */
-    public function getActions()
+    public function getActions(): array
     {
         uasort($this->actions, fn ($a, $b): int => strnatcasecmp(
             $a['label'], $b['label']));

--- a/app/bundles/StatsBundle/Aggregate/Collector.php
+++ b/app/bundles/StatsBundle/Aggregate/Collector.php
@@ -17,10 +17,8 @@ class Collector
 
     /**
      * @param string $statName
-     *
-     * @return StatCollection
      */
-    public function fetchStats($statName, \DateTime $fromDateTime, \DateTime $toDateTime, ?FetchOptions $fetchOptions = null)
+    public function fetchStats($statName, \DateTime $fromDateTime, \DateTime $toDateTime, ?FetchOptions $fetchOptions = null): StatCollection
     {
         if (null === $fetchOptions) {
             $fetchOptions = new FetchOptions();

--- a/app/bundles/StatsBundle/Event/AggregateStatRequestEvent.php
+++ b/app/bundles/StatsBundle/Event/AggregateStatRequestEvent.php
@@ -38,34 +38,22 @@ class AggregateStatRequestEvent extends Event
         return $this->statName;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getFromDateTime()
+    public function getFromDateTime(): \DateTimeInterface
     {
         return $this->fromDateTime;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getToDateTime()
+    public function getToDateTime(): \DateTimeInterface
     {
         return $this->toDateTime;
     }
 
-    /**
-     * @return FetchOptions
-     */
-    public function getOptions()
+    public function getOptions(): FetchOptions
     {
         return $this->options;
     }
 
-    /**
-     * @return StatCollection
-     */
-    public function getStatCollection()
+    public function getStatCollection(): StatCollection
     {
         return $this->statCollection;
     }

--- a/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
@@ -23,10 +23,7 @@ class AuthenticationContentEvent extends Event
         $this->postLogout = $request->getSession()->get('post_logout', false);
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }

--- a/app/bundles/UserBundle/Event/AuthenticationEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationEvent.php
@@ -107,7 +107,7 @@ class AuthenticationEvent extends Event
      *
      * @return PluginToken
      */
-    public function getToken()
+    public function getToken(): TokenInterface
     {
         return $this->token;
     }
@@ -134,7 +134,7 @@ class AuthenticationEvent extends Event
      *
      * @return UserProvider
      */
-    public function getUserProvider()
+    public function getUserProvider(): UserProviderInterface
     {
         return $this->userProvider;
     }
@@ -241,10 +241,8 @@ class AuthenticationEvent extends Event
 
     /**
      * Get the request.
-     *
-     * @return Request
      */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }

--- a/app/bundles/UserBundle/Event/LoginEvent.php
+++ b/app/bundles/UserBundle/Event/LoginEvent.php
@@ -12,10 +12,7 @@ class LoginEvent extends Event
     ) {
     }
 
-    /**
-     * @return User|null
-     */
-    public function getUser()
+    public function getUser(): User
     {
         return $this->user;
     }

--- a/app/bundles/UserBundle/Event/LogoutEvent.php
+++ b/app/bundles/UserBundle/Event/LogoutEvent.php
@@ -16,10 +16,7 @@ class LogoutEvent extends Event
     ) {
     }
 
-    /**
-     * @return User
-     */
-    public function getUser()
+    public function getUser(): User
     {
         return $this->user;
     }
@@ -34,18 +31,13 @@ class LogoutEvent extends Event
 
     /**
      * Get session items to be added after session has been cleared.
-     *
-     * @return array
      */
-    public function getPostSessionItems()
+    public function getPostSessionItems(): array
     {
         return $this->session;
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }

--- a/app/bundles/WebhookBundle/Event/WebhookBuilderEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookBuilderEvent.php
@@ -37,10 +37,8 @@ class WebhookBuilderEvent extends Event
 
     /**
      * Get webhook events.
-     *
-     * @return array
      */
-    public function getEvents()
+    public function getEvents(): array
     {
         static $sorted = false;
 

--- a/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
@@ -40,10 +40,8 @@ class WebhookQueueEvent extends CommonEvent
 
     /**
      * Returns the Webhook entity.
-     *
-     * @return Webhook
      */
-    public function getWebhook()
+    public function getWebhook(): Webhook
     {
         return $this->webhook;
     }

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -89,7 +89,7 @@ class LeadListSubscriber implements EventSubscriberInterface
         // get Integration Campaign members
         $list    = $event->getList();
         $success = false;
-        $filters = ($list instanceof LeadList) ? $list->getFilters() : $list['filters'];
+        $filters = $list['filters'];
 
         foreach ($filters as $filter) {
             if ('integration_campaigns' == $filter['field']) {

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\EventListener;
 
-use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
 use Mautic\LeadBundle\Event\ListPreProcessListEvent;
 use Mautic\LeadBundle\Helper\FormFieldHelper;

--- a/plugins/MauticFocusBundle/Event/FocusViewEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusViewEvent.php
@@ -12,10 +12,7 @@ class FocusViewEvent extends Event
     ) {
     }
 
-    /**
-     * @return Stat
-     */
-    public function getStat()
+    public function getStat(): Stat
     {
         return $this->stat;
     }

--- a/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
+++ b/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
@@ -59,10 +59,7 @@ class SocialMonitorEvent extends CommonEvent
         return $this->updatedLeadCount + $this->newLeadCount;
     }
 
-    /**
-     * @return array
-     */
-    public function getLeadIds()
+    public function getLeadIds(): array
     {
         return $this->leadIds;
     }


### PR DESCRIPTION
Split from larger rector type-levels branch. Adds return type declarations (level 6) to **event classes** only (`*/Event/*`). No config changes (no rector.php / phpstan.neon).