### PR TITLE
[pre phpunit 11]  remove parent __construct() in test case, use no assertion exected, restore error handler where reported

### DIFF
--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -93,6 +93,16 @@ abstract class AbstractMauticTestCase extends WebTestCase
         $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // The kernel boot registers an exception handler that is not removed on shutdown.
+        // PHPUnit 11.5 fails the test if a leaked handler remains on the stack.
+        // @see https://github.com/sebastianbergmann/phpunit/issues/5721
+        restore_exception_handler();
+    }
+
     protected function setUpSymfony(array $defaultConfigOptions = []): void
     {
         putenv('MAUTIC_CONFIG_PARAMETERS='.json_encode($defaultConfigOptions));

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -26,20 +26,15 @@ abstract class MauticMysqlTestCase extends AbstractMauticTestCase
      */
     protected $useCleanupRollback = true;
 
-    public function __construct(?string $name = null)
-    {
-        parent::__construct($name);
-
-        $this->configParams += [
-            'db_driver' => 'pdo_mysql',
-        ];
-    }
-
     /**
      * @throws \Exception
      */
     protected function setUp(): void
     {
+        $this->configParams += [
+            'db_driver' => 'pdo_mysql',
+        ];
+
         $this->setUpInvoked = true;
 
         parent::setUp();

--- a/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
@@ -41,4 +41,14 @@ class RememberMeTest extends TestCase
 
         $this->assertSame($v1, $v2);
     }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // The kernel boot registers an exception handler that is not removed on shutdown.
+        // PHPUnit 11.5 fails the test if a leaked handler remains on the stack.
+        // @see https://github.com/sebastianbergmann/phpunit/issues/5721
+        restore_exception_handler();
+    }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/AbstractStepTestCase.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/AbstractStepTestCase.php
@@ -40,4 +40,14 @@ abstract class AbstractStepTestCase extends TestCase
 
         $this->progressBar = new ProgressBar($this->output);
     }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // The kernel boot registers an exception handler that is not removed on shutdown.
+        // PHPUnit 11.5 fails the test if a leaked handler remains on the stack.
+        // @see https://github.com/sebastianbergmann/phpunit/issues/5721
+        restore_exception_handler();
+    }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -5,6 +5,7 @@ namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand as MigrateCommand;
 use Mautic\CoreBundle\Exception\UpdateFailedException;
 use Mautic\CoreBundle\Update\Step\UpdateSchemaStep;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleEvent;
@@ -134,6 +135,7 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
         $this->step->execute($this->progressBar, $this->input, $this->output);
     }
 
+    #[DoesNotPerformAssertions]
     public function testExceptionNotThrownIfMigrationsWereSuccessful(): void
     {
         $this->migrateCommand->method('run')
@@ -156,11 +158,6 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
             ->method('trans')
             ->willReturn('');
 
-        try {
-            $this->step->execute($this->progressBar, $this->input, $this->output);
-            $this->expectNotToPerformAssertions();
-        } catch (UpdateFailedException) {
-            $this->fail('UpdateFailedException should not have been thrown');
-        }
+        $this->step->execute($this->progressBar, $this->input, $this->output);
     }
 }

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -25,6 +25,16 @@ class ConfigFormTest extends KernelTestCase
         self::bootKernel();
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // The kernel boot registers an exception handler that is not removed on shutdown.
+        // PHPUnit 11.5 fails the test if a leaked handler remains on the stack.
+        // @see https://github.com/sebastianbergmann/phpunit/issues/5721
+        restore_exception_handler();
+    }
+
     public function testConfigForm(): void
     {
         $plugins = $this->getIntegrationObject()->getIntegrationObjects();


### PR DESCRIPTION
Split off https://github.com/mautic/mautic/pull/16393