### PR TITLE
[rector] Add return type declarations to model classes

### DIFF
--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -197,26 +197,17 @@ class SendEmailToContact
         $this->mailer->reset();
     }
 
-    /**
-     * @return array
-     */
-    public function getSentCounts()
+    public function getSentCounts(): array
     {
         return $this->emailSentCounts;
     }
 
-    /**
-     * @return array
-     */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errorMessages;
     }
 
-    /**
-     * @return array
-     */
-    public function getFailedContacts()
+    public function getFailedContacts(): array
     {
         return $this->failedContacts;
     }

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -39,10 +39,7 @@ class DeviceModel extends FormModel
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
 
-    /**
-     * @return LeadDeviceRepository
-     */
-    public function getRepository()
+    public function getRepository(): LeadDeviceRepository
     {
         return $this->leadDeviceRepository;
     }

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -222,10 +222,7 @@ class DoNotContact implements MauticModelInterface
         return $reasonChannelCombinations;
     }
 
-    /**
-     * @return DoNotContactRepository
-     */
-    public function getDncRepo()
+    public function getDncRepo(): DoNotContactRepository
     {
         return $this->dncRepo;
     }

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -83,10 +83,7 @@ class TrackableModel extends AbstractCommonModel
         return $this->em->getRepository(Trackable::class);
     }
 
-    /**
-     * @return RedirectModel
-     */
-    protected function getRedirectModel()
+    protected function getRedirectModel(): RedirectModel
     {
         return $this->redirectModel;
     }
@@ -738,10 +735,7 @@ class TrackableModel extends AbstractCommonModel
         return $content;
     }
 
-    /**
-     * @return array
-     */
-    protected function getContactFieldUrlTokens()
+    protected function getContactFieldUrlTokens(): array
     {
         if (null !== $this->contactFieldUrlTokens) {
             return $this->contactFieldUrlTokens;

--- a/app/bundles/PluginBundle/Model/PluginModel.php
+++ b/app/bundles/PluginBundle/Model/PluginModel.php
@@ -86,10 +86,8 @@ class PluginModel extends FormModel
 
     /**
      * Loads config.php arrays for all plugins.
-     *
-     * @return array
      */
-    public function getAllPluginsConfig()
+    public function getAllPluginsConfig(): array
     {
         return $this->bundleHelper->getPluginBundles();
     }

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -145,9 +145,9 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * Gets array of custom actions from bundles subscribed PointEvents::POINT_ON_BUILD.
      *
-     * @return mixed
+     * @return array{actions: array<string, mixed>, list: array<int, string>, choices: array<string, string>}
      */
-    public function getPointActions()
+    public function getPointActions(): array
     {
         if ([] === $this->actions) {
             // build them

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -40,7 +40,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @var array<string, mixed[]>
      */
-    private $cachedEvents = [];
+    private array $cachedEvents = [];
 
     public function __construct(
         protected IpLookupHelper $ipLookupHelper,
@@ -275,7 +275,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      *
      * @return mixed[]
      */
-    public function getEvents()
+    public function getEvents(): array
     {
         if (empty($this->cachedEvents)) {
             $event = new TriggerBuilderEvent($this->translator);


### PR DESCRIPTION
Split from larger rector type-levels branch. Adds return type declarations (level 6) to **model classes** only (`*/Model/*`). No config changes (no rector.php / phpstan.neon).