### PR TITLE
[rector] Add return type declarations to entity classes

### DIFF
--- a/app/bundles/AssetBundle/Entity/Download.php
+++ b/app/bundles/AssetBundle/Entity/Download.php
@@ -297,10 +297,7 @@ class Download
         return $this->trackingId;
     }
 
-    /**
-     * @return Lead|null
-     */
-    public function getLead()
+    public function getLead(): ?Lead
     {
         return $this->lead;
     }

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -582,7 +582,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * @return Lead[]|Collection
      */
-    public function getLeads()
+    public function getLeads(): Collection
     {
         return $this->leads;
     }
@@ -590,7 +590,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * @return ArrayCollection<int, LeadList>
      */
-    public function getLists()
+    public function getLists(): Collection
     {
         return $this->lists;
     }
@@ -616,7 +616,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * @return ArrayCollection<int, Form>
      */
-    public function getForms()
+    public function getForms(): Collection
     {
         return $this->forms;
     }
@@ -642,7 +642,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * @return array<string, mixed>
      */
-    public function getCanvasSettings()
+    public function getCanvasSettings(): array
     {
         return $this->canvasSettings;
     }
@@ -657,7 +657,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
      */
     public function hasOrphanEvents(): bool
     {
-        $canvasSettings = $this->getCanvasSettings() ?? [];
+        $canvasSettings = $this->getCanvasSettings();
 
         if (empty($canvasSettings['nodes'])) {
             return false;

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -1148,10 +1148,8 @@ class Event implements ChannelInterface, UuidInterface
 
     /**
      * Get the value of triggerRestrictedDaysOfWeek.
-     *
-     * @return array
      */
-    public function getTriggerRestrictedDaysOfWeek()
+    public function getTriggerRestrictedDaysOfWeek(): array
     {
         return (array) $this->triggerRestrictedDaysOfWeek;
     }

--- a/app/bundles/CoreBundle/Entity/IpAddress.php
+++ b/app/bundles/CoreBundle/Entity/IpAddress.php
@@ -154,10 +154,8 @@ class IpAddress
 
     /**
      * Get list of IPs to not track.
-     *
-     * @return array
      */
-    public function getDoNotTrackList()
+    public function getDoNotTrackList(): array
     {
         return $this->doNotTrack;
     }

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -331,10 +331,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
         return $this->id;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -352,10 +349,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -384,10 +378,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
         return $this->type;
     }
 
-    /**
-     * @return Category|null
-     */
-    public function getCategory()
+    public function getCategory(): ?Category
     {
         return $this->category;
     }

--- a/app/bundles/EmailBundle/Entity/EmailReply.php
+++ b/app/bundles/EmailBundle/Entity/EmailReply.php
@@ -71,18 +71,12 @@ class EmailReply
         return $this->id;
     }
 
-    /**
-     * @return Stat
-     */
-    public function getStat()
+    public function getStat(): Stat
     {
         return $this->stat;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getDateReplied()
+    public function getDateReplied(): \DateTimeInterface
     {
         return $this->dateReplied;
     }

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -708,7 +708,7 @@ class Form extends FormEntity implements UuidInterface
     /**
      * @return Collection|Submission[]
      */
-    public function getSubmissions()
+    public function getSubmissions(): Collection
     {
         return $this->submissions;
     }

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
@@ -153,10 +153,7 @@ class ObjectMapping
         return $this;
     }
 
-    /**
-     * @return \DateTimeInterface|null
-     */
-    public function getDateCreated()
+    public function getDateCreated(): ?\DateTimeInterface
     {
         return $this->dateCreated;
     }
@@ -258,10 +255,7 @@ class ObjectMapping
         return $this;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getLastSyncDate()
+    public function getLastSyncDate(): ?\DateTimeInterface
     {
         return $this->lastSyncDate;
     }

--- a/app/bundles/LeadBundle/Entity/FrequencyRule.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRule.php
@@ -239,18 +239,12 @@ class FrequencyRule extends CommonEntity
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isPreferredChannel()
+    public function isPreferredChannel(): bool
     {
         return $this->preferredChannel;
     }
 
-    /**
-     * @return bool
-     */
-    public function getPreferredChannel()
+    public function getPreferredChannel(): bool
     {
         return $this->preferredChannel;
     }

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -620,10 +620,7 @@ class Hit
         return $this;
     }
 
-    /**
-     * @return ?Page
-     */
-    public function getPage()
+    public function getPage(): ?Page
     {
         return $this->page;
     }

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -127,10 +127,7 @@ class PointInsight extends FormEntity
             ->build();
     }
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/app/bundles/ReportBundle/Entity/Scheduler.php
+++ b/app/bundles/ReportBundle/Entity/Scheduler.php
@@ -48,18 +48,12 @@ class Scheduler
         return $this->id;
     }
 
-    /**
-     * @return Report
-     */
-    public function getReport()
+    public function getReport(): Report
     {
         return $this->report;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getScheduleDate()
+    public function getScheduleDate(): \DateTimeInterface
     {
         return $this->scheduleDate;
     }

--- a/app/bundles/WebhookBundle/Entity/WebhookQueue.php
+++ b/app/bundles/WebhookBundle/Entity/WebhookQueue.php
@@ -57,18 +57,12 @@ class WebhookQueue
             ->build();
     }
 
-    /**
-     * @return string|null
-     */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    /**
-     * @return Webhook|null
-     */
-    public function getWebhook()
+    public function getWebhook(): ?Webhook
     {
         return $this->webhook;
     }
@@ -85,10 +79,7 @@ class WebhookQueue
         return $this;
     }
 
-    /**
-     * @return \DateTimeInterface|null
-     */
-    public function getDateAdded()
+    public function getDateAdded(): ?\DateTime
     {
         return $this->dateAdded;
     }
@@ -137,10 +128,7 @@ class WebhookQueue
         return $this;
     }
 
-    /**
-     * @return Event|null
-     */
-    public function getEvent()
+    public function getEvent(): ?Event
     {
         return $this->event;
     }

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -145,7 +145,7 @@ class WebhookModelTest extends TestCase
         $queueMock->method('getPayload')->willReturn('{"the": "payload"}');
         $queueMock->method('getEvent')->willReturn($event);
         $queueMock->method('getDateAdded')->willReturn(new \DateTime('2018-04-10T15:04:57+00:00'));
-        $queueMock->method('getId')->willReturn(12);
+        $queueMock->method('getId')->willReturn('12');
 
         $queueRepositoryMock = $this->createMock(WebhookQueueRepository::class);
 

--- a/plugins/MauticSocialBundle/Entity/TweetStat.php
+++ b/plugins/MauticSocialBundle/Entity/TweetStat.php
@@ -216,10 +216,7 @@ class TweetStat
         $this->lead = $lead;
     }
 
-    /**
-     * @return ?int
-     */
-    public function getRetryCount()
+    public function getRetryCount(): ?int
     {
         return $this->retryCount;
     }
@@ -237,10 +234,7 @@ class TweetStat
         $this->setRetryCount($this->getRetryCount() + 1);
     }
 
-    /**
-     * @return ?int
-     */
-    public function getFavoriteCount()
+    public function getFavoriteCount(): ?int
     {
         return $this->favoriteCount;
     }
@@ -257,10 +251,7 @@ class TweetStat
         return $this;
     }
 
-    /**
-     * @return ?int
-     */
-    public function getRetweetCount()
+    public function getRetweetCount(): ?int
     {
         return $this->retweetCount;
     }
@@ -277,10 +268,7 @@ class TweetStat
         return $this;
     }
 
-    /**
-     * @return ?bool
-     */
-    public function getIsFailed()
+    public function getIsFailed(): ?bool
     {
         return $this->isFailed;
     }
@@ -293,10 +281,7 @@ class TweetStat
         $this->isFailed = $isFailed;
     }
 
-    /**
-     * @return ?bool
-     */
-    public function isFailed()
+    public function isFailed(): ?bool
     {
         return $this->getIsFailed();
     }
@@ -352,7 +337,7 @@ class TweetStat
     /**
      * @return ?mixed[]
      */
-    public function getResponseDetails()
+    public function getResponseDetails(): ?array
     {
         return $this->responseDetails;
     }


### PR DESCRIPTION
Split from larger rector type-levels branch. Adds return type declarations (level 6) to **entity classes** only (`*/Entity/*`). No config changes (no rector.php / phpstan.neon).