### PR TITLE
[rector] Register and apply AddParamTypeFromPropertyTypeRector

### DIFF
--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -63,7 +63,7 @@ class ClientModel extends FormModel implements GlobalSearchInterface
         return self::DEFAULT_API_MODE;
     }
 
-    public function setApiMode($apiMode): void
+    public function setApiMode(?string $apiMode): void
     {
         $this->apiMode = $apiMode;
     }

--- a/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
+++ b/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
@@ -67,7 +67,7 @@ class ApiMetadataDriver implements DriverInterface
      *
      * @return $this
      */
-    public function setGroupPrefix($name)
+    public function setGroupPrefix(string $name)
     {
         $this->groupPrefix = $name;
 

--- a/app/bundles/AssetBundle/Entity/Download.php
+++ b/app/bundles/AssetBundle/Entity/Download.php
@@ -302,10 +302,7 @@ class Download
         return $this->lead;
     }
 
-    /**
-     * @param mixed $lead
-     */
-    public function setLead($lead): void
+    public function setLead(?Lead $lead): void
     {
         $this->lead = $lead;
     }

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -184,10 +184,7 @@ class EventLogger
         return $this->persistQueuedLogs();
     }
 
-    /**
-     * @param int $campaignId
-     */
-    public function hydrateContactRotationsForNewLogs(array $contactIds, $campaignId): void
+    public function hydrateContactRotationsForNewLogs(array $contactIds, int $campaignId): void
     {
         $this->contactRotations[$campaignId]     = $this->leadRepository->getContactRotations($contactIds, $campaignId);
         $this->lastUsedCampaignIdToFetchRotation = $campaignId;

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -133,10 +133,7 @@ class ChannelBroadcastEvent extends Event
         return $this->maxContactIdFilter;
     }
 
-    /**
-     * @param int $limit
-     */
-    public function setLimit($limit): void
+    public function setLimit(int $limit): void
     {
         $this->limit = $limit;
     }
@@ -146,10 +143,7 @@ class ChannelBroadcastEvent extends Event
         return $this->limit;
     }
 
-    /**
-     * @param int $batch
-     */
-    public function setBatch($batch): void
+    public function setBatch(int $batch): void
     {
         $this->batch = $batch;
     }

--- a/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
+++ b/app/bundles/CoreBundle/Event/TokenReplacementEvent.php
@@ -87,7 +87,7 @@ class TokenReplacementEvent extends CommonEvent
     /**
      * @param mixed[] $clickthrough
      */
-    public function setClickthrough($clickthrough): void
+    public function setClickthrough(array $clickthrough): void
     {
         $this->clickthrough = $clickthrough;
     }

--- a/app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
@@ -100,20 +100,16 @@ class IdToEntityModelTransformer implements DataTransformerInterface
 
     /**
      * Set the repository to use.
-     *
-     * @param string $repo
      */
-    public function setRepository($repo): void
+    public function setRepository(string $repo): void
     {
         $this->repository = $repo;
     }
 
     /**
      * Set the identifier to use.
-     *
-     * @param string $id
      */
-    public function setIdentifier($id): void
+    public function setIdentifier(string $id): void
     {
         $this->id = $id;
     }

--- a/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
@@ -146,11 +146,9 @@ final class ButtonHelper
     }
 
     /**
-     * @param string $groupType
-     *
      * @return $this
      */
