### PR TITLE
[rector] Register and apply ParamTypeByParentCallTypeRector

### DIFF
--- a/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
+++ b/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
@@ -8,6 +8,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ApiPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
+++ b/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ApiPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
+++ b/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class CampaignPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addExtendedPermissions('campaigns');

--- a/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
+++ b/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class CampaignPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
+++ b/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class CategoryPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
+++ b/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class CategoryPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
+++ b/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ChannelPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
+++ b/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ChannelPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -30,7 +30,7 @@ class ExceptionListener extends ErrorListener
      */
     public function __construct(
         protected Router $router,
-        $controller,
+        string|object|array|null $controller,
         ?LoggerInterface $logger = null,
     ) {
         parent::__construct($controller, $logger);

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ExceptionListener extends ErrorListener
 {
     /**
-     * @param mixed $controller
+     * @param string|object|mixed[]|null $controller
      */
     public function __construct(
         protected Router $router,

--- a/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
@@ -6,6 +6,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class SystemPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class SystemPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addStandardPermissions('themes');

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -120,7 +120,8 @@ class DynamicContentSubscriber implements EventSubscriberInterface
 
             $dwc     =  $this->dynamicContentModel->getEntity($clickthrough['dynamic_content_id']);
             $utmTags = [];
-            if ($dwc && $dwc instanceof DynamicContent) {
+
+            if ($dwc instanceof DynamicContent) {
                 $utmTags = $dwc->getUtmTags();
             }
 

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DynamicContentPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class DynamicContentPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -8,6 +8,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class EmailPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class EmailPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
+++ b/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class FormPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
+++ b/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
@@ -7,10 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class FormPermissions extends AbstractPermissions
 {
-    /**
-     * @param array $params
-     */
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addCustomPermission('export', ['enable' => 1024]);

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -26,6 +26,9 @@ class LeadPermissions extends AbstractPermissions
 
     public const LISTS_FULL         = 'lead:lists:full';
 
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -26,7 +26,7 @@ class LeadPermissions extends AbstractPermissions
 
     public const LISTS_FULL         = 'lead:lists:full';
 
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
+++ b/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class NotificationPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
+++ b/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class NotificationPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addStandardPermissions('categories');

--- a/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
+++ b/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PagePermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
+++ b/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PagePermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addExtendedPermissions('pages');

--- a/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
+++ b/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PluginPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
+++ b/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PluginPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addManagePermission('plugins');

--- a/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
+++ b/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PointPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
+++ b/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class PointPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
+++ b/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
@@ -25,7 +25,7 @@ final class ProjectPermissions extends AbstractPermissions
     /**
      * @param mixed[] $params
      */
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
+++ b/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ReportPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addExtendedPermissions('reports');

--- a/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
+++ b/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ReportPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
+++ b/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class SmsPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
+++ b/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class SmsPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addStandardPermissions('categories');

--- a/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
+++ b/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class StagePermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
+++ b/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class StagePermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -8,6 +8,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class UserPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class UserPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->permissions = [

--- a/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
+++ b/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class WebhookPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addExtendedPermissions('webhooks');

--- a/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
+++ b/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class WebhookPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -212,11 +212,9 @@ class DynamicsIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $settings
-     *
      * @throws ApiErrorException
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         $dynamicsFields    = [];
         $silenceExceptions = $settings['silence_exceptions'] ?? true;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -199,13 +199,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $settings
-     *
      * @return mixed[]
      *
      * @throws InvalidArgumentException
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         $silenceExceptions = $settings['silence_exceptions'] ?? true;
         $salesForceObjects = [];

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -256,11 +256,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $settings
-     *
      * @throws \Exception
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         $sugarFields       = [];
         $silenceExceptions = $settings['silence_exceptions'] ?? true;

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -130,7 +130,7 @@ class VtigerIntegration extends CrmAbstractIntegration
     /**
      * @return mixed[]
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         $vTigerFields      = [];
         $silenceExceptions = $settings['silence_exceptions'] ?? true;

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -702,7 +702,7 @@ class ZohoIntegration extends CrmAbstractIntegration
      *
      * @throws ApiErrorException
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         $zohoFields        = [];
         $silenceExceptions = $settings['silence_exceptions'] ?? true;

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -71,11 +71,9 @@ class MailchimpIntegration extends EmailAbstractIntegration
     }
 
     /**
-     * @param array $settings
-     *
      * @return mixed[]
      */
-    public function getAvailableLeadFields($settings = []): array
+    public function getAvailableLeadFields(array $settings = []): array
     {
         if (isset($settings['list'])) {
             // Ajax update

--- a/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
+++ b/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class FocusPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
+++ b/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class FocusPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addStandardPermissions('categories');

--- a/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
+++ b/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class MauticSocialPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
+++ b/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class MauticSocialPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
         $this->addStandardPermissions('categories');

--- a/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+++ b/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class TagManagerPermissions extends AbstractPermissions
 {
-    public function __construct($params)
+    public function __construct(array $params)
     {
         parent::__construct($params);
 

--- a/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+++ b/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
@@ -7,6 +7,9 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class TagManagerPermissions extends AbstractPermissions
 {
+    /**
+     * @param mixed[] $params
+     */
     public function __construct(array $params)
     {
         parent::__construct($params);

--- a/rector.php
+++ b/rector.php
@@ -9,8 +9,19 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+<<<<<<< HEAD
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
+<<<<<<< HEAD
 use Rector\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector;
+=======
+=======
+<<<<<<< HEAD
+=======
+use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
+>>>>>>> ef7ee2b39a (Type coverage: register ParamTypeByParentCallTypeRector)
+>>>>>>> eae9b7f93d (Type coverage: register ParamTypeByParentCallTypeRector)
+>>>>>>> c375e8dbcf (Type coverage: register ParamTypeByParentCallTypeRector)
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
@@ -37,12 +48,29 @@ return RectorConfig::configure()
     ->withPhpSets(php80: true)
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+        Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
+>>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
+<<<<<<< HEAD
         AddParamTypeFromPropertyTypeRector::class,
+<<<<<<< HEAD
         KnownMagicClassMethodTypeRector::class,
+<<<<<<< HEAD
         // flips nested negated conditions to same-meaning clear ones
         Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector::class,
         Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
+=======
+=======
+=======
+=======
+        ParamTypeByParentCallTypeRector::class,
+>>>>>>> 72f0bc69f0 (Type coverage: register ParamTypeByParentCallTypeRector)
+>>>>>>> eae9b7f93d (Type coverage: register ParamTypeByParentCallTypeRector)
+>>>>>>> c375e8dbcf (Type coverage: register ParamTypeByParentCallTypeRector)
+>>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,

--- a/rector.php
+++ b/rector.php
@@ -38,43 +38,13 @@ return RectorConfig::configure()
     ->withPhpSets(php80: true)
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
->>>>>>> ca5200203c (fix phpstan)
         Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
->>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
         AddParamTypeFromPropertyTypeRector::class,
         KnownMagicClassMethodTypeRector::class,
-<<<<<<< HEAD
-<<<<<<< HEAD
         // flips nested negated conditions to same-meaning clear ones
         Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector::class,
-        Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
-=======
-=======
-=======
-=======
         ParamTypeByParentCallTypeRector::class,
->>>>>>> 72f0bc69f0 (Type coverage: register ParamTypeByParentCallTypeRector)
->>>>>>> eae9b7f93d (Type coverage: register ParamTypeByParentCallTypeRector)
-<<<<<<< HEAD
->>>>>>> c375e8dbcf (Type coverage: register ParamTypeByParentCallTypeRector)
-<<<<<<< HEAD
->>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
-=======
-=======
-=======
-        ParamTypeByParentCallTypeRector::class,
->>>>>>> 0a5a5dbc58 (fix phpstan)
->>>>>>> de77409813 (fix phpstan)
->>>>>>> ca5200203c (fix phpstan)
-=======
-        ParamTypeByParentCallTypeRector::class,
->>>>>>> 2c83503805 (rebase)
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,

--- a/rector.php
+++ b/rector.php
@@ -9,19 +9,9 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-<<<<<<< HEAD
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
-<<<<<<< HEAD
 use Rector\TypeDeclaration\Rector\ClassMethod\KnownMagicClassMethodTypeRector;
-=======
-=======
-<<<<<<< HEAD
-=======
-use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByParentCallTypeRector;
->>>>>>> ef7ee2b39a (Type coverage: register ParamTypeByParentCallTypeRector)
->>>>>>> eae9b7f93d (Type coverage: register ParamTypeByParentCallTypeRector)
->>>>>>> c375e8dbcf (Type coverage: register ParamTypeByParentCallTypeRector)
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
@@ -49,15 +39,17 @@ return RectorConfig::configure()
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 <<<<<<< HEAD
+=======
+>>>>>>> ca5200203c (fix phpstan)
         Rector\TypeDeclaration\Rector\Empty_\EmptyOnNullableObjectToInstanceOfRector::class,
 >>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
-<<<<<<< HEAD
         AddParamTypeFromPropertyTypeRector::class,
-<<<<<<< HEAD
         KnownMagicClassMethodTypeRector::class,
+<<<<<<< HEAD
 <<<<<<< HEAD
         // flips nested negated conditions to same-meaning clear ones
         Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector::class,
@@ -69,8 +61,20 @@ return RectorConfig::configure()
         ParamTypeByParentCallTypeRector::class,
 >>>>>>> 72f0bc69f0 (Type coverage: register ParamTypeByParentCallTypeRector)
 >>>>>>> eae9b7f93d (Type coverage: register ParamTypeByParentCallTypeRector)
+<<<<<<< HEAD
 >>>>>>> c375e8dbcf (Type coverage: register ParamTypeByParentCallTypeRector)
+<<<<<<< HEAD
 >>>>>>> aa468ca272 (Type coverage: register ParamTypeByParentCallTypeRector)
+=======
+=======
+=======
+        ParamTypeByParentCallTypeRector::class,
+>>>>>>> 0a5a5dbc58 (fix phpstan)
+>>>>>>> de77409813 (fix phpstan)
+>>>>>>> ca5200203c (fix phpstan)
+=======
+        ParamTypeByParentCallTypeRector::class,
+>>>>>>> 2c83503805 (rebase)
         ReturnTypeFromStrictTypedCallRector::class,
         TypedPropertyFromAssignsRector::class,
         ReturnTypeFromStrictNativeCallRector::class,


### PR DESCRIPTION
Adds native parameter types inferred from the type used in the parent method call (e.g. `__construct(array $params)`).
