### PR TITLE
[rector] Register and apply KnownMagicClassMethodTypeRector

### DIFF
--- a/app/bundles/CoreBundle/Entity/CommonEntity.php
+++ b/app/bundles/CoreBundle/Entity/CommonEntity.php
@@ -28,11 +28,11 @@ class CommonEntity implements \Stringable
     /**
      * Wrapper function for isProperty methods.
      *
-     * @param string $name
+     * @param mixed[] $arguments
      *
      * @throws \InvalidArgumentException
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         if (str_starts_with($name, 'is') && method_exists($this, 'get'.ucfirst($name))) {
             return $this->{'get'.ucfirst($name)}();

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -96,9 +96,11 @@ class InputHelper
     /**
      * Wrapper to InputHelper.
      *
+     * @param mixed[] $arguments
+     *
      * @return mixed
      */
-    public static function __callStatic($name, $arguments)
+    public static function __callStatic(string $name, array $arguments)
     {
         return self::getFilter()->clean($arguments[0], $name);
     }

--- a/app/bundles/CoreBundle/Menu/MenuBuilder.php
+++ b/app/bundles/CoreBundle/Menu/MenuBuilder.php
@@ -20,9 +20,11 @@ class MenuBuilder
     }
 
     /**
+     * @param mixed[] $arguments
+     *
      * @return mixed
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments)
     {
         $name = str_replace('Menu', '', $name);
 

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,7 @@ use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
@@ -39,6 +40,7 @@ return RectorConfig::configure()
         Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
         AddParamTypeFromPropertyTypeRector::class,
+        KnownMagicClassMethodTypeRector::class,
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,


### PR DESCRIPTION
Adds native param types to magic method signatures:
- `__call(string $name, array $arguments)`
- `__callStatic(string $name, array $arguments)`