-    public function setGroupType($groupType)
+    public function setGroupType(string $groupType)
     {
         $this->groupType = $groupType;
 
@@ -232,11 +230,10 @@ final class ButtonHelper
      * Reset the buttons.
      *
      * @param string $buttonCount
-     * @param string $groupType
      *
      * @return $this
      */
-    public function reset(Request $request, $buttonCount, $groupType = self::TYPE_GROUP, $item = null)
+    public function reset(Request $request, $buttonCount, string $groupType = self::TYPE_GROUP, $item = null)
     {
         // @escopecz: I think there is a possible bug here
         $this->location       = $buttonCount;

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -337,11 +337,9 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     }
 
     /**
-     * @param string $name
-     *
      * @return $this
      */
-    public function setName($name)
+    public function setName(?string $name)
     {
         $this->isChanged('name', $name);
         $this->name = $name;
@@ -355,11 +353,9 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     }
 
     /**
-     * @param string $description
-     *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription(?string $description)
     {
         $this->description = $description;
 
@@ -384,11 +380,9 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     }
 
     /**
-     * @param Category $category
-     *
      * @return $this
      */
-    public function setCategory($category)
+    public function setCategory(?Category $category)
     {
         $this->isChanged('category', $category);
         $this->category = $category;

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -134,7 +134,7 @@ class EmailSendEvent extends CommonEvent
     /**
      * Set email content.
      */
-    public function setContent($content): void
+    public function setContent(string $content): void
     {
         if (null !== $this->helper) {
             $this->helper->setBody($content, 'text/html', null, true);
@@ -158,7 +158,7 @@ class EmailSendEvent extends CommonEvent
         return $this->plainText;
     }
 
-    public function setPlainText($content): void
+    public function setPlainText(string $content): void
     {
         if (null !== $this->helper) {
             $this->helper->setPlainText($content);
@@ -195,10 +195,7 @@ class EmailSendEvent extends CommonEvent
         return $this->subject;
     }
 
-    /**
-     * @param string $subject
-     */
-    public function setSubject($subject): void
+    public function setSubject(string $subject): void
     {
         if (null !== $this->helper) {
             $this->helper->setSubject($subject);

--- a/app/bundles/EmailBundle/Event/ParseEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/ParseEmailEvent.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\EmailBundle\Event;
 
+use Mautic\EmailBundle\MonitoredEmail\Message;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class ParseEmailEvent extends Event
@@ -28,7 +29,7 @@ class ParseEmailEvent extends Event
     /**
      * Get the array of messages.
      *
-     * @return \Mautic\EmailBundle\MonitoredEmail\Message[]
+     * @return Message[]
      */
     public function getMessages(): array
     {
@@ -36,9 +37,11 @@ class ParseEmailEvent extends Event
     }
 
     /**
+     * @param Message[] $messages
+     *
      * @return $this
      */
-    public function setMessages($messages)
+    public function setMessages(array $messages)
     {
         $this->messages = $messages;
 
@@ -51,11 +54,9 @@ class ParseEmailEvent extends Event
     }
 
     /**
-     * @param array $keys
-     *
      * @return $this
      */
-    public function setKeys($keys)
+    public function setKeys(array $keys)
     {
         $this->keys = $keys;
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1059,10 +1059,9 @@ class MailHelper
     /**
      * Set reply to address(es) for this mailer instance.
      *
-     * @param array<string>|string $addresses
-     * @param string               $name
+     * @param string             $name
      */
-    public function setReplyTo($addresses, $name = null): void
+    public function setReplyTo(?string $addresses, $name = null): void
     {
         $this->replyTo = $addresses;
     }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1059,7 +1059,7 @@ class MailHelper
     /**
      * Set reply to address(es) for this mailer instance.
      *
-     * @param string             $name
+     * @param string $name
      */
     public function setReplyTo(?string $addresses, $name = null): void
     {

--- a/app/bundles/EmailBundle/Stats/FetchOptions/EmailStatOptions.php
+++ b/app/bundles/EmailBundle/Stats/FetchOptions/EmailStatOptions.php
@@ -118,10 +118,7 @@ class EmailStatOptions extends FetchOptions
         return $this->canViewOthers;
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function setCanViewOthers($canViewOthers): self
+    public function setCanViewOthers(bool $canViewOthers): self
     {
         $this->canViewOthers = $canViewOthers;
 

--- a/app/bundles/FormBundle/Event/SubmissionEvent.php
+++ b/app/bundles/FormBundle/Event/SubmissionEvent.php
@@ -117,11 +117,9 @@ class SubmissionEvent extends CommonEvent
     }
 
     /**
-     * @param array $results
-     *
      * @return SubmissionEvent
      */
-    public function setResults($results)
+    public function setResults(array $results)
     {
         $this->results = $results;
 
@@ -134,11 +132,9 @@ class SubmissionEvent extends CommonEvent
     }
 
     /**
-     * @param array $fields
-     *
      * @return SubmissionEvent
      */
-    public function setFields($fields)
+    public function setFields(array $fields)
     {
         $this->fields = $fields;
 
@@ -151,11 +147,9 @@ class SubmissionEvent extends CommonEvent
     }
 
     /**
-     * @param array $tokens
-     *
      * @return SubmissionEvent
      */
-    public function setTokens($tokens)
+    public function setTokens(array $tokens)
     {
         $this->tokens = $tokens;
 
@@ -168,11 +162,9 @@ class SubmissionEvent extends CommonEvent
     }
 
     /**
-     * @param array $contactFieldMatches
-     *
      * @return SubmissionEvent
      */
-    public function setContactFieldMatches($contactFieldMatches)
+    public function setContactFieldMatches(array $contactFieldMatches)
     {
         $this->contactFieldMatches = $contactFieldMatches;
 

--- a/app/bundles/FormBundle/Event/ValidationEvent.php
+++ b/app/bundles/FormBundle/Event/ValidationEvent.php
@@ -33,7 +33,7 @@ class ValidationEvent extends CommonEvent
         return $this->value;
     }
 
-    public function failedValidation($reason): void
+    public function failedValidation(string $reason): void
     {
         $this->valid         = false;
         $this->invalidReason = $reason;

--- a/app/bundles/IntegrationsBundle/DTO/IntegrationObjectToken.php
+++ b/app/bundles/IntegrationsBundle/DTO/IntegrationObjectToken.php
@@ -74,10 +74,7 @@ class IntegrationObjectToken
         return $this->integration;
     }
 
-    /**
-     * @param string $defaultValue
-     */
-    public function setDefaultValue($defaultValue): void
+    public function setDefaultValue(string $defaultValue): void
     {
         $this->defaultValue = $defaultValue;
     }

--- a/app/bundles/LeadBundle/Entity/FrequencyRule.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRule.php
@@ -250,11 +250,9 @@ class FrequencyRule extends CommonEntity
     }
 
     /**
-     * @param bool $preferredChannel
-     *
      * @return FrequencyRule
      */
-    public function setPreferredChannel($preferredChannel)
+    public function setPreferredChannel(bool $preferredChannel)
     {
         $this->isChanged('preferredChannel', $preferredChannel);
 

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -619,11 +619,9 @@ class Import extends FormEntity
     }
 
     /**
-     * @param string $object
-     *
      * @return Import
      */
-    public function setObject($object)
+    public function setObject(string $object)
     {
         $this->isChanged('object', $object);
         $this->object = $object;

--- a/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
@@ -70,18 +70,12 @@ class LeadBuildSearchEvent extends CommonEvent
         return $this->queryBuilder;
     }
 
-    /**
-     * @param bool $status
-     */
-    public function setSearchStatus($status): void
+    public function setSearchStatus(bool $status): void
     {
         $this->isSearchDone = $status;
     }
 
-    /**
-     * @param string $query
-     */
-    public function setSubQuery($query): void
+    public function setSubQuery(string $query): void
     {
         $this->subQuery = $query;
 
@@ -111,10 +105,7 @@ class LeadBuildSearchEvent extends CommonEvent
         return $this->strict;
     }
 
-    /**
-     * @param bool $val
-     */
-    public function setStrict($val): void
+    public function setStrict(bool $val): void
     {
         $this->strict = $val;
     }
@@ -124,10 +115,7 @@ class LeadBuildSearchEvent extends CommonEvent
         return $this->returnParameters;
     }
 
-    /**
-     * @param bool $val
-     */
-    public function setReturnParameters($val): void
+    public function setReturnParameters(bool $val): void
     {
         $this->returnParameters = $val;
     }
@@ -137,10 +125,7 @@ class LeadBuildSearchEvent extends CommonEvent
         return $this->parameters;
     }
 
-    /**
-     * @param array $val
-     */
-    public function setParameters($val): void
+    public function setParameters(array $val): void
     {
         $this->parameters = $val;
     }

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -87,18 +87,12 @@ class LeadListFilteringEvent extends CommonEvent
         return $this->queryBuilder;
     }
 
-    /**
-     * @param bool $status
-     */
-    public function setFilteringStatus($status): void
+    public function setFilteringStatus(bool $status): void
     {
         $this->isFilteringDone = $status;
     }
 
-    /**
-     * @param string $query
-     */
-    public function setSubQuery($query): void
+    public function setSubQuery(string $query): void
     {
         $this->subQuery = $query;
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
@@ -51,11 +51,9 @@ class BaseFilterQueryBuilder implements FilterQueryBuilderInterface
     }
 
     /**
-     * @param RandomParameterName $parameterNameGenerator
-     *
      * @return BaseFilterQueryBuilder
      */
-    public function setParameterNameGenerator($parameterNameGenerator)
+    public function setParameterNameGenerator(RandomParameterName $parameterNameGenerator)
     {
         $this->parameterNameGenerator = $parameterNameGenerator;
 

--- a/app/bundles/PageBundle/Event/PageDisplayEvent.php
+++ b/app/bundles/PageBundle/Event/PageDisplayEvent.php
@@ -38,10 +38,8 @@ class PageDisplayEvent extends Event
 
     /**
      * Set page content.
-     *
-     * @param string $content
      */
-    public function setContent($content): void
+    public function setContent(string $content): void
     {
         $this->content = $content;
     }
@@ -56,10 +54,8 @@ class PageDisplayEvent extends Event
 
     /**
      * Set params.
-     *
-     * @param array $params
      */
-    public function setParams($params): void
+    public function setParams(array $params): void
     {
         $this->params = $params;
     }

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -138,11 +138,9 @@ class PointInsight extends FormEntity
     }
 
     /**
-     * @param string $name
-     *
      * @return PointInsight
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->isChanged('name', $name);
         $this->name = $name;

--- a/app/bundles/ReportBundle/Event/ReportDataEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportDataEvent.php
@@ -24,10 +24,7 @@ class ReportDataEvent extends AbstractReportEvent
         return $this->data;
     }
 
-    /**
-     * @param array $data
-     */
-    public function setData($data): void
+    public function setData(array $data): void
     {
         $this->data = $data;
     }

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -25,10 +25,7 @@ class ReportQueryEvent extends AbstractReportEvent
         return $this->query;
     }
 
-    /**
-     * @param QueryBuilder $query
-     */
-    public function setQuery($query): void
+    public function setQuery(QueryBuilder $query): void
     {
         $this->query = $query;
     }

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -488,11 +488,9 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
     }
 
     /**
-     * @param int $pendingCount
-     *
      * @return Sms
      */
-    public function setPendingCount($pendingCount)
+    public function setPendingCount(int $pendingCount)
     {
         $this->pendingCount = $pendingCount;
 

--- a/app/bundles/SmsBundle/Event/SmsSendEvent.php
+++ b/app/bundles/SmsBundle/Event/SmsSendEvent.php
@@ -42,10 +42,7 @@ class SmsSendEvent extends CommonEvent
         return $this->lead;
     }
 
-    /**
-     * @param Lead $lead
-     */
-    public function setLead($lead): void
+    public function setLead(Lead $lead): void
     {
         $this->lead = $lead;
     }

--- a/app/bundles/SmsBundle/Event/TokensBuildEvent.php
+++ b/app/bundles/SmsBundle/Event/TokensBuildEvent.php
@@ -24,7 +24,7 @@ class TokensBuildEvent extends Event
     /**
      * @param array<string, string> $tokens
      */
-    public function setTokens($tokens): void
+    public function setTokens(array $tokens): void
     {
         $this->tokens = $tokens;
     }

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -475,11 +475,9 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     /**
      * Set username.
      *
-     * @param string $username
-     *
      * @return User
      */
-    public function setUsername($username)
+    public function setUsername(?string $username)
     {
         $this->isChanged('username', $username);
         $this->username = $username;

--- a/app/bundles/WebhookBundle/Entity/WebhookQueue.php
+++ b/app/bundles/WebhookBundle/Entity/WebhookQueue.php
@@ -68,11 +68,9 @@ class WebhookQueue
     }
 
     /**
-     * @param Webhook|null $webhook
-     *
      * @return WebhookQueue
      */
-    public function setWebhook($webhook)
+    public function setWebhook(?Webhook $webhook)
     {
         $this->webhook = $webhook;
 
@@ -85,11 +83,9 @@ class WebhookQueue
     }
 
     /**
-     * @param \DateTime|null $dateAdded
-     *
      * @return WebhookQueue
      */
-    public function setDateAdded($dateAdded)
+    public function setDateAdded(?\DateTime $dateAdded)
     {
         $this->dateAdded = $dateAdded;
 
@@ -134,11 +130,9 @@ class WebhookQueue
     }
 
     /**
-     * @param Event|null $event
-     *
      * @return WebhookQueue
      */
-    public function setEvent($event)
+    public function setEvent(?Event $event)
     {
         $this->event = $event;
 

--- a/plugins/MauticSocialBundle/Entity/TweetStat.php
+++ b/plugins/MauticSocialBundle/Entity/TweetStat.php
@@ -221,10 +221,7 @@ class TweetStat
         return $this->retryCount;
     }
 
-    /**
-     * @param ?int $retryCount
-     */
-    public function setRetryCount($retryCount): void
+    public function setRetryCount(?int $retryCount): void
     {
         $this->retryCount = $retryCount;
     }
@@ -240,11 +237,9 @@ class TweetStat
     }
 
     /**
-     * @param ?int $favoriteCount
-     *
      * @return $this
      */
-    public function setFavoriteCount($favoriteCount)
+    public function setFavoriteCount(?int $favoriteCount)
     {
         $this->favoriteCount = $favoriteCount;
 
@@ -257,11 +252,9 @@ class TweetStat
     }
 
     /**
-     * @param ?int $retweetCount
-     *
      * @return $this
      */
-    public function setRetweetCount($retweetCount)
+    public function setRetweetCount(?int $retweetCount)
     {
         $this->retweetCount = $retweetCount;
 
@@ -273,10 +266,7 @@ class TweetStat
         return $this->isFailed;
     }
 
-    /**
-     * @param ?bool $isFailed
-     */
-    public function setIsFailed($isFailed): void
+    public function setIsFailed(?bool $isFailed): void
     {
         $this->isFailed = $isFailed;
     }
@@ -347,7 +337,7 @@ class TweetStat
      *
      * @return self
      */
-    public function setResponseDetails($responseDetails)
+    public function setResponseDetails(?array $responseDetails)
     {
         $this->responseDetails = $responseDetails;
 

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
@@ -37,6 +38,7 @@ return RectorConfig::configure()
     ->withRules([
         Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
+        AddParamTypeFromPropertyTypeRector::class,
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,


### PR DESCRIPTION
Adds native parameter types to setters/methods, inferred from the assigned property type (e.g. `setApiMode(?string $apiMode)`, `setLimit(int $limit)`).
