### PR TITLE
[tests] inline setUp properties used just once

### DIFF
--- a/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
@@ -20,11 +20,6 @@ class ApiSubscriberTest extends CommonMocks
     private MockObject $coreParametersHelper;
 
     /**
-     * @var Translator&MockObject
-     */
-    private MockObject $translator;
-
-    /**
      * @var Request&MockObject
      */
     private MockObject $request;
@@ -41,13 +36,13 @@ class ApiSubscriberTest extends CommonMocks
         parent::setUp();
 
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->translator           = $this->createMock(Translator::class);
+        $translator                 = $this->createMock(Translator::class);
         $this->request              = $this->createMock(Request::class);
         $this->request->headers     = new HeaderBag();
         $this->event                = $this->createMock(RequestEvent::class);
         $this->subscriber           = new ApiSubscriber(
             $this->coreParametersHelper,
-            $this->translator
+            $translator
         );
     }
 

--- a/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
+++ b/app/bundles/ApiBundle/Tests/Form/Type/ClientTypeTest.php
@@ -22,60 +22,35 @@ class ClientTypeTest extends TestCase
     private ClientType $clientType;
 
     /**
-     * @var MockObject&RequestStack
-     */
-    private MockObject $requestStack;
-
-    /**
-     * @var MockObject&TranslatorInterface
-     */
-    private MockObject $translator;
-
-    /**
-     * @var MockObject&ValidatorInterface
-     */
-    private MockObject $validator;
-
-    /**
-     * @var MockObject&RouterInterface
-     */
-    private MockObject $router;
-
-    /**
      * @var MockObject&FormBuilderInterface
      */
     private MockObject $builder;
-
-    /**
-     * @var MockObject&Request
-     */
-    private MockObject $request;
 
     private Client $client;
 
     protected function setUp(): void
     {
-        $this->requestStack = $this->createMock(RequestStack::class);
-        $this->translator   = $this->createMock(TranslatorInterface::class);
-        $this->validator    = $this->createMock(ValidatorInterface::class);
-        $this->router       = $this->createMock(RouterInterface::class);
+        $requestStack       = $this->createMock(RequestStack::class);
+        $translator         = $this->createMock(TranslatorInterface::class);
+        $validator          = $this->createMock(ValidatorInterface::class);
+        $router             = $this->createMock(RouterInterface::class);
         $this->builder      = $this->createMock(FormBuilderInterface::class);
-        $this->request      = $this->createMock(Request::class);
+        $request            = $this->createMock(Request::class);
         $this->client       = new Client();
 
-        $this->requestStack->expects($this->once())
+        $requestStack->expects($this->once())
             ->method('getCurrentRequest')
-            ->willReturn($this->request);
+            ->willReturn($request);
 
-        $this->request->expects($this->once())
+        $request->expects($this->once())
             ->method('get')
             ->with('api_mode', null);
 
         $this->clientType = new ClientType(
-            $this->requestStack,
-            $this->translator,
-            $this->validator,
-            $this->router
+            $requestStack,
+            $translator,
+            $validator,
+            $router
         );
     }
 

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -40,10 +40,6 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
 
     private CoreParametersHelper&MockObject $coreParametersHelper;
 
-    private ContainerInterface&MockObject $container;
-
-    private CacheProvider $cacheProvider;
-
     private LeadModel&MockObject $leadModel;
 
     private CategoryModel&MockObject $categoryModel;
@@ -83,13 +79,13 @@ class AssetModelTest extends \PHPUnit\Framework\TestCase
             ->with($this->equalTo('max_size'))
             ->willReturn('2MB');
 
-        $this->container             = $this->createMock(ContainerInterface::class);
-        $this->cacheProvider         = new CacheProvider($this->coreParametersHelper, $this->container);
+        $container                   = $this->createMock(ContainerInterface::class);
+        $cacheProvider               = new CacheProvider($this->coreParametersHelper, $container);
         $this->leadModel             = $this->createMock(LeadModel::class);
         $this->categoryModel         = $this->createMock(CategoryModel::class);
         $this->requestStack          = $this->createMock(RequestStack::class);
         $this->ipLookupHelper        = $this->createMock(IpLookupHelper::class);
-        $this->deviceDetectorFactory = new DeviceDetectorFactory($this->cacheProvider);
+        $this->deviceDetectorFactory = new DeviceDetectorFactory($cacheProvider);
         $this->deviceCreatorService  = new DeviceCreatorService();
         $this->deviceTrackingService = $this->createMock(DeviceTrackingServiceInterface::class);
         $this->contactTracker        = $this->createMock(ContactTracker::class);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
@@ -19,22 +19,19 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 
 class CampaignMapStatsControllerTest extends MauticMysqlTestCase
 {
-    private MockObject $campaignModelMock;
-
     private CampaignMapStatsController $mapController;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->campaignModelMock       = $this->createMock(CampaignModel::class);
-        $this->mapController           = new CampaignMapStatsController($this->campaignModelMock);
+        $campaignModelMock             = $this->createMock(CampaignModel::class);
+        $this->mapController           = new CampaignMapStatsController($campaignModelMock);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -37,15 +37,13 @@ class CampaignEventSubscriberTest extends TestCase
 
     private MockObject $eventDispatcherMock;
 
-    private DateHelper $dateHelper;
-
     protected function setUp(): void
     {
         $this->eventRepo                  = $this->createMock(EventRepository::class);
         $this->campaignModelMock          = $this->createMock(CampaignModel::class);
         $this->leadEventLogRepositoryMock = $this->createMock(LeadEventLogRepository::class);
         $this->eventDispatcherMock        = $this->createMock(EventDispatcherInterface::class);
-        $this->dateHelper                 = new DateHelper(
+        $dateHelper                       = new DateHelper(
             'F j, Y g:i a T',
             'D, M d',
             'F j, Y',
@@ -58,7 +56,7 @@ class CampaignEventSubscriberTest extends TestCase
             $this->campaignModelMock,
             $this->leadEventLogRepositoryMock,
             $this->eventDispatcherMock,
-            $this->dateHelper
+            $dateHelper
         );
     }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -37,8 +37,6 @@ class RealTimeExecutionerTest extends TestCase
 
     private MockObject&ContactTracker $contactTracker;
 
-    private MockObject&LeadRepository $leadRepository;
-
     private DecisionHelper $decisionHelper;
 
     private EventRedirectionHelper&MockObject $redirectionHelper;
@@ -59,9 +57,9 @@ class RealTimeExecutionerTest extends TestCase
 
         $this->contactTracker = $this->createMock(ContactTracker::class);
 
-        $this->leadRepository = $this->createMock(LeadRepository::class);
+        $leadRepository = $this->createMock(LeadRepository::class);
 
-        $this->decisionHelper    = new DecisionHelper($this->leadRepository);
+        $this->decisionHelper    = new DecisionHelper($leadRepository);
         $this->redirectionHelper = $this->createMock(EventRedirectionHelper::class);
 
         // Configure the redirection helper mock to return the event it receives

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -50,16 +50,6 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $dispatcher;
 
-    /**
-     * @var CoreParametersHelper|MockObject
-     */
-    private MockObject $coreParamtersHelper;
-
-    /**
-     * @var PeakInteractionTimer|MockObject
-     */
-    private MockObject $peakInteractionTimer;
-
     private EventScheduler $scheduler;
 
     /**
@@ -70,14 +60,14 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->logger              = new NullLogger();
-        $this->coreParamtersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->coreParamtersHelper->method('getDefaultTimezone')
+        $coreParamtersHelper       = $this->createMock(CoreParametersHelper::class);
+        $coreParamtersHelper->method('getDefaultTimezone')
             ->willReturn('America/New_York');
         $this->eventLogger                = $this->createMock(EventLogger::class);
-        $this->peakInteractionTimer       = $this->createMock(PeakInteractionTimer::class);
-        $this->intervalScheduler          = new Interval($this->logger, $this->coreParamtersHelper);
+        $peakInteractionTimer             = $this->createMock(PeakInteractionTimer::class);
+        $this->intervalScheduler          = new Interval($this->logger, $coreParamtersHelper);
         $this->dateTimeScheduler          = new DateTime($this->logger);
-        $this->optimizedScheduler         = new Optimized($this->peakInteractionTimer);
+        $this->optimizedScheduler         = new Optimized($peakInteractionTimer);
         $this->eventCollector             = $this->createMock(EventCollector::class);
         $this->dispatcher                 = $this->createMock(EventDispatcherInterface::class);
         $this->publishStateService        = $this->createMock(PublishStateService::class);
@@ -89,7 +79,7 @@ class EventSchedulerTest extends \PHPUnit\Framework\TestCase
             $this->optimizedScheduler,
             $this->eventCollector,
             $this->dispatcher,
-            $this->coreParamtersHelper,
+            $coreParamtersHelper,
             $this->createMock(OptimisticLockServiceInterface::class),
             $this->publishStateService
         );

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -12,7 +12,6 @@ use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,8 +29,6 @@ class CampaignRotationTest extends MauticMysqlTestCase
 
     private Lead $lead;
 
-    private ContactTracker $contactTracker;
-
     private LeadRepository $campaignLeadRepository;
 
     private LeadEventLogRepository $leadEventLogRepository;
@@ -47,7 +44,7 @@ class CampaignRotationTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->contactTracker         = static::getContainer()->get('mautic.tracker.contact');
+        $contactTracker               = static::getContainer()->get('mautic.tracker.contact');
         $this->campaignLeadRepository = static::getContainer()->get('mautic.campaign.repository.lead');
         $this->leadEventLogRepository = static::getContainer()->get('mautic.campaign.repository.lead_event_log');
 
@@ -64,7 +61,7 @@ class CampaignRotationTest extends MauticMysqlTestCase
         $flashBagMock->method('all')
             ->willReturn([]);
 
-        $this->contactTracker->setSystemContact($this->lead);
+        $contactTracker->setSystemContact($this->lead);
     }
 
     public function testTwoCampaignsWithPageHitEventsDoNotInterfereWithEachOthersRotation(): void

--- a/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
@@ -26,50 +26,33 @@ class InactiveHelperTest extends TestCase
     private MockObject $scheduler;
 
     /**
-     * @var InactiveContactFinder|MockObject
-     */
-    private MockObject $inactiveContactFinder;
-
-    /**
      * @var LeadEventLogRepository|MockObject
      */
     private MockObject $eventLogRepository;
-
-    /**
-     * @var EventRepository|MockObject
-     */
-    private MockObject $eventRepository;
 
     /**
      * @var LeadRepository|MockObject
      */
     private MockObject $leadRepository;
 
-    /**
-     * @var LoggerInterface|MockObject
-     */
-    private MockObject $logger;
-
     private InactiveHelper $inactiveHelper;
-
-    private DecisionHelper $decisionHelper;
 
     protected function setUp(): void
     {
         $this->scheduler             = $this->createMock(EventScheduler::class);
-        $this->inactiveContactFinder = $this->createMock(InactiveContactFinder::class);
+        $inactiveContactFinder       = $this->createMock(InactiveContactFinder::class);
         $this->eventLogRepository    = $this->createMock(LeadEventLogRepository::class);
-        $this->eventRepository       = $this->createMock(EventRepository::class);
+        $eventRepository             = $this->createMock(EventRepository::class);
         $this->leadRepository        = $this->createMock(LeadRepository::class);
-        $this->logger                = $this->createMock(LoggerInterface::class);
-        $this->decisionHelper        = new DecisionHelper($this->leadRepository);
+        $logger                      = $this->createMock(LoggerInterface::class);
+        $decisionHelper              = new DecisionHelper($this->leadRepository);
         $this->inactiveHelper        = new InactiveHelper(
             $this->scheduler,
-            $this->inactiveContactFinder,
+            $inactiveContactFinder,
             $this->eventLogRepository,
-            $this->eventRepository,
-            $this->logger,
-            $this->decisionHelper
+            $eventRepository,
+            $logger,
+            $decisionHelper
         );
     }
 

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
@@ -32,11 +32,6 @@ final class MembershipBuilderTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $leadRepository;
 
-    /**
-     * @var TranslatorInterface|MockObject
-     */
-    private MockObject $translator;
-
     private MembershipBuilder $membershipBuilder;
 
     protected function setUp(): void
@@ -44,12 +39,12 @@ final class MembershipBuilderTest extends \PHPUnit\Framework\TestCase
         $this->manager                  = $this->createMock(MembershipManager::class);
         $this->campaignMemberRepository = $this->createMock(CampaignMemberRepository::class);
         $this->leadRepository           = $this->createMock(LeadRepository::class);
-        $this->translator               = $this->createMock(TranslatorInterface::class);
+        $translator                     = $this->createMock(TranslatorInterface::class);
         $this->membershipBuilder        = new MembershipBuilder(
             $this->manager,
             $this->campaignMemberRepository,
             $this->leadRepository,
-            $this->translator
+            $translator
         );
     }
 

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -23,11 +23,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class EventModelTest extends TestCase
 {
     /**
+<<<<<<< HEAD
      * @var EntityManagerInterface|MockObject
      */
     private MockObject $entityManagerMock;
 
     /**
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var EventRepository|MockObject
      */
     private MockObject $eventRepositoryMock;
@@ -41,12 +44,12 @@ class EventModelTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->entityManagerMock   = $this->createMock(EntityManagerInterface::class);
+        $entityManagerMock         = $this->createMock(EntityManagerInterface::class);
         $this->eventRepositoryMock = $this->createMock(EventRepository::class);
         $this->dispatcherMock      = $this->createMock(EventDispatcherInterface::class);
 
         $this->eventModel          = new EventModel(
-            $this->entityManagerMock,
+            $entityManagerMock,
             $this->createMock(CorePermissions::class),
             $this->dispatcherMock,
             $this->createMock(UrlGeneratorInterface::class),
@@ -56,7 +59,7 @@ class EventModelTest extends TestCase
             $this->createMock(CoreParametersHelper::class)
         );
 
-        $this->entityManagerMock
+        $entityManagerMock
             ->method('getRepository')
             ->with(Event::class)
             ->willReturn($this->eventRepositoryMock);

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -23,15 +23,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class EventModelTest extends TestCase
 {
     /**
-<<<<<<< HEAD
-     * @var EntityManagerInterface|MockObject
-     */
-    private MockObject $entityManagerMock;
-
-    /**
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
-     * @var EventRepository|MockObject
+     * @var EventRepository&MockObject
      */
     private MockObject $eventRepositoryMock;
 

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -33,37 +33,13 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private EventDispatcher $dispatcher;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|MessageModel
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $messageModel;
-
-    private ActionDispatcher $eventDispatcher;
-
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|EventCollector
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $eventCollector;
-
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|Translator
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $translator;
-
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|EventScheduler
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $scheduler;
-
-    private LegacyEventDispatcher $legacyDispatcher;
-
     protected function setUp(): void
     {
         $this->dispatcher = new EventDispatcher();
 
-        $this->messageModel = $this->createMock(MessageModel::class);
+        $messageModel = $this->createMock(MessageModel::class);
 
-        $this->messageModel->method('getChannels')
+        $messageModel->method('getChannels')
             ->willReturn(
                 [
                     'email' => [
@@ -89,7 +65,7 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->messageModel->method('getMessageChannels')
+        $messageModel->method('getMessageChannels')
             ->willReturn(
                 [
                     'email' => [
@@ -107,28 +83,28 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->scheduler = $this->createMock(EventScheduler::class);
+        $scheduler = $this->createMock(EventScheduler::class);
 
         $contactTracker = $this->createMock(ContactTracker::class);
 
         /** @phpstan-ignore new.deprecated */
-        $this->legacyDispatcher = new LegacyEventDispatcher(
+        $legacyDispatcher = new LegacyEventDispatcher(
             $this->dispatcher,
-            $this->scheduler,
+            $scheduler,
             new NullLogger(),
             $contactTracker
         );
 
-        $this->eventDispatcher = new ActionDispatcher(
+        $eventDispatcher = new ActionDispatcher(
             $this->dispatcher,
             new NullLogger(),
-            $this->scheduler,
-            $this->legacyDispatcher
+            $scheduler,
+            $legacyDispatcher
         );
 
-        $this->eventCollector = $this->createMock(EventCollector::class);
+        $eventCollector = $this->createMock(EventCollector::class);
 
-        $this->eventCollector->method('getEventConfig')
+        $eventCollector->method('getEventConfig')
             ->willReturnCallback(
                 function (Event $event) {
                     switch ($event->getType()) {
@@ -164,14 +140,14 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $this->translator = $this->createMock(Translator::class);
+        $translator = $this->createMock(Translator::class);
 
         $campaignSubscriber = new CampaignSubscriber(
-            $this->messageModel,
-            $this->eventDispatcher,
-            $this->eventCollector,
+            $messageModel,
+            $eventDispatcher,
+            $eventCollector,
             new NullLogger(),
-            $this->translator
+            $translator
         );
 
         $this->dispatcher->addSubscriber($campaignSubscriber);

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -21,8 +21,6 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
 
     private \PHPUnit\Framework\MockObject\MockObject $doNotContactMock;
 
-    private \PHPUnit\Framework\MockObject\MockObject $translatorMock;
-
     private ChannelActionModel $actionModel;
 
     protected function setUp(): void
@@ -33,11 +31,11 @@ class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $this->contactMock6     = $this->createMock(Lead::class);
         $this->contactModelMock = $this->createMock(LeadModel::class);
         $this->doNotContactMock = $this->createMock(DoNotContact::class);
-        $this->translatorMock   = $this->createMock(TranslatorInterface::class);
+        $translatorMock         = $this->createMock(TranslatorInterface::class);
         $this->actionModel      = new ChannelActionModel(
             $this->contactModelMock,
             $this->doNotContactMock,
-            $this->translatorMock
+            $translatorMock
         );
 
         $this->contactMock5->method('getId')->willReturn(5);

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/CommonStatsSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/CommonStatsSubscriberTest.php
@@ -22,11 +22,6 @@ class CommonStatsSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $security;
 
     /**
-     * @var EntityManager|MockObject
-     */
-    private MockObject $entityManager;
-
-    /**
      * @var User|MockObject
      */
     private MockObject $user;
@@ -50,7 +45,7 @@ class CommonStatsSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
         $this->security      = $this->createMock(CorePermissions::class);
-        $this->entityManager = $this->createMock(EntityManager::class);
+        $entityManager       = $this->createMock(EntityManager::class);
         $this->user          = $this->createMock(User::class);
         $this->repository    = $this->createMock(CommonRepository::class);
         $this->statsEvent    = $this->createMock(StatsEvent::class);
@@ -58,7 +53,7 @@ class CommonStatsSubscriberTest extends \PHPUnit\Framework\TestCase
             ->setConstructorArgs(
                 [
                     $this->security,
-                    $this->entityManager,
+                    $entityManager,
                 ]
             )
             ->onlyMethods([])

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
@@ -16,16 +16,6 @@ use Psr\Log\LoggerInterface;
 class DoctrineGeneratedColumnsListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var GeneratedColumnsProviderInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $generatedColumnsProvider;
-
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $logger;
-
-    /**
      * @var GenerateSchemaEventArgs|\PHPUnit\Framework\MockObject\MockObject
      */
     private \PHPUnit\Framework\MockObject\MockObject $event;
@@ -46,19 +36,19 @@ class DoctrineGeneratedColumnsListenerTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->generatedColumnsProvider = $this->createMock(GeneratedColumnsProviderInterface::class);
-        $this->logger                   = $this->createMock(LoggerInterface::class);
+        $generatedColumnsProvider       = $this->createMock(GeneratedColumnsProviderInterface::class);
+        $logger                         = $this->createMock(LoggerInterface::class);
         $this->event                    = $this->createMock(GenerateSchemaEventArgs::class);
         $this->schema                   = $this->createMock(Schema::class);
         $this->table                    = $this->createMock(Table::class);
-        $this->listener                 = new DoctrineGeneratedColumnsListener($this->generatedColumnsProvider, $this->logger);
+        $this->listener                 = new DoctrineGeneratedColumnsListener($generatedColumnsProvider, $logger);
 
         $generatedColumn  = new GeneratedColumn('page_hits', 'generated_hit_date', 'DATE', 'not important');
         $generatedColumns = new GeneratedColumns();
 
         $generatedColumns->add($generatedColumn);
 
-        $this->generatedColumnsProvider->method('getGeneratedColumns')->willReturn($generatedColumns);
+        $generatedColumnsProvider->method('getGeneratedColumns')->willReturn($generatedColumns);
         $this->event->method('getSchema')->willReturn($this->schema);
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Factory/TransifexFactoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Factory/TransifexFactoryTest.php
@@ -15,11 +15,6 @@ use Psr\Http\Client\ClientInterface;
 class TransifexFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var ClientInterface&MockObject
-     */
-    private MockObject $client;
-
-    /**
      * @var CoreParametersHelper&MockObject
      */
     private MockObject $coreParametersHelper;
@@ -28,9 +23,9 @@ class TransifexFactoryTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->client               = $this->createMock(ClientInterface::class);
+        $client                     = $this->createMock(ClientInterface::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->transifexFactory     = new TransifexFactory($this->client, $this->coreParametersHelper);
+        $this->transifexFactory     = new TransifexFactory($client, $this->coreParametersHelper);
     }
 
     public function testCreatingTransifexWithoutCredentials(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -6,7 +6,6 @@ namespace Mautic\CoreBundle\Tests\Unit\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\DynamicContentFilterEntryFiltersType;
 use Mautic\LeadBundle\Model\ListModel;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -17,25 +16,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DynamicContentFilterEntryFiltersTypeTest extends TestCase
 {
-    /**
-     * @var MockObject&TranslatorInterface
-     */
-    private MockObject $translator;
-
-    /**
-     * @var ListModel&MockObject
-     */
-    private MockObject $listModel;
-
     private DynamicContentFilterEntryFiltersType $form;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->listModel  = $this->createMock(ListModel::class);
-        $this->form       =  new DynamicContentFilterEntryFiltersType($this->translator, $this->listModel);
+        $translator       = $this->createMock(TranslatorInterface::class);
+        $listModel        = $this->createMock(ListModel::class);
+        $this->form       =  new DynamicContentFilterEntryFiltersType($translator, $listModel);
     }
 
     public function testBuildForm(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -19,8 +19,6 @@ class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
 
     private MockObject&ExecutionContext $context;
 
-    private MockObject&RequestStack $requestStack;
-
     private Request $request;
 
     private CircularDependencyValidator $validator;
@@ -31,14 +29,14 @@ class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
 
         $this->mockListModel = $this->createMock(ListModel::class);
         $this->context       = $this->createMock(ExecutionContext::class);
-        $this->requestStack  = $this->createMock(RequestStack::class);
+        $requestStack        = $this->createMock(RequestStack::class);
         $this->request       = new Request();
 
-        $this->requestStack->expects($this->once())
+        $requestStack->expects($this->once())
             ->method('getCurrentRequest')
             ->willReturn($this->request);
 
-        $this->validator = new CircularDependencyValidator($this->mockListModel, $this->requestStack);
+        $this->validator = new CircularDependencyValidator($this->mockListModel, $requestStack);
         $this->validator->initialize($this->context);
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
@@ -22,17 +22,12 @@ class CookieHelperTest extends TestCase
      */
     private MockObject $requestStackMock;
 
-    /**
-     * @var Request&MockObject
-     */
-    private MockObject $requestMock;
-
     protected function setUp(): void
     {
         $this->requestStackMock = $this->createMock(RequestStack::class);
-        $this->requestMock      = $this->createMock(Request::class);
+        $requestMock            = $this->createMock(Request::class);
         $this->requestStackMock->method('getMainRequest')
-            ->willReturn($this->requestMock);
+            ->willReturn($requestMock);
     }
 
     #[\PHPUnit\Framework\Attributes\TestDox('The helper is instantiated correctly when secure and contains samesite=lax')]

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
@@ -50,20 +50,19 @@ class ExportHelperTest extends TestCase
     private array $filePaths = [];
 
     private MockObject&FilePathResolver $filePathResolver;
-    private MockObject&ProcessSignalService $processSignalService;
 
     protected function setUp(): void
     {
         $this->translatorInterfaceMock  = $this->createMock(TranslatorInterface::class);
         $this->coreParametersHelperMock = $this->createMock(CoreParametersHelper::class);
         $this->filePathResolver         = $this->createMock(FilePathResolver::class);
-        $this->processSignalService     = $this->createMock(ProcessSignalService::class);
+        $processSignalService           = $this->createMock(ProcessSignalService::class);
 
         $this->exportHelper             = new ExportHelper(
             $this->translatorInterfaceMock,
             $this->coreParametersHelperMock,
             $this->filePathResolver,
-            $this->processSignalService,
+            $processSignalService,
             $this->createMock(EventDispatcherInterface::class),
         );
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
@@ -24,8 +24,6 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fileMock;
 
-    private InputHelper $inputHelper;
-
     private FilePathResolver $filePathResolver;
 
     protected function setUp(): void
@@ -33,8 +31,8 @@ class FilePathResolverTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
         $this->filesystemMock   = $this->createMock(Filesystem::class);
         $this->fileMock         = $this->createMock(UploadedFile::class);
-        $this->inputHelper      = new InputHelper();
-        $this->filePathResolver = new FilePathResolver($this->filesystemMock, $this->inputHelper);
+        $inputHelper            = new InputHelper();
+        $this->filePathResolver = new FilePathResolver($this->filesystemMock, $inputHelper);
     }
 
     #[\PHPUnit\Framework\Attributes\TestDox('Get correct name if few previous names are taken')]

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
@@ -10,7 +10,6 @@ use Mautic\CoreBundle\Helper\FilePathResolver;
 use Mautic\CoreBundle\Helper\ImportHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -21,8 +20,6 @@ class ImportHelperTest extends TestCase
     private ExportHelper $exportHelper;
 
     private ImportHelper $importHelper;
-
-    private PathsHelper&MockObject $pathsHelper;
 
     /**
      * @var array<string>
@@ -43,17 +40,17 @@ class ImportHelperTest extends TestCase
 
         $systemTempDirBase = sys_get_temp_dir().'/import_helper_test';
         $this->paths[]     = $systemTempDirBase;
-        $this->pathsHelper = $this->createMock(PathsHelper::class);
+        $pathsHelper       = $this->createMock(PathsHelper::class);
 
         $testTempDir = $systemTempDirBase.'/tmp';
-        $this->pathsHelper->method('getTemporaryPath')->willReturn($testTempDir);
+        $pathsHelper->method('getTemporaryPath')->willReturn($testTempDir);
         $filesystem->mkdir($testTempDir);
 
         $mediaDir = $systemTempDirBase.'/media';
-        $this->pathsHelper->method('getMediaPath')->willReturn($mediaDir);
+        $pathsHelper->method('getMediaPath')->willReturn($mediaDir);
         $filesystem->mkdir($mediaDir);
 
-        $this->importHelper = new ImportHelper($this->pathsHelper);
+        $this->importHelper = new ImportHelper($pathsHelper);
     }
 
     protected function tearDown(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
@@ -14,21 +14,17 @@ class PageHelperTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&SessionInterface $session;
 
-    private MockObject&RequestStack $requestStack;
-
-    private MockObject&CoreParametersHelper $coreParametersHelper;
-
     private PageHelper $pageHelper;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->session              = $this->createMock(SessionInterface::class);
-        $this->requestStack         = $this->createMock(RequestStack::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->pageHelper           = new PageHelper($this->requestStack, $this->coreParametersHelper, 'mautic.test', 0);
+        $requestStack               = $this->createMock(RequestStack::class);
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
+        $this->pageHelper           = new PageHelper($requestStack, $coreParametersHelper, 'mautic.test', 0);
 
-        $this->requestStack->method('getSession')->willReturn($this->session);
+        $requestStack->method('getSession')->willReturn($this->session);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('PageProvider')]

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -24,11 +24,6 @@ use Psr\Http\Message\StreamInterface;
 class UpdateHelperTest extends TestCase
 {
     /**
-     * @var PathsHelper|MockObject
-     */
-    private MockObject $pathsHelper;
-
-    /**
      * @var Logger|MockObject
      */
     private MockObject $logger;
@@ -67,8 +62,8 @@ class UpdateHelperTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->pathsHelper = $this->createMock(PathsHelper::class);
-        $this->pathsHelper->method('getSystemPath')
+        $pathsHelper = $this->createMock(PathsHelper::class);
+        $pathsHelper->method('getSystemPath')
             ->with('cache')
             ->willReturn(__DIR__.'/resource/update/tmp');
 
@@ -85,7 +80,7 @@ class UpdateHelperTest extends TestCase
         $this->client = $this->createMock(Client::class);
 
         $this->helper = new UpdateHelper(
-            $this->pathsHelper,
+            $pathsHelper,
             $this->logger,
             $this->coreParametersHelper,
             $this->client, $this->releaseParser,

--- a/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
@@ -16,17 +16,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CorePermissionsTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var MockObject|UserHelper
-     */
-    private MockObject $userHelper;
-
     private CorePermissions $corePermissions;
-
-    /**
-     * @var MockObject|TranslatorInterface
-     */
-    private MockObject $translator;
 
     /**
      * @var MockObject|CoreParametersHelper
@@ -36,12 +26,12 @@ class CorePermissionsTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->userHelper           = $this->createMock(UserHelper::class);
-        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $userHelper                 = $this->createMock(UserHelper::class);
+        $translator                 = $this->createMock(TranslatorInterface::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $this->corePermissions      = new CorePermissions(
-            $this->userHelper,
-            $this->translator,
+            $userHelper,
+            $translator,
             $this->coreParametersHelper,
             [
                 $this->mockBundleArray(ApiPermissions::class),

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
@@ -13,7 +13,6 @@ use Twig\TwigFunction;
 
 class DateExtensionTest extends TestCase
 {
-    private DateHelper $dateHelper;
     private DateExtension $dateExtension;
 
     protected function setUp(): void
@@ -32,7 +31,7 @@ class DateExtensionTest extends TestCase
 
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
 
-        $this->dateHelper = new DateHelper(
+        $dateHelper = new DateHelper(
             'F j, Y g:i a T',
             'D, M d',
             'F j, Y',
@@ -41,7 +40,7 @@ class DateExtensionTest extends TestCase
             $coreParametersHelper
         );
 
-        $this->dateExtension = new DateExtension($this->dateHelper);
+        $this->dateExtension = new DateExtension($dateHelper);
     }
 
     // Add this method to allow injection of a mocked DateHelper

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
@@ -16,14 +16,7 @@ class FormatterHelperTest extends \PHPUnit\Framework\TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $translator;
 
-    private DateHelper $dateHelper;
-
     private FormatterHelper $formatterHelper;
-
-    /**
-     * @var CoreParametersHelper|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $coreParametersHelper;
 
     private string $previousTimeZone;
 
@@ -31,16 +24,16 @@ class FormatterHelperTest extends \PHPUnit\Framework\TestCase
     {
         $this->previousTimeZone     = date_default_timezone_get();
         $this->translator           = $this->createMock(TranslatorInterface::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->dateHelper           = new DateHelper(
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
+        $dateHelper                 = new DateHelper(
             'F j, Y g:i a T',
             'D, M d',
             'F j, Y',
             'g:i a',
             $this->translator,
-            $this->coreParametersHelper
+            $coreParametersHelper
         );
-        $this->formatterHelper               = new FormatterHelper($this->dateHelper, $this->translator);
+        $this->formatterHelper               = new FormatterHelper($dateHelper, $this->translator);
     }
 
     protected function tearDown(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -29,16 +29,6 @@ class FinalizeUpdateStepTest extends AbstractStepTestCase
     private MockObject $session;
 
     /**
-     * @var MockObject&Request
-     */
-    private MockObject $request;
-
-    /**
-     * @var MockObject&RequestStack
-     */
-    private MockObject $requestStack;
-
-    /**
      * @var MockObject&AppVersion
      */
     private MockObject $appVersion;
@@ -52,16 +42,16 @@ class FinalizeUpdateStepTest extends AbstractStepTestCase
         $this->translator   = $this->createMock(TranslatorInterface::class);
         $this->pathsHelper  = $this->createMock(PathsHelper::class);
         $this->session      = $this->createMock(Session::class);
-        $this->requestStack = $this->createMock(RequestStack::class);
+        $requestStack       = $this->createMock(RequestStack::class);
         $this->appVersion   = $this->createMock(AppVersion::class);
-        $this->request      = $this->createMock(Request::class);
+        $request            = $this->createMock(Request::class);
 
-        $this->request->method('hasSession')->willReturn(true);
-        $this->request->method('getSession')->willReturn($this->session);
-        $this->requestStack->method('getSession')->willReturn($this->session);
-        $this->requestStack->method('getCurrentRequest')->willReturn($this->request);
+        $request->method('hasSession')->willReturn(true);
+        $request->method('getSession')->willReturn($this->session);
+        $requestStack->method('getSession')->willReturn($this->session);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
 
-        $this->step = new FinalizeUpdateStep($this->translator, $this->pathsHelper, $this->requestStack, $this->appVersion);
+        $this->step = new FinalizeUpdateStep($this->translator, $this->pathsHelper, $requestStack, $this->appVersion);
     }
 
     public function testFinalizationCleansUpFiles(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -25,11 +25,6 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
     private MockObject $translator;
 
     /**
-     * @var MockObject|KernelInterface
-     */
-    private MockObject $kernel;
-
-    /**
      * @var MockObject|MigrateCommand
      */
     private MockObject $migrateCommand;
@@ -39,11 +34,6 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
      */
     private MockObject $eventDispatcher;
 
-    /**
-     * @var MockObject&HelperSet
-     */
-    private MockObject $helperSet;
-
     private UpdateSchemaStep $step;
 
     protected function setUp(): void
@@ -51,9 +41,9 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
         parent::setUp();
 
         $this->translator     = $this->createMock(TranslatorInterface::class);
-        $this->kernel         = $this->createMock(KernelInterface::class);
-        $this->helperSet      = $this->createMock(HelperSet::class);
-        $this->kernel
+        $kernel               = $this->createMock(KernelInterface::class);
+        $helperSet            = $this->createMock(HelperSet::class);
+        $kernel
             ->method('getBundles')
             ->willReturn([]);
 
@@ -65,7 +55,7 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
         $this->migrateCommand->method('getAliases')
             ->willReturn([]);
         $this->migrateCommand->method('getHelperSet')
-            ->willReturn($this->helperSet);
+            ->willReturn($helperSet);
 
         $definition = $this->createMock(InputDefinition::class);
         $definition->method('hasArgument')
@@ -86,7 +76,7 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
             ->willReturnMap([
-                ['kernel', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->kernel],
+                ['kernel', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $kernel],
                 ['event_dispatcher', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->eventDispatcher],
                 ['doctrine:migrations:migrate', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->migrateCommand],
             ]);
@@ -102,7 +92,7 @@ class UpdateSchemaStepTest extends AbstractStepTestCase
                 ['doctrine:migrations:migrate']
             );
 
-        $this->kernel->method('getContainer')
+        $kernel->method('getContainer')
             ->willReturn($container);
 
         $this->step = new UpdateSchemaStep($this->translator, $container);

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
@@ -33,11 +33,6 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
     private MockObject $requestMock;
 
     /**
-     * @var MockObject|CorePermissions
-     */
-    private MockObject $securityMock;
-
-    /**
      * @var MockObject|Translator
      */
     private MockObject $translatorMock;
@@ -56,11 +51,6 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
      * @var MockObject|RouterInterface
      */
     private MockObject $routerMock;
-
-    /**
-     * @var MockObject&FlashBag
-     */
-    private MockObject $flashBagMock;
 
     /**
      * @var MockObject|Container
@@ -84,9 +74,9 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelper     = $this->createMock(CoreParametersHelper::class);
         $dispatcher               = $this->createMock(EventDispatcherInterface::class);
         $this->translatorMock     = $this->createMock(Translator::class);
-        $this->flashBagMock       = $this->createMock(FlashBag::class);
+        $flashBagMock             = $this->createMock(FlashBag::class);
         $requestStack             = new RequestStack();
-        $this->securityMock       = $this->createMock(CorePermissions::class);
+        $securityMock             = $this->createMock(CorePermissions::class);
 
         $requestStack->push($this->requestMock);
         $this->controller = new DashboardController(
@@ -96,9 +86,9 @@ class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             $coreParametersHelper,
             $dispatcher,
             $this->translatorMock,
-            $this->flashBagMock,
+            $flashBagMock,
             $requestStack,
-            $this->securityMock
+            $securityMock
         );
         $this->controller->setContainer($this->containerMock);
     }

--- a/app/bundles/DashboardBundle/Tests/Dashboard/WidgetTest.php
+++ b/app/bundles/DashboardBundle/Tests/Dashboard/WidgetTest.php
@@ -30,11 +30,6 @@ class WidgetTest extends TestCase
     private MockObject $userHelper;
 
     /**
-     * @var MockObject&RequestStack
-     */
-    private MockObject $requestStack;
-
-    /**
      * @var User&MockObject
      */
     private MockObject $user;
@@ -47,7 +42,7 @@ class WidgetTest extends TestCase
 
         $this->dashboardModel = $this->createMock(DashboardModel::class);
         $this->userHelper     = $this->createMock(UserHelper::class);
-        $this->requestStack   = $this->createMock(RequestStack::class);
+        $requestStack         = $this->createMock(RequestStack::class);
 
         $this->user = $this->createMock(User::class);
         $this->user
@@ -57,7 +52,7 @@ class WidgetTest extends TestCase
         $this->widget = new Widget(
             $this->dashboardModel,
             $this->userHelper,
-            $this->requestStack
+            $requestStack
         );
     }
 

--- a/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
+++ b/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
@@ -12,7 +12,6 @@ class WidgetDetailEventTest extends \PHPUnit\Framework\TestCase
 {
     private WidgetDetailEvent $widgetDetailEvent;
     private MockObject $translator;
-    private MockObject $security;
     private MockObject $widget;
 
     protected function setUp(): void
@@ -20,12 +19,12 @@ class WidgetDetailEventTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->translator            = $this->createMock(Translator::class);
-        $this->security              = $this->createMock(CorePermissions::class);
+        $security                    = $this->createMock(CorePermissions::class);
         $this->widget                = $this->createMock(Widget::class);
 
         $this->widgetDetailEvent = new WidgetDetailEvent(
             $this->translator,
-            $this->security,
+            $security,
             $this->widget
         );
     }

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
@@ -49,11 +49,6 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $focusTokenHelper;
 
     /**
-     * @var MockObject|AuditLogModel
-     */
-    private MockObject $auditLogModel;
-
-    /**
      * @var MockObject|DynamicContentHelper
      */
     private MockObject $dynamicContentHelper;
@@ -89,7 +84,7 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->assetTokenHelper          = $this->createMock(AssetTokenHelper::class);
         $this->formTokenHelper           = $this->createMock(FormTokenHelper::class);
         $this->focusTokenHelper          = $this->createMock(FocusTokenHelper::class);
-        $this->auditLogModel             = $this->createMock(AuditLogModel::class);
+        $auditLogModel                   = $this->createMock(AuditLogModel::class);
         $this->contactTracker            = $this->createMock(ContactTracker::class);
         $this->dynamicContentHelper      = $this->createMock(DynamicContentHelper::class);
         $this->dynamicContentModel       = $this->createMock(DynamicContentModel::class);
@@ -103,7 +98,7 @@ class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->assetTokenHelper,
             $this->formTokenHelper,
             $this->focusTokenHelper,
-            $this->auditLogModel,
+            $auditLogModel,
             $this->dynamicContentHelper,
             $this->dynamicContentModel,
             $this->security,

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
@@ -25,11 +25,6 @@ class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
     private MockObject $mockModel;
 
     /**
-     * @var MockObject&RealTimeExecutioner
-     */
-    private MockObject $realTimeExecutioner;
-
-    /**
      * @var MockObject&EventDispatcher
      */
     private MockObject $mockDispatcher;
@@ -44,12 +39,12 @@ class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->mockModel           = $this->createMock(DynamicContentModel::class);
-        $this->realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
+        $realTimeExecutioner       = $this->createMock(RealTimeExecutioner::class);
         $this->mockDispatcher      = $this->createMock(EventDispatcher::class);
         $this->leadModel           = $this->createMock(LeadModel::class);
         $this->helper              = new DynamicContentHelper(
             $this->mockModel,
-            $this->realTimeExecutioner,
+            $realTimeExecutioner,
             $this->mockDispatcher,
             $this->leadModel,
         );

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -35,11 +35,6 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
     private MockObject $modelFactoryMock;
 
     /**
-     * @var MockObject|Container
-     */
-    private MockObject $containerMock;
-
-    /**
      * @var MockObject|EmailModel
      */
     private MockObject $modelMock;
@@ -51,21 +46,16 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
 
     private AjaxController $controller;
 
-    /**
-     * @var MockObject&ManagerRegistry
-     */
-    private MockObject $managerRegistry;
-
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sessionMock      = $this->createMock(Session::class);
-        $this->containerMock    = $this->createMock(Container::class);
+        $containerMock          = $this->createMock(Container::class);
         $this->modelMock        = $this->createMock(EmailModel::class);
         $this->emailMock        = $this->createMock(Email::class);
 
-        $this->managerRegistry  = $this->createMock(ManagerRegistry::class);
+        $managerRegistry        = $this->createMock(ManagerRegistry::class);
         $this->modelFactoryMock = $this->createMock(ModelFactory::class);
         $userHelper             = $this->createMock(UserHelper::class);
         $coreParametersHelper   = $this->createMock(CoreParametersHelper::class);
@@ -76,7 +66,7 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
         $security               = $this->createMock(CorePermissions::class);
 
         $this->controller = new AjaxController(
-            $this->managerRegistry,
+            $managerRegistry,
             $this->modelFactoryMock,
             $userHelper,
             $coreParametersHelper,
@@ -86,18 +76,26 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
             $requestStack,
             $security
         );
-        $this->controller->setContainer($this->containerMock);
+        $this->controller->setContainer($containerMock);
 
         $parameterBag = $this->createMock(ContainerBagInterface::class);
         $parameterBag->expects($this->once())
             ->method('get')
             ->with('kernel.environment')
             ->willReturn('test');
+<<<<<<< HEAD
         $this->containerMock->expects($this->once())
             ->method('has')
             ->with('parameter_bag')
             ->willReturn(true);
         $this->containerMock->expects($this->once())
+=======
+        $containerMock->expects(self::once())
+            ->method('has')
+            ->with('parameter_bag')
+            ->willReturn(true);
+        $containerMock->expects(self::once())
+>>>>>>> 60d468ce74 ([tests] inline setUp properties used just once)
             ->method('get')
             ->with('parameter_bag')
             ->willReturn($parameterBag);

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -76,6 +76,7 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
             $requestStack,
             $security
         );
+
         $this->controller->setContainer($containerMock);
 
         $parameterBag = $this->createMock(ContainerBagInterface::class);
@@ -83,19 +84,12 @@ class AjaxControllerTest extends \PHPUnit\Framework\TestCase
             ->method('get')
             ->with('kernel.environment')
             ->willReturn('test');
-<<<<<<< HEAD
-        $this->containerMock->expects($this->once())
-            ->method('has')
-            ->with('parameter_bag')
-            ->willReturn(true);
-        $this->containerMock->expects($this->once())
-=======
-        $containerMock->expects(self::once())
+
+        $containerMock->expects($this->once())
             ->method('has')
             ->with('parameter_bag')
             ->willReturn(true);
         $containerMock->expects(self::once())
->>>>>>> 60d468ce74 ([tests] inline setUp properties used just once)
             ->method('get')
             ->with('parameter_bag')
             ->willReturn($parameterBag);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -38,7 +38,6 @@ class EmailControllerTest extends TestCase
      * @var string
      */
     public const NEW_CATEGORY_TITLE = 'New category';
-    private MockObject $translatorMock;
 
     /**
      * @var MockObject|Session
@@ -69,11 +68,6 @@ class EmailControllerTest extends TestCase
      * @var MockObject|Email
      */
     private MockObject $emailMock;
-
-    /**
-     * @var MockObject|FlashBag
-     */
-    private MockObject $flashBagMock;
 
     private EmailController $controller;
 
@@ -123,8 +117,8 @@ class EmailControllerTest extends TestCase
         $helperUserMock                   = $this->createMock(UserHelper::class);
         $coreParametersHelper             = $this->createMock(CoreParametersHelper::class);
         $this->dispatcher                 = $this->createMock(EventDispatcherInterface::class);
-        $this->translatorMock             = $this->createMock(Translator::class);
-        $this->flashBagMock               = $this->createMock(FlashBag::class);
+        $translatorMock                   = $this->createMock(Translator::class);
+        $flashBagMock                     = $this->createMock(FlashBag::class);
         $this->requestStack               = new RequestStack();
         $this->corePermissionsMock        = $this->createMock(CorePermissions::class);
 
@@ -139,8 +133,8 @@ class EmailControllerTest extends TestCase
             $helperUserMock,
             $coreParametersHelper,
             $this->dispatcher,
-            $this->translatorMock,
-            $this->flashBagMock,
+            $translatorMock,
+            $flashBagMock,
             $this->requestStack,
             $this->corePermissionsMock
         );

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
@@ -16,8 +16,6 @@ class EmailRepositoryIncrementReadTest extends \PHPUnit\Framework\TestCase
 
     private QueryBuilder $queryBuilder;
 
-    private QueryBuilder $subQueryBuilder;
-
     /**
      * @var EmailRepository|object
      */
@@ -28,10 +26,10 @@ class EmailRepositoryIncrementReadTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
         $this->repo             = $this->configureRepository(Email::class);
         $this->queryBuilder     = new QueryBuilder($this->connection);
-        $this->subQueryBuilder  = new QueryBuilder($this->connection);
+        $subQueryBuilder        = new QueryBuilder($this->connection);
         $this->connection->method('createQueryBuilder')->willReturnOnConsecutiveCalls(
             $this->queryBuilder,
-            $this->subQueryBuilder
+            $subQueryBuilder
         );
     }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -28,10 +28,6 @@ class BuilderSubscriberTest extends TestCase
 
     private MockObject&EmailModel $emailModel;
 
-    private MockObject&TrackableModel $trackableModel;
-
-    private MockObject&RedirectModel $redirectModel;
-
     private MockObject&TranslatorInterface $translator;
 
     private MockObject&LeadRepository $leadRepository;
@@ -40,16 +36,16 @@ class BuilderSubscriberTest extends TestCase
     {
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $this->emailModel           = $this->createMock(EmailModel::class);
-        $this->trackableModel       = $this->createMock(TrackableModel::class);
-        $this->redirectModel        = $this->createMock(RedirectModel::class);
+        $trackableModel             = $this->createMock(TrackableModel::class);
+        $redirectModel              = $this->createMock(RedirectModel::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
         $this->leadRepository       = $this->createMock(LeadRepository::class);
         $fromEmailHelper            = new FromEmailHelper($this->coreParametersHelper, $this->leadRepository);
         $this->builderSubscriber    = new BuilderSubscriber(
             $this->coreParametersHelper,
             $this->emailModel,
-            $this->trackableModel,
-            $this->redirectModel,
+            $trackableModel,
+            $redirectModel,
             $this->translator,
             new MailHashHelper($this->coreParametersHelper),
             $fromEmailHelper

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -20,24 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var EmailModel|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $emailModel;
-
-    /**
-     * @var RealTimeExecutioner&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $realTimeExecutioner;
-
-    /**
      * @var SendEmailToUser|\PHPUnit\Framework\MockObject\MockObject
      */
     private \PHPUnit\Framework\MockObject\MockObject $sendEmailToUser;
-
-    /**
-     * @var TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $translator;
 
     private CampaignSubscriber $subscriber;
 
@@ -45,18 +30,18 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->emailModel          = $this->createMock(EmailModel::class);
-        $this->realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
+        $emailModel                = $this->createMock(EmailModel::class);
+        $realTimeExecutioner       = $this->createMock(RealTimeExecutioner::class);
         $this->sendEmailToUser     = $this->createMock(SendEmailToUser::class);
-        $this->translator          = $this->createMock(TranslatorInterface::class);
+        $translator                = $this->createMock(TranslatorInterface::class);
         $leadModel                 = $this->createMock(LeadModel::class);
         $statRepository            = $this->createMock(StatRepository::class);
 
         $this->subscriber = new CampaignSubscriber(
-            $this->emailModel,
-            $this->realTimeExecutioner,
+            $emailModel,
+            $realTimeExecutioner,
             $this->sendEmailToUser,
-            $this->translator,
+            $translator,
             $leadModel,
             $statRepository
         );

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -42,24 +42,9 @@ use Twig\Environment;
 final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&IpLookupHelper
-     */
-    private MockObject $ipLookupHelper;
-
-    /**
-     * @var MockObject&AuditLogModel
-     */
-    private MockObject $auditLogModel;
-
-    /**
      * @var MockObject&EmailModel
      */
     private MockObject $emailModel;
-
-    /**
-     * @var MockObject&TranslatorInterface
-     */
-    private MockObject $translator;
 
     /**
      * @var MockObject&MauticMessage
@@ -72,12 +57,12 @@ final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->ipLookupHelper   = $this->createMock(IpLookupHelper::class);
-        $this->auditLogModel    = $this->createMock(AuditLogModel::class);
+        $ipLookupHelper         = $this->createMock(IpLookupHelper::class);
+        $auditLogModel          = $this->createMock(AuditLogModel::class);
         $this->emailModel       = $this->createMock(EmailModel::class);
-        $this->translator       = $this->createMock(TranslatorInterface::class);
+        $translator             = $this->createMock(TranslatorInterface::class);
         $this->mockMessage      = $this->createMock(MauticMessage::class);
-        $this->subscriber       = new EmailSubscriber($this->ipLookupHelper, $this->auditLogModel, $this->emailModel, $this->translator, $this->createMock(EntityManagerInterface::class), $this->createMock(EmailDraftModel::class));
+        $this->subscriber       = new EmailSubscriber($ipLookupHelper, $auditLogModel, $this->emailModel, $translator, $this->createMock(EntityManagerInterface::class), $this->createMock(EmailDraftModel::class));
     }
 
     public function testOnEmailResendWithNoLeadIdHash(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ProcessUnsubscribeSubscriberTest.php
@@ -10,29 +10,18 @@ use Mautic\EmailBundle\EventListener\ProcessUnsubscribeSubscriber;
 use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\MonitoredEmail\Processor\FeedbackLoop;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe;
-use PHPUnit\Framework\MockObject\MockObject;
 
 final class ProcessUnsubscribeSubscriberTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var MockObject&Unsubscribe
-     */
-    private MockObject $unsubscribe;
-
-    /**
-     * @var MockObject&FeedbackLoop
-     */
-    private MockObject $feedbackLoop;
-
     private ProcessUnsubscribeSubscriber $subscriber;
 
     protected function setup(): void
     {
         parent::setUp();
 
-        $this->unsubscribe      = $this->createMock(Unsubscribe::class);
-        $this->feedbackLoop     = $this->createMock(FeedbackLoop::class);
-        $this->subscriber       = new ProcessUnsubscribeSubscriber($this->unsubscribe, $this->feedbackLoop, $this->createMock(CoreParametersHelper::class));
+        $unsubscribe            = $this->createMock(Unsubscribe::class);
+        $feedbackLoop           = $this->createMock(FeedbackLoop::class);
+        $this->subscriber       = new ProcessUnsubscribeSubscriber($unsubscribe, $feedbackLoop, $this->createMock(CoreParametersHelper::class));
     }
 
     public function testOnEmailSend(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -42,19 +42,9 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $companyReportDataMock;
 
     /**
-     * @var MockObject|StatRepository
-     */
-    private MockObject $statRepository;
-
-    /**
      * @var MockObject|EmailRepository
      */
     private MockObject $emailRepository;
-
-    /**
-     * @var MockObject&GeneratedColumnsProviderInterface
-     */
-    private MockObject $generatedColumnsProvider;
 
     /**
      * @var MockObject|Report
@@ -72,30 +62,25 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fieldsBuilderMock;
 
-    /**
-     * @var MockObject|DncReportService
-     */
-    private MockObject $dncReportService;
-
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->connectionMock            = $this->getMockedConnection();
         $this->companyReportDataMock     = $this->createMock(CompanyReportData::class);
-        $this->statRepository            = $this->createMock(StatRepository::class);
+        $statRepository                  = $this->createMock(StatRepository::class);
         $this->emailRepository           = $this->createMock(EmailRepository::class);
-        $this->generatedColumnsProvider  = $this->createMock(GeneratedColumnsProviderInterface::class);
+        $generatedColumnsProvider        = $this->createMock(GeneratedColumnsProviderInterface::class);
         $this->fieldsBuilderMock         = $this->createMock(FieldsBuilder::class);
-        $this->dncReportService          = $this->createMock(DncReportService::class);
+        $dncReportService                = $this->createMock(DncReportService::class);
         $this->subscriber                = new ReportSubscriber(
             $this->connectionMock,
             $this->companyReportDataMock,
-            $this->statRepository,
+            $statRepository,
             $this->emailRepository,
-            $this->generatedColumnsProvider,
+            $generatedColumnsProvider,
             $this->fieldsBuilderMock,
-            $this->dncReportService,
+            $dncReportService,
         );
 
         $this->report             = $this->createMock(Report::class);

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -21,21 +21,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class EmailTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&TranslatorInterface
-     */
-    private MockObject $translator;
-
-    /**
-     * @var MockObject&EntityManager
-     */
-    private MockObject $entityManager;
-
-    /**
-     * @var MockObject&StageModel
-     */
-    private MockObject $stageModel;
-
-    /**
      * @var MockObject&FormBuilderInterface
      */
     private MockObject $formBuilder;
@@ -43,57 +28,40 @@ class EmailTypeTest extends \PHPUnit\Framework\TestCase
     private EmailType $form;
 
     /**
-     * @var CoreParametersHelper&MockObject
-     */
-    private MockObject $coreParametersHelper;
-
-    /**
-     * @var CorePermissions&MockObject
-     */
-    private MockObject $corePermissions;
-
-    /**
-     * @var EmailConfigInterface&MockObject
-     */
-    private MockObject $emailConfig;
-
-    /**
      * @var ThemeHelperInterface&MockObject
      */
     private MockObject $themeHelper;
-
-    private EmailDefaultsHelper&MockObject $defaultsHelper;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->translator           = $this->createMock(TranslatorInterface::class);
-        $this->entityManager        = $this->createMock(EntityManager::class);
-        $this->stageModel           = $this->createMock(StageModel::class);
+        $translator                 = $this->createMock(TranslatorInterface::class);
+        $entityManager              = $this->createMock(EntityManager::class);
+        $stageModel                 = $this->createMock(StageModel::class);
         $this->formBuilder          = $this->createMock(FormBuilderInterface::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->corePermissions      = $this->createMock(CorePermissions::class);
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
+        $corePermissions            = $this->createMock(CorePermissions::class);
         $this->themeHelper          = $this->createMock(ThemeHelperInterface::class);
-        $this->emailConfig          = $this->createMock(EmailConfigInterface::class);
-        $this->defaultsHelper       = $this->createMock(EmailDefaultsHelper::class);
+        $emailConfig                = $this->createMock(EmailConfigInterface::class);
+        $defaultsHelper             = $this->createMock(EmailDefaultsHelper::class);
         $this->form                 = new EmailType(
-            $this->translator,
-            $this->entityManager,
-            $this->stageModel,
-            $this->coreParametersHelper,
+            $translator,
+            $entityManager,
+            $stageModel,
+            $coreParametersHelper,
             $this->themeHelper,
-            $this->corePermissions,
-            $this->emailConfig,
-            $this->defaultsHelper,
+            $corePermissions,
+            $emailConfig,
+            $defaultsHelper,
         );
 
         $this->formBuilder->method('create')->willReturnSelf();
         $this->formBuilder->method('add')->willReturnSelf();
         $this->formBuilder->method('addModelTransformer')->willReturnSelf();
-        $this->corePermissions->method('hasPublishAccessForEntity')->willReturn(true);
-        $this->translator->method('trans')->willReturn('translated');
-        $this->emailConfig->method('isDraftEnabled')->willReturn(false);
+        $corePermissions->method('hasPublishAccessForEntity')->willReturn(true);
+        $translator->method('trans')->willReturn('translated');
+        $emailConfig->method('isDraftEnabled')->willReturn(false);
     }
 
     public function testBuildForm(): void

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -213,7 +213,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-<<<<<<< HEAD
         $this->ipLookupHelper            = $this->createMock(IpLookupHelper::class);
         $this->themeHelper               = $this->createMock(ThemeHelperInterface::class);
         $this->mailboxHelper             = $this->createMock(Mailbox::class);
@@ -237,7 +236,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         $this->sendToContactModel        = new SendEmailToContact($this->mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $this->deviceTrackerMock         = $this->createMock(DeviceTracker::class);
         $this->redirectRepositoryMock    = $this->createMock(RedirectRepository::class);
-=======
+
         $this->ipLookupHelper           = $this->createMock(IpLookupHelper::class);
         $this->themeHelper              = $this->createMock(ThemeHelperInterface::class);
         $this->mailboxHelper            = $this->createMock(Mailbox::class);
@@ -261,7 +260,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         $this->sendToContactModel       = new SendEmailToContact($this->mailHelper, $statHelper, $dncModel, $this->translator);
         $this->deviceTrackerMock        = $this->createMock(DeviceTracker::class);
         $this->redirectRepositoryMock   = $this->createMock(RedirectRepository::class);
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
+
         // @phpstan-ignore classConstant.deprecatedClass
         $this->cacheStorageHelperMock    = $this->createMock(CacheStorageHelper::class);
         $this->contactTracker            = $this->createMock(ContactTracker::class);

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -230,10 +230,10 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         $this->messageModel              = $this->createMock(MessageQueueModel::class);
         $this->companyModel              = $this->createMock(CompanyModel::class);
         $this->companyRepository         = $this->createMock(CompanyRepository::class);
-        $this->dncModel                  = $this->createMock(DoNotContact::class);
+        $dncModel                        = $this->createMock(DoNotContact::class);
         $this->emailStatModel            = $this->createMock(EmailStatModel::class);
-        $this->statHelper                = new StatHelper($this->emailStatModel);
-        $this->sendToContactModel        = new SendEmailToContact($this->mailHelper, $this->statHelper, $this->dncModel, $this->translator);
+        $statHelper                      = new StatHelper($this->emailStatModel);
+        $this->sendToContactModel        = new SendEmailToContact($this->mailHelper, $statHelper, $dncModel, $this->translator);
         $this->deviceTrackerMock         = $this->createMock(DeviceTracker::class);
         $this->redirectRepositoryMock    = $this->createMock(RedirectRepository::class);
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -158,13 +158,6 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $companyRepository;
 
-    /**
-     * @var MockObject&DoNotContact
-     */
-    private MockObject $dncModel;
-
-    private StatHelper $statHelper;
-
     private SendEmailToContact $sendToContactModel;
 
     /**
@@ -220,6 +213,7 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
+<<<<<<< HEAD
         $this->ipLookupHelper            = $this->createMock(IpLookupHelper::class);
         $this->themeHelper               = $this->createMock(ThemeHelperInterface::class);
         $this->mailboxHelper             = $this->createMock(Mailbox::class);
@@ -243,6 +237,31 @@ class EmailModelTest extends \PHPUnit\Framework\TestCase
         $this->sendToContactModel        = new SendEmailToContact($this->mailHelper, $this->statHelper, $this->dncModel, $this->translator);
         $this->deviceTrackerMock         = $this->createMock(DeviceTracker::class);
         $this->redirectRepositoryMock    = $this->createMock(RedirectRepository::class);
+=======
+        $this->ipLookupHelper           = $this->createMock(IpLookupHelper::class);
+        $this->themeHelper              = $this->createMock(ThemeHelperInterface::class);
+        $this->mailboxHelper            = $this->createMock(Mailbox::class);
+        $this->mailHelper               = $this->createMock(MailHelper::class);
+        $this->leadModel                = $this->createMock(LeadModel::class);
+        $this->trackableModel           = $this->createMock(TrackableModel::class);
+        $this->userModel                = $this->createMock(UserModel::class);
+        $this->userHelper               = $this->createMock(UserHelper::class);
+        $this->translator               = $this->createMock(Translator::class);
+        $this->emailEntity              = $this->createMock(Email::class);
+        $this->entityManager            = $this->createMock(EntityManager::class);
+        $this->statRepository           = $this->createMock(StatRepository::class);
+        $this->emailRepository          = $this->createMock(EmailRepository::class);
+        $this->frequencyRepository      = $this->createMock(FrequencyRuleRepository::class);
+        $this->messageModel             = $this->createMock(MessageQueueModel::class);
+        $this->companyModel             = $this->createMock(CompanyModel::class);
+        $this->companyRepository        = $this->createMock(CompanyRepository::class);
+        $dncModel                       = $this->createMock(DoNotContact::class);
+        $this->emailStatModel           = $this->createMock(EmailStatModel::class);
+        $statHelper                     = new StatHelper($this->emailStatModel);
+        $this->sendToContactModel       = new SendEmailToContact($this->mailHelper, $statHelper, $dncModel, $this->translator);
+        $this->deviceTrackerMock        = $this->createMock(DeviceTracker::class);
+        $this->redirectRepositoryMock   = $this->createMock(RedirectRepository::class);
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
         // @phpstan-ignore classConstant.deprecatedClass
         $this->cacheStorageHelperMock    = $this->createMock(CacheStorageHelper::class);
         $this->contactTracker            = $this->createMock(ContactTracker::class);

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -26,8 +26,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ReplyTest extends \PHPUnit\Framework\TestCase
 {
-    private EmailAddressHelper $emailAddressHelper;
-
     /**
      * @var MockObject&StatRepository
      */
@@ -44,19 +42,9 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
     private MockObject $contactFinder;
 
     /**
-     * @var MockObject&LeadModel
-     */
-    private MockObject $leadModel;
-
-    /**
      * @var MockObject&EventDispatcherInterface
      */
     private MockObject $dispatcher;
-
-    /**
-     * @var MockObject&Logger
-     */
-    private MockObject $logger;
 
     /**
      * @var MockObject&ContactTracker
@@ -77,21 +65,21 @@ class ReplyTest extends \PHPUnit\Framework\TestCase
         $this->statRepo           = $this->createMock(StatRepository::class);
         $this->emailStatModel     = $this->createMock(EmailStatModel::class);
         $this->contactFinder      = $this->createMock(ContactFinder::class);
-        $this->leadModel          = $this->createMock(LeadModel::class);
+        $leadModel                = $this->createMock(LeadModel::class);
         $this->dispatcher         = $this->createMock(EventDispatcherInterface::class);
-        $this->logger             = $this->createMock(Logger::class);
+        $logger                   = $this->createMock(Logger::class);
         $this->contactTracker     = $this->createMock(ContactTracker::class);
-        $this->emailAddressHelper = new EmailAddressHelper();
+        $emailAddressHelper       = new EmailAddressHelper();
         $this->leadRepository     = $this->createMock(LeadRepository::class);
-        $this->leadModel->method('getRepository')->willReturn($this->leadRepository);
+        $leadModel->method('getRepository')->willReturn($this->leadRepository);
         $this->processor          = new Reply(
             $this->emailStatModel,
             $this->contactFinder,
-            $this->leadModel,
+            $leadModel,
             $this->dispatcher,
-            $this->logger,
+            $logger,
             $this->contactTracker,
-            $this->emailAddressHelper
+            $emailAddressHelper
         );
 
         $this->emailStatModel->method('getRepository')->willReturn($this->statRepo);

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -50,18 +50,11 @@ class ReportSubscriberTest extends AbstractMauticTestCase
     private ReportHelper $reportHelper;
 
     /**
-     * @var CoreParametersHelper|MockObject
-     */
-    private MockObject $coreParametersHelper;
-
-    /**
      * @var TranslatorInterface|MockObject
      */
     private MockObject $translator;
 
     private ReportSubscriber $subscriber;
-
-    private MockObject&DncReportService $dncReportService;
 
     protected function setUp(): void
     {
@@ -74,17 +67,17 @@ class ReportSubscriberTest extends AbstractMauticTestCase
         $this->formModel            = $this->createMock(FormModel::class);
         $this->formRepository       = $this->createMock(FormRepository::class);
         $this->reportHelper         = new ReportHelper($this->createMock(EventDispatcher::class));
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
-        $this->dncReportService     = $this->createMock(DncReportService::class);
+        $dncReportService           = $this->createMock(DncReportService::class);
         $this->subscriber           = new ReportSubscriber(
             $this->companyReportData,
             $this->submissionRepository,
             $this->formModel,
             $this->reportHelper,
-            $this->coreParametersHelper,
+            $coreParametersHelper,
             $this->translator,
-            $this->dncReportService
+            $dncReportService
         );
     }
 

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -38,61 +38,6 @@ use Twig\Environment;
 class FormModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&RequestStack
-     */
-    private MockObject $requestStack;
-
-    /**
-     * @var MockObject&Environment
-     */
-    private MockObject $twigMock;
-
-    /**
-     * @var MockObject&ThemeHelper
-     */
-    private MockObject $themeHelper;
-
-    /**
-     * @var MockObject&ActionModel
-     */
-    private MockObject $formActionModel;
-
-    /**
-     * @var MockObject&FieldModel
-     */
-    private MockObject $formFieldModel;
-
-    /**
-     * @var MockObject&EventDispatcher
-     */
-    private MockObject $dispatcher;
-
-    /**
-     * @var MockObject&Translator
-     */
-    private MockObject $translator;
-
-    /**
-     * @var MockObject&EntityManager
-     */
-    private MockObject $entityManager;
-
-    /**
-     * @var MockObject&FormUploader
-     */
-    private MockObject $formUploaderMock;
-
-    /**
-     * @var MockObject&ColumnSchemaHelper
-     */
-    private MockObject $columnSchemaHelper;
-
-    /**
-     * @var MockObject&TableSchemaHelper
-     */
-    private MockObject $tableSchemaHelper;
-
-    /**
      * @var MockObject&FormRepository
      */
     private MockObject $formRepository;
@@ -117,11 +62,6 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $primaryCompanyHelper;
 
-    /**
-     * @var MockObject&MappedObjectCollectorInterface
-     */
-    private MockObject $mappedObjectCollector;
-
     private FormModel $formModel;
 
     protected function setUp(): void
@@ -130,25 +70,25 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
             $_ENV['MAUTIC_UPLOAD_DIR'] = sys_get_temp_dir();
         }
 
-        $this->requestStack          = $this->createMock(RequestStack::class);
-        $this->twigMock              = $this->createMock(Environment::class);
-        $this->themeHelper           = $this->createMock(ThemeHelper::class);
-        $this->formActionModel       = $this->createMock(ActionModel::class);
-        $this->formFieldModel        = $this->createMock(FieldModel::class);
+        $requestStack                = $this->createMock(RequestStack::class);
+        $twigMock                    = $this->createMock(Environment::class);
+        $themeHelper                 = $this->createMock(ThemeHelper::class);
+        $formActionModel             = $this->createMock(ActionModel::class);
+        $formFieldModel              = $this->createMock(FieldModel::class);
         $this->contactTracker        = $this->createMock(ContactTracker::class);
         $this->fieldHelper           = $this->createMock(FormFieldHelper::class);
         $this->primaryCompanyHelper  = $this->createMock(PrimaryCompanyHelper::class);
-        $this->dispatcher            = $this->createMock(EventDispatcher::class);
-        $this->translator            = $this->createMock(Translator::class);
-        $this->entityManager         = $this->createMock(EntityManager::class);
-        $this->formUploaderMock      = $this->createMock(FormUploader::class);
+        $dispatcher                  = $this->createMock(EventDispatcher::class);
+        $translator                  = $this->createMock(Translator::class);
+        $entityManager               = $this->createMock(EntityManager::class);
+        $formUploaderMock            = $this->createMock(FormUploader::class);
         $this->leadFieldModel        = $this->createMock(LeadFieldModel::class);
         $this->formRepository        = $this->createMock(FormRepository::class);
-        $this->columnSchemaHelper    = $this->createMock(ColumnSchemaHelper::class);
-        $this->tableSchemaHelper     = $this->createMock(TableSchemaHelper::class);
-        $this->mappedObjectCollector = $this->createMock(MappedObjectCollectorInterface::class);
+        $columnSchemaHelper          = $this->createMock(ColumnSchemaHelper::class);
+        $tableSchemaHelper           = $this->createMock(TableSchemaHelper::class);
+        $mappedObjectCollector       = $this->createMock(MappedObjectCollectorInterface::class);
 
-        $this->entityManager->expects($this
+        $entityManager->expects($this
             ->any())
             ->method('getRepository')
             ->willReturnMap(
@@ -158,24 +98,24 @@ class FormModelTest extends \PHPUnit\Framework\TestCase
             );
 
         $this->formModel = new FormModel(
-            $this->requestStack,
-            $this->twigMock,
-            $this->themeHelper,
-            $this->formActionModel,
-            $this->formFieldModel,
+            $requestStack,
+            $twigMock,
+            $themeHelper,
+            $formActionModel,
+            $formFieldModel,
             $this->fieldHelper,
             $this->primaryCompanyHelper,
             $this->leadFieldModel,
-            $this->formUploaderMock,
+            $formUploaderMock,
             $this->contactTracker,
-            $this->columnSchemaHelper,
-            $this->tableSchemaHelper,
-            $this->mappedObjectCollector,
-            $this->entityManager,
+            $columnSchemaHelper,
+            $tableSchemaHelper,
+            $mappedObjectCollector,
+            $entityManager,
             $this->createMock(CorePermissions::class),
-            $this->dispatcher,
+            $dispatcher,
             $this->createMock(UrlGeneratorInterface::class),
-            $this->translator,
+            $translator,
             $this->createMock(UserHelper::class),
             $this->createMock(LoggerInterface::class),
             $this->createMock(CoreParametersHelper::class)

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
@@ -55,34 +55,14 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
     private MockObject $ipLookupHelper;
 
     /**
-     * @var MockObject|Environment
-     */
-    private MockObject $twigMock;
-
-    /**
      * @var MockObject|FormModel
      */
     private MockObject $formModel;
 
     /**
-     * @var MockObject|PageModel
-     */
-    private MockObject $pageModel;
-
-    /**
-     * @var MockObject|LeadModel
-     */
-    private MockObject $leadModel;
-
-    /**
      * @var MockObject|CampaignModel
      */
     private MockObject $campaignModel;
-
-    /**
-     * @var MockObject|MembershipManager
-     */
-    private MockObject $membershipManager;
 
     /**
      * @var MockObject|LeadFieldModel
@@ -93,16 +73,6 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
      * @var MockObject|CompanyModel
      */
     private MockObject $companyModel;
-
-    /**
-     * @var MockObject|FormFieldHelper
-     */
-    private MockObject $fieldHelper;
-
-    /**
-     * @var MockObject|EventDispatcherInterface
-     */
-    private MockObject $dispatcher;
 
     /**
      * @var MockObject|Translator
@@ -126,8 +96,6 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $entityManager;
 
-    private MockObject&Connection $connection;
-
     /**
      * @var MockObject|SubmissionRepository
      */
@@ -139,24 +107,9 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadRepository;
 
     /**
-     * @var MockObject|Logger
-     */
-    private MockObject $mockLogger;
-
-    /**
      * @var MockObject|UploadFieldValidator
      */
     private MockObject $uploadFieldValidatorMock;
-
-    /**
-     * @var MockObject|FormUploader
-     */
-    private MockObject $formUploaderMock;
-
-    /**
-     * @var MockObject|DeviceTrackingServiceInterface
-     */
-    private MockObject $deviceTrackingService;
 
     /**
      * @var MockObject|UploadedFile
@@ -173,11 +126,6 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $contactTracker;
 
-    /**
-     * @var MockObject|ContactMerger
-     */
-    private MockObject $contactMerger;
-
     private SubmissionModel $submissionModel;
 
     /**
@@ -190,16 +138,16 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->ipLookupHelper           = $this->createMock(IpLookupHelper::class);
-        $this->twigMock                 = $this->createMock(Environment::class);
+        $twigMock                       = $this->createMock(Environment::class);
         $this->formModel                = $this->createMock(FormModel::class);
-        $this->pageModel                = $this->createMock(PageModel::class);
-        $this->leadModel                = $this->createMock(LeadModel::class);
+        $pageModel                      = $this->createMock(PageModel::class);
+        $leadModel                      = $this->createMock(LeadModel::class);
         $this->campaignModel            = $this->createMock(CampaignModel::class);
-        $this->membershipManager        = $this->createMock(MembershipManager::class);
+        $membershipManager              = $this->createMock(MembershipManager::class);
         $this->leadFieldModel           = $this->createMock(LeadFieldModel::class);
         $this->companyModel             = $this->createMock(CompanyModel::class);
-        $this->fieldHelper              = $this->createMock(FormFieldHelper::class);
-        $this->dispatcher               = $this->createMock(EventDispatcherInterface::class);
+        $fieldHelper                    = $this->createMock(FormFieldHelper::class);
+        $dispatcher                     = $this->createMock(EventDispatcherInterface::class);
         $this->translator               = $this->createMock(Translator::class);
         $this->dateHelper               = new DateHelper(
             'Y-m-d H:i:s',
@@ -212,28 +160,28 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
         $this->userHelper                 = $this->createMock(UserHelper::class);
         $this->fieldsWithUniqueIdentifier = $this->createMock(FieldsWithUniqueIdentifier::class);
         $this->entityManager              = $this->createMock(EntityManager::class);
-        $this->connection                 = $this->createMock(Connection::class);
-        $this->entityManager->method('getConnection')->willReturn($this->connection);
+        $connection                       = $this->createMock(Connection::class);
+        $this->entityManager->method('getConnection')->willReturn($connection);
         $schemaManager = $this->createMock(AbstractSchemaManager::class);
         $schemaManager->method('tablesExist')->willReturn(true);
-        $this->connection->method('createSchemaManager')->willReturn($schemaManager);
-        $this->connection->method('beginTransaction')->willReturn(true);
-        $this->connection->method('commit')->willReturn(true);
-        $this->connection->method('rollBack')->willReturn(true);
-        $this->connection->method('executeStatement')->willReturn(1);
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
+        $connection->method('beginTransaction')->willReturn(true);
+        $connection->method('commit')->willReturn(true);
+        $connection->method('rollBack')->willReturn(true);
+        $connection->method('executeStatement')->willReturn(1);
         $classMetadata = $this->createMock(\Doctrine\ORM\Mapping\ClassMetadata::class);
         $classMetadata->method('getTableName')->willReturn('forms');
         $this->entityManager->method('getClassMetadata')->willReturn($classMetadata);
         $this->submissioRepository        = $this->createMock(SubmissionRepository::class);
         $this->leadRepository             = $this->createMock(LeadRepository::class);
-        $this->mockLogger                 = $this->createMock(Logger::class);
+        $mockLogger                       = $this->createMock(Logger::class);
         $this->uploadFieldValidatorMock   = $this->createMock(UploadFieldValidator::class);
-        $this->formUploaderMock           = $this->createMock(FormUploader::class);
-        $this->deviceTrackingService      = $this->createMock(DeviceTrackingServiceInterface::class);
+        $formUploaderMock                 = $this->createMock(FormUploader::class);
+        $deviceTrackingService            = $this->createMock(DeviceTrackingServiceInterface::class);
         $this->file1Mock                  = $this->createMock(UploadedFile::class);
         $this->router                     = $this->createMock(RouterInterface::class);
         $this->contactTracker             = $this->createMock(ContactTracker::class);
-        $this->contactMerger              = $this->createMock(ContactMerger::class);
+        $contactMerger                    = $this->createMock(ContactMerger::class);
         $userRepository                   = $this->createMock(UserRepository::class);
 
         $this->entityManager->method('getRepository')->willReturnCallback(fn (string $class) => match ($class) {
@@ -243,8 +191,8 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
             default           => null,
         });
 
-        $this->dispatcher->method('hasListeners')->willReturn(false);
-        $this->deviceTrackingService->method('getTrackedDevice')->willReturn(null);
+        $dispatcher->method('hasListeners')->willReturn(false);
+        $deviceTrackingService->method('getTrackedDevice')->willReturn(null);
         $this->formModel->method('getCustomComponents')->willReturn([
             'viewOnlyFields' => [],
             'fields'         => [],
@@ -253,34 +201,34 @@ class SubmissionModelTest extends \PHPUnit\Framework\TestCase
         $this->leadFieldModel->method('getFieldListWithProperties')->willReturn([]);
         $this->ipLookupHelper->method('getIpAddress')->willReturn(new IpAddress());
 
-        $this->fieldHelper->method('getFieldFilter')->willReturn('string');
+        $fieldHelper->method('getFieldFilter')->willReturn('string');
 
         $this->submissionModel = new SubmissionModel(
             $this->ipLookupHelper,
-            $this->twigMock,
+            $twigMock,
             $this->formModel,
-            $this->pageModel,
-            $this->leadModel,
+            $pageModel,
+            $leadModel,
             $this->campaignModel,
-            $this->membershipManager,
+            $membershipManager,
             $this->leadFieldModel,
             $this->companyModel,
-            $this->fieldHelper,
+            $fieldHelper,
             $this->uploadFieldValidatorMock,
-            $this->formUploaderMock,
-            $this->deviceTrackingService,
+            $formUploaderMock,
+            $deviceTrackingService,
             new FieldValueTransformer($this->router),
             $this->dateHelper,
             $this->contactTracker,
-            $this->contactMerger,
+            $contactMerger,
             $this->fieldsWithUniqueIdentifier,
             $this->entityManager,
             $this->createMock(CorePermissions::class),
-            $this->dispatcher,
+            $dispatcher,
             $this->createMock(UrlGeneratorInterface::class),
             $this->translator,
             $this->userHelper,
-            $this->mockLogger,
+            $mockLogger,
             $this->createMock(CoreParametersHelper::class)
         );
 

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -25,21 +25,11 @@ use Symfony\Component\Routing\Router;
 
 class InstallControllerTest extends \PHPUnit\Framework\TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $translatorMock;
-
-    private \PHPUnit\Framework\MockObject\MockObject $sessionMock;
-
-    private \PHPUnit\Framework\MockObject\MockObject $containerMock;
-
     private \PHPUnit\Framework\MockObject\MockObject $routerMock;
-
-    private \PHPUnit\Framework\MockObject\MockObject $flashBagMock;
 
     private InstallController $controller;
 
     private \PHPUnit\Framework\MockObject\MockObject $pathsHelper;
-
-    private \PHPUnit\Framework\MockObject\MockObject $configurator;
 
     private \PHPUnit\Framework\MockObject\MockObject $installer;
 
@@ -47,41 +37,41 @@ class InstallControllerTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->sessionMock          = $this->createMock(Session::class);
-        $this->containerMock        = $this->createMock(Container::class);
+        $sessionMock                = $this->createMock(Session::class);
+        $containerMock              = $this->createMock(Container::class);
         $this->routerMock           = $this->createMock(Router::class);
-        $this->flashBagMock         = $this->createMock(FlashBagInterface::class);
+        $flashBagMock               = $this->createMock(FlashBagInterface::class);
         $this->pathsHelper          = $this->createMock(PathsHelper::class);
 
-        $this->configurator   = $this->createMock(Configurator::class);
+        $configurator         = $this->createMock(Configurator::class);
         $this->installer      = $this->createMock(InstallService::class);
         $doctrine             = $this->createMock(ManagerRegistry::class);
         $modelFactory         = $this->createMock(ModelFactory::class);
         $userHelper           = $this->createMock(UserHelper::class);
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $dispatcher           = $this->createMock(EventDispatcherInterface::class);
-        $this->translatorMock = $this->createMock(Translator::class);
+        $translatorMock       = $this->createMock(Translator::class);
         $flashBag             = $this->createMock(FlashBag::class);
         $requestStack         = new RequestStack();
         $security             = $this->createMock(CorePermissions::class);
 
         $this->controller = new InstallController(
-            $this->configurator,
+            $configurator,
             $this->installer,
             $doctrine,
             $modelFactory,
             $userHelper,
             $coreParametersHelper,
             $dispatcher,
-            $this->translatorMock,
+            $translatorMock,
             $flashBag,
             $requestStack,
             $security
         );
-        $this->controller->setContainer($this->containerMock);
-        $this->sessionMock->method('getFlashBag')->willReturn($this->flashBagMock);
+        $this->controller->setContainer($containerMock);
+        $sessionMock->method('getFlashBag')->willReturn($flashBagMock);
 
-        $this->containerMock->method('get')
+        $containerMock->method('get')
             ->with('router')
             ->willReturn($this->routerMock);
     }

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -38,16 +38,6 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
 
     private MockObject $validator;
 
-<<<<<<< HEAD
-    private MockObject $hasher;
-
-    /**
-     * @var MockObject&FixturesLoaderInterface
-     */
-    private MockObject $fixtureLoader;
-
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private InstallService $installer;
 
     protected function setUp(): void

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -36,10 +36,9 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
 
     private MockObject $translator;
 
-    private MockObject $kernel;
-
     private MockObject $validator;
 
+<<<<<<< HEAD
     private MockObject $hasher;
 
     /**
@@ -47,6 +46,8 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fixtureLoader;
 
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private InstallService $installer;
 
     protected function setUp(): void
@@ -58,10 +59,10 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
         $this->pathsHelper          = $this->createMock(PathsHelper::class);
         $this->entityManager        = $this->createMock(EntityManager::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
-        $this->kernel               = $this->createMock(KernelInterface::class);
+        $kernel                     = $this->createMock(KernelInterface::class);
         $this->validator            = $this->createMock(ValidatorInterface::class);
-        $this->hasher               = $this->createMock(UserPasswordHasher::class);
-        $this->fixtureLoader        = $this->createMock(FixturesLoaderInterface::class);
+        $hasher                     = $this->createMock(UserPasswordHasher::class);
+        $fixtureLoader              = $this->createMock(FixturesLoaderInterface::class);
 
         $this->installer = new InstallService(
             $this->configurator,
@@ -69,10 +70,10 @@ class InstallServiceTest extends \PHPUnit\Framework\TestCase
             $this->pathsHelper,
             $this->entityManager,
             $this->translator,
-            $this->kernel,
+            $kernel,
             $this->validator,
-            $this->hasher,
-            $this->fixtureLoader
+            $hasher,
+            $fixtureLoader
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/BuilderIntegrationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/BuilderIntegrationsHelperTest.php
@@ -10,22 +10,16 @@ use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\IntegrationsBundle\Integration\Interfaces\BuilderInterface;
 use Mautic\PluginBundle\Entity\Integration;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class BuilderIntegrationsHelperTest extends TestCase
 {
-    /**
-     * @var IntegrationsHelper|MockObject
-     */
-    private MockObject $integrationsHelper;
-
     private BuilderIntegrationsHelper $builderIntegrationsHelper;
 
     protected function setUp(): void
     {
-        $this->integrationsHelper        = $this->createMock(IntegrationsHelper::class);
-        $this->builderIntegrationsHelper = new BuilderIntegrationsHelper($this->integrationsHelper);
+        $integrationsHelper              = $this->createMock(IntegrationsHelper::class);
+        $this->builderIntegrationsHelper = new BuilderIntegrationsHelper($integrationsHelper);
     }
 
     public function testBuilderNotFoundIfFeatureSupportedButNotEnabled(): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
@@ -31,18 +31,6 @@ class FieldHelperTest extends TestCase
     private MockObject $fieldsWithUniqueIdentifier;
 
     /**
-     * @var VariableExpresserHelperInterface&MockObject
-     */
-    private MockObject $variableExpresserHelper;
-
-    /**
-     * @var ChannelListHelper&MockObject
-     */
-    private MockObject $channelListHelper;
-
-    private MockObject $eventDispatcher;
-
-    /**
      * @var MauticSyncFieldsLoadEvent&MockObject
      */
     private MockObject $mauticSyncFieldsLoadEvent;
@@ -57,15 +45,15 @@ class FieldHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->fieldModel              = $this->createMock(FieldModel::class);
-        $this->variableExpresserHelper = $this->createMock(VariableExpresserHelperInterface::class);
-        $this->channelListHelper       = $this->createMock(ChannelListHelper::class);
+        $variableExpresserHelper       = $this->createMock(VariableExpresserHelperInterface::class);
+        $channelListHelper             = $this->createMock(ChannelListHelper::class);
         $this->objectProvider          = $this->createMock(ObjectProvider::class);
-        $this->channelListHelper->method('getFeatureChannels')
+        $channelListHelper->method('getFeatureChannels')
             ->willReturn(['Email' => 'email']);
 
         $this->mauticSyncFieldsLoadEvent = $this->createMock(MauticSyncFieldsLoadEvent::class);
-        $this->eventDispatcher           = $this->createMock(EventDispatcherInterface::class);
-        $this->eventDispatcher->method('dispatch')
+        $eventDispatcher                 = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')
             ->willReturn($this->mauticSyncFieldsLoadEvent);
 
         $this->fieldsWithUniqueIdentifier = $this->createMock(FieldsWithUniqueIdentifier::class);
@@ -73,10 +61,10 @@ class FieldHelperTest extends TestCase
         $this->fieldHelper = new FieldHelper(
             $this->fieldModel,
             $this->fieldsWithUniqueIdentifier,
-            $this->variableExpresserHelper,
-            $this->channelListHelper,
+            $variableExpresserHelper,
+            $channelListHelper,
             $this->createMock(TranslatorInterface::class),
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->objectProvider
         );
     }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
@@ -50,17 +50,7 @@ class MauticSyncDataExchangeTest extends TestCase
      */
     private MockObject $partialObjectReportBuilder;
 
-    /**
-     * @var MockObject|OrderExecutioner
-     */
-    private MockObject $orderExecutioner;
-
     private MauticSyncDataExchange $mauticSyncDataExchange;
-
-    /**
-     * @var SyncDateHelper&MockObject
-     */
-    private MockObject $syncDateHelper;
 
     protected function setUp(): void
     {
@@ -69,8 +59,8 @@ class MauticSyncDataExchangeTest extends TestCase
         $this->mappingHelper              = $this->createMock(MappingHelper::class);
         $this->fullObjectReportBuilder    = $this->createMock(FullObjectReportBuilder::class);
         $this->partialObjectReportBuilder = $this->createMock(PartialObjectReportBuilder::class);
-        $this->orderExecutioner           = $this->createMock(OrderExecutioner::class);
-        $this->syncDateHelper             = $this->createMock(SyncDateHelper::class);
+        $orderExecutioner                 = $this->createMock(OrderExecutioner::class);
+        $syncDateHelper                   = $this->createMock(SyncDateHelper::class);
 
         $this->mauticSyncDataExchange = new MauticSyncDataExchange(
             $this->fieldChangeRepository,
@@ -78,8 +68,8 @@ class MauticSyncDataExchangeTest extends TestCase
             $this->mappingHelper,
             $this->fullObjectReportBuilder,
             $this->partialObjectReportBuilder,
-            $this->orderExecutioner,
-            $this->syncDateHelper
+            $orderExecutioner,
+            $syncDateHelper
         );
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
@@ -33,34 +33,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class SyncProcessTest extends TestCase
 {
     /**
-     * @var MockObject|MappingManualDAO
-     */
-    private MockObject $mappingManualDAO;
-
-    /**
      * @var MockObject|MauticSyncDataExchange
      */
     private MockObject $internalSyncDataExchange;
 
     /**
-     * @var MockObject|SyncDataExchangeInterface
-     */
-    private MockObject $integrationSyncDataExchange;
-
-    /**
      * @var MockObject|SyncDateHelper
      */
     private MockObject $syncDateHelper;
-
-    /**
-     * @var MockObject|MappingHelper
-     */
-    private MockObject $mappingHelper;
-
-    /**
-     * @var MockObject|RelationsHelper
-     */
-    private MockObject $relationsHelper;
 
     /**
      * @var MockObject|IntegrationSyncProcess
@@ -78,50 +58,40 @@ class SyncProcessTest extends TestCase
     private MockObject $eventDispatcher;
 
     /**
-     * @var MockObject|Notifier
-     */
-    private MockObject $notifier;
-
-    /**
      * @var MockObject|InputOptionsDAO
      */
     private MockObject $inputOptionsDAO;
-
-    /**
-     * @var MockObject|SyncServiceInterface
-     */
-    private MockObject $syncService;
 
     private SyncProcess $syncProcess;
 
     protected function setUp(): void
     {
         $this->syncDateHelper              = $this->createMock(SyncDateHelper::class);
-        $this->mappingHelper               = $this->createMock(MappingHelper::class);
-        $this->relationsHelper             = $this->createMock(RelationsHelper::class);
+        $mappingHelper                     = $this->createMock(MappingHelper::class);
+        $relationsHelper                   = $this->createMock(RelationsHelper::class);
         $this->integrationSyncProcess      = $this->createMock(IntegrationSyncProcess::class);
         $this->mauticSyncProcess           = $this->createMock(MauticSyncProcess::class);
         $this->eventDispatcher             = $this->createMock(EventDispatcherInterface::class);
-        $this->notifier                    = $this->createMock(Notifier::class);
-        $this->mappingManualDAO            = $this->createMock(MappingManualDAO::class);
-        $this->integrationSyncDataExchange = $this->createMock(SyncDataExchangeInterface::class);
+        $notifier                          = $this->createMock(Notifier::class);
+        $mappingManualDAO                  = $this->createMock(MappingManualDAO::class);
+        $integrationSyncDataExchange       = $this->createMock(SyncDataExchangeInterface::class);
         $this->internalSyncDataExchange    = $this->createMock(MauticSyncDataExchange::class);
         $this->inputOptionsDAO             = $this->createMock(InputOptionsDAO::class);
-        $this->syncService                 = $this->createMock(SyncServiceInterface::class);
+        $syncService                       = $this->createMock(SyncServiceInterface::class);
 
         $this->syncProcess = new SyncProcess(
             $this->syncDateHelper,
-            $this->mappingHelper,
-            $this->relationsHelper,
+            $mappingHelper,
+            $relationsHelper,
             $this->integrationSyncProcess,
             $this->mauticSyncProcess,
             $this->eventDispatcher,
-            $this->notifier,
-            $this->mappingManualDAO,
+            $notifier,
+            $mappingManualDAO,
             $this->internalSyncDataExchange,
-            $this->integrationSyncDataExchange,
+            $integrationSyncDataExchange,
             $this->inputOptionsDAO,
-            $this->syncService
+            $syncService
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -27,11 +27,6 @@ class ContactMergerTest extends \PHPUnit\Framework\TestCase
     private \PHPUnit\Framework\MockObject\MockObject $leadModel;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&LeadRepository
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $leadRepo;
-
-    /**
      * @var \PHPUnit\Framework\MockObject\MockObject|MergeRecordRepository
      */
     private \PHPUnit\Framework\MockObject\MockObject $mergeRecordRepo;
@@ -51,13 +46,13 @@ class ContactMergerTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->leadModel       = $this->createMock(LeadModel::class);
-        $this->leadRepo        = $this->createMock(LeadRepository::class);
+        $leadRepo              = $this->createMock(LeadRepository::class);
         $this->mergeRecordRepo = $this->createMock(MergeRecordRepository::class);
         $this->dispatcher      = $this->createMock(EventDispatcher::class);
         $this->logger          = $this->createMock(Logger::class);
         $this->companyLeadRepo = $this->createMock(CompanyLeadRepository::class);
 
-        $this->leadModel->method('getRepository')->willReturn($this->leadRepo);
+        $this->leadModel->method('getRepository')->willReturn($leadRepo);
     }
 
     public function testMergeTimestamps(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -139,8 +139,6 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     private $subscriber;
 
-    private FilterOperatorProvider $filterOperatorProvider;
-
     /**
      * @var DoNotContact|MockObject
      */
@@ -156,7 +154,7 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
         $mockCampaignModel            = $this->createMock(CampaignModel::class);
         $this->doNotContact           = $this->createMock(DoNotContact::class);
         $mockGroupModel               = $this->createMock(PointGroupModel::class);
-        $this->filterOperatorProvider = new FilterOperatorProvider(
+        $filterOperatorProvider       = new FilterOperatorProvider(
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(TranslatorInterface::class)
         );
@@ -174,7 +172,7 @@ class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             $mockCoreParametersHelper,
             $this->doNotContact,
             $mockGroupModel,
-            $this->filterOperatorProvider
+            $filterOperatorProvider
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
@@ -22,8 +22,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class FilterOperatorSubscriberTest extends TestCase
 {
-    private OperatorOptions $operatorOptions;
-
     /**
      * @var MockObject|LeadFieldRepository
      */
@@ -50,14 +48,14 @@ final class FilterOperatorSubscriberTest extends TestCase
     {
         parent::setUp();
 
-        $this->operatorOptions      = new OperatorOptions();
+        $operatorOptions            = new OperatorOptions();
         $this->leadFieldRepository  = $this->createMock(LeadFieldRepository::class);
         $this->typeOperatorProvider = $this->createMock(TypeOperatorProviderInterface::class);
         $this->fieldChoicesProvider = $this->createMock(FieldChoicesProviderInterface::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
 
         $this->subscriber = new FilterOperatorSubscriber(
-            $this->operatorOptions,
+            $operatorOptions,
             $this->leadFieldRepository,
             $this->typeOperatorProvider,
             $this->fieldChoicesProvider,

--- a/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
@@ -25,20 +25,26 @@ use Symfony\Component\HttpFoundation\Request;
 class FormSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
+<<<<<<< HEAD
      * @var DoNotContact|(DoNotContact&MockObject)|MockObject
      */
     private MockObject $doNotContact;
 
     /**
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var LeadModel|MockObject
      */
     private MockObject $leadModel;
 
+<<<<<<< HEAD
     /**
      * @var PointGroupModel|(PointGroupModel&object&MockObject)|(PointGroupModel&MockObject)|(object&MockObject)|MockObject
      */
     private MockObject $pointGroupModel;
 
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private FormSubscriber $subscriber;
 
     /**
@@ -47,36 +53,30 @@ class FormSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $contactTracker;
 
     /**
-     * @var MockObject|LeadFieldRepository
-     */
-    private MockObject $leadFieldRepostory;
-
-    /**
      * @var MockObject|IpLookupHelper
      */
     private MockObject $ipLookupHelper;
 
     private MockObject $submissionEvent;
-    private MockObject $fieldModel;
 
     protected function setUp(): void
     {
         $this->leadModel          = $this->createMock(LeadModel::class);
         $this->contactTracker     = $this->createMock(ContactTracker::class);
         $this->ipLookupHelper     = $this->createMock(IpLookupHelper::class);
-        $this->leadFieldRepostory = $this->createMock(LeadFieldRepository::class);
-        $this->pointGroupModel    = $this->createMock(PointGroupModel::class);
-        $this->doNotContact       = $this->createMock(DoNotContact::class);
+        $leadFieldRepostory       = $this->createMock(LeadFieldRepository::class);
+        $pointGroupModel          = $this->createMock(PointGroupModel::class);
+        $doNotContact             = $this->createMock(DoNotContact::class);
         $this->submissionEvent    = $this->createMock(SubmissionEvent::class);
-        $this->fieldModel         = $this->createMock(FieldModel::class);
+        $fieldModel               = $this->createMock(FieldModel::class);
         $this->subscriber         = new FormSubscriber(
             $this->leadModel,
             $this->contactTracker,
             $this->ipLookupHelper,
-            $this->leadFieldRepostory,
-            $this->pointGroupModel,
-            $this->doNotContact,
-            $this->fieldModel
+            $leadFieldRepostory,
+            $pointGroupModel,
+            $doNotContact,
+            $fieldModel
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
@@ -25,19 +25,9 @@ use Symfony\Component\HttpFoundation\Request;
 class FormSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var DoNotContact|(DoNotContact&MockObject)|MockObject
-     */
-    private MockObject $doNotContact;
-
-    /**
      * @var LeadModel|MockObject
      */
     private MockObject $leadModel;
-
-    /**
-     * @var PointGroupModel|(PointGroupModel&object&MockObject)|(PointGroupModel&MockObject)|(object&MockObject)|MockObject
-     */
-    private MockObject $pointGroupModel;
 
     private FormSubscriber $subscriber;
 

--- a/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
@@ -25,26 +25,20 @@ use Symfony\Component\HttpFoundation\Request;
 class FormSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-<<<<<<< HEAD
      * @var DoNotContact|(DoNotContact&MockObject)|MockObject
      */
     private MockObject $doNotContact;
 
     /**
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var LeadModel|MockObject
      */
     private MockObject $leadModel;
 
-<<<<<<< HEAD
     /**
      * @var PointGroupModel|(PointGroupModel&object&MockObject)|(PointGroupModel&MockObject)|(object&MockObject)|MockObject
      */
     private MockObject $pointGroupModel;
 
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private FormSubscriber $subscriber;
 
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -76,15 +76,18 @@ class OwnerSubscriberTest extends TestCase
         ],
     ];
 
+<<<<<<< HEAD
     /** @var MockObject&CoreParametersHelper */
     private MockObject $coreParametersHelper;
 
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private MailHashHelper $mailHashHelper;
 
     protected function setUp(): void
     {
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->mailHashHelper       = new MailHashHelper($this->coreParametersHelper);
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
+        $this->mailHashHelper       = new MailHashHelper($coreParametersHelper);
     }
 
     public function testOnEmailBuild(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -76,12 +76,6 @@ class OwnerSubscriberTest extends TestCase
         ],
     ];
 
-<<<<<<< HEAD
-    /** @var MockObject&CoreParametersHelper */
-    private MockObject $coreParametersHelper;
-
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private MailHashHelper $mailHashHelper;
 
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -45,21 +45,6 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadFieldModelMock;
 
     /**
-     * @var MockObject|StageModel
-     */
-    private MockObject $stageModelMock;
-
-    /**
-     * @var MockObject|CampaignModel
-     */
-    private MockObject $campaignModelMock;
-
-    /**
-     * @var MockObject|EventCollector
-     */
-    private MockObject $eventCollectorMock;
-
-    /**
      * @var MockObject|CompanyModel
      */
     private MockObject $companyModelMock;
@@ -89,11 +74,6 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     private ReportHelper $reportHelperMock;
 
     /**
-     * @var MockObject|CampaignRepository
-     */
-    private MockObject $campaignRepositoryMock;
-
-    /**
      * @var MockObject|ReportBuilderEvent
      */
     private MockObject $reportBuilderEventMock;
@@ -102,11 +82,6 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
      * @var MockObject|QueryBuilder
      */
     private MockObject $queryBuilderMock;
-
-    /**
-     * @var MockObject|ExpressionBuilder
-     */
-    private MockObject $expressionBuilderMock;
 
     /**
      * @var MockObject|ReportGraphEvent
@@ -129,8 +104,6 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $reportDataEventMock;
 
     private ReportSubscriber $reportSubscriber;
-
-    private MockObject&DncReportService $dncReportService;
 
     /** @var array<string, array<string, string>> */
     private array $leadColumns = [
@@ -161,9 +134,9 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $this->leadModelMock                    = $this->createMock(LeadModel::class);
         $this->leadFieldModelMock               = $this->createMock(FieldModel::class);
-        $this->stageModelMock                   = $this->createMock(StageModel::class);
-        $this->campaignModelMock                = $this->createMock(CampaignModel::class);
-        $this->eventCollectorMock               = $this->createMock(EventCollector::class);
+        $stageModelMock                         = $this->createMock(StageModel::class);
+        $campaignModelMock                      = $this->createMock(CampaignModel::class);
+        $eventCollectorMock                     = $this->createMock(EventCollector::class);
         $this->companyModelMock                 = $this->createMock(CompanyModel::class);
         $this->companyReportDataMock            = $this->createMock(CompanyReportData::class);
         $this->fieldsBuilderMock                = $this->createMock(FieldsBuilder::class);
@@ -172,30 +145,30 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->reportDataEventMock              = $this->createMock(ReportDataEvent::class);
         $this->channelListHelperMock            = new ChannelListHelper($this->createMock(EventDispatcherInterface::class), $this->createMock(Translator::class));
         $this->reportHelperMock                 = new ReportHelper($this->createMock(EventDispatcherInterface::class));
-        $this->campaignRepositoryMock           = $this->createMock(CampaignRepository::class);
+        $campaignRepositoryMock                 = $this->createMock(CampaignRepository::class);
         $this->reportBuilderEventMock           = $this->createMock(ReportBuilderEvent::class);
         $this->queryBuilderMock                 = $this->createMock(QueryBuilder::class);
-        $this->expressionBuilderMock            = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilderMock                  = $this->createMock(ExpressionBuilder::class);
         $this->reportGraphEventMock             = $this->createMock(ReportGraphEvent::class);
         $this->companyRepositoryMock            = $this->createMock(CompanyRepository::class);
         $this->pointsChangeLogRepositoryMock    = $this->createMock(PointsChangeLogRepository::class);
-        $this->dncReportService                 = $this->createMock(DncReportService::class);
+        $dncReportService                       = $this->createMock(DncReportService::class);
         $this->reportSubscriber                 = new ReportSubscriber(
             $this->leadModelMock,
             $this->leadFieldModelMock,
-            $this->stageModelMock,
-            $this->campaignModelMock,
-            $this->eventCollectorMock,
+            $stageModelMock,
+            $campaignModelMock,
+            $eventCollectorMock,
             $this->companyModelMock,
             $this->companyReportDataMock,
             $this->fieldsBuilderMock,
             $this->translatorMock,
-            $this->dncReportService
+            $dncReportService
         );
 
         $this->queryBuilderMock->expects($this->any())
                 ->method('expr')
-                ->willReturn($this->expressionBuilderMock);
+                ->willReturn($expressionBuilderMock);
 
         $this->queryBuilderMock->expects($this->any())
             ->method('resetQueryParts')
@@ -267,9 +240,9 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('orderBy')
             ->willReturn($this->queryBuilderMock);
 
-        $this->campaignModelMock->method('getRepository')->willReturn($this->campaignRepositoryMock);
+        $campaignModelMock->method('getRepository')->willReturn($campaignRepositoryMock);
 
-        $this->eventCollectorMock->expects($this->any())
+        $eventCollectorMock->expects($this->any())
             ->method('getEventsArray')
             ->willReturn(
                 [
@@ -309,7 +282,7 @@ class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('hasId')
             ->willReturn(false);
 
-        $this->stageModelMock->expects($this->any())
+        $stageModelMock->expects($this->any())
             ->method('getUserStages')
             ->willReturn([
                 'stage' => [

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -48,11 +48,6 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
     private MockObject $emailModel;
 
     /**
-     * @var MockObject&StageModel
-     */
-    private MockObject $stageModel;
-
-    /**
      * @var MockObject&StageRepository
      */
     private MockObject $stageRepository;
@@ -66,11 +61,6 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
      * @var MockObject&AssetModel
      */
     private MockObject $assetModel;
-
-    /**
-     * @var MockObject&TranslatorInterface
-     */
-    private MockObject $translator;
 
     /**
      * @var MockObject&FormInterface<FormInterface<mixed>>
@@ -87,25 +77,25 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->listModel       = $this->createMock(ListModel::class);
         $this->campaignModel   = $this->createMock(CampaignModel::class);
         $this->emailModel      = $this->createMock(EmailModel::class);
-        $this->stageModel      = $this->createMock(StageModel::class);
+        $stageModel            = $this->createMock(StageModel::class);
         $this->stageRepository = $this->createMock(StageRepository::class);
         $this->categoryModel   = $this->createMock(CategoryModel::class);
         $this->assetModel      = $this->createMock(AssetModel::class);
-        $this->translator      = $this->createMock(TranslatorInterface::class);
+        $translator            = $this->createMock(TranslatorInterface::class);
         $this->form            = $this->createMock(FormInterface::class);
         $this->subscriber      = new TypeOperatorSubscriber(
             $this->leadModel,
             $this->listModel,
             $this->campaignModel,
             $this->emailModel,
-            $this->stageModel,
+            $stageModel,
             $this->categoryModel,
             $this->assetModel,
-            $this->translator
+            $translator
         );
 
-        $this->stageModel->method('getRepository')->willReturn($this->stageRepository);
-        $this->translator->method('trans')->willReturnArgument(0);
+        $stageModel->method('getRepository')->willReturn($this->stageRepository);
+        $translator->method('trans')->willReturnArgument(0);
     }
 
     public function testOnTypeOperatorsCollect(): void

--- a/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
@@ -39,11 +39,14 @@ class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadFieldSaver;
 
     /**
+<<<<<<< HEAD
      * @var MockObject&LeadFieldDeleter
      */
     private MockObject $leadFieldDeleter;
 
     /**
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var MockObject&FieldColumnBackgroundJobDispatcher
      */
     private MockObject $fieldColumnBackgroundJobDispatcher;
@@ -58,7 +61,7 @@ class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
         $this->fieldModel                         = $this->createMock(FieldModel::class);
         $this->customFieldColumn                  = $this->createMock(CustomFieldColumn::class);
         $this->leadFieldSaver                     = $this->createMock(LeadFieldSaver::class);
-        $this->leadFieldDeleter                   = $this->createMock(LeadFieldDeleter::class);
+        $leadFieldDeleter                         = $this->createMock(LeadFieldDeleter::class);
         $this->fieldColumnBackgroundJobDispatcher = $this->createMock(FieldColumnBackgroundJobDispatcher::class);
         $this->customFieldNotification            = $this->createMock(CustomFieldNotification::class);
 
@@ -66,7 +69,7 @@ class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
             $this->fieldModel,
             $this->customFieldColumn,
             $this->leadFieldSaver,
-            $this->leadFieldDeleter,
+            $leadFieldDeleter,
             $this->fieldColumnBackgroundJobDispatcher,
             $this->customFieldNotification
         );

--- a/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
@@ -39,14 +39,11 @@ class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadFieldSaver;
 
     /**
-<<<<<<< HEAD
      * @var MockObject&LeadFieldDeleter
      */
     private MockObject $leadFieldDeleter;
 
     /**
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var MockObject&FieldColumnBackgroundJobDispatcher
      */
     private MockObject $fieldColumnBackgroundJobDispatcher;

--- a/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
@@ -39,11 +39,6 @@ class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadFieldSaver;
 
     /**
-     * @var MockObject&LeadFieldDeleter
-     */
-    private MockObject $leadFieldDeleter;
-
-    /**
      * @var MockObject&FieldColumnBackgroundJobDispatcher
      */
     private MockObject $fieldColumnBackgroundJobDispatcher;

--- a/app/bundles/LeadBundle/Tests/Field/Command/DeleteCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Command/DeleteCustomFieldCommandTest.php
@@ -24,22 +24,17 @@ final class DeleteCustomFieldCommandTest extends TestCase
      */
     private MockObject $translatorInterfaceMock;
 
-    /**
-     * @var MockObject&LeadFieldRepository
-     */
-    private MockObject $leadFieldRepository;
-
     private DeleteCustomFieldCommand $deleteCustomFieldCommand;
 
     protected function setUp(): void
     {
         $this->backgroundServiceMock    = $this->createMock(BackgroundService::class);
         $this->translatorInterfaceMock  = $this->createMock(TranslatorInterface::class);
-        $this->leadFieldRepository      = $this->createMock(LeadFieldRepository::class);
+        $leadFieldRepository            = $this->createMock(LeadFieldRepository::class);
         $this->deleteCustomFieldCommand = new DeleteCustomFieldCommand(
             $this->backgroundServiceMock,
             $this->translatorInterfaceMock,
-            $this->leadFieldRepository,
+            $leadFieldRepository,
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
@@ -32,11 +32,6 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
     private MockObject $schemaDefinition;
 
     /**
-     * @var MockObject|Logger
-     */
-    private MockObject $logger;
-
-    /**
      * @var MockObject|LeadFieldSaver
      */
     private MockObject $leadFieldSaver;
@@ -51,11 +46,6 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fieldColumnDispatcher;
 
-    /**
-     * @var MockObject|TranslatorInterface
-     */
-    private MockObject $translator;
-
     private CustomFieldColumn $customFieldColumn;
 
     protected function setUp(): void
@@ -64,19 +54,19 @@ class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
 
         $this->columnSchemaHelper    = $this->createMock(ColumnSchemaHelper::class);
         $this->schemaDefinition      = $this->createMock(SchemaDefinition::class);
-        $this->logger                = $this->createMock(Logger::class);
+        $logger                      = $this->createMock(Logger::class);
         $this->leadFieldSaver        = $this->createMock(LeadFieldSaver::class);
         $this->customFieldIndex      = $this->createMock(CustomFieldIndex::class);
         $this->fieldColumnDispatcher = $this->createMock(FieldColumnDispatcher::class);
-        $this->translator            = $this->createMock(TranslatorInterface::class);
+        $translator                  = $this->createMock(TranslatorInterface::class);
         $this->customFieldColumn     = new CustomFieldColumn(
             $this->columnSchemaHelper,
             $this->schemaDefinition,
-            $this->logger,
+            $logger,
             $this->leadFieldSaver,
             $this->customFieldIndex,
             $this->fieldColumnDispatcher,
-            $this->translator
+            $translator
         );
     }
 

--- a/app/bundles/LeadBundle/Tests/Field/CustomFieldIndexTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/CustomFieldIndexTest.php
@@ -15,8 +15,6 @@ final class CustomFieldIndexTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&IndexSchemaHelper $indexSchemaHelperMock;
 
-    private MockObject&Logger $loggerMock;
-
     private MockObject&FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifierMock;
 
     private MockObject&LeadField $leadFieldMock;
@@ -26,9 +24,9 @@ final class CustomFieldIndexTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->indexSchemaHelperMock          = $this->createMock(IndexSchemaHelper::class);
-        $this->loggerMock                     = $this->createMock(Logger::class);
+        $loggerMock                           = $this->createMock(Logger::class);
         $this->fieldsWithUniqueIdentifierMock = $this->createMock(FieldsWithUniqueIdentifier::class);
-        $this->customFieldIndex               = new CustomFieldIndex($this->indexSchemaHelperMock, $this->loggerMock, $this->fieldsWithUniqueIdentifierMock);
+        $this->customFieldIndex               = new CustomFieldIndex($this->indexSchemaHelperMock, $loggerMock, $this->fieldsWithUniqueIdentifierMock);
         $this->leadFieldMock                  = $this->createMock(LeadField::class);
     }
 

--- a/app/bundles/LeadBundle/Tests/Form/DataTransformer/FieldFilterTransformerTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/DataTransformer/FieldFilterTransformerTest.php
@@ -11,11 +11,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class FieldFilterTransformerTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var MockObject|TranslatorInterface
-     */
-    private MockObject $translator;
-
     private FieldFilterTransformer $transformer;
 
     /**
@@ -27,9 +22,9 @@ final class FieldFilterTransformerTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->translator   = $this->createMock(TranslatorInterface::class);
+        $translator         = $this->createMock(TranslatorInterface::class);
         $this->relativeDate = $this->createMock(RelativeDate::class);
-        $this->translator->expects($this->any())
+        $translator->expects($this->any())
             ->method('trans')
             ->willReturnCallback(fn ($id, $parameters, $domain, $locale): string => match ($id) {
                 'mautic.lead.list.month_last'  => isset($locale) ? 'last month' : 'letzter Monat',
@@ -47,7 +42,7 @@ final class FieldFilterTransformerTest extends \PHPUnit\Framework\TestCase
                 'mautic.lead.list.anniversary' => isset($locale) ? 'anniversary' : 'Jahrestag',
                 default                        => isset($locale) ? 'today' : 'heute',
             });
-        $this->transformer  = new FieldFilterTransformer($this->translator, $this->relativeDate);
+        $this->transformer  = new FieldFilterTransformer($translator, $this->relativeDate);
     }
 
     public function testTransform(): void

--- a/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
@@ -15,23 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FieldAliasKeywordValidatorTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var ContactSegmentFilterDictionary|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $contactSegmentFilterDictionary;
-
-    private \PHPUnit\Framework\MockObject\MockObject $listModelMock;
-
-    private \PHPUnit\Framework\MockObject\MockObject $fieldAliasHelperlMock;
-
     private \PHPUnit\Framework\MockObject\MockObject $executionContextMock;
-
-    private \PHPUnit\Framework\MockObject\MockObject $entityManagerMock;
-
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|TranslatorInterface
-     */
-    private \PHPUnit\Framework\MockObject\MockObject $translatorMock;
 
     private \PHPUnit\Framework\MockObject\MockObject $unitOfWorkMock;
 
@@ -41,19 +25,19 @@ class FieldAliasKeywordValidatorTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->fieldAliasHelperlMock          = $this->createMock(FieldAliasHelper::class);
-        $this->listModelMock                  = $this->createMock(ListModel::class);
+        $fieldAliasHelperlMock                = $this->createMock(FieldAliasHelper::class);
+        $listModelMock                        = $this->createMock(ListModel::class);
         $this->executionContextMock           = $this->createMock(ExecutionContextInterface::class);
-        $this->entityManagerMock              = $this->createMock(EntityManager::class);
+        $entityManagerMock                    = $this->createMock(EntityManager::class);
         $this->unitOfWorkMock                 = $this->createMock(UnitOfWork::class);
-        $this->translatorMock                 = $this->createMock(TranslatorInterface::class);
-        $this->contactSegmentFilterDictionary = $this->createMock(ContactSegmentFilterDictionary::class);
+        $translatorMock                       = $this->createMock(TranslatorInterface::class);
+        $contactSegmentFilterDictionary       = $this->createMock(ContactSegmentFilterDictionary::class);
 
-        $this->entityManagerMock
+        $entityManagerMock
             ->method('getUnitOfWork')
             ->willReturn($this->unitOfWorkMock);
 
-        $this->listModelMock->method('getChoiceFields')
+        $listModelMock->method('getChoiceFields')
             ->willReturn(
                 [
                     'lead' => [
@@ -73,18 +57,18 @@ class FieldAliasKeywordValidatorTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $this->contactSegmentFilterDictionary->method('getFilters')->willReturn(
+        $contactSegmentFilterDictionary->method('getFilters')->willReturn(
             []
         );
 
-        $this->translatorMock->method('trans')->willReturn('');
+        $translatorMock->method('trans')->willReturn('');
 
         $this->validator = new FieldAliasKeywordValidator(
-            $this->listModelMock,
-            $this->fieldAliasHelperlMock,
-            $this->entityManagerMock,
-            $this->translatorMock,
-            $this->contactSegmentFilterDictionary
+            $listModelMock,
+            $fieldAliasHelperlMock,
+            $entityManagerMock,
+            $translatorMock,
+            $contactSegmentFilterDictionary
         );
         $this->validator->initialize($this->executionContextMock);
     }

--- a/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
@@ -17,17 +17,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class AvatarHelperTest extends \PHPUnit\Framework\TestCase
 {
-    private AssetsHelper $assetsHelperMock;
-
-    /**
-     * @var MockObject&PathsHelper
-     */
-    private MockObject $pathsHelperMock;
-
-    private GravatarHelper $gravatarHelperMock;
-
-    private DefaultAvatarHelper $defaultAvatarHelperMock;
-
     /**
      * @var MockObject&Lead
      */
@@ -45,20 +34,20 @@ class AvatarHelperTest extends \PHPUnit\Framework\TestCase
         /** @var CoreParametersHelper&MockObject $coreParametersHelper */
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
 
-        $this->assetsHelperMock = new AssetsHelper($packagesMock);
-        $this->pathsHelperMock  = $this->createMock(PathsHelper::class);
-        $this->pathsHelperMock->method('getSystemPath')
+        $assetsHelperMock = new AssetsHelper($packagesMock);
+        $pathsHelperMock  = $this->createMock(PathsHelper::class);
+        $pathsHelperMock->method('getSystemPath')
         ->willReturn('http://localhost');
-        $this->pathsHelperMock->method('getAssetsPath')
+        $pathsHelperMock->method('getAssetsPath')
           ->willReturn($root.'/app/assets');
-        $this->pathsHelperMock->method('getMediaPath')
+        $pathsHelperMock->method('getMediaPath')
           ->willReturn($root.'/media');
 
-        $this->assetsHelperMock->setPathsHelper($this->pathsHelperMock);
-        $this->defaultAvatarHelperMock = new DefaultAvatarHelper($this->assetsHelperMock);
-        $this->gravatarHelperMock      = new GravatarHelper($this->defaultAvatarHelperMock, $coreParametersHelper, $this->createMock(RequestStack::class));
+        $assetsHelperMock->setPathsHelper($pathsHelperMock);
+        $defaultAvatarHelperMock       = new DefaultAvatarHelper($assetsHelperMock);
+        $gravatarHelperMock            = new GravatarHelper($defaultAvatarHelperMock, $coreParametersHelper, $this->createMock(RequestStack::class));
         $this->leadMock                = $this->createMock(Lead::class);
-        $this->avatarHelper            = new AvatarHelper($this->assetsHelperMock, $this->pathsHelperMock, $this->gravatarHelperMock, $this->defaultAvatarHelperMock);
+        $this->avatarHelper            = new AvatarHelper($assetsHelperMock, $pathsHelperMock, $gravatarHelperMock, $defaultAvatarHelperMock);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
@@ -27,11 +27,7 @@ class FieldAliasHelperTest extends \PHPUnit\Framework\TestCase
             'lastname',
         ]);
 
-<<<<<<< HEAD
-        $this->fieldModel->method('cleanAlias')->willReturnCallback(fn (): mixed => func_get_args()[0]);
-=======
-        $fieldModel->method('cleanAlias')->willReturnCallback(fn () => func_get_args()[0]);
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
+        $fieldModel->method('cleanAlias')->willReturnCallback(fn (): mixed => func_get_args()[0]);
 
         $fieldModel->method('getRepository')->willReturn($fieldRepository);
 

--- a/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
@@ -9,33 +9,33 @@ use Mautic\LeadBundle\Model\FieldModel;
 
 class FieldAliasHelperTest extends \PHPUnit\Framework\TestCase
 {
-    private \PHPUnit\Framework\MockObject\MockObject $fieldModel;
-
-    private \PHPUnit\Framework\MockObject\MockObject $fieldRepository;
-
     private FieldAliasHelper $helper;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->fieldRepository = $this->createMock(LeadFieldRepository::class);
-        $this->fieldModel      = $this->getMockBuilder(FieldModel::class)
+        $fieldRepository = $this->createMock(LeadFieldRepository::class);
+        $fieldModel      = $this->getMockBuilder(FieldModel::class)
             ->onlyMethods(['cleanAlias', 'getRepository'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->fieldRepository->method('getAliases')->willReturn([
+        $fieldRepository->method('getAliases')->willReturn([
             'title',
             'firstname',
             'lastname',
         ]);
 
+<<<<<<< HEAD
         $this->fieldModel->method('cleanAlias')->willReturnCallback(fn (): mixed => func_get_args()[0]);
+=======
+        $fieldModel->method('cleanAlias')->willReturnCallback(fn () => func_get_args()[0]);
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
 
-        $this->fieldModel->method('getRepository')->willReturn($this->fieldRepository);
+        $fieldModel->method('getRepository')->willReturn($fieldRepository);
 
-        $this->helper = new FieldAliasHelper($this->fieldModel);
+        $this->helper = new FieldAliasHelper($fieldModel);
     }
 
     public function testDuplicatedAliasWithAliasSet(): void

--- a/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
@@ -22,11 +22,6 @@ class IpAddressModelTest extends TestCase
      */
     private MockObject $entityManager;
 
-    /**
-     * @var MockObject|LoggerInterface
-     */
-    private MockObject $logger;
-
     private IpAddressModel $ipAddressModel;
 
     protected function setUp(): void
@@ -34,8 +29,8 @@ class IpAddressModelTest extends TestCase
         parent::setUp();
 
         $this->entityManager  = $this->createMock(EntityManager::class);
-        $this->logger         = $this->createMock(LoggerInterface::class);
-        $this->ipAddressModel = new IpAddressModel($this->entityManager, $this->logger);
+        $logger               = $this->createMock(LoggerInterface::class);
+        $this->ipAddressModel = new IpAddressModel($this->entityManager, $logger);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -22,23 +22,6 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $eventDispatcherMock;
 
-    private ContactSegmentFilterDictionary $contactSegmentFilterDictionary;
-
-    /**
-     * @var MockObject|BaseDecorator
-     */
-    private MockObject $baseDecorator;
-
-    /**
-     * @var MockObject|CustomMappedDecorator
-     */
-    private MockObject $customMappedDecorator;
-
-    /**
-     * @var MockObject|CompanyDecorator
-     */
-    private MockObject $companyDecorator;
-
     /**
      * @var MockObject|DateOptionFactory
      */
@@ -51,17 +34,17 @@ class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->eventDispatcherMock            = $this->createMock(EventDispatcherInterface::class);
-        $this->contactSegmentFilterDictionary = new ContactSegmentFilterDictionary($this->eventDispatcherMock);
-        $this->baseDecorator                  = $this->createMock(BaseDecorator::class);
-        $this->customMappedDecorator          = $this->createMock(CustomMappedDecorator::class);
-        $this->companyDecorator               = $this->createMock(CompanyDecorator::class);
+        $contactSegmentFilterDictionary       = new ContactSegmentFilterDictionary($this->eventDispatcherMock);
+        $baseDecorator                        = $this->createMock(BaseDecorator::class);
+        $customMappedDecorator                = $this->createMock(CustomMappedDecorator::class);
+        $companyDecorator                     = $this->createMock(CompanyDecorator::class);
         $this->dateOptionFactory              = $this->createMock(DateOptionFactory::class);
         $this->decoratorFactory               = new DecoratorFactory(
-            $this->contactSegmentFilterDictionary,
-            $this->baseDecorator,
-            $this->customMappedDecorator,
+            $contactSegmentFilterDictionary,
+            $baseDecorator,
+            $customMappedDecorator,
             $this->dateOptionFactory,
-            $this->companyDecorator,
+            $companyDecorator,
             $this->eventDispatcherMock);
     }
 

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
@@ -32,11 +32,6 @@ class ChannelClickQueryBuilderTest extends TestCase
     private MockObject $randomParameterMock;
 
     /**
-     * @var MockObject|EventDispatcherInterface
-     */
-    private MockObject $dispatcherMock;
-
-    /**
      * @var Connection|MockObject
      */
     private MockObject $connectionMock;
@@ -46,11 +41,11 @@ class ChannelClickQueryBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->randomParameterMock = $this->createMock(RandomParameterName::class);
-        $this->dispatcherMock      = $this->createMock(EventDispatcherInterface::class);
+        $dispatcherMock            = $this->createMock(EventDispatcherInterface::class);
         $this->connectionMock      = $this->getMockedConnection();
         $this->queryBuilder        = new ChannelClickQueryBuilder(
             $this->randomParameterMock,
-            $this->dispatcherMock
+            $dispatcherMock
         );
 
         $this->connectionMock->method('quote')

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
@@ -26,7 +26,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ForeignValueFilterQueryBuilderTest extends TestCase
 {
     use MockedConnectionTrait;
-    private RandomParameterName $randomParameter;
 
     /**
      * @var EventDispatcherInterface&MockObject
@@ -43,11 +42,11 @@ class ForeignValueFilterQueryBuilderTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->randomParameter     = new RandomParameterName();
+        $randomParameter           = new RandomParameterName();
         $this->dispatcher          = $this->createMock(EventDispatcherInterface::class);
         $this->connectionMock      = $this->getMockedConnection();
         $this->queryBuilder        = new ForeignValueFilterQueryBuilder(
-            $this->randomParameter,
+            $randomParameter,
             $this->dispatcher
         );
     }

--- a/app/bundles/LeadBundle/Tests/Segment/Query/QueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/QueryBuilderTest.php
@@ -19,12 +19,11 @@ use PHPUnit\Framework\TestCase;
 class QueryBuilderTest extends TestCase
 {
     private QueryBuilder $queryBuilder;
-    private Connection $connection;
 
     protected function setUp(): void
     {
-        $this->connection    = $this->createConnectionFake();
-        $this->queryBuilder  = new QueryBuilder($this->connection);
+        $connection          = $this->createConnectionFake();
+        $this->queryBuilder  = new QueryBuilder($connection);
     }
 
     public function testExpr(): void

--- a/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
@@ -13,10 +13,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class CompanyColumnsDictionaryTest extends TestCase
 {
-    private FieldList&MockObject $fieldList;
-
-    private TranslatorInterface&MockObject $translator;
-
     private CoreParametersHelper&MockObject $coreParametersHelper;
 
     private CompanyColumnsDictionary $dictionary;
@@ -25,20 +21,20 @@ final class CompanyColumnsDictionaryTest extends TestCase
     {
         parent::setUp();
 
-        $this->fieldList            = $this->createMock(FieldList::class);
-        $this->translator           = $this->createMock(TranslatorInterface::class);
+        $fieldList                  = $this->createMock(FieldList::class);
+        $translator                 = $this->createMock(TranslatorInterface::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
 
-        $this->translator->method('trans')->willReturnArgument(0);
+        $translator->method('trans')->willReturnArgument(0);
 
-        $this->fieldList->expects($this->once())
+        $fieldList->expects($this->once())
             ->method('getFieldList')
             ->with(false, true, ['isPublished' => true, 'object' => 'company'])
             ->willReturn(['annual_revenue' => 'Annual Revenue']);
 
         $this->dictionary = new CompanyColumnsDictionary(
-            $this->fieldList,
-            $this->translator,
+            $fieldList,
+            $translator,
             $this->coreParametersHelper,
         );
     }

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -34,8 +34,6 @@ class ReportSubscriberTest extends TestCase
      */
     private \PHPUnit\Framework\MockObject\MockObject $translator;
 
-    private \PHPUnit\Framework\MockObject\MockObject&DncReportService $dncReportService;
-
     private ReportSubscriber $subscriber;
 
     protected function setUp(): void
@@ -45,12 +43,12 @@ class ReportSubscriberTest extends TestCase
         $this->companyReportData   = $this->createMock(CompanyReportData::class);
         $this->hitRepository       = $this->createMock(HitRepository::class);
         $this->translator          = $this->createMock(TranslatorInterface::class);
-        $this->dncReportService    = $this->createMock(DncReportService::class);
+        $dncReportService          = $this->createMock(DncReportService::class);
         $this->subscriber          = new ReportSubscriber(
             $this->companyReportData,
             $this->hitRepository,
             $this->translator,
-            $this->dncReportService
+            $dncReportService
         );
     }
 

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -25,11 +25,14 @@ class PointActionHelperTest extends TestCase
     private MockObject $hitRepository;
 
     /**
+<<<<<<< HEAD
      * @var MockObject|Lead
      */
     private MockObject $lead;
 
     /**
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var MockObject|Hit
      */
     private MockObject $eventDetails;
@@ -38,10 +41,10 @@ class PointActionHelperTest extends TestCase
     {
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->hitRepository = $this->createMock(HitRepository::class);
-        $this->lead          = $this->createMock(Lead::class);
+        $lead                = $this->createMock(Lead::class);
         $this->eventDetails  = $this->createMock(Hit::class);
 
-        $this->eventDetails->method('getLead')->willReturn($this->lead);
+        $this->eventDetails->method('getLead')->willReturn($lead);
         $this->entityManager->method('getRepository')->willReturn($this->hitRepository);
     }
 

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -25,14 +25,6 @@ class PointActionHelperTest extends TestCase
     private MockObject $hitRepository;
 
     /**
-<<<<<<< HEAD
-     * @var MockObject|Lead
-     */
-    private MockObject $lead;
-
-    /**
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
      * @var MockObject|Hit
      */
     private MockObject $eventDetails;

--- a/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
@@ -28,56 +28,48 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class PointModelTest extends TestCase
 {
-    private RequestStack&MockObject $requestStack;
     private IpLookupHelper&MockObject $ipLookupHelper;
     private LeadModel&MockObject $leadModel;
-    private ContactTracker&MockObject $contactTracker;
     private EntityManager&MockObject $em;
     private CorePermissions&MockObject $security;
     private EventDispatcherInterface&MockObject $dispatcher;
-    private UrlGeneratorInterface&MockObject $router;
     private Translator&MockObject $translator;
-    private UserHelper&MockObject $userHelper;
-    private LoggerInterface&MockObject $mauticLogger;
-    private CoreParametersHelper&MockObject $coreParametersHelper;
-    private PointGroupModel&MockObject $pointGroupModel;
     private PointModel $pointModel;
 
     protected function setUp(): void
     {
-        $this->requestStack         = $this->createMock(RequestStack::class);
+        $requestStack               = $this->createMock(RequestStack::class);
         $this->ipLookupHelper       = $this->createMock(IpLookupHelper::class);
         $this->leadModel            = $this->createMock(LeadModel::class);
-        $this->contactTracker       = $this->createMock(ContactTracker::class);
+        $contactTracker             = $this->createMock(ContactTracker::class);
         $this->em                   = $this->createMock(EntityManager::class);
         $this->security             = $this->createMock(CorePermissions::class);
         $this->dispatcher           = $this->createMock(EventDispatcherInterface::class);
-        $this->router               = $this->createMock(RouterInterface::class);
+        $router                     = $this->createMock(RouterInterface::class);
         $this->translator           = $this->createMock(Translator::class);
-        $this->userHelper           = $this->createMock(UserHelper::class);
-        $this->mauticLogger         = $this->createMock(LoggerInterface::class);
-        $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->pointGroupModel      = $this->createMock(PointGroupModel::class);
+        $userHelper                 = $this->createMock(UserHelper::class);
+        $mauticLogger               = $this->createMock(LoggerInterface::class);
+        $coreParametersHelper       = $this->createMock(CoreParametersHelper::class);
+        $pointGroupModel            = $this->createMock(PointGroupModel::class);
         $this->pointModel           = new PointModel(
-            $this->requestStack,
+            $requestStack,
             $this->ipLookupHelper,
             $this->leadModel,
-            $this->contactTracker,
+            $contactTracker,
             $this->em,
             $this->security,
             $this->dispatcher,
-            $this->router,
+            $router,
             $this->translator,
-            $this->userHelper,
-            $this->mauticLogger,
-            $this->coreParametersHelper,
-            $this->pointGroupModel,
+            $userHelper,
+            $mauticLogger,
+            $coreParametersHelper,
+            $pointGroupModel,
         );
     }
 

--- a/app/bundles/PointBundle/Tests/Unit/Model/TriggerModelTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Model/TriggerModelTest.php
@@ -25,34 +25,13 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class TriggerModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var IpLookupHelper&MockObject
-     */
-    private MockObject $ipLookupHelper;
-
-    /**
-     * @var LeadModel&MockObject
-     */
-    private MockObject $leadModel;
-
-    /**
-     * @var TriggerEventModel&MockObject
-     */
-    private MockObject $triggerEventModel;
-
-    /**
      * @var EventDispatcherInterface&MockObject
      */
     private MockObject $dispatcher;
-
-    /**
-     * @var TranslatorInterface&MockObject
-     */
-    private MockObject $translator;
 
     /**
      * @var EntityManager&MockObject
@@ -66,32 +45,27 @@ final class TriggerModelTest extends \PHPUnit\Framework\TestCase
 
     private TriggerModel $triggerModel;
 
-    /**
-     * @var ContactTracker&MockObject
-     */
-    private MockObject $contactTracker;
-
     protected function setUp(): void
     {
         parent::setUp();
-        $this->ipLookupHelper         = $this->createMock(IpLookupHelper::class);
-        $this->leadModel              = $this->createMock(LeadModel::class);
-        $this->triggerEventModel      = $this->createMock(TriggerEventModel::class);
-        $this->contactTracker         = $this->createMock(ContactTracker::class);
+        $ipLookupHelper               = $this->createMock(IpLookupHelper::class);
+        $leadModel                    = $this->createMock(LeadModel::class);
+        $triggerEventModel            = $this->createMock(TriggerEventModel::class);
+        $contactTracker               = $this->createMock(ContactTracker::class);
         $this->dispatcher             = $this->createMock(EventDispatcherInterface::class);
-        $this->translator             = $this->createMock(Translator::class);
+        $translator                   = $this->createMock(Translator::class);
         $this->entityManager          = $this->createMock(EntityManager::class);
         $this->triggerEventRepository = $this->createMock(TriggerEventRepository::class);
         $this->triggerModel           = new TriggerModel(
-            $this->ipLookupHelper,
-            $this->leadModel,
-            $this->triggerEventModel,
-            $this->contactTracker,
+            $ipLookupHelper,
+            $leadModel,
+            $triggerEventModel,
+            $contactTracker,
             $this->entityManager,
             $this->createMock(CorePermissions::class),
             $this->dispatcher,
             $this->createMock(UrlGeneratorInterface::class),
-            $this->translator,
+            $translator,
             $this->createMock(UserHelper::class),
             $this->createMock(LoggerInterface::class),
             $this->createMock(CoreParametersHelper::class)

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -25,8 +25,6 @@ class ReportGeneratorEventTest extends TestCase
      */
     private MockObject $queryBuilder;
 
-    private ChannelListHelper $channelListHelper;
-
     private ReportGeneratorEvent $reportGeneratorEvent;
 
     protected function setUp(): void
@@ -35,12 +33,12 @@ class ReportGeneratorEventTest extends TestCase
 
         $this->report                = $this->createMock(Report::class);
         $this->queryBuilder          = $this->createMock(QueryBuilder::class);
-        $this->channelListHelper     = new ChannelListHelper($this->createMock(EventDispatcher::class), $this->createMock(Translator::class));
+        $channelListHelper           = new ChannelListHelper($this->createMock(EventDispatcher::class), $this->createMock(Translator::class));
         $this->reportGeneratorEvent  = new ReportGeneratorEvent(
             $this->report,
             [], // Use the setter if you need different options
             $this->queryBuilder,
-            $this->channelListHelper
+            $channelListHelper
         );
     }
 

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
@@ -35,8 +35,11 @@ class SendScheduleTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fileHandler;
 
+<<<<<<< HEAD
     private MockObject $eventDispatcher;
 
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
         parent::setUp();
@@ -46,7 +49,7 @@ class SendScheduleTest extends \PHPUnit\Framework\TestCase
         $this->mailHelperMock  = $this->createMock(MailHelper::class);
         $this->messageSchedule = $this->createMock(MessageSchedule::class);
         $this->fileHandler     = $this->createMock(FileHandler::class);
-        $this->eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher       = $this->createMock(EventDispatcher::class);
 
         $this->mailHelperMock->expects($this->once())
             ->method('getMailer')
@@ -56,7 +59,7 @@ class SendScheduleTest extends \PHPUnit\Framework\TestCase
             $this->mailHelperMock,
             $this->messageSchedule,
             $this->fileHandler,
-            $this->eventDispatcher
+            $eventDispatcher
         );
     }
 

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
@@ -35,11 +35,6 @@ class SendScheduleTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $fileHandler;
 
-<<<<<<< HEAD
-    private MockObject $eventDispatcher;
-
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
         parent::setUp();

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
@@ -23,23 +23,6 @@ final class PasswordSubscriberTest extends TestCase
 {
     private PasswordSubscriber $passwordSubscriber;
 
-    private PasswordStrengthEstimatorModel $passwordStrengthEstimatorModel;
-
-    /**
-     * @var MockObject&AuthenticationEvent
-     */
-    private MockObject $authenticationEvent;
-
-    /**
-     * @var MockObject&PluginToken
-     */
-    private MockObject $pluginToken;
-
-    /**
-     * @var MockObject&EventDispatcherInterface
-     */
-    private MockObject $dispatcher;
-
     protected function setUp(): void
     {
         $dispatcher                           = $this->createMock(EventDispatcherInterface::class);

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
@@ -11,7 +11,6 @@ use Mautic\UserBundle\Model\PasswordStrengthEstimatorModel;
 use Mautic\UserBundle\Security\Authentication\Token\PluginToken;
 use Mautic\UserBundle\Security\Authenticator\Passport\Badge\PasswordStrengthBadge;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
@@ -24,6 +23,7 @@ final class PasswordSubscriberTest extends TestCase
 {
     private PasswordSubscriber $passwordSubscriber;
 
+<<<<<<< HEAD
     private PasswordStrengthEstimatorModel $passwordStrengthEstimatorModel;
 
     /**
@@ -41,17 +41,19 @@ final class PasswordSubscriberTest extends TestCase
      */
     private MockObject $dispatcher;
 
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
-        $this->dispatcher                     = $this->createMock(EventDispatcherInterface::class);
-        $this->passwordStrengthEstimatorModel = new PasswordStrengthEstimatorModel($this->dispatcher);
-        $this->passwordSubscriber             = new PasswordSubscriber($this->passwordStrengthEstimatorModel);
-        $this->authenticationEvent            = $this->createMock(AuthenticationEvent::class);
-        $this->pluginToken                    = $this->createMock(PluginToken::class);
+        $dispatcher                           = $this->createMock(EventDispatcherInterface::class);
+        $passwordStrengthEstimatorModel       = new PasswordStrengthEstimatorModel($dispatcher);
+        $this->passwordSubscriber             = new PasswordSubscriber($passwordStrengthEstimatorModel);
+        $authenticationEvent                  = $this->createMock(AuthenticationEvent::class);
+        $pluginToken                          = $this->createMock(PluginToken::class);
 
-        $this->authenticationEvent->expects($this->any())
+        $authenticationEvent->expects($this->any())
             ->method('getToken')
-            ->willReturn($this->pluginToken);
+            ->willReturn($pluginToken);
     }
 
     public function testThatItIsSubscribedToEvents(): void

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
@@ -23,7 +23,6 @@ final class PasswordSubscriberTest extends TestCase
 {
     private PasswordSubscriber $passwordSubscriber;
 
-<<<<<<< HEAD
     private PasswordStrengthEstimatorModel $passwordStrengthEstimatorModel;
 
     /**
@@ -41,8 +40,6 @@ final class PasswordSubscriberTest extends TestCase
      */
     private MockObject $dispatcher;
 
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
         $dispatcher                           = $this->createMock(EventDispatcherInterface::class);

--- a/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
@@ -26,27 +26,7 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $client;
 
-    /**
-     * @var MockObject|CompanyModel
-     */
-    private MockObject $companyModel;
-
-    /**
-     * @var MockObject|CompanyRepository
-     */
-    private MockObject $companyRepository;
-
-    /**
-     * @var ArrayCollection<int,IpAddress>
-     */
-    private ArrayCollection $ipCollection;
-
     private CampaignHelper $campaignHelper;
-
-    /**
-     * @var MockObject|EventDispatcherInterface
-     */
-    private MockObject $dispatcher;
 
     protected function setUp(): void
     {
@@ -54,22 +34,22 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->contact           = $this->createMock(Lead::class);
         $this->client            = $this->createMock(Client::class);
-        $this->companyModel      = $this->createMock(CompanyModel::class);
-        $this->dispatcher        = $this->createMock(EventDispatcherInterface::class);
-        $this->ipCollection      = new ArrayCollection();
-        $this->companyRepository = $this->getMockBuilder(CompanyRepository::class)
+        $companyModel            = $this->createMock(CompanyModel::class);
+        $dispatcher              = $this->createMock(EventDispatcherInterface::class);
+        $ipCollection            = new ArrayCollection();
+        $companyRepository       = $this->getMockBuilder(CompanyRepository::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getCompaniesByLeadId'])
             ->getMock();
 
-        $this->companyRepository->method('getCompaniesByLeadId')->willReturn([new Company()]);
+        $companyRepository->method('getCompaniesByLeadId')->willReturn([new Company()]);
 
-        $this->companyModel->method('getRepository')->willReturn($this->companyRepository);
+        $companyModel->method('getRepository')->willReturn($companyRepository);
 
-        $this->campaignHelper = new CampaignHelper($this->client, $this->companyModel, $this->dispatcher);
+        $this->campaignHelper = new CampaignHelper($this->client, $companyModel, $dispatcher);
 
-        $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.1'));
-        $this->ipCollection->add((new IpAddress())->setIpAddress('127.0.0.2'));
+        $ipCollection->add((new IpAddress())->setIpAddress('127.0.0.1'));
+        $ipCollection->add((new IpAddress())->setIpAddress('127.0.0.2'));
 
         $this->contact->expects($this->once())
             ->method('getProfileFields')
@@ -77,7 +57,7 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->contact->expects($this->once())
             ->method('getIpAddresses')
-            ->willReturn($this->ipCollection);
+            ->willReturn($ipCollection);
     }
 
     public function testFireWebhookWithGet(): void

--- a/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
@@ -71,6 +71,7 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
 
     private ?string $modifiedBy = null;
 
+<<<<<<< HEAD
     /**
      * @var MockObject|UserRepository
      */
@@ -80,6 +81,10 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
 
     private MockObject $eventDispatcher;
 
+=======
+    private WebhookNotificationSender $webhookNotificationSender;
+
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
         $this->translatorMock        = $this->createMock(TranslatorInterface::class);
@@ -88,9 +93,9 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
         $this->mailHelperMock        = $this->createMock(MailHelper::class);
         $this->coreParamHelperMock   = $this->createMock(CoreParametersHelper::class);
         $this->webhook               = $this->createMock(Webhook::class);
-        $this->userRepositoryMock    = $this->createMock(UserRepository::class);
+        $userRepositoryMock          = $this->createMock(UserRepository::class);
         $twig                        = $this->createMock(Environment::class);
-        $this->eventDispatcher       = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher             = $this->createMock(EventDispatcherInterface::class);
 
         $webhookNotificationEventMock =  $this->createMock(WebhookNotificationEvent::class);
         $webhookNotificationEventMock->method('canSend')->willReturn(true);
@@ -99,7 +104,7 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
             ->method('render')
             ->willReturn($this->details);
 
-        $this->eventDispatcher->method('dispatch')
+        $eventDispatcher->method('dispatch')
             ->willReturn(
                 $webhookNotificationEventMock
             );
@@ -109,8 +114,8 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
             $this->entityManagerMock,
             $this->mailHelperMock,
             $this->coreParamHelperMock,
-            $this->userRepositoryMock,
-            $this->eventDispatcher
+            $userRepositoryMock,
+            $eventDispatcher
         );
     }
 

--- a/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
@@ -71,20 +71,8 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
 
     private ?string $modifiedBy = null;
 
-<<<<<<< HEAD
-    /**
-     * @var MockObject|UserRepository
-     */
-    private MockObject $userRepositoryMock;
-
     private WebhookNotificationSender $webhookNotificationSender;
 
-    private MockObject $eventDispatcher;
-
-=======
-    private WebhookNotificationSender $webhookNotificationSender;
-
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     protected function setUp(): void
     {
         $this->translatorMock        = $this->createMock(TranslatorInterface::class);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,7 @@ parameters:
 	type_coverage:
 		return: 80
 		param: 70
-		property: 65
+		property: 64
 	paths:
 		- app/bundles
 		- app/migrations

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
@@ -21,27 +21,28 @@ final class EmailSubscriberTest extends TestCase
 {
     /** @var MockObject&Config */
     private MockObject $config;
-    /** @var MockObject&GrapesJsBuilderModel */
-    private MockObject $grapesJsBuilderModel;
     /** @var MockObject&GrapesJsBuilderRepository */
     private MockObject $grapesJsBuilderRepo;
+<<<<<<< HEAD
     private MockObject $emailModel;
     private MockObject $emailConfig;
+=======
+>>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
     private EmailSubscriber $subscriber;
 
     protected function setUp(): void
     {
         $this->config               = $this->createMock(Config::class);
-        $this->grapesJsBuilderModel = $this->createMock(GrapesJsBuilderModel::class);
-        $this->emailModel           = $this->createMock(EmailModel::class);
-        $this->emailConfig          = $this->createMock(EmailConfigInterface::class);
+        $grapesJsBuilderModel       = $this->createMock(GrapesJsBuilderModel::class);
+        $emailModel                 = $this->createMock(EmailModel::class);
+        $emailConfig                = $this->createMock(EmailConfigInterface::class);
         $this->grapesJsBuilderRepo  = $this->createMock(GrapesJsBuilderRepository::class);
-        $this->subscriber           = new EmailSubscriber($this->config, $this->grapesJsBuilderModel, $this->emailModel, $this->emailConfig);
+        $this->subscriber           = new EmailSubscriber($this->config, $grapesJsBuilderModel, $emailModel, $emailConfig);
 
-        $this->emailModel->method('getRepository')
+        $emailModel->method('getRepository')
             ->willReturn($this->createMock(EmailRepository::class));
 
-        $this->grapesJsBuilderModel->method('getRepository')
+        $grapesJsBuilderModel->method('getRepository')
             ->willReturn($this->grapesJsBuilderRepo);
     }
 

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
@@ -23,11 +23,7 @@ final class EmailSubscriberTest extends TestCase
     private MockObject $config;
     /** @var MockObject&GrapesJsBuilderRepository */
     private MockObject $grapesJsBuilderRepo;
-<<<<<<< HEAD
-    private MockObject $emailModel;
-    private MockObject $emailConfig;
-=======
->>>>>>> f71dbbecbb ([tests] inline setUp properties used just once)
+
     private EmailSubscriber $subscriber;
 
     protected function setUp(): void

--- a/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
@@ -10,25 +10,19 @@ use Mautic\PluginBundle\Event\PluginIntegrationKeyEvent;
 use Mautic\PluginBundle\PluginEvents;
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class HubspotIntegrationTest extends AbstractIntegrationTestCase
 {
-    /**
-     * @var MockObject&UserHelper
-     */
-    private MockObject $userHelper;
-
     private HubspotIntegration $integration;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->userHelper  = $this->createMock(UserHelper::class);
+        $userHelper        = $this->createMock(UserHelper::class);
         $this->integration = new HubspotIntegration(
             $this->dispatcher,
             $this->cache,
@@ -46,7 +40,7 @@ class HubspotIntegrationTest extends AbstractIntegrationTestCase
             $this->integrationEntityModel,
             $this->doNotContact,
             $this->fieldsWithUniqueIdentifier,
-            $this->userHelper
+            $userHelper
         );
     }
 

--- a/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
+++ b/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
@@ -20,11 +20,6 @@ class TokenHelperTest extends TestCase
     private MockObject $model;
 
     /**
-     * @var MockObject|RouterInterface
-     */
-    private MockObject $router;
-
-    /**
      * @var CorePermissions|MockObject
      */
     private MockObject $security;
@@ -36,10 +31,10 @@ class TokenHelperTest extends TestCase
         parent::setUp();
 
         $this->model    = $this->createMock(FocusModel::class);
-        $this->router   = $this->createMock(RouterInterface::class);
+        $router         = $this->createMock(RouterInterface::class);
         $this->security = $this->createMock(CorePermissions::class);
 
-        $this->helper = new TokenHelper($this->model, $this->router, $this->security);
+        $this->helper = new TokenHelper($this->model, $router, $this->security);
     }
 
     public function testFindFocusTokensNotFound(): void


### PR DESCRIPTION
Preparing for PHPUnit 12.x where mocks without expectations have to be stubs. This will streamline the tests structure

Ref https://github.com/mautic/mautic/pull/16393