### PR TITLE
Using CKEditor's built in translation feature instead of a plugin

### DIFF
--- a/app/assets/libraries/ckeditor/src/ckeditor.ts
+++ b/app/assets/libraries/ckeditor/src/ckeditor.ts
@@ -40,7 +40,8 @@ type WindowWithMauticLocale = Window & {
 };
 
 function getEditorLanguage(): string {
-    const mauticLocale = (window as WindowWithMauticLocale).mauticLocale;
+    const w = window as WindowWithMauticLocale;
+    const mauticLocale = w.mauticLocale ?? (w.parent as WindowWithMauticLocale)?.mauticLocale;
 
     if (!mauticLocale) {
         return 'en';

--- a/app/assets/libraries/ckeditor/src/ckeditor.ts
+++ b/app/assets/libraries/ckeditor/src/ckeditor.ts
@@ -5,7 +5,6 @@
 
 // The editor creator to use.
 import 'ckeditor5/ckeditor5.css';
-import enTranslations from 'ckeditor5/translations/en.js';
 import { ClassicEditor as ClassicEditorBase } from '@ckeditor/ckeditor5-editor-classic';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { CKFinderUploadAdapter } from '@ckeditor/ckeditor5-adapter-ckfinder';
@@ -34,6 +33,56 @@ import { SourceEditing } from "@ckeditor/ckeditor5-source-editing";
 import { GeneralHtmlSupport } from "@ckeditor/ckeditor5-html-support";
 import { Mention } from "@ckeditor/ckeditor5-mention";
 import TokenPlugin from './TokenPlugin';
+
+type TranslationModule = {
+    default: Record<string, {
+        dictionary: Record<string, string>;
+        getPluralForm?: (n: number) => number;
+    }>;
+};
+
+type TranslationRequireContext = {
+    keys(): string[];
+    <T>(id: string): T;
+};
+
+type WindowWithMauticLocale = Window & {
+    mauticLocale?: string;
+};
+
+declare const require: {
+    context(directory: string, useSubdirectories?: boolean, regExp?: RegExp): TranslationRequireContext;
+};
+
+const translationContext = require.context('../../../../../node_modules/ckeditor5/dist/translations', false, /^(?!.*\.umd\.js$).*\.js$/);
+const translations = translationContext.keys().map((translationFile) => translationContext<TranslationModule>(translationFile).default);
+const availableTranslationLanguages = new Set(
+    translationContext
+        .keys()
+        .map((translationFile) => translationFile.replace('./', '').replace('.js', ''))
+);
+
+function getEditorLanguage(): string {
+    const mauticLocale = (window as WindowWithMauticLocale).mauticLocale;
+
+    if (!mauticLocale) {
+        return 'en';
+    }
+
+    const normalizedLocale = mauticLocale.toLowerCase().replace('_', '-');
+
+    if (availableTranslationLanguages.has(normalizedLocale)) {
+        return normalizedLocale;
+    }
+
+    const baseLanguage = normalizedLocale.split('-')[0];
+
+    if (availableTranslationLanguages.has(baseLanguage)) {
+        return baseLanguage;
+    }
+
+    return 'en';
+}
 
 export default class ClassicEditor extends ClassicEditorBase {
     public static override builtinPlugins = [
@@ -93,7 +142,7 @@ export default class ClassicEditor extends ClassicEditorBase {
 
     public static override defaultConfig = {
         licenseKey: 'GPL',
-        language: 'en',
-        translations: [enTranslations]
+        language: getEditorLanguage(),
+        translations
     };
 }

--- a/app/assets/libraries/ckeditor/src/ckeditor.ts
+++ b/app/assets/libraries/ckeditor/src/ckeditor.ts
@@ -5,6 +5,7 @@
 
 // The editor creator to use.
 import 'ckeditor5/ckeditor5.css';
+import enTranslations from 'ckeditor5/translations/en.js';
 import { ClassicEditor as ClassicEditorBase } from '@ckeditor/ckeditor5-editor-classic';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { CKFinderUploadAdapter } from '@ckeditor/ckeditor5-adapter-ckfinder';
@@ -91,6 +92,8 @@ export default class ClassicEditor extends ClassicEditorBase {
     ];
 
     public static override defaultConfig = {
-        licenseKey: 'GPL'
+        licenseKey: 'GPL',
+        language: 'en',
+        translations: [enTranslations]
     };
 }

--- a/app/assets/libraries/ckeditor/src/ckeditor.ts
+++ b/app/assets/libraries/ckeditor/src/ckeditor.ts
@@ -33,34 +33,11 @@ import { SourceEditing } from "@ckeditor/ckeditor5-source-editing";
 import { GeneralHtmlSupport } from "@ckeditor/ckeditor5-html-support";
 import { Mention } from "@ckeditor/ckeditor5-mention";
 import TokenPlugin from './TokenPlugin';
-
-type TranslationModule = {
-    default: Record<string, {
-        dictionary: Record<string, string>;
-        getPluralForm?: (n: number) => number;
-    }>;
-};
-
-type TranslationRequireContext = {
-    keys(): string[];
-    <T>(id: string): T;
-};
+import translations, { availableTranslationLanguages } from './translations';
 
 type WindowWithMauticLocale = Window & {
     mauticLocale?: string;
 };
-
-declare const require: {
-    context(directory: string, useSubdirectories?: boolean, regExp?: RegExp): TranslationRequireContext;
-};
-
-const translationContext = require.context('../../../../../node_modules/ckeditor5/dist/translations', false, /^(?!.*\.umd\.js$).*\.js$/);
-const translations = translationContext.keys().map((translationFile) => translationContext<TranslationModule>(translationFile).default);
-const availableTranslationLanguages = new Set(
-    translationContext
-        .keys()
-        .map((translationFile) => translationFile.replace('./', '').replace('.js', ''))
-);
 
 function getEditorLanguage(): string {
     const mauticLocale = (window as WindowWithMauticLocale).mauticLocale;

--- a/app/assets/libraries/ckeditor/src/translations.ts
+++ b/app/assets/libraries/ckeditor/src/translations.ts
@@ -1,0 +1,232 @@
+type TranslationModule = Record<string, {
+    dictionary: Record<string, string>;
+    getPluralForm?: (n: number) => number;
+}>;
+
+import afTranslations from 'ckeditor5/translations/af.js';
+import arTranslations from 'ckeditor5/translations/ar.js';
+import astTranslations from 'ckeditor5/translations/ast.js';
+import azTranslations from 'ckeditor5/translations/az.js';
+import beTranslations from 'ckeditor5/translations/be.js';
+import bgTranslations from 'ckeditor5/translations/bg.js';
+import bnTranslations from 'ckeditor5/translations/bn.js';
+import bsTranslations from 'ckeditor5/translations/bs.js';
+import caTranslations from 'ckeditor5/translations/ca.js';
+import csTranslations from 'ckeditor5/translations/cs.js';
+import daTranslations from 'ckeditor5/translations/da.js';
+import de_chTranslations from 'ckeditor5/translations/de-ch.js';
+import deTranslations from 'ckeditor5/translations/de.js';
+import elTranslations from 'ckeditor5/translations/el.js';
+import en_auTranslations from 'ckeditor5/translations/en-au.js';
+import en_gbTranslations from 'ckeditor5/translations/en-gb.js';
+import enTranslations from 'ckeditor5/translations/en.js';
+import eoTranslations from 'ckeditor5/translations/eo.js';
+import es_coTranslations from 'ckeditor5/translations/es-co.js';
+import esTranslations from 'ckeditor5/translations/es.js';
+import etTranslations from 'ckeditor5/translations/et.js';
+import euTranslations from 'ckeditor5/translations/eu.js';
+import faTranslations from 'ckeditor5/translations/fa.js';
+import fiTranslations from 'ckeditor5/translations/fi.js';
+import frTranslations from 'ckeditor5/translations/fr.js';
+import glTranslations from 'ckeditor5/translations/gl.js';
+import guTranslations from 'ckeditor5/translations/gu.js';
+import heTranslations from 'ckeditor5/translations/he.js';
+import hiTranslations from 'ckeditor5/translations/hi.js';
+import hrTranslations from 'ckeditor5/translations/hr.js';
+import huTranslations from 'ckeditor5/translations/hu.js';
+import hyTranslations from 'ckeditor5/translations/hy.js';
+import idTranslations from 'ckeditor5/translations/id.js';
+import itTranslations from 'ckeditor5/translations/it.js';
+import jaTranslations from 'ckeditor5/translations/ja.js';
+import jvTranslations from 'ckeditor5/translations/jv.js';
+import kkTranslations from 'ckeditor5/translations/kk.js';
+import kmTranslations from 'ckeditor5/translations/km.js';
+import knTranslations from 'ckeditor5/translations/kn.js';
+import koTranslations from 'ckeditor5/translations/ko.js';
+import kuTranslations from 'ckeditor5/translations/ku.js';
+import ltTranslations from 'ckeditor5/translations/lt.js';
+import lvTranslations from 'ckeditor5/translations/lv.js';
+import msTranslations from 'ckeditor5/translations/ms.js';
+import nbTranslations from 'ckeditor5/translations/nb.js';
+import neTranslations from 'ckeditor5/translations/ne.js';
+import nlTranslations from 'ckeditor5/translations/nl.js';
+import noTranslations from 'ckeditor5/translations/no.js';
+import ocTranslations from 'ckeditor5/translations/oc.js';
+import plTranslations from 'ckeditor5/translations/pl.js';
+import pt_brTranslations from 'ckeditor5/translations/pt-br.js';
+import ptTranslations from 'ckeditor5/translations/pt.js';
+import roTranslations from 'ckeditor5/translations/ro.js';
+import ruTranslations from 'ckeditor5/translations/ru.js';
+import siTranslations from 'ckeditor5/translations/si.js';
+import skTranslations from 'ckeditor5/translations/sk.js';
+import slTranslations from 'ckeditor5/translations/sl.js';
+import sqTranslations from 'ckeditor5/translations/sq.js';
+import sr_latnTranslations from 'ckeditor5/translations/sr-latn.js';
+import srTranslations from 'ckeditor5/translations/sr.js';
+import svTranslations from 'ckeditor5/translations/sv.js';
+import thTranslations from 'ckeditor5/translations/th.js';
+import tiTranslations from 'ckeditor5/translations/ti.js';
+import tkTranslations from 'ckeditor5/translations/tk.js';
+import trTranslations from 'ckeditor5/translations/tr.js';
+import ttTranslations from 'ckeditor5/translations/tt.js';
+import ugTranslations from 'ckeditor5/translations/ug.js';
+import ukTranslations from 'ckeditor5/translations/uk.js';
+import urTranslations from 'ckeditor5/translations/ur.js';
+import uzTranslations from 'ckeditor5/translations/uz.js';
+import viTranslations from 'ckeditor5/translations/vi.js';
+import zh_cnTranslations from 'ckeditor5/translations/zh-cn.js';
+import zhTranslations from 'ckeditor5/translations/zh.js';
+
+const translations: TranslationModule[] = [
+    afTranslations,
+    arTranslations,
+    astTranslations,
+    azTranslations,
+    beTranslations,
+    bgTranslations,
+    bnTranslations,
+    bsTranslations,
+    caTranslations,
+    csTranslations,
+    daTranslations,
+    de_chTranslations,
+    deTranslations,
+    elTranslations,
+    en_auTranslations,
+    en_gbTranslations,
+    enTranslations,
+    eoTranslations,
+    es_coTranslations,
+    esTranslations,
+    etTranslations,
+    euTranslations,
+    faTranslations,
+    fiTranslations,
+    frTranslations,
+    glTranslations,
+    guTranslations,
+    heTranslations,
+    hiTranslations,
+    hrTranslations,
+    huTranslations,
+    hyTranslations,
+    idTranslations,
+    itTranslations,
+    jaTranslations,
+    jvTranslations,
+    kkTranslations,
+    kmTranslations,
+    knTranslations,
+    koTranslations,
+    kuTranslations,
+    ltTranslations,
+    lvTranslations,
+    msTranslations,
+    nbTranslations,
+    neTranslations,
+    nlTranslations,
+    noTranslations,
+    ocTranslations,
+    plTranslations,
+    pt_brTranslations,
+    ptTranslations,
+    roTranslations,
+    ruTranslations,
+    siTranslations,
+    skTranslations,
+    slTranslations,
+    sqTranslations,
+    sr_latnTranslations,
+    srTranslations,
+    svTranslations,
+    thTranslations,
+    tiTranslations,
+    tkTranslations,
+    trTranslations,
+    ttTranslations,
+    ugTranslations,
+    ukTranslations,
+    urTranslations,
+    uzTranslations,
+    viTranslations,
+    zh_cnTranslations,
+    zhTranslations,
+];
+
+export const availableTranslationLanguages = new Set([
+    'af',
+    'ar',
+    'ast',
+    'az',
+    'be',
+    'bg',
+    'bn',
+    'bs',
+    'ca',
+    'cs',
+    'da',
+    'de-ch',
+    'de',
+    'el',
+    'en-au',
+    'en-gb',
+    'en',
+    'eo',
+    'es-co',
+    'es',
+    'et',
+    'eu',
+    'fa',
+    'fi',
+    'fr',
+    'gl',
+    'gu',
+    'he',
+    'hi',
+    'hr',
+    'hu',
+    'hy',
+    'id',
+    'it',
+    'ja',
+    'jv',
+    'kk',
+    'km',
+    'kn',
+    'ko',
+    'ku',
+    'lt',
+    'lv',
+    'ms',
+    'nb',
+    'ne',
+    'nl',
+    'no',
+    'oc',
+    'pl',
+    'pt-br',
+    'pt',
+    'ro',
+    'ru',
+    'si',
+    'sk',
+    'sl',
+    'sq',
+    'sr-latn',
+    'sr',
+    'sv',
+    'th',
+    'ti',
+    'tk',
+    'tr',
+    'tt',
+    'ug',
+    'uk',
+    'ur',
+    'uz',
+    'vi',
+    'zh-cn',
+    'zh',
+]);
+
+export default translations;

--- a/app/assets/scaffold/files/package-lock.json
+++ b/app/assets/scaffold/files/package-lock.json
@@ -20,7 +20,6 @@
         "@ckeditor/ckeditor5-ckfinder": "^48.0.1",
         "@ckeditor/ckeditor5-cloud-services": "^48.0.1",
         "@ckeditor/ckeditor5-core": "^48.0.1",
-        "@ckeditor/ckeditor5-dev-translations": "^56.4.0",
         "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
         "@ckeditor/ckeditor5-easy-image": "^48.0.1",
         "@ckeditor/ckeditor5-editor-classic": "^48.0.1",
@@ -69,20 +68,6 @@
       "devDependencies": {
         "patch-package": "^8.0.1",
         "webpack-cli": "^5.1.4"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -260,22 +245,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
@@ -291,33 +260,6 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
@@ -429,66 +371,6 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@carbon/pictograms": {
       "version": "12.78.0",
@@ -679,28 +561,6 @@
         "@ckeditor/ckeditor5-utils": "48.2.0",
         "@ckeditor/ckeditor5-watchdog": "48.2.0",
         "es-toolkit": "1.45.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-dev-translations": {
-      "version": "56.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-56.4.0.tgz",
-      "integrity": "sha512-hqwjpMAf9HiYJfCYiAGq8YWy4svsFyrHf/shUxzV8tgUSf0B+RLbJsrikSKjzKhMlfjCJ3b+HLWJbHitAlRWMw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@babel/traverse": "^7.29.0",
-        "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
-        "glob": "^13.0.6",
-        "plural-forms": "^0.5.5",
-        "pofile": "^1.1.4",
-        "rimraf": "^6.1.3",
-        "typescript": "5.5.4",
-        "upath": "^2.0.1",
-        "webpack-sources": "^3.3.4"
-      },
-      "engines": {
-        "node": ">=24.11.0",
-        "npm": ">=5.7.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils": {
@@ -1864,6 +1724,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1874,6 +1735,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1893,13 +1755,15 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4663,17 +4527,12 @@
         "jquery": ">=1.8"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4931,9 +4790,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4953,9 +4809,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4977,9 +4830,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4999,9 +4849,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6604,12 +6451,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/pacote": {
       "version": "21.5.1",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
@@ -6804,18 +6645,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/plural-forms": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/plural-forms/-/plural-forms-0.5.5.tgz",
-      "integrity": "sha512-rJw4xp22izsfJOVqta5Hyvep2lR3xPkFUtj7dyQtpf/FbxUiX7PQCajTn2EHDRylizH5N/Uqqodfdu22I0ju+g==",
-      "license": "MIT"
-    },
-    "node_modules/pofile": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.1.4.tgz",
-      "integrity": "sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==",
-      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -7274,25 +7103,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.3",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -7952,19 +7762,6 @@
       "integrity": "sha512-yGaLzGjVHyryZdNfrWz2NHXUwEO7hrlVmGMGCo5+6mH3nEEhcQ0Te3mK3G60uRnxfERu8twOWSU4WmwScbwhMg==",
       "dependencies": {
         "jquery": ">=1.7"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/app/assets/scaffold/files/package.json
+++ b/app/assets/scaffold/files/package.json
@@ -19,7 +19,6 @@
     "@ckeditor/ckeditor5-ckfinder": "^48.0.1",
     "@ckeditor/ckeditor5-cloud-services": "^48.0.1",
     "@ckeditor/ckeditor5-core": "^48.0.1",
-    "@ckeditor/ckeditor5-dev-translations": "^56.4.0",
     "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
     "@ckeditor/ckeditor5-easy-image": "^48.0.1",
     "@ckeditor/ckeditor5-editor-classic": "^48.0.1",

--- a/app/assets/scaffold/files/webpack.config.js
+++ b/app/assets/scaffold/files/webpack.config.js
@@ -10,7 +10,6 @@ const path = require( 'path' );
 const glob = require("glob")
 const fs = require( 'fs' );
 const { loaders } = require( '@ckeditor/ckeditor5-dev-utils' );
-const { CKEditorTranslationsPlugin } = require( '@ckeditor/ckeditor5-dev-translations' );
 
 // Find the webroot path if it is not the same folder as the current dir.
 // This is the case for Composer based installations following the best practices.
@@ -39,13 +38,6 @@ module.exports = {
 		libraryTarget: 'umd',
 		libraryExport: 'default'
 	},
-
-	plugins: [
-		new CKEditorTranslationsPlugin( {
-			language: 'en',
-			additionalLanguages: 'all'
-		} )
-	],
 
 	module: {
 		rules: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@ckeditor/ckeditor5-ckfinder": "^48.0.1",
         "@ckeditor/ckeditor5-cloud-services": "^48.0.1",
         "@ckeditor/ckeditor5-core": "^48.0.1",
-        "@ckeditor/ckeditor5-dev-translations": "^56.4.0",
         "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
         "@ckeditor/ckeditor5-easy-image": "^48.0.1",
         "@ckeditor/ckeditor5-editor-classic": "^48.0.1",
@@ -69,20 +68,6 @@
       "devDependencies": {
         "patch-package": "^8.0.1",
         "webpack-cli": "^5.1.4"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -260,22 +245,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
@@ -291,33 +260,6 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
@@ -429,66 +371,6 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@carbon/pictograms": {
       "version": "12.78.0",
@@ -679,28 +561,6 @@
         "@ckeditor/ckeditor5-utils": "48.2.0",
         "@ckeditor/ckeditor5-watchdog": "48.2.0",
         "es-toolkit": "1.45.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-dev-translations": {
-      "version": "56.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-56.4.0.tgz",
-      "integrity": "sha512-hqwjpMAf9HiYJfCYiAGq8YWy4svsFyrHf/shUxzV8tgUSf0B+RLbJsrikSKjzKhMlfjCJ3b+HLWJbHitAlRWMw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@babel/traverse": "^7.29.0",
-        "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
-        "glob": "^13.0.6",
-        "plural-forms": "^0.5.5",
-        "pofile": "^1.1.4",
-        "rimraf": "^6.1.3",
-        "typescript": "5.5.4",
-        "upath": "^2.0.1",
-        "webpack-sources": "^3.3.4"
-      },
-      "engines": {
-        "node": ">=24.11.0",
-        "npm": ">=5.7.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils": {
@@ -1864,6 +1724,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1874,6 +1735,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1893,13 +1755,15 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4663,17 +4527,12 @@
         "jquery": ">=1.8"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4931,9 +4790,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4953,9 +4809,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4977,9 +4830,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4999,9 +4849,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6604,12 +6451,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/pacote": {
       "version": "21.5.1",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
@@ -6804,18 +6645,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/plural-forms": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/plural-forms/-/plural-forms-0.5.5.tgz",
-      "integrity": "sha512-rJw4xp22izsfJOVqta5Hyvep2lR3xPkFUtj7dyQtpf/FbxUiX7PQCajTn2EHDRylizH5N/Uqqodfdu22I0ju+g==",
-      "license": "MIT"
-    },
-    "node_modules/pofile": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.1.4.tgz",
-      "integrity": "sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==",
-      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -7274,25 +7103,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.3",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -7952,19 +7762,6 @@
       "integrity": "sha512-yGaLzGjVHyryZdNfrWz2NHXUwEO7hrlVmGMGCo5+6mH3nEEhcQ0Te3mK3G60uRnxfERu8twOWSU4WmwScbwhMg==",
       "dependencies": {
         "jquery": ">=1.7"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@ckeditor/ckeditor5-ckfinder": "^48.0.1",
     "@ckeditor/ckeditor5-cloud-services": "^48.0.1",
     "@ckeditor/ckeditor5-core": "^48.0.1",
-    "@ckeditor/ckeditor5-dev-translations": "^56.4.0",
     "@ckeditor/ckeditor5-dev-utils": "^56.4.0",
     "@ckeditor/ckeditor5-easy-image": "^48.0.1",
     "@ckeditor/ckeditor5-editor-classic": "^48.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ const path = require( 'path' );
 const glob = require("glob")
 const fs = require( 'fs' );
 const { loaders } = require( '@ckeditor/ckeditor5-dev-utils' );
-const { CKEditorTranslationsPlugin } = require( '@ckeditor/ckeditor5-dev-translations' );
 
 // Find the webroot path if it is not the same folder as the current dir.
 // This is the case for Composer based installations following the best practices.
@@ -39,13 +38,6 @@ module.exports = {
 		libraryTarget: 'umd',
 		libraryExport: 'default'
 	},
-
-	plugins: [
-		new CKEditorTranslationsPlugin( {
-			language: 'en',
-			additionalLanguages: 'all'
-		} )
-	],
 
 	module: {
 		rules: [


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A <!-- required for new features -->
| Related developer documentation PR URL | N/A <!-- required for developer-facing changes -->
| Issue(s) addressed                     | N/A - no issue was filed for this build regression <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This fixes the CKEditor webpack build failure caused by the translation integration after the CKEditor 48 package layout change.

Before this change, `npm run build` failed with errors like:

```text
Cannot find the CKEditor 5 core translation package (which defaults to `@ckeditor/ckeditor5-core`).
[CKEditorTranslationsPlugin] Error: No translation has been found for the en language.
```

The root cause is that CKEditor 48 ships built translation bundles in `dist/translations`, while the webpack translation plugin that was configured here expects older translation metadata from `@ckeditor/ckeditor5-core`.

This PR removes that incompatible webpack translation step and switches the editor build to CKEditor 48's shipped English translation bundle by importing `ckeditor5/translations/en.js` directly into the editor configuration.

As a result, the CKEditor bundle no longer depends on the broken translation extraction step during `npm run build`.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `npm install` in the project root to make sure frontend dependencies are installed for this branch.
3. Run `npm run build`.
4. Confirm the build no longer fails with either of these CKEditor translation errors:

```text
Cannot find the CKEditor 5 core translation package (which defaults to `@ckeditor/ckeditor5-core`).
[CKEditorTranslationsPlugin] Error: No translation has been found for the en language.
```

5. Open any Mautic screen that uses the CKEditor instance built from `media/libraries/ckeditor/ckeditor.js`.
6. Confirm the editor loads normally and the toolbar/UI labels are shown in the language that you have your Mautic locale configured.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->