### PR TITLE
[rector] Add return type declarations to helper classes

### DIFF
--- a/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
+++ b/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
@@ -29,10 +29,7 @@ class BatchIdToEntityHelper
         return !empty($this->ids);
     }
 
-    /**
-     * @return array
-     */
-    public function getIds()
+    public function getIds(): array
     {
         return $this->ids;
     }
@@ -42,10 +39,7 @@ class BatchIdToEntityHelper
         return !empty($this->errors);
     }
 
-    /**
-     * @return array
-     */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
@@ -99,10 +99,7 @@ class InactiveHelper
         }
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getEarliestInactiveDateTime()
+    public function getEarliestInactiveDateTime(): ?\DateTimeInterface
     {
         return $this->earliestInactiveDate;
     }

--- a/app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
+++ b/app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
@@ -45,10 +45,7 @@ class RemovedContactTracker
         return !empty($this->removedContacts[$campaignId][$contactId]);
     }
 
-    /**
-     * @return array
-     */
-    public function getRemovedContacts()
+    public function getRemovedContacts(): array
     {
         return $this->removedContacts;
     }

--- a/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
+++ b/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
@@ -75,10 +75,7 @@ class ChannelListHelper
         return $channels;
     }
 
-    /**
-     * @return array
-     */
-    public function getChannels()
+    public function getChannels(): array
     {
         $this->setupChannels();
 

--- a/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
@@ -73,7 +73,7 @@ class ColumnSchemaHelper
      *
      * @return \Doctrine\DBAL\Schema\AbstractSchemaManager<\Doctrine\DBAL\Platforms\AbstractMySQLPlatform>
      */
-    public function getSchemaManager()
+    public function getSchemaManager(): \Doctrine\DBAL\Schema\AbstractSchemaManager
     {
         return $this->sm;
     }

--- a/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
@@ -47,7 +47,7 @@ class TableSchemaHelper
      *
      * @return \Doctrine\DBAL\Schema\AbstractSchemaManager<\Doctrine\DBAL\Platforms\AbstractMySQLPlatform>
      */
-    public function getSchemaManager()
+    public function getSchemaManager(): \Doctrine\DBAL\Schema\AbstractSchemaManager
     {
         return $this->sm;
     }

--- a/app/bundles/CoreBundle/Helper/BundleHelper.php
+++ b/app/bundles/CoreBundle/Helper/BundleHelper.php
@@ -32,10 +32,8 @@ class BundleHelper
 
     /**
      * Get's an array of details for enabled Mautic plugins.
-     *
-     * @return array
      */
-    public function getPluginBundles()
+    public function getPluginBundles(): array
     {
         return $this->pluginBundles;
     }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -857,10 +857,8 @@ class MailHelper
 
     /**
      * Return the content identifier.
-     *
-     * @return string
      */
-    public function getContentHash()
+    public function getContentHash(): ?string
     {
         return $this->contentHash;
     }
@@ -1130,10 +1128,7 @@ class MailHelper
         }
     }
 
-    /**
-     * @return string|null
-     */
-    public function getIdHash()
+    public function getIdHash(): ?string
     {
         return $this->idHash;
     }
@@ -1641,10 +1636,8 @@ class MailHelper
 
     /**
      * Returns if the mailer supports and is in tokenization mode.
-     *
-     * @return bool
      */
-    public function inTokenizationMode()
+    public function inTokenizationMode(): bool
     {
         return $this->tokenizationEnabled;
     }

--- a/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/SyncIntegrationsHelper.php
@@ -50,9 +50,9 @@ class SyncIntegrationsHelper
     }
 
     /**
-     * @return array<int,string>|null
+     * @return array<int,string>
      */
-    public function getEnabledIntegrations()
+    public function getEnabledIntegrations(): array
     {
         if (null !== $this->enabled) {
             return $this->enabled;

--- a/app/bundles/LeadBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/FormFieldHelper.php
@@ -100,10 +100,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
         $this->translationKeyPrefix = 'mautic.lead.field.type.';
     }
 
-    /**
-     * @return array
-     */
-    public function getTypes()
+    public function getTypes(): array
     {
         return self::$types;
     }

--- a/app/bundles/PluginBundle/Model/PluginModel.php
+++ b/app/bundles/PluginBundle/Model/PluginModel.php
@@ -86,10 +86,8 @@ class PluginModel extends FormModel
 
     /**
      * Loads config.php arrays for all plugins.
-     *
-     * @return array
      */
-    public function getAllPluginsConfig()
+    public function getAllPluginsConfig(): array
     {
         return $this->bundleHelper->getPluginBundles();
     }

--- a/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
+++ b/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
@@ -52,10 +52,7 @@ class TwitterCommandHelper
         return $this->updatedLeads;
     }
 
-    /**
-     * @return array
-     */
-    public function getManipulatedLeads()
+    public function getManipulatedLeads(): array
     {
         return $this->manipulatedLeads;
     }


### PR DESCRIPTION
Split from larger rector type-levels branch. Adds return type declarations (level 6) to **helper classes** only (`*/Helper/*`). No config changes (no rector.php / phpstan.neon).