### PR TITLE
[rector] Skip return type declarations in FormController

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -16,6 +16,7 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRect
 // use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictStringReturnsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
@@ -70,6 +71,9 @@ return RectorConfig::configure()
         ],
         StringReturnTypeFromStrictStringReturnsRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Entity/FormEntity.php',
+        ],
+        ReturnTypeFromStrictTypedPropertyRector::class => [
+            __DIR__.'/app/bundles/CoreBundle/Controller/FormController.php',
         ],
 
         TypedPropertyFromAssignsRector::class => [


### PR DESCRIPTION
This class is designed to be extended, so we better skip any return type changes :+1: 