### PR TITLE
fix(core): assign return value of setTimezone() in UTCDateTimeType

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
@@ -12,7 +12,7 @@ class UTCDateTimeType extends DateTimeType
     private static ?\DateTimeZone $utc = null;
 
     /**
-     * @param \DateTime $value
+     * @param \DateTime|\DateTimeImmutable|null $value
      *
      * @return string|null
      */

--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
@@ -33,7 +33,7 @@ class UTCDateTimeType extends DateTimeType
             $value = clone $value;
         }
 
-        $value->setTimezone(self::$utc);
+        $value = $value->setTimezone(self::$utc);
 
         return parent::convertToDatabaseValue($value, $platform);
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeTypeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Type;
+
+use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Mautic\CoreBundle\Doctrine\Type\UTCDateTimeType;
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class UTCDateTimeTypeTest extends TestCase
+{
+    private string $previousTimeZone;
+    private UTCDateTimeType $type;
+    private MySQL80Platform $platform;
+
+    protected function setUp(): void
+    {
+        $this->previousTimeZone = date_default_timezone_get();
+        $this->type             = new UTCDateTimeType();
+        $this->platform         = new MySQL80Platform();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->previousTimeZone);
+    }
+
+    public function testConvertToDatabaseValueWithNull(): void
+    {
+        Assert::assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('timezoneProvider')]
+    public function testConvertToDatabaseValueWithDateTime(string $timezone, string $date): void
+    {
+        date_default_timezone_set($timezone);
+
+        $databaseValue = $this->type->convertToDatabaseValue(new \DateTime($date), $this->platform);
+
+        Assert::assertIsString($databaseValue);
+        Assert::assertSame($this->convertDateTimezone($date, $timezone, 'UTC'), $databaseValue, 'Database value should be converted to UTC.');
+    }
+
+    /**
+     * Passing a DateTimeImmutable to a datetime (mutable) column must not trigger a PHP warning
+     * about the return value of DateTimeImmutable::setTimezone() being discarded, and must still
+     * persist the correct UTC value.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timezoneProvider')]
+    public function testConvertToDatabaseValueWithDateTimeImmutable(string $timezone, string $date): void
+    {
+        date_default_timezone_set($timezone);
+
+        $databaseValue = $this->type->convertToDatabaseValue(new \DateTimeImmutable($date), $this->platform);
+
+        Assert::assertIsString($databaseValue);
+        Assert::assertSame($this->convertDateTimezone($date, $timezone, 'UTC'), $databaseValue, 'Database value should be converted to UTC even when a DateTimeImmutable is passed.');
+    }
+
+    public function testConvertToPHPValueWithNull(): void
+    {
+        Assert::assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('timezoneProvider')]
+    public function testConvertToPHPValueWithDate(string $timezone, string $date): void
+    {
+        date_default_timezone_set($timezone);
+
+        $phpValue = $this->type->convertToPHPValue($date, $this->platform);
+
+        Assert::assertInstanceOf(\DateTime::class, $phpValue);
+        Assert::assertSame($this->convertDateTimezone($date, 'UTC', $timezone), $phpValue->format(DateTimeHelper::FORMAT_DB), sprintf('PHP value should be converted to %s.', $timezone));
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public static function timezoneProvider(): iterable
+    {
+        yield ['America/Cayman', '2023-12-14 10:39:25'];
+        yield ['Europe/Prague', '2022-11-18 18:32:27'];
+        yield ['Indian/Maldives', '2018-01-01 02:02:55'];
+        yield ['Asia/Taipei', '2019-03-01 13:09:45'];
+    }
+
+    private function convertDateTimezone(string $date, string $timezoneFrom, string $timezoneTo): string
+    {
+        return (new \DateTimeImmutable($date, new \DateTimeZone($timezoneFrom)))
+            ->setTimezone(new \DateTimeZone($timezoneTo))
+            ->format(DateTimeHelper::FORMAT_DB);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix?                               | ✔️
| New feature/enhancement?               | ❌
| Deprecations?                          | ❌
| BC breaks?                             | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

`UTCDateTimeType::convertToDatabaseValue()` calls `$value->setTimezone()` without assigning the return value. When `$value` is a `DateTimeImmutable` (which happens because `clone` of a `DateTimeImmutable` stays a `DateTimeImmutable`), `setTimezone()` does not modify the object in place — it returns a new object. The result was silently discarded, meaning the timezone conversion to UTC was skipped and PHP 8.4 emits a warning.

**Root cause:** `DateTimeImmutable::setTimezone()` is a pure method — it has no side effects and must have its return value used. PHP 8.4 introduced a compile-time warning when the return value of such methods is discarded. Mautic's `ErrorHandler` promotes PHP warnings to exceptions, so this warning becomes a 500 error.

**Fix:** assign the return value back to `$value`. For `DateTime` (mutable), `setTimezone()` both modifies in place and returns `$this`, so the assignment is a no-op. For `DateTimeImmutable`, the assignment correctly captures the new object with the UTC timezone applied.

## Steps to test this PR

1. Create an entity that uses `datetime` (mutable) column type.
2. Set a `DateTimeImmutable` value on one of its `datetime` fields.
3. Call `$em->flush()`.
4. Before: PHP warning → 500 error. After: saves correctly with UTC timezone.

Alternatively, run the new unit test:
```
bin/phpunit app/bundles/CoreBundle/Tests/Unit/Type/UTCDateTimeTypeTest.php
```