### PR TITLE
[rector] Register and apply AddClosureParamTypeForArrayMapRector

### DIFF
--- a/app/bundles/CoreBundle/Helper/ArrayHelper.php
+++ b/app/bundles/CoreBundle/Helper/ArrayHelper.php
@@ -127,7 +127,7 @@ class ArrayHelper
      */
     private static function sumOrSub(array $a1, array $b2, $subtracted = false): array
     {
-        return array_map(function ($x, $y) use ($subtracted) {
+        return array_map(function ($x, int|string $y) use ($subtracted) {
             if ($subtracted) {
                 return $x - $y;
             }

--- a/app/bundles/ReportBundle/Helper/ReportHelper.php
+++ b/app/bundles/ReportBundle/Helper/ReportHelper.php
@@ -118,7 +118,7 @@ final class ReportHelper
         $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_COLUMN_COLLECT);
 
         return array_map(
-            function ($item) {
+            function (array $item) {
                 if (isset($item['type'])) {
                     $item['type'] =  $this->getReportBuilderFieldType($item['type']);
                 }

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -84,7 +84,7 @@ class AjaxController extends CommonAjaxController
      *
      * @param string|null $query
      *
-     * @return array<string, string>
+     * @return array<string|int, int>
      */
     protected function getBuilderTokens($query): array
     {
@@ -96,7 +96,7 @@ class AjaxController extends CommonAjaxController
         $tokens       = $components['tokens'];
 
         array_map(
-            function ($token, $value) use ($findTokens, &$returnTokens): void {
+            function (int|string $token, int $value) use ($findTokens, &$returnTokens): void {
                 foreach ($findTokens as $findToken) {
                     if (str_starts_with($token, $findToken)) {
                         $returnTokens[$token] = $value;

--- a/rector.php
+++ b/rector.php
@@ -15,9 +15,11 @@ use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRec
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
+// use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictStringReturnsRector;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
@@ -41,6 +43,7 @@ return RectorConfig::configure()
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
         AddParamTypeFromPropertyTypeRector::class,
         KnownMagicClassMethodTypeRector::class,
+        AddClosureParamTypeForArrayMapRector::class,
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,


### PR DESCRIPTION
Adds native parameter types to `array_map()` closures inferred from the mapped array element type.
