### PR TITLE
Fix symfony debug bar behaviour

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Default/base.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/base.html.twig
@@ -42,19 +42,6 @@
 
             <script>
                 Mautic.onPageLoad('body');
-                {% if app.environment is same as 'dev' %}
-                mQuery( document ).ajaxComplete(function(event, XMLHttpRequest, ajaxOption){
-                    if(XMLHttpRequest.responseJSON && typeof XMLHttpRequest.responseJSON.ignore_wdt == 'undefined' && XMLHttpRequest.getResponseHeader('x-debug-token')) {
-                        if (mQuery('[class*="sf-tool"]').length) {
-                            mQuery('[class*="sf-tool"]').remove();
-                        }
-
-                        mQuery.get(mauticBaseUrl + '_wdt/'+XMLHttpRequest.getResponseHeader('x-debug-token'),function(data){
-                            mQuery('body').append('<div class="sf-toolbar-reload">'+data+'</div>');
-                        });
-                    }
-                });
-                {% endif %}
             </script>
             {{ outputScripts('bodyClose') }}
             {{ include('@MauticCore/Helper/modal.html.twig', {

--- a/app/config/config_dev.php
+++ b/app/config/config_dev.php
@@ -40,7 +40,10 @@ $container->loadFromExtension('framework', [
 ]);
 
 $container->loadFromExtension('web_profiler', [
-    'toolbar'             => true,
+    'toolbar' => [
+        'enabled'      => true,
+        'ajax_replace' => true,
+    ],
     'intercept_redirects' => false,
 ]);
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #... 

## Description

Symfony debug bar has no CSS and is completely invisible.
<img width="357" height="234" alt="Snímek obrazovky 2026-06-26 v 9 42 08" src="https://github.com/user-attachments/assets/93099116-427a-4ff6-bc8c-ea09da625cdd" />

This PR removes environment check from template as it is not really recommended to expose such logic (env check) in production or change code behaviour.

### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Refresh any page (hard)
3. Debug bar is visible, you can hide it with JS and is refreshed with every Ajax request
