### PR TITLE
[tests] make use of PHPUnit assert with failure reporting over most likely forgotten assert() calls that depens on php.ini

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -40,10 +40,10 @@ class CommonApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals(Response::HTTP_CONFLICT, $error['code']);
 
         $translator = static::getContainer()->get('translator');
-        assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $coreParametersHelper = static::getContainer()->get('mautic.helper.core_parameters');
-        assert($coreParametersHelper instanceof CoreParametersHelper);
+        $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');
         $timeFormat = $coreParametersHelper->get('date_format_timeonly');
 
@@ -112,10 +112,10 @@ class CommonApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals(Response::HTTP_CONFLICT, $error['code']);
 
         $translator = static::getContainer()->get('translator');
-        assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $coreParametersHelper = static::getContainer()->get('mautic.helper.core_parameters');
-        assert($coreParametersHelper instanceof CoreParametersHelper);
+        $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');
         $timeFormat = $coreParametersHelper->get('date_format_timeonly');
 

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -408,7 +408,7 @@ class AssetControllerFunctionalTest extends AbstractAssetTestCase
         // Set new permissions
         $role->setIsAdmin(false);
         $roleModel = static::getContainer()->get('mautic.user.model.role');
-        \assert($roleModel instanceof RoleModel);
+        $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);
         $this->em->flush();

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -85,7 +85,7 @@ class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $downloadRepo = $this->em->getRepository(Download::class);
 
         $download = $downloadRepo->findOneBy(['asset' => $this->asset]);
-        \assert($download instanceof Download);
+        $this->assertInstanceOf(Download::class, $download);
         $this->assertSame('test2', $download->getUtmSource());
         $this->assertSame('test3', $download->getUtmMedium());
         $this->assertSame('test4', $download->getUtmTerm());

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -58,7 +58,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
 
         // Authenticate as restricted user
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -131,7 +131,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
 
         // Authenticate as restricted user
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.collection.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -209,7 +209,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
 
         // Authenticate as restricted user
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.pagination.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
@@ -47,7 +47,7 @@ class AssetModelFunctionalTest extends MauticMysqlTestCase
         $expectedUrl = 'https://localhost/asset/'.$slug.$expectedQuery;
 
         $assetModel = static::getContainer()->get('mautic.asset.model.asset');
-        assert($assetModel instanceof AssetModel);
+        $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, $absolute, $clickthrough, $stream);
 
         $this->assertSame($expectedUrl, $generatedUrl);
@@ -117,7 +117,7 @@ class AssetModelFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('1:the-alias', $asset->getSlug());
 
         $assetModel = static::getContainer()->get('mautic.asset.model.asset');
-        assert($assetModel instanceof AssetModel);
+        $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, true, [], null);
         $this->assertSame('https://localhost/asset/1:the-alias', $generatedUrl);
     }

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -92,10 +92,10 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
         $this->em->clear();
 
         $leadEventLogRepository = $this->em->getRepository(LeadEventLog::class);
-        \assert($leadEventLogRepository instanceof LeadEventLogRepository);
+        $this->assertInstanceOf(LeadEventLogRepository::class, $leadEventLogRepository);
 
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
 
         Assert::assertTrue($log->getIsScheduled());
 
@@ -114,7 +114,7 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
         Assert::assertStringContainsString('0 total events were scheduled', $commandResult->getDisplay());
 
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
 
         Assert::assertTrue($log->getIsScheduled());
         Assert::assertArrayHasKey('triggerDateLog', $log->getMetadata());
@@ -141,10 +141,10 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
         $this->em->clear();
 
         $leadEventLogRepository = $this->em->getRepository(LeadEventLog::class);
-        \assert($leadEventLogRepository instanceof LeadEventLogRepository);
+        $this->assertInstanceOf(LeadEventLogRepository::class, $leadEventLogRepository);
 
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
 
         Assert::assertTrue($log->getIsScheduled());
 
@@ -163,7 +163,7 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
         Assert::assertStringContainsString('0 total events were scheduled', $commandResult->getDisplay());
 
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
 
         Assert::assertTrue($log->getIsScheduled());
         Assert::assertArrayHasKey('triggerDateLog', $log->getMetadata());
@@ -188,10 +188,10 @@ class ExecuteEventCommandTest extends AbstractCampaignCommand
         Assert::assertStringContainsString('1 total event was scheduled', $commandResult->getDisplay());
 
         $leadEventLogRepository = $this->em->getRepository(LeadEventLog::class);
-        \assert($leadEventLogRepository instanceof LeadEventLogRepository);
+        $this->assertInstanceOf(LeadEventLogRepository::class, $leadEventLogRepository);
 
         $log = $leadEventLogRepository->findOneBy(['lead' => $contact, 'campaign' => $campaign]);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
 
         Assert::assertTrue($log->getIsScheduled());
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -714,7 +714,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $segmentMemberRepo->deleteEntities($segmentMemberRepo->findAll());
 
         $campaign = $campaignRepo->find(1); // Created in parent::setUp()
-        \assert($campaign instanceof Campaign);
+        $this->assertInstanceOf(Campaign::class, $campaign);
 
         $campaign->setAllowRestart(true);
 
@@ -873,7 +873,7 @@ class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
 
         $eventLog = $this->em->find(LeadEventLog::class, $logId);
-        \assert($eventLog instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $eventLog);
 
         Assert::assertSame($expectedTriggerDate, $eventLog->getTriggerDate()?->format(DateTimeHelper::FORMAT_DB));
         Assert::assertSame($expectedIsScheduled, $eventLog->getIsScheduled());

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -253,7 +253,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertQueuedEmailCount(2);
 
         $email1 = $this->getMailerMessagesByToAddress('contact@one.email')[0];
-        \assert($email1 instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email1);
 
         // The email is has mailer is owner ON but this contact doesn't have any owner. So it uses default FROM and Reply-To.
         Assert::assertSame('Ahoy contact@one.email', $email1->getSubject());
@@ -270,7 +270,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame($this->configParams['mailer_from_email'], $email1->getReplyTo()[0]->getAddress());
 
         $email2 = $this->getMailerMessagesByToAddress('contact@two.email')[0];
-        \assert($email2 instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email2);
 
         // This contact does have an owner so it uses FROM and Rply-to from the owner.
         Assert::assertSame('Ahoy contact@two.email', $email2->getSubject());

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
@@ -34,7 +34,7 @@ class EventRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testGetContactPendingEventsConsidersCampaignPublishUpAndDown(?\DateTime $publishUp, ?\DateTime $publishDown, int $expectedCount): void
     {
         $repository = static::getContainer()->get('mautic.campaign.repository.event');
-        \assert($repository instanceof EventRepository);
+        $this->assertInstanceOf(EventRepository::class, $repository);
 
         $campaign = $this->createCampaign();
         $event    = $this->createEvent($campaign);
@@ -52,7 +52,7 @@ class EventRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testSetEventsAsDeletedWithRedirectUpdatesChains(): void
     {
         $repository = static::getContainer()->get('mautic.campaign.repository.event');
-        \assert($repository instanceof EventRepository);
+        $this->assertInstanceOf(EventRepository::class, $repository);
 
         $campaign = $this->createCampaign();
 
@@ -153,7 +153,7 @@ class EventRepositoryFunctionalTest extends MauticMysqlTestCase
 
         // 4. Call the method under test
         $repository   = self::getContainer()->get('mautic.campaign.repository.event');
-        \assert($repository instanceof EventRepository);
+        $this->assertInstanceOf(EventRepository::class, $repository);
         $resultEmails = $repository->getCampaignEmailEvents($campaign->getId());
 
         // 5. Assert the results

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
@@ -107,7 +107,7 @@ class ActionDispatcherTest extends \PHPUnit\Framework\TestCase
                     ++$dispatcCounter;
                     if (1 === $dispatcCounter) {
                         Assert::assertInstanceOf(PendingEvent::class, $event);
-                        \assert($event instanceof PendingEvent);
+                        $this->assertInstanceOf(PendingEvent::class, $event);
                         $event->pass($logs->get(1));
                         $event->fail($logs->get(2), 'just because');
                     } elseif (2 === $dispatcCounter) {

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
@@ -51,7 +51,7 @@ final class EventExecutionerLockTest extends MauticMysqlTestCase
         Assert::assertCount(1, $logs);
 
         $log = reset($logs);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
         Assert::assertSame(2, $log->getVersion(), 'Version should be incremented.');
 
         $this->eventExecutioner->executeLogs($event, new ArrayCollection($logs));
@@ -81,7 +81,7 @@ final class EventExecutionerLockTest extends MauticMysqlTestCase
         Assert::assertCount(1, $logs);
 
         $log = reset($logs);
-        \assert($log instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $log);
         Assert::assertSame(1, $log->getVersion(), 'Version should be reset when execution failed.');
 
         $this->makeEventExecutionPass($listener);

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
@@ -87,7 +87,7 @@ final class ScheduledExecutionerExtendTriggerDateTest extends AbstractCampaignCo
         $this->assertSame(0, $commandTester->getStatusCode());
 
         $eventLog = $this->em->find(LeadEventLog::class, $logId);
-        \assert($eventLog instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $eventLog);
 
         Assert::assertSame($expectedTriggerDate, $eventLog->getTriggerDate()?->format(DateTimeHelper::FORMAT_DB));
         Assert::assertSame($expectedIsScheduled, $eventLog->getIsScheduled());

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerFunctionalTest.php
@@ -23,7 +23,7 @@ final class ScheduledExecutionerFunctionalTest extends MauticMysqlTestCase
         parent::setUp();
 
         $this->scheduledExecutioner = self::getContainer()->get('mautic.campaign.executioner.scheduled');
-        \assert($this->scheduledExecutioner instanceof ScheduledExecutioner);
+        $this->assertInstanceOf(ScheduledExecutioner::class, $this->scheduledExecutioner);
     }
 
     public function testEventsAreExecuted(): void
@@ -377,7 +377,7 @@ final class ScheduledExecutionerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
 
         $reloaded = $this->em->find(LeadEventLog::class, $logId);
-        \assert($reloaded instanceof LeadEventLog);
+        $this->assertInstanceOf(LeadEventLog::class, $reloaded);
 
         $this->assertTrue(
             $reloaded->getIsScheduled(),

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignDecisionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignDecisionTest.php
@@ -149,7 +149,7 @@ class CampaignDecisionTest extends MauticMysqlTestCase
     {
         $leadIds = [];
         foreach ($campaignEventLogs as $log) {
-            \assert($log instanceof LeadEventLog);
+            $this->assertInstanceOf(LeadEventLog::class, $log);
             $leadIds[] = $log->getLead()->getId();
         }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
@@ -81,7 +81,7 @@ final class CampaignEventDetailsTimelineFunctionalTest extends MauticMysqlTestCa
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
         $translator = static::getContainer()->get('translator');
-        \assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $this->client->request('GET', sprintf('/s/contacts/view/%s', $lead1->getId()));
         $this->assertStringContainsString(

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
@@ -102,7 +102,7 @@ final class CampaignAuditLogTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $translator = static::getContainer()->get('translator');
-        \assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $this->assertStringContainsString(
             $translator->trans('mautic.campaign.changelog.event_updated'),

--- a/app/bundles/CampaignBundle/Tests/Functional/Executioner/InactiveExecutionerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Executioner/InactiveExecutionerFunctionalTest.php
@@ -27,7 +27,7 @@ final class InactiveExecutionerFunctionalTest extends MauticMysqlTestCase
         parent::setUp();
 
         $this->inactiveExecutioner = self::getContainer()->get('mautic.campaign.executioner.inactive');
-        \assert($this->inactiveExecutioner instanceof InactiveExecutioner);
+        $this->assertInstanceOf(InactiveExecutioner::class, $this->inactiveExecutioner);
     }
 
     public function testDecisionRedirectionToAlreadyExecutedAction(): void

--- a/app/bundles/CampaignBundle/Tests/Service/PublishStateServiceTest.php
+++ b/app/bundles/CampaignBundle/Tests/Service/PublishStateServiceTest.php
@@ -45,7 +45,7 @@ final class PublishStateServiceTest extends MauticMysqlTestCase
         $this->saveAuditLogs($this->em, $auditLogs, $campaign);
 
         $unpublishStateService = $this->getContainer()->get(PublishStateService::class);
-        \assert($unpublishStateService instanceof PublishStateService);
+        $this->assertInstanceOf(PublishStateService::class, $unpublishStateService);
 
         Assert::assertSame($expectedunpublishedranges, array_map(
             fn (PublishStateDateRange $range) => [

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -316,7 +316,7 @@ class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('mautic'));
         $user->setRole($role);
 

--- a/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
@@ -14,7 +14,7 @@ class SysinfoControllerTest extends MauticMysqlTestCase
     public function testDbInfoIsShown(): void
     {
         $sysinfoModel = static::getContainer()->get(SysinfoModel::class);
-        \assert($sysinfoModel instanceof SysinfoModel);
+        $this->assertInstanceOf(SysinfoModel::class, $sysinfoModel);
         $dbInfo = $sysinfoModel->getDbInfo();
 
         // Request sysinfo page

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -104,7 +104,7 @@ abstract class AbstractMauticTestCase extends WebTestCase
         $this->client->followRedirects(true);
 
         $this->em = static::getContainer()->get('doctrine')->getManager();
-        \assert($this->em instanceof EntityManagerInterface);
+        $this->assertInstanceOf(EntityManagerInterface::class, $this->em);
         $this->connection = $this->em->getConnection();
         $this->router     = static::getContainer()->get('router');
         $scheme           = $this->router->getContext()->getScheme();

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -388,7 +388,7 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
     private function clearCache(): void
     {
         $cacheProvider = static::getContainer()->get('mautic.cache.provider');
-        \assert($cacheProvider instanceof CacheItemPoolInterface);
+        $this->assertInstanceOf(CacheItemPoolInterface::class, $cacheProvider);
         $cacheProvider->clear();
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -491,7 +491,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
 
         $this->em->persist($user);

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
@@ -140,7 +140,7 @@ final class ExportControllerTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
 

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
@@ -24,9 +24,9 @@ final class ThemeControllerTest extends MauticMysqlTestCase
         parent::setUp();
 
         $this->pathsHelper = $this->getContainer()->get('mautic.helper.paths');
-        \assert($this->pathsHelper instanceof PathsHelper);
+        $this->assertInstanceOf(PathsHelper::class, $this->pathsHelper);
         $this->filesystem  = $this->getContainer()->get('mautic.filesystem');
-        \assert($this->filesystem instanceof Filesystem);
+        $this->assertInstanceOf(Filesystem::class, $this->filesystem);
 
         $themePath = $this->pathsHelper->getThemesPath();
 
@@ -72,7 +72,7 @@ final class ThemeControllerTest extends MauticMysqlTestCase
     public function testBatchDeleteActionWithNonCoreTheme(): void
     {
         $themeHelper = self::getContainer()->get(ThemeHelper::class);
-        \assert($themeHelper instanceof ThemeHelper);
+        $this->assertInstanceOf(ThemeHelper::class, $themeHelper);
         $themeHelper->copy('blank', 'blanktest');
         $themeHelper->copy('blank', 'auroratest');
 

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
@@ -20,7 +20,7 @@ class SystemThemeTemplatePathPassTest extends MauticMysqlTestCase
         // This test require cache to be cleared
         // as the template override must exist before the cache is generated.
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');
-        \assert($pathsHelper instanceof PathsHelper);
+        $this->assertInstanceOf(PathsHelper::class, $pathsHelper);
         $cacheDir    = $pathsHelper->getCachePath();
 
         $filesystem = new Filesystem();

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
@@ -32,7 +32,7 @@ class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
         $this->schemaHelper->updateColumnLength($this->field->getAlias(), $length);
 
         $column = $this->schemaHelper->getColumns()[$this->field->getAlias()];
-        \assert($column instanceof Column);
+        $this->assertInstanceOf(Column::class, $column);
 
         $this->assertEquals($length, $column->getLength(), 'Column length updated.');
     }
@@ -77,7 +77,7 @@ class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
         $field->setCharLengthLimit(64);
 
         $fieldModel = $this->getContainer()->get('mautic.lead.model.field');
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $fieldModel->saveEntity($field);
         $fieldModel->getRepository()->detachEntity($field);
 

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
@@ -25,7 +25,7 @@ class SimplePaginatorTest extends MauticMysqlTestCase
         parent::setUp();
 
         $debugDataHolder = static::getContainer()->get('doctrine.debug_data_holder');
-        \assert($debugDataHolder instanceof DebugDataHolder);
+        $this->assertInstanceOf(DebugDataHolder::class, $debugDataHolder);
         $debugDataHolder->reset();
 
         $this->debugDataHolder = $debugDataHolder;

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
@@ -13,7 +13,7 @@ final class LanguageHelperTest extends MauticMysqlTestCase
     public function testGettingLanguageFiles(): void
     {
         $languageHelper = static::getContainer()->get(LanguageHelper::class);
-        \assert($languageHelper instanceof LanguageHelper);
+        $this->assertInstanceOf(LanguageHelper::class, $languageHelper);
 
         $languageFiles = $languageHelper->getLanguageFiles();
 

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -57,20 +57,20 @@ class SamlTest extends MauticMysqlTestCase
 
         // Select your entity ID
         $samlIdField = $configForm['config[userconfig][saml_idp_entity_id]'];
-        \assert($samlIdField instanceof ChoiceFormField);
+        $this->assertInstanceOf(ChoiceFormField::class, $samlIdField);
         $availableSamlIdOptions = $samlIdField->availableOptionValues();
         Assert::assertCount(2, $availableSamlIdOptions, print_r($availableSamlIdOptions, true));
         $samlIdField->setValue($availableSamlIdOptions[1]);
 
         $samlDefaultRoleField = $configForm['config[userconfig][saml_idp_default_role]'];
-        \assert($samlDefaultRoleField instanceof ChoiceFormField);
+        $this->assertInstanceOf(ChoiceFormField::class, $samlDefaultRoleField);
         $availableDefaultRoleOptions = $samlDefaultRoleField->availableOptionValues();
         Assert::assertCount(3, $availableDefaultRoleOptions, print_r($availableDefaultRoleOptions, true));
         $samlDefaultRoleField->setValue($availableDefaultRoleOptions[1]);
 
         // Upload the metadata.xml file
         $samlProviderMetadata = $configForm['config[userconfig][saml_idp_metadata]'];
-        \assert($samlProviderMetadata instanceof FileFormField);
+        $this->assertInstanceOf(FileFormField::class, $samlProviderMetadata);
         $samlProviderMetadata->upload($temporaryFile);
 
         // Fill in email in the fields Email, First Name and Last name (we are testing, so no problem that the actual values are not correct)
@@ -122,14 +122,14 @@ class SamlTest extends MauticMysqlTestCase
             RequestOptions::ALLOW_REDIRECTS => false,
         ]);
         $response = $guzzleClient->request(Request::METHOD_GET, $url);
-        \assert($response instanceof \GuzzleHttp\Psr7\Response);
+        $this->assertInstanceOf(\GuzzleHttp\Psr7\Response::class, $response);
         Assert::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
         $url = $response->getHeaderLine('Location');
         Assert::assertStringContainsString('http://'.$host.':'.$port.'/simplesaml/module.php/core/loginuserpass.php?AuthState=', $url);
 
         // Get the form for authentication.
         $response = $guzzleClient->request(Request::METHOD_GET, $url);
-        \assert($response instanceof \GuzzleHttp\Psr7\Response);
+        $this->assertInstanceOf(\GuzzleHttp\Psr7\Response::class, $response);
         Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $body    = (string) $response->getBody();
@@ -148,7 +148,7 @@ class SamlTest extends MauticMysqlTestCase
                 'form_params' => $form->getPhpValues(),
             ]
         );
-        \assert($response instanceof \GuzzleHttp\Psr7\Response);
+        $this->assertInstanceOf(\GuzzleHttp\Psr7\Response::class, $response);
         // Because guzzle does not support javascript the answer is a form.
         Assert::assertSame(Response::HTTP_OK, $response->getStatusCode());
 

--- a/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
@@ -28,7 +28,7 @@ class CorePermissionsTest extends MauticMysqlTestCase
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'sales']);
         $this->loginUser($user);
         $permissions = self::getContainer()->get('mautic.security');
-        \assert($permissions instanceof CorePermissions);
+        $this->assertInstanceOf(CorePermissions::class, $permissions);
         $permissions->setPermissionObject($this->createVirtualPermission($grant));
 
         Assert::assertSame($grant, $permissions->isGranted('test:group:action', 'MATCH_ALL', $user));

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PRedisConnectionHelperTest.php
@@ -73,7 +73,7 @@ class PRedisConnectionHelperTest extends TestCase
         $client  = PRedisConnectionHelper::createClient(['tcp://1.1.1.1'], ['prefix' => $prefix]);
         $options = $client->getOptions();
 
-        \assert($options->prefix instanceof KeyPrefixProcessor);
+        $this->assertInstanceOf(KeyPrefixProcessor::class, $options->prefix);
         Assert::assertSame($prefix, $options->prefix->getPrefix());
         Assert::assertNull($options->aggregate);
 
@@ -84,7 +84,7 @@ class PRedisConnectionHelperTest extends TestCase
 
         if ($connection instanceof RedisCluster || $connection instanceof PredisCluster) {
             $clusterStrategy = $connection->getClusterStrategy();
-            \assert($clusterStrategy instanceof ClusterStrategy);
+            $this->assertInstanceOf(ClusterStrategy::class, $clusterStrategy);
 
             Assert::assertContains(Unlink::ID, $clusterStrategy->getSupportedCommands());
         }
@@ -96,7 +96,7 @@ class PRedisConnectionHelperTest extends TestCase
         $client  = PRedisConnectionHelper::createClient(['tcp://1.1.1.1'], ['prefix' => $prefix, 'replication' => 'sentinel']);
         $options = $client->getOptions();
 
-        \assert($options->prefix instanceof KeyPrefixProcessor);
+        $this->assertInstanceOf(KeyPrefixProcessor::class, $options->prefix);
         Assert::assertSame($prefix, $options->prefix->getPrefix());
         Assert::assertIsCallable($options->aggregate);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
@@ -13,7 +13,7 @@ class AssetExtensionTest extends AbstractMauticTestCase
     public function testGetCountryFlag(): void
     {
         $assetExtension = static::getContainer()->get(AssetExtension::class);
-        \assert($assetExtension instanceof AssetExtension);
+        $this->assertInstanceOf(AssetExtension::class, $assetExtension);
 
         Assert::assertStringStartsWith('/./app/assets/images/flags/Belgium.png', $assetExtension->getCountryFlag('Belgium'));
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
@@ -14,7 +14,7 @@ class MenuExtensionTest extends AbstractMauticTestCase
     public function testParseMenuAttributes(): void
     {
         $menuExtension = static::getContainer()->get(MenuExtension::class);
-        \assert($menuExtension instanceof MenuExtension);
+        $this->assertInstanceOf(MenuExtension::class, $menuExtension);
 
         $menuAttributes = [
             'id'    => 'myId',
@@ -30,7 +30,7 @@ class MenuExtensionTest extends AbstractMauticTestCase
     public function testBuildMenuClasses(): void
     {
         $menuExtension = static::getContainer()->get(MenuExtension::class);
-        \assert($menuExtension instanceof MenuExtension);
+        $this->assertInstanceOf(MenuExtension::class, $menuExtension);
 
         // create a menu and menu items to test with
         $factory = new MenuFactory();

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -160,7 +160,7 @@ class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         $contact = new Lead();
         $contact->setFirstName('John');
         $contactModel = self::getContainer()->get('mautic.lead.model.lead');
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
         $contactModel->deleteEntity($contact);
         $this->em->clear();

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -166,7 +166,7 @@ class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
 

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -87,7 +87,7 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEmailCount(1);
 
         $email = KernelTestCase::getMailerMessage();
-        \assert($email instanceof EmailMime);
+        $this->assertInstanceOf(EmailMime::class, $email);
 
         /** @var UserHelper $userHelper */
         $userHelper = static::getContainer()->get(UserHelper::class);

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -534,7 +534,7 @@ class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         $hasher = static::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
 
         $user->setPassword($hasher->hash('password'));
         $this->em->persist($user);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -324,7 +324,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->sendBatchEmail($email);
 
         $email = self::getMailerMessage();
-        \assert($email instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email);
 
         $quote = $singleOrDoubleQuotes ? '\'' : '"';
         // The order of the recipients is not guaranteed, so we need to check both possibilities.
@@ -420,7 +420,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->sendBatchEmail($email);
 
         $email = $this->getMailerMessage();
-        \assert($email instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email);
 
         // The order of the recipients is not guaranteed, so we need to check both possibilities.
         Assert::assertSame('Subject A', $email->getSubject());

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -46,7 +46,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        \assert($message instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString(
@@ -70,7 +70,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        \assert($message instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Contact emails is [Email]. Company details: [Company Name], [City].', $message->getBody()->toString());
@@ -142,7 +142,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        \assert($message instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Default Dynamic Content', $message->getBody()->toString());
@@ -234,7 +234,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        \assert($message instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Variant 1 Dynamic Content', $message->getBody()->toString());
@@ -326,7 +326,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         $message = $this->getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        \assert($message instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Default Dynamic Content', $message->getBody()->toString());

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendDisabledTrackingFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendDisabledTrackingFunctionalTest.php
@@ -78,7 +78,7 @@ final class EmailSendDisabledTrackingFunctionalTest extends MauticMysqlTestCase
         ];
 
         foreach ($messages as $message) {
-            assert($message instanceof MauticMessage);
+            $this->assertInstanceOf(MauticMessage::class, $message);
             $body = quoted_printable_decode($message->getBody()->bodyToString());
             preg_match('/<a href=\"([^\"]*)\">(.*)<\/a>/iU', $body, $match);
             Assert::assertArrayHasKey(1, $match, $body);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -215,7 +215,7 @@ final class EmailSendFunctionalTest extends MauticMysqlTestCase
 
         $rawMessage = self::getMailerMessagesByToAddress('contact-flood-0@doe.com')[0];
         Assert::assertInstanceOf(Message::class, $rawMessage);
-        \assert($rawMessage instanceof Message);
+        $this->assertInstanceOf(Message::class, $rawMessage);
 
         $body = quoted_printable_decode($rawMessage->getBody()->bodyToString());
         preg_match('/<a href=\"([^\"]*)\">(.*)<\/a>/iU', $body, $match);

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -142,7 +142,7 @@ class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         // Assert that the contact has the DNC record now.
         $dncRepository = $this->em->getRepository(DoNotContact::class);
-        \assert($dncRepository instanceof DoNotContactRepository);
+        $this->assertInstanceOf(DoNotContactRepository::class, $dncRepository);
         $dncRecords = $dncRepository->findBy(['lead' => $lead->getId()]);
         Assert::assertCount(1, $dncRecords);
         Assert::assertSame(DoNotContact::UNSUBSCRIBED, $dncRecords[0]->getReason());

--- a/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
@@ -59,7 +59,7 @@ class PendingQueryFunctionalTest extends MauticMysqlTestCase
         }
 
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);
 
         return $contacts;

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
@@ -53,7 +53,7 @@ class BuilderSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->assertQueuedEmailCount(3);
 
         foreach ($this->getMailerMessages() as $message) {
-            \assert($message instanceof MauticMessage);
+            $this->assertInstanceOf(MauticMessage::class, $message);
             $clickThrough = $this->parseClickThrough($message->getHtmlBody());
             $email        = $message->getTo()[0]->getAddress();
             Assert::assertSame((string) $leads[$email]->getId(), $clickThrough['lead'], '"lead" parameter within the click through should match the contact\'s ID.');

--- a/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
@@ -47,7 +47,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->em->clear();
 
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -108,7 +108,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->em->clear();
 
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');

--- a/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
@@ -50,7 +50,7 @@ final class EmailClickTrackingTest extends MauticMysqlTestCase
         Assert::assertTrue($this->client->getResponse()->isSuccessful());
 
         $pageHitRepository = $this->em->getRepository(Hit::class);
-        \assert($pageHitRepository instanceof HitRepository);
+        $this->assertInstanceOf(HitRepository::class, $pageHitRepository);
 
         $hit = $pageHitRepository->findOneBy(['page' => $page]);
         Assert::assertSame($contact->getId(), $hit->getLead()->getId());

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -43,7 +43,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         parent::setUp();
 
         $emailModel = static::getContainer()->get('mautic.email.model.email');
-        \assert($emailModel instanceof EmailModel);
+        $this->assertInstanceOf(EmailModel::class, $emailModel);
         $this->emailModel = $emailModel;
     }
 
@@ -137,7 +137,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
         }
 
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);
 
         return $contacts;
@@ -683,7 +683,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
     private function assertEmailIsNotPostponed(): void
     {
         $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
-        \assert($messageQueueRepository instanceof MessageQueueRepository);
+        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
 
         Assert::assertSame(0, $messageQueueRepository->count([]), 'Email should not be postponed.');
     }
@@ -691,7 +691,7 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
     private function assertEmailIsPostponed(Email $email, Lead $contact): void
     {
         $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
-        \assert($messageQueueRepository instanceof MessageQueueRepository);
+        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
 
         $queuedMessages = $messageQueueRepository->findBy([]);
         Assert::assertCount(1, $queuedMessages, 'Email should be postponed.');

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
@@ -31,11 +31,11 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $emailModel = static::getContainer()->get('mautic.email.model.email');
-        \assert($emailModel instanceof EmailModel);
+        $this->assertInstanceOf(EmailModel::class, $emailModel);
 
         // Re-fetch the email to get the updated stats
         $email = $emailModel->getEntity($email->getId());
-        \assert($email instanceof Email);
+        $this->assertInstanceOf(Email::class, $email);
 
         $this->assertEquals(self::CONTACT_COUNT, $email->getSentCount(true));
     }
@@ -63,7 +63,7 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
     private function createContacts(): array
     {
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
 
         $contacts = [];
 

--- a/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
@@ -21,7 +21,7 @@ final class FieldCollectorTest extends \PHPUnit\Framework\TestCase
             {
                 ++$this->dispatchMethodCallCounter;
 
-                \assert($event instanceof FieldCollectEvent);
+                Assert::assertInstanceOf(FieldCollectEvent::class, $event);
                 Assert::assertSame('contact', $event->getObject());
 
                 return new FieldCollection();

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -424,7 +424,7 @@ class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $translator = $this->getContainer()->get('translator');
-        \assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         foreach ($expectedMessages as $expectedMessage) {
             $translatedMessage = $translator->trans($expectedMessage['message'], $expectedMessage['message_arg']);

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -592,7 +592,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash($this->getUserPlainPassword()));
 
         /** @var UserRepository $userRepo */

--- a/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
+++ b/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
@@ -102,7 +102,7 @@ class InstallWorkflowTest extends MauticMysqlTestCase
         $fieldRepository = $this->em->getRepository(LeadField::class);
 
         $emailField = $fieldRepository->findOneBy(['alias' => 'email']);
-        \assert($emailField instanceof LeadField);
+        $this->assertInstanceOf(LeadField::class, $emailField);
         Assert::assertSame('Email', $emailField->getLabel());
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
@@ -86,7 +86,7 @@ final class ObjectMappingRepositoryTest extends MauticMysqlTestCase
         Assert::assertSame(1, $this->repository->count([]));
 
         $objectMapping = $this->repository->findAll()[0];
-        \assert($objectMapping instanceof ObjectMapping);
+        $this->assertInstanceOf(ObjectMapping::class, $objectMapping);
 
         Assert::assertSame(self::INTEGRATION, $objectMapping->getIntegration());
         Assert::assertSame(self::INTEGRATION_OBJECT_NAME, $objectMapping->getIntegrationObjectName());

--- a/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
@@ -73,7 +73,7 @@ final class DeduplicateCommandFunctionalTest extends MauticMysqlTestCase
         $this->saveContact('jane.gabriel@gmail.com', '4444444444'); // 5
 
         $phoneField = $fieldRepository->findOneBy(['alias' => 'phone']);
-        \assert($phoneField instanceof LeadField);
+        $this->assertInstanceOf(LeadField::class, $phoneField);
         $phoneField->setIsUniqueIdentifer(true);
         $phoneField->setLabel('Cell phone'); // Testing also field with more words.
         $this->em->persist($phoneField);
@@ -105,7 +105,7 @@ final class DeduplicateCommandFunctionalTest extends MauticMysqlTestCase
         $this->saveContact('jane.gabriel@gmail.com', '4444444444'); // 3
 
         $phoneField = $fieldRepository->findOneBy(['alias' => 'phone']);
-        \assert($phoneField instanceof LeadField);
+        $this->assertInstanceOf(LeadField::class, $phoneField);
         $phoneField->setIsUniqueIdentifer(true);
         $phoneField->setLabel('Cell phone'); // Testing also field with more words.
         $this->em->persist($phoneField);

--- a/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
@@ -114,7 +114,7 @@ class DeleteLeadListsCommandFunctionalTest extends MauticMysqlTestCase
     {
         // Add 1 segment
         $segmentRepo = $this->em->getRepository(LeadList::class);
-        \assert($segmentRepo instanceof LeadListRepository);
+        $this->assertInstanceOf(LeadListRepository::class, $segmentRepo);
 
         $segment = new LeadList();
         $filters = [

--- a/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
@@ -284,7 +284,7 @@ final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
 
         $contact->addUpdatedField($fieldAlias, $contactValue);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
 
         $segmentValue = [];
@@ -395,7 +395,7 @@ final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
 
         $contact->addUpdatedField($fieldAlias, $contactValue);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
 
         $segmentValue = [];
@@ -504,7 +504,7 @@ final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
         $company->addUpdatedField($fieldAlias, $companyValue);
 
         $companyModel = self::getContainer()->get(\Mautic\LeadBundle\Model\CompanyModel::class);
-        \assert($companyModel instanceof \Mautic\LeadBundle\Model\CompanyModel);
+        $this->assertInstanceOf(\Mautic\LeadBundle\Model\CompanyModel::class, $companyModel);
         $companyModel->saveEntity($company);
 
         $contact = $this->createLead('First name', emailId: 'halusky@bramborak.makovec');
@@ -598,7 +598,7 @@ final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
         $company->addUpdatedField($fieldAlias, $companyValue);
 
         $companyModel = self::getContainer()->get(\Mautic\LeadBundle\Model\CompanyModel::class);
-        \assert($companyModel instanceof \Mautic\LeadBundle\Model\CompanyModel);
+        $this->assertInstanceOf(\Mautic\LeadBundle\Model\CompanyModel::class, $companyModel);
         $companyModel->saveEntity($company);
 
         $contact = $this->createLead('First name', emailId: 'halusky@bramborak.makovec');

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -87,14 +87,14 @@ class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $contact  = $this->createContact('blabla@contact.email');
 
         $userRepository = $this->em->getRepository(User::class);
-        \assert($userRepository instanceof UserRepository);
+        $this->assertInstanceOf(UserRepository::class, $userRepository);
 
         $role = new Role();
         $role->setName('No-campaign-edit-access');
         $role->setIsAdmin(false);
 
         $roleRepository = $this->em->getRepository(Role::class);
-        \assert($roleRepository instanceof RoleRepository);
+        $this->assertInstanceOf(RoleRepository::class, $roleRepository);
         $roleRepository->saveEntity($role);
 
         $user = new User();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -420,7 +420,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $fieldRepository   = $this->em->getRepository(LeadField::class);
         $companyEmailField = $fieldRepository->findOneBy(['alias' => 'companyemail']);
-        \assert($companyEmailField instanceof LeadField);
+        $this->assertInstanceOf(LeadField::class, $companyEmailField);
         $companyEmailField->setIsUniqueIdentifer(true);
         $this->em->persist($companyEmailField);
         $this->em->flush();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -171,7 +171,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $fieldAlias = 'test_multi';
 
         $fieldModel = $this->getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
 
         $fields = $fieldModel->getLeadFieldCustomFields();
         Assert::assertEmpty($fields, 'There are no Custom Fields.');
@@ -207,7 +207,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $contact->addUpdatedField($fieldAlias, ['bramborak', 'makovec']);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
 
         $this->em->flush();
@@ -283,7 +283,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $fieldAlias = 'test_single';
 
         $fieldModel = $this->getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
 
         $fields = $fieldModel->getLeadFieldCustomFields();
         Assert::assertEmpty($fields, 'There are no Custom Fields.');
@@ -319,7 +319,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $contact->addUpdatedField($fieldAlias, ['makovec']);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
 
         $this->em->flush();

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
@@ -70,7 +70,7 @@ final class LeadApiControllerProfilerTest extends MauticMysqlTestCase
     {
         // We have to reset the param counter to emulate 2 requests otherwise the counter will cause the queries to be different.
         $leadRepository = $this->em->getRepository(Lead::class);
-        \assert($leadRepository instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $leadRepository);
         $reflection = new \ReflectionClass($leadRepository);
         $counter    = $reflection->getProperty('lastUsedParameterId');
         $counter->setValue($leadRepository, 0);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -119,7 +119,7 @@ class TagApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testSearchMatchesTagDescription(): void
     {
         $tagRepository = $this->em->getRepository(Tag::class);
-        \assert($tagRepository instanceof TagRepository);
+        $this->assertInstanceOf(TagRepository::class, $tagRepository);
 
         $matchingTag = (new Tag('alpha_tag'))->setDescription('Contains the test keyword.');
         $otherTag    = (new Tag('beta_tag'))->setDescription('No relevant text here.');

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -134,10 +134,10 @@ class CompanyControllerTest extends MauticMysqlTestCase
     public function testListCompanyContacts(): void
     {
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
-        \assert($companyModel instanceof CompanyModel);
+        $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
         $leadModel = self::getContainer()->get('mautic.lead.model.lead');
-        \assert($leadModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $leadModel);
 
         $company1 = $companyModel->getEntity($this->company1Id);
 
@@ -364,7 +364,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $form          = $buttonCrawler->form();
 
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
-        \assert($companyModel instanceof CompanyModel);
+        $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
         $company     = $companyModel->getEntity($this->company1Id);
         $updatedName = $company->getName().' - Updated';
@@ -397,7 +397,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $content = $clientResponse->getContent();
 
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
-        \assert($companyModel instanceof CompanyModel);
+        $this->assertInstanceOf(CompanyModel::class, $companyModel);
         $company1 = $companyModel->getEntity($this->company1Id);
         $company2 = $companyModel->getEntity($this->company2Id);
 
@@ -423,7 +423,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
-        \assert($companyModel instanceof CompanyModel);
+        $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
         $company = $companyModel->getEntity($this->company1Id);
 

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -141,7 +141,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
         Assert::assertStringContainsString('Import process was successfully created.', $crawler->html());
 
         $importRepository = $this->em->getRepository(Import::class);
-        \assert($importRepository instanceof ImportRepository);
+        $this->assertInstanceOf(ImportRepository::class, $importRepository);
         $importEntity = $importRepository->findOneBy(['originalFile' => $filename]);
 
         Assert::assertInstanceOf(Import::class, $importEntity);
@@ -162,7 +162,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
         Assert::assertSame(Import::IMPORTED, $importEntity->getStatus());
 
         $leadRepository = $this->em->getRepository(Lead::class);
-        \assert($leadRepository instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $leadRepository);
 
         /** @var Lead[] $contacts */
         $contacts = $leadRepository->findBy([], ['id' => 'asc']);
@@ -171,7 +171,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
         Assert::assertSame('Existing-owned-after', $contacts[1]->getFirstname(), 'This contact should be updated as the user has permission to edit own.');
 
         $eventLogRepository = $this->em->getRepository(LeadEventLog::class);
-        \assert($eventLogRepository instanceof LeadEventLogRepository);
+        $this->assertInstanceOf(LeadEventLogRepository::class, $eventLogRepository);
 
         /** @var LeadEventLog[] $logs */
         $logs = $eventLogRepository->findBy(['bundle' => 'lead', 'object' => 'import'], ['id' => 'asc']);
@@ -545,7 +545,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
         $user->setUsername($username);
         $user->setEmail($email);
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
         $this->em->persist($user);

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -635,7 +635,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $this->assertQueuedEmailCount(1);
 
         $email = $this->getMailerMessage();
-        \assert($email instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email);
 
         $userHelper = static::getContainer()->get(UserHelper::class);
         $user       = $userHelper->getUser();
@@ -685,7 +685,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $this->assertQueuedEmailCount(1);
 
         $email = $this->getMailerMessage();
-        \assert($email instanceof MauticMessage);
+        $this->assertInstanceOf(MauticMessage::class, $email);
 
         $userHelper = static::getContainer()->get(UserHelper::class);
         $user       = $userHelper->getUser();
@@ -1189,16 +1189,16 @@ EMAIL;
         Assert::assertStringContainsString('1 contact affected', $clientResponse->getContent());
 
         $dncRepository = $this->em->getRepository(DoNotContact::class);
-        \assert($dncRepository instanceof DoNotContactRepository);
+        $this->assertInstanceOf(DoNotContactRepository::class, $dncRepository);
 
         $contactRepository = $this->em->getRepository(Lead::class);
-        \assert($contactRepository instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $contactRepository);
 
         $dnc = $dncRepository->findOneBy(['lead' => $contact]);
-        \assert($dnc instanceof DoNotContact);
+        $this->assertInstanceOf(DoNotContact::class, $dnc);
 
         $fetchedContact = $contactRepository->find($contact->getId());
-        \assert($fetchedContact instanceof Lead);
+        $this->assertInstanceOf(Lead::class, $fetchedContact);
 
         // Ensure the DNC recored was created.
         Assert::assertSame(DoNotContact::MANUAL, $dnc->getReason());

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -42,17 +42,17 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->configParams['delete_segment_in_background']               = false;
         parent::setUp();
         $this->listModel = static::getContainer()->get('mautic.lead.model.list');
-        \assert($this->listModel instanceof ListModel);
+        $this->assertInstanceOf(ListModel::class, $this->listModel);
         $this->listRepo = $this->listModel->getRepository();
-        \assert($this->listRepo instanceof LeadListRepository);
+        $this->assertInstanceOf(LeadListRepository::class, $this->listRepo);
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($leadModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $leadModel);
         $this->segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');
         $this->leadRepo                = $leadModel->getRepository();
-        \assert($this->leadRepo instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $this->leadRepo);
         $this->prefix                  = self::getContainer()->getParameter('mautic.db_table_prefix');
         $this->translator              = self::getContainer()->get('translator');
-        \assert($this->translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
     }
 
     public function testBCSegmentWithPageHitInLeadObject(): void
@@ -100,7 +100,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $project->setName('Test Project');
 
         $projectModel = self::getContainer()->get(ProjectModel::class);
-        \assert($projectModel instanceof ProjectModel);
+        $this->assertInstanceOf(ProjectModel::class, $projectModel);
         $projectModel->saveEntity($project);
 
         $this->em->clear();

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
@@ -701,7 +701,7 @@ final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
 
         $this->em->persist($user);

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
@@ -18,10 +18,10 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactFound(): void
     {
         $model = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($model instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $model);
 
         $merger = static::getContainer()->get('mautic.lead.merger');
-        \assert($merger instanceof ContactMerger);
+        $this->assertInstanceOf(ContactMerger::class, $merger);
 
         $bob = new Lead();
         $bob->setFirstname('Bob')
@@ -72,13 +72,13 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactsPointsAreAccurate(): void
     {
         $model = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($model instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $model);
 
         $em = static::getContainer()->get('doctrine.orm.entity_manager');
-        \assert($em instanceof EntityManager);
+        $this->assertInstanceOf(EntityManager::class, $em);
 
         $merger = static::getContainer()->get('mautic.lead.merger');
-        \assert($merger instanceof ContactMerger);
+        $this->assertInstanceOf(ContactMerger::class, $merger);
 
         // Startout Jane with 50 points
         $jane = new Lead();
@@ -139,16 +139,16 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactKeepsCompanyAssociations(): void
     {
         $model = static::getContainer()->get('mautic.lead.model.lead');
-        \assert($model instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $model);
 
         $companyModel = static::getContainer()->get('mautic.lead.model.company');
-        \assert($companyModel instanceof CompanyModel);
+        $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
         $merger = static::getContainer()->get('mautic.lead.merger');
-        \assert($merger instanceof ContactMerger);
+        $this->assertInstanceOf(ContactMerger::class, $merger);
 
         $companyLeadRepository = static::getContainer()->get('mautic.lead.repository.company_lead');
-        \assert($companyLeadRepository instanceof CompanyLeadRepository);
+        $this->assertInstanceOf(CompanyLeadRepository::class, $companyLeadRepository);
 
         // Jane is a known contact associated with a primary company
         $jane = new Lead();

--- a/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
@@ -26,7 +26,7 @@ final class DoNotContactRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $repository = $this->em->getRepository(DoNotContact::class);
-        \assert($repository instanceof DoNotContactRepository);
+        $this->assertInstanceOf(DoNotContactRepository::class, $repository);
 
         $allDncRecords = $repository->getChannelList(null);
         $allSmsRecords = $repository->getChannelList('sms');

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
@@ -158,13 +158,13 @@ class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         );
 
         $fieldModel = self::getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $fieldModel->saveEntity($field);
 
         $lead = new Lead();
         $lead->addUpdatedField('colors', 'green|blue');
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
 
         $contactModel->saveEntity($lead);
         $repository = $fieldModel->getRepository();
@@ -198,13 +198,13 @@ class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         );
 
         $fieldModel = self::getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $fieldModel->saveEntity($field);
 
         $lead = new Lead();
         $lead->addUpdatedField('job_title', self::ADMINISTRATOR_VALUE);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
 
         $contactModel->saveEntity($lead);
         $repository = $fieldModel->getRepository();

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -24,7 +24,7 @@ class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
     public function testOnReportDisplay(string $value, string $type, array $properties, string $expected): void
     {
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
-        \assert($fieldModel instanceof FieldModel);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $field = new LeadField();
         $field->setType($type);
         $field->setObject('lead');
@@ -37,7 +37,7 @@ class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
         $contact->setEmail('contact@example.com');
         $contact->addUpdatedField('field1', $value);
         $contactModel = self::getContainer()->get(LeadModel::class);
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);
 
         $report = new Report();

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
@@ -31,7 +31,7 @@ class SearchSubscriberFunctionalTest extends MauticMysqlTestCase
         $event = new LeadBuildSearchEvent((string) $this->email->getId(), 'email_pending', $alias, false, $qb);
 
         $dispatcher = self::getContainer()->get('event_dispatcher');
-        \assert($dispatcher instanceof EventDispatcherInterface);
+        $this->assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
 
         $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
         $expectedQuery = 'l.id IN (SELECT l.id FROM '.MAUTIC_TABLE_PREFIX.'leads l WHERE (l.id IN (SELECT ll.lead_id FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads ll WHERE (ll.lead_id = l.id) AND (ll.leadlist_id IN (:listIds)) AND (ll.manually_removed = :false))) AND (l.id NOT IN (SELECT dnc.lead_id FROM '.MAUTIC_TABLE_PREFIX."lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'email'))) AND (l.id NOT IN (SELECT stat.lead_id FROM ".MAUTIC_TABLE_PREFIX.'email_stats stat WHERE (stat.lead_id IS NOT NULL) AND (stat.email_id IN (:variantIds)))) AND (l.id NOT IN (SELECT mq.lead_id FROM '.MAUTIC_TABLE_PREFIX."message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'email') AND (mq.channel_id IN (:variantIds)))) AND (l.id NOT IN (SELECT lc.lead_id FROM ".MAUTIC_TABLE_PREFIX.'lead_categories lc INNER JOIN '.MAUTIC_TABLE_PREFIX."emails e ON e.category_id = lc.category_id WHERE (e.id = {$this->email->getId()}) AND (lc.manually_removed = 1))) AND ((l.email IS NOT NULL) AND (l.email <> '')))";

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -34,13 +34,13 @@ class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
     public function testOnSegmentChange(): void
     {
         $contactRepository = $this->em->getRepository(Lead::class);
-        \assert($contactRepository instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $contactRepository);
 
         $segmentModel = static::getContainer()->get('mautic.lead.model.list');
-        \assert($segmentModel instanceof ListModel);
+        $this->assertInstanceOf(ListModel::class, $segmentModel);
 
         $webhookQueueRepository = $this->em->getRepository(WebhookQueue::class);
-        \assert($webhookQueueRepository instanceof WebhookQueueRepository);
+        $this->assertInstanceOf(WebhookQueueRepository::class, $webhookQueueRepository);
 
         $webhook = $this->createWebhook();
 

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
@@ -46,7 +46,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->em->clear();
 
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -107,7 +107,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->em->clear();
 
         $restrictedUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'restricted.user']);
-        \assert($restrictedUser instanceof User);
+        $this->assertInstanceOf(User::class, $restrictedUser);
         $this->loginUser($restrictedUser);
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -168,7 +168,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
 
         // Test 1: newOwner (current owner) SHOULD see the company
         $newOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'new.owner']);
-        \assert($newOwner instanceof User);
+        $this->assertInstanceOf(User::class, $newOwner);
         $this->loginUser($newOwner);
         $this->client->setServerParameter('PHP_AUTH_USER', $newOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -188,7 +188,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
 
         // Test 2: originalOwner (creator but no longer owner) should NOT see the company
         $originalOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'original.owner']);
-        \assert($originalOwner instanceof User);
+        $this->assertInstanceOf(User::class, $originalOwner);
         $this->loginUser($originalOwner);
         $this->client->setServerParameter('PHP_AUTH_USER', $originalOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -44,7 +44,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->em->clear();
 
         $attacker = $this->em->getRepository(User::class)->findOneBy(['username' => 'attacker.user']);
-        \assert($attacker instanceof User);
+        $this->assertInstanceOf(User::class, $attacker);
         $this->client->getCookieJar()->clear();
         $this->client->setServerParameter('PHP_AUTH_USER', $attacker->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -105,7 +105,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->em->clear();
 
         $attacker = $this->em->getRepository(User::class)->findOneBy(['username' => 'attacker.collection.user']);
-        \assert($attacker instanceof User);
+        $this->assertInstanceOf(User::class, $attacker);
 
         $this->client->getCookieJar()->clear();
         $this->client->setServerParameter('PHP_AUTH_USER', $attacker->getUserIdentifier());
@@ -335,7 +335,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
 
         // Test 1: newOwner (current owner) SHOULD see the contact
         $newOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'new.contact.owner']);
-        \assert($newOwner instanceof User);
+        $this->assertInstanceOf(User::class, $newOwner);
         $this->loginUser($newOwner);
         $this->client->setServerParameter('PHP_AUTH_USER', $newOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
@@ -355,7 +355,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
 
         // Test 2: originalOwner (creator but no longer owner) should NOT see the contact
         $originalOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'original.contact.owner']);
-        \assert($originalOwner instanceof User);
+        $this->assertInstanceOf(User::class, $originalOwner);
         $this->loginUser($originalOwner);
         $this->client->setServerParameter('PHP_AUTH_USER', $originalOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/OwnershipScopedApiAuthorizationTestBase.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/OwnershipScopedApiAuthorizationTestBase.php
@@ -33,7 +33,7 @@ abstract class OwnershipScopedApiAuthorizationTestBase extends MauticMysqlTestCa
         $user->setRole($role);
 
         $hasher = static::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash($password));
 
         $this->em->persist($role);

--- a/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
@@ -34,7 +34,7 @@ class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $kernel = static::getContainer()->get('kernel');
-        \assert($kernel instanceof KernelInterface);
+        $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;
         $customFieldNotification = self::createMock(CustomFieldNotification::class);
@@ -88,7 +88,7 @@ class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $kernel = static::getContainer()->get('kernel');
-        \assert($kernel instanceof KernelInterface);
+        $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;
         $customFieldNotification = self::createMock(CustomFieldNotification::class);

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -61,7 +61,7 @@ class CompanyControllerTest extends MauticMysqlTestCase
         $user->setUsername(self::USERNAME);
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
@@ -270,7 +270,7 @@ class ImportControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->assertSelectorExists('.alert.alert-danger a.text-danger');
         $translator = self::getContainer()->get('translator');
-        \assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $this->assertSelectorTextContains(
             '.alert.alert-danger a.text-danger',

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -178,7 +178,7 @@ class LeadControllerTest extends MauticMysqlTestCase
         $user->setUsername(self::USERNAME);
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
@@ -85,7 +85,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
     public function testSMimeWithEncryptedPrivateKey(): void
     {
         $encryptionHelper = self::getContainer()->get('mautic.helper.encryption');
-        \assert($encryptionHelper instanceof EncryptionHelper);
+        $this->assertInstanceOf(EncryptionHelper::class, $encryptionHelper);
 
         $certPath       = $this->sMimeHelper->getSMimeCertificatePath();
         $privateKeyPath = $certPath.'/admin@test-beta.mautibot.com.pem';
@@ -212,7 +212,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
         Assert::assertCount(1, $messages, 'Expected exactly one email message to be sent');
         $rawMessage = $messages[0];
         Assert::assertInstanceOf(\Symfony\Component\Mime\Message::class, $rawMessage);
-        \assert($rawMessage instanceof \Symfony\Component\Mime\Message);
+        $this->assertInstanceOf(\Symfony\Component\Mime\Message::class, $rawMessage);
 
         // For signed messages, use toString() instead of getBody()
         $email   = $rawMessage->toString();

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
@@ -41,7 +41,7 @@ class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
         $leadMergeEvent = new LeadMergeEvent($contactB, $contactA);
 
         $subscriber = self::getContainer()->get(LeadSubscriber::class);
-        \assert($subscriber instanceof LeadSubscriber);
+        $this->assertInstanceOf(LeadSubscriber::class, $subscriber);
 
         $subscriber->onLeadMerge($leadMergeEvent);
 

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -104,7 +104,7 @@ class SegmentSubscriberTest extends MauticMysqlTestCase
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segmentId]);
 
         $listModel = $this->getContainer()->get('mautic.lead.model.list');
-        \assert($listModel instanceof ListModel);
+        $this->assertInstanceOf(ListModel::class, $listModel);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentId);
         self::assertSame(5, $leadCount);
@@ -128,7 +128,7 @@ class SegmentSubscriberTest extends MauticMysqlTestCase
     {
         // Add 5 contacts
         $contactRepo = $this->em->getRepository(Lead::class);
-        \assert($contactRepo instanceof LeadRepository);
+        $this->assertInstanceOf(LeadRepository::class, $contactRepo);
 
         $contacts = [];
 
@@ -149,7 +149,7 @@ class SegmentSubscriberTest extends MauticMysqlTestCase
     private function saveSegment(string $name, string $alias, array $filters): LeadList
     {
         $segmentRepo = $this->em->getRepository(LeadList::class);
-        \assert($segmentRepo instanceof LeadListRepository);
+        $this->assertInstanceOf(LeadListRepository::class, $segmentRepo);
         $segment     = new LeadList();
         $segment->setName($name)
             ->setPublicName($name)

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
@@ -42,7 +42,7 @@ final class FieldModelDeleteTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $leadFieldRepository = $this->em->getRepository(LeadField::class);
-        \assert($leadFieldRepository instanceof LeadFieldRepository);
+        $this->assertInstanceOf(LeadFieldRepository::class, $leadFieldRepository);
 
         Assert::assertCount(1, $leadFieldRepository->findBy(['alias' => 'test_lead_field']));
         Assert::assertTrue($this->columnExists('leads', 'test_lead_field'));

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
@@ -250,7 +250,7 @@ class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
     public function testSegmentRebuildCommandFailsOnMissingTable(): void
     {
         $segment = $this->fixtures->getReference('table-name-missing-in-filter');
-        \assert($segment instanceof LeadList);
+        $this->assertInstanceOf(LeadList::class, $segment);
 
         $this->expectException(TableNotFoundException::class);
         $this->contactSegmentService->getTotalLeadListLeadsCount($segment);
@@ -259,7 +259,7 @@ class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
     public function testGetNewLeadListLeadsWithLeadIdsLimiter(): void
     {
         $segment = $this->fixtures->getReference('segment-having-company');
-        \assert($segment instanceof LeadList);
+        $this->assertInstanceOf(LeadList::class, $segment);
 
         $this->connection->delete(MAUTIC_TABLE_PREFIX.'lead_lists_leads', ['leadlist_id' => $segment->getId()]);
 

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -19,10 +19,10 @@ class EmailAddressValidatorTest extends AbstractMauticTestCase
     {
         /** @var EmailAddressValidator $emailAddressValidator */
         $emailAddressValidator = static::getContainer()->get('mautic.validator.emailaddress');
-        \assert($emailAddressValidator instanceof EmailAddressValidator);
+        $this->assertInstanceOf(EmailAddressValidator::class, $emailAddressValidator);
 
         $translator = static::getContainer()->get('translator');
-        \assert($translator instanceof TranslatorInterface);
+        $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $context = new ExecutionContext($this->createMock(ValidatorInterface::class), null, $translator);
 

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
@@ -63,7 +63,7 @@ class NotificationTypeTest extends TypeTestCase
         Assert::assertTrue($form->isSynchronized());
 
         $formData = $form->getData();
-        \assert($formData instanceof Notification);
+        $this->assertInstanceOf(Notification::class, $formData);
 
         $expected->setChanges($formData->getChanges());
         Assert::assertEquals($expected, $formData);
@@ -75,7 +75,7 @@ class NotificationTypeTest extends TypeTestCase
         $errorCount    = 0;
         foreach ($view->children as $fieldName => $child) {
             $errors = $view->children[$fieldName]->vars['errors'];
-            \assert($errors instanceof FormErrorIterator);
+            $this->assertInstanceOf(FormErrorIterator::class, $errors);
 
             if (in_array($fieldName, $invalidFields, true)) {
                 ++$errorCount;
@@ -117,7 +117,7 @@ class NotificationTypeTest extends TypeTestCase
         Assert::assertTrue($form->isSynchronized());
 
         $formData = $form->getData();
-        \assert($formData instanceof Notification);
+        $this->assertInstanceOf(Notification::class, $formData);
 
         $expected->setChanges($formData->getChanges());
         Assert::assertEquals($expected, $formData);
@@ -127,7 +127,7 @@ class NotificationTypeTest extends TypeTestCase
         $view = $form->createView();
         foreach ($view->children as $fieldName => $child) {
             $errors = $view->children[$fieldName]->vars['errors'];
-            \assert($errors instanceof FormErrorIterator);
+            $this->assertInstanceOf(FormErrorIterator::class, $errors);
             self::assertCount(0, $errors);
         }
 

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -74,7 +74,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, sprintf('/r/%s', $redirect->getRedirectId()));
 
         $response = $this->client->getResponse();
-        \assert($response instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
         Assert::assertSame($url, $response->getTargetUrl());
     }
@@ -121,7 +121,7 @@ class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct));
 
         $response = $this->client->getResponse();
-        \assert($response instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
         Assert::assertSame($url, $response->getTargetUrl(), 'The dots in the query part must be preserved.');
 

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -69,7 +69,7 @@ class BuilderSubscriberTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $mailHashHelper = static::getContainer()->get(MailHashHelper::class);
-        \assert($mailHashHelper instanceof MailHashHelper);
+        $this->assertInstanceOf(MailHashHelper::class, $mailHashHelper);
 
         $unsubscribeUrl = $this->router->generate('mautic_email_unsubscribe', [
             'idHash'     => $emailStat->getTrackingHash(),

--- a/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
@@ -256,7 +256,7 @@ class IntegrationsListTypeTest extends TestCase
 
         $callsBuilder = 0;
         $builder      = $this->createMock(FormBuilderInterface::class);
-        \assert($builder instanceof FormBuilderInterface);
+        \PHPUnit\Framework\Assert::assertInstanceOf(FormBuilderInterface::class, $builder);
         $builder->method('add')
             ->willReturnCallback(static function (string $key, string $fieldFQCN, array $options) use ($pluginName, &$callsBuilder, $builder): FormBuilderInterface {
                 if ('integration' === $key) {

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -64,7 +64,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     public function testCreatingDuplicateProject(): void
     {
         $projectModel = self::getContainer()->get('mautic.project.model.project');
-        \assert($projectModel instanceof ProjectModel);
+        $this->assertInstanceOf(ProjectModel::class, $projectModel);
 
         $this->assertCount(
             0,
@@ -124,7 +124,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     public function testProjectNamesAreEscapedInAjaxResponse(string $xssPayload, string $dangerousSubstring): void
     {
         $projectModel = self::getContainer()->get('mautic.project.model.project');
-        \assert($projectModel instanceof ProjectModel);
+        $this->assertInstanceOf(ProjectModel::class, $projectModel);
 
         // Create a project with an XSS payload in the name
         $project = new Project();
@@ -226,7 +226,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     public function testProjectNamesWithSpecialCharactersAreEscapedAndFunctional(string $projectName): void
     {
         $projectModel = self::getContainer()->get('mautic.project.model.project');
-        \assert($projectModel instanceof ProjectModel);
+        $this->assertInstanceOf(ProjectModel::class, $projectModel);
 
         // Create a project with special characters
         $project = new Project();

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
@@ -222,7 +222,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
         $user->setUsername(self::USERNAME);
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('mautic'));
         $user->setRole($role);
 

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -94,7 +94,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         // Set new permissions
         $role->setIsAdmin(false);
         $roleModel = static::getContainer()->get('mautic.user.model.role');
-        \assert($roleModel instanceof RoleModel);
+        $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);
         $this->em->flush();
@@ -110,7 +110,7 @@ class ReportApiControllerTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash($password));
         $user->setRole($role);
 

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -508,7 +508,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         self::assertResponseIsSuccessful();
 
         $schedulerRepository = self::getContainer()->get(SchedulerRepository::class);
-        \assert($schedulerRepository instanceof SchedulerRepository);
+        $this->assertInstanceOf(SchedulerRepository::class, $schedulerRepository);
         $scheduler = $schedulerRepository->getSchedulerByReport($report);
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/config/edit');
@@ -536,7 +536,7 @@ class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->testSymfonyCommand('mautic:reports:scheduler');
 
         $reportFileWriter = self::getContainer()->get(ReportFileWriter::class);
-        \assert($reportFileWriter instanceof ReportFileWriter);
+        $this->assertInstanceOf(ReportFileWriter::class, $reportFileWriter);
 
         $csvPath = $reportFileWriter->getFilePath($scheduler);
         self::assertFileExists($csvPath);

--- a/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
@@ -29,10 +29,10 @@ final class SmsSubscriberTokenTest extends MauticMysqlTestCase
     {
         $transport = $this->configureTwilioWithArrayTransport();
         $smsModel  = $this->getContainer()->get('mautic.sms.model.sms');
-        \assert($smsModel instanceof SmsModel);
+        $this->assertInstanceOf(SmsModel::class, $smsModel);
 
         $contactModel = $this->getContainer()->get('mautic.lead.model.lead');
-        \assert($contactModel instanceof LeadModel);
+        $this->assertInstanceOf(LeadModel::class, $contactModel);
 
         $page = new Page();
         $page->setTitle('Test Page');

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
@@ -19,12 +19,12 @@ final class TwilioConfigurationFunctionalTest extends MauticMysqlTestCase
         $this->configureTwilioWithArrayTransport();
 
         $integration = $this->getContainer()->get('mautic.integration.twilio');
-        \assert($integration instanceof TwilioIntegration);
+        $this->assertInstanceOf(TwilioIntegration::class, $integration);
 
         $integrationRepository = $this->em->getRepository(Integration::class);
 
         $integrationConfig = $integrationRepository->findOneBy(['name' => $integration->getName()]);
-        \assert($integrationConfig instanceof Integration);
+        $this->assertInstanceOf(Integration::class, $integrationConfig);
         Assert::assertSame('messaging_sid', $integrationConfig->getFeatureSettings()['messaging_service_sid']);
     }
 }

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -183,7 +183,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash($password));
         $user->setRole($role);
         $this->em->persist($user);
@@ -243,7 +243,7 @@ class UserApiControllerFunctionalTest extends MauticMysqlTestCase
 
             // Verify the password was hashed correctly by checking if we can verify it
             $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-            \assert($hasher instanceof PasswordHasherInterface);
+            $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
             $this->assertTrue(
                 $hasher->verify($user->getPassword(), $userData['plainPassword']),
                 'Password should be properly hashed and verifiable'

--- a/app/bundles/UserBundle/Tests/Entity/UserTest.php
+++ b/app/bundles/UserBundle/Tests/Entity/UserTest.php
@@ -14,7 +14,7 @@ class UserTest extends \PHPUnit\Framework\TestCase
         $user->setCurrentPassword('currentPass');
 
         $user = unserialize(serialize($user));
-        \assert($user instanceof User);
+        $this->assertInstanceOf(User::class, $user);
 
         $this->assertSame('testUser', $user->getUsername());
         $this->assertNull($user->getPlainPassword());

--- a/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
@@ -103,7 +103,7 @@ class PublicControllerTest extends MauticMysqlTestCase
     public function testInviteShowsErrorWhenInvitedEmailAlreadyExists(): void
     {
         $user = $this->em->getRepository(User::class)->find(1);
-        \assert($user instanceof User);
+        $this->assertInstanceOf(User::class, $user);
 
         [, $token] = $this->createInvite($user->getEmail(), 'existing-user-invite-token');
 

--- a/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
@@ -27,7 +27,7 @@ class UserLogoutFunctionalTest extends MauticMysqlTestCase
         $user->setEmail('john.doe@email.com');
         $user->setRole($role);
         $hasher = static::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $this->em->persist($user);
 

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
@@ -93,16 +93,16 @@ class PluginAuthenticatorTest extends TestCase
         );
 
         $authenticateResult = $authenticateResult->authenticate($request);
-        \assert($authenticateResult instanceof SelfValidatingPassport);
+        $this->assertInstanceOf(SelfValidatingPassport::class, $authenticateResult);
         self::assertCount(2, $authenticateResult->getBadges());
 
         $userBadge = $authenticateResult->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($userIdentifier, $userBadge->getUserIdentifier());
         self::assertSame($authenticatedUser, $userBadge->getUser());
 
         $pluginBadge = $authenticateResult->getBadge(PluginBadge::class);
-        \assert($pluginBadge instanceof PluginBadge);
+        $this->assertInstanceOf(PluginBadge::class, $pluginBadge);
         self::assertSame($returnedPluginToken, $pluginBadge->getPreAuthenticatedToken());
         self::assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
     }
@@ -168,16 +168,15 @@ class PluginAuthenticatorTest extends TestCase
         );
 
         $authenticateResult = $pluginAuthenticator->authenticate($request);
-        \assert($authenticateResult instanceof SelfValidatingPassport);
         self::assertCount(2, $authenticateResult->getBadges());
 
         $userBadge = $authenticateResult->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        \PHPUnit\Framework\Assert::assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($userIdentifier, $userBadge->getUserIdentifier());
         self::assertSame($authenticatedUser, $userBadge->getUser());
 
         $pluginBadge = $authenticateResult->getBadge(PluginBadge::class);
-        \assert($pluginBadge instanceof PluginBadge);
+        \PHPUnit\Framework\Assert::assertInstanceOf(PluginBadge::class, $pluginBadge);
         self::assertEquals(new PluginToken($firewallName, $integration, $authenticatedUser), $pluginBadge->getPreAuthenticatedToken());
         self::assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
     }

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
@@ -254,11 +254,11 @@ class SsoAuthenticatorTest extends TestCase
         self::assertCount($enableCsrf ? 4 : 3, $badges);
 
         $userBadge = $passport->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($username, $userBadge->getUserIdentifier());
 
         $passwordBadge = $passport->getBadge(PasswordCredentials::class);
-        \assert($passwordBadge instanceof PasswordCredentials);
+        $this->assertInstanceOf(PasswordCredentials::class, $passwordBadge);
         self::assertSame($password, $passwordBadge->getPassword());
 
         self::assertTrue($passport->hasBadge(RememberMeBadge::class));
@@ -274,7 +274,7 @@ class SsoAuthenticatorTest extends TestCase
         }
 
         $csrfTokenBadge = $passport->getBadge(CsrfTokenBadge::class);
-        \assert($csrfTokenBadge instanceof CsrfTokenBadge);
+        $this->assertInstanceOf(CsrfTokenBadge::class, $csrfTokenBadge);
         self::assertSame($csrfToken, $csrfTokenBadge->getCsrfToken());
         self::assertSame('authenticate', $csrfTokenBadge->getCsrfTokenId());
     }
@@ -339,7 +339,7 @@ class SsoAuthenticatorTest extends TestCase
         $passport = $authenticator->authenticate($request);
 
         $userBadge = $passport->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($username, $userBadge->getUserIdentifier());
 
         $this->expectException(UserNotFoundException::class);
@@ -405,7 +405,7 @@ class SsoAuthenticatorTest extends TestCase
         $passport = $authenticator->authenticate($request);
 
         $userBadge = $passport->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($username, $userBadge->getUserIdentifier());
         self::assertSame($user, $userBadge->getUser());
     }
@@ -496,7 +496,7 @@ class SsoAuthenticatorTest extends TestCase
         $passport = $authenticator->authenticate($request);
 
         $userBadge = $passport->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($username, $userBadge->getUserIdentifier());
 
         $this->expectException(AuthenticationException::class);
@@ -585,7 +585,7 @@ class SsoAuthenticatorTest extends TestCase
         $passport = $authenticator->authenticate($request);
 
         $userBadge = $passport->getBadge(UserBadge::class);
-        \assert($userBadge instanceof UserBadge);
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
         self::assertSame($username, $userBadge->getUserIdentifier());
 
         self::assertSame($user, $userBadge->getUser());

--- a/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
@@ -73,7 +73,7 @@ class WebhookFunctionalTest extends MauticMysqlTestCase
     public function testWebhookWorkflowWithCommandProcess(): void
     {
         $webhookQueueRepository = $this->em->getRepository(WebhookQueue::class);
-        \assert($webhookQueueRepository instanceof WebhookQueueRepository);
+        $this->assertInstanceOf(WebhookQueueRepository::class, $webhookQueueRepository);
         $this->mockSuccessfulWebhookResponse(2);
         $webhook = $this->createWebhook();
         // Ensure we have a clean slate. There should be no rows waiting to be processed at this point.

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -89,7 +89,7 @@ class MonitoringControllerTest extends MauticMysqlTestCase
         $user->setUsername(self::USERNAME);
         $user->setEmail('john.doe@email.com');
         $hasher = self::getContainer()->get('security.password_hasher_factory')->getPasswordHasher($user);
-        \assert($hasher instanceof PasswordHasherInterface);
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $user->setRole($role);
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -80,12 +80,12 @@ class TagControllerTest extends MauticMysqlTestCase
     public function testIndexActionWhenFilteredByDescription(): void
     {
         $matchingTag = $this->tagRepository->findOneBy(['tag' => 'tag1']);
-        \assert($matchingTag instanceof Tag);
+        $this->assertInstanceOf(Tag::class, $matchingTag);
         $matchingTag->setDescription('Contains the test keyword.');
         $this->tagRepository->saveEntity($matchingTag, false);
 
         $otherTag = $this->tagRepository->findOneBy(['tag' => 'tag2']);
-        \assert($otherTag instanceof Tag);
+        $this->assertInstanceOf(Tag::class, $otherTag);
         $otherTag->setDescription('No related content.');
         $this->tagRepository->saveEntity($otherTag);
 
@@ -109,7 +109,7 @@ class TagControllerTest extends MauticMysqlTestCase
     public function testTagDeletionRemovesContactAssociations(): void
     {
         $tag = $this->tagRepository->findOneBy([]);
-        \assert($tag instanceof Tag);
+        $this->assertInstanceOf(Tag::class, $tag);
 
         $contact = new Lead();
         $contact->setEmail('tagged-contact@example.com');
@@ -372,8 +372,8 @@ class TagControllerTest extends MauticMysqlTestCase
     {
         $primaryTag   = $this->tagRepository->findOneBy(['tag' => 'tag1']);
         $secondaryTag = $this->tagRepository->findOneBy(['tag' => 'tag2']);
-        \assert($primaryTag instanceof Tag);
-        \assert($secondaryTag instanceof Tag);
+        $this->assertInstanceOf(Tag::class, $primaryTag);
+        $this->assertInstanceOf(Tag::class, $secondaryTag);
 
         $primaryTagId     = (int) $primaryTag->getId();
         $secondaryTagId   = (int) $secondaryTag->getId();
@@ -399,29 +399,29 @@ class TagControllerTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $campaignChangeEvent = $this->em->find(Event::class, $campaignChangeEventId);
-        \assert($campaignChangeEvent instanceof Event);
+        $this->assertInstanceOf(Event::class, $campaignChangeEvent);
         Assert::assertSame([$primaryTagName], $campaignChangeEvent->getProperties()['add_tags']);
         Assert::assertSame([$primaryTagId], $campaignChangeEvent->getProperties()['properties']['add_tags']);
 
         $campaignTagCondition = $this->em->find(Event::class, $campaignConditionId);
-        \assert($campaignTagCondition instanceof Event);
+        $this->assertInstanceOf(Event::class, $campaignTagCondition);
         Assert::assertSame([$primaryTagName], $campaignTagCondition->getProperties()['tags']);
         Assert::assertSame([$primaryTagId], $campaignTagCondition->getProperties()['properties']['tags']);
 
         $segment = $this->em->find(LeadList::class, $segmentId);
-        \assert($segment instanceof LeadList);
+        $this->assertInstanceOf(LeadList::class, $segment);
         Assert::assertSame([$primaryTagId], $segment->getFilters()[0]['properties']['filter']);
 
         $formAction = $this->em->find(Action::class, $formActionId);
-        \assert($formAction instanceof Action);
+        $this->assertInstanceOf(Action::class, $formAction);
         Assert::assertSame([$primaryTagName], $formAction->getProperties()['add_tags']);
 
         $pointTriggerEvent = $this->em->find(TriggerEvent::class, $pointTriggerEventId);
-        \assert($pointTriggerEvent instanceof TriggerEvent);
+        $this->assertInstanceOf(TriggerEvent::class, $pointTriggerEvent);
         Assert::assertSame([$primaryTagName], $pointTriggerEvent->getProperties()['add_tags']);
 
         $report = $this->em->find(Report::class, $reportId);
-        \assert($report instanceof Report);
+        $this->assertInstanceOf(Report::class, $report);
         Assert::assertSame([$primaryTagId], $report->getFilters()[0]['value']);
         Assert::assertNull($this->tagRepository->find($secondaryTagId));
     }


### PR DESCRIPTION
This way PHPUnit clearly reports if something goes wrong :+1: 