### PR TITLE
[tests] add strict types to ensure tests verify exact types in scalars

### DIFF
--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;

--- a/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests\EventListener;
 
 use Mautic\ApiBundle\EventListener\ApiSubscriber;

--- a/app/bundles/ApiBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests\EventListener;
 
 use Mautic\ApiBundle\EventListener\ConfigSubscriber;

--- a/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests\Helper;
 
 use Mautic\ApiBundle\Helper\BatchIdToEntityHelper;

--- a/app/bundles/ApiBundle/Tests/Helper/RequestHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/RequestHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ApiBundle\Tests\Helper;
 
 use Mautic\ApiBundle\Helper\RequestHelper;

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -67,7 +67,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', 'api/assets/new', $payload);
         $response = $this->client->getResponse();
         $content  = $response->getContent();
-        $this->assertResponseStatusCodeSame(400, $response);
+        $this->assertResponseStatusCodeSame(400, $response->getContent());
         $this->assertStringContainsString($expectedError, $content);
     }
 

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\AssetBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Asset;

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Download;

--- a/app/bundles/CampaignBundle/Tests/CampaignTestAbstract.php
+++ b/app/bundles/CampaignBundle/Tests/CampaignTestAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Tests/Command/AbstractCampaignCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Entity\LeadEventLog;

--- a/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Command\SummarizeCommand;

--- a/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Executioner\InactiveExecutioner;

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTestCase;

--- a/app/bundles/CampaignBundle/Tests/Entity/ContactLimiterTraitTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/ContactLimiterTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Entity;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CampaignBundle/Tests/Event/CampaignBuilderEventTest.php
+++ b/app/bundles/CampaignBundle/Tests/Event/CampaignBuilderEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Event;
 
 use Mautic\AssetBundle\Form\Type\PointActionAssetDownloadType;

--- a/app/bundles/CampaignBundle/Tests/Event/PendingEventTest.php
+++ b/app/bundles/CampaignBundle/Tests/Event/PendingEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Event;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/ActionAccessorTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/ActionAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Accessor\Event;
 
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/ConditionAccessorTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/ConditionAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Accessor\Event;
 
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ConditionAccessor;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/DecisionAccessorTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/Event/DecisionAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Accessor\Event;
 
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/EventAccessorTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Accessor/EventAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Accessor;
 
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Builder/ConnectionBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Builder/ConnectionBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Builder;
 
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Builder/EventBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Builder/EventBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventCollector\Builder;
 
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfFailureSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfFailureSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfUnpublishSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfUnpublishSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/InactiveContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/InactiveContactFinderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\ContactFinder;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/KickoffContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/KickoffContactFinderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\ContactFinder;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/Limiter/ContactLimiterTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/Limiter/ContactLimiterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\ContactFinder\Limiter;
 
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/ScheduledContactFinderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\ContactFinder;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/InactiveExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/InactiveExecutionerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\Logger;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Result/CounterTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Result/CounterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\Result;
 
 use Mautic\CampaignBundle\Executioner\Result\Counter;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Result/EvalutatedContactsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Result/EvalutatedContactsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\Result;
 
 use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Result/ResponsesTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Result/ResponsesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\Result;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Executioner\Scheduler;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Helper/CampaignEventHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/CampaignEventHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Helper;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CampaignBundle/Tests/Helper/ChannelExtractorTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/ChannelExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Helper;
 
 use Mautic\CampaignBundle\Entity\Event;

--- a/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Helper;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Helper/NotificationHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/NotificationHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Helper;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CampaignBundle/Tests/Membership/Action/AdderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/Action/AdderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Membership\Action;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CampaignBundle/Tests/Membership/Action/RemoverTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/Action/RemoverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Membership\Action;
 
 use Mautic\CampaignBundle\Entity\Lead as CampaignMember;

--- a/app/bundles/CampaignBundle/Tests/Membership/EventDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/EventDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Membership;
 
 use Mautic\CampaignBundle\CampaignEvents;

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Membership;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Model;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Model;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
+++ b/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CampaignBundle\Tests\Service;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CategoryBundle\Tests\Controller;
 
 use Mautic\CategoryBundle\Entity\Category;

--- a/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
+++ b/app/bundles/CategoryBundle/Tests/Entity/CategoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CategoryBundle\Tests\Entity;
 
 use Mautic\CategoryBundle\Entity\Category;

--- a/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
+++ b/app/bundles/ChannelBundle/Tests/Entity/MessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\Entity;
 
 use Mautic\CategoryBundle\Entity\Category;

--- a/app/bundles/ChannelBundle/Tests/Event/ChannelBroadcastEventTest.php
+++ b/app/bundles/ChannelBundle/Tests/Event/ChannelBroadcastEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\Event;
 
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/ChannelBundle/Tests/Model/FrequencyActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/FrequencyActionModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\Model;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;

--- a/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/ChannelBundle/Tests/PreferenceBuilder/ChannelPreferencesTest.php
+++ b/app/bundles/ChannelBundle/Tests/PreferenceBuilder/ChannelPreferencesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\PreferenceBuilder;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/ChannelBundle/Tests/PreferenceBuilder/PreferenceBuilderTest.php
+++ b/app/bundles/ChannelBundle/Tests/PreferenceBuilder/PreferenceBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ChannelBundle\Tests\PreferenceBuilder;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/ConfigBundle/Tests/Event/ConfigBuilderEventTest.php
+++ b/app/bundles/ConfigBundle/Tests/Event/ConfigBuilderEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Event;
 
 use Mautic\ConfigBundle\Event\ConfigBuilderEvent;

--- a/app/bundles/ConfigBundle/Tests/Event/ConfigEventTest.php
+++ b/app/bundles/ConfigBundle/Tests/Event/ConfigEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Event;
 
 use Mautic\ConfigBundle\Event\ConfigEvent;

--- a/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Form\Helper;
 
 use Mautic\ConfigBundle\Form\DataTransformer\DsnTransformerFactory;

--- a/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Mapper;
 
 use Mautic\ConfigBundle\Exception\BadFormConfigException;

--- a/app/bundles/ConfigBundle/Tests/Mapper/Helper/ConfigHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Mapper/Helper/ConfigHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Mapper\Helper;
 
 use Mautic\ConfigBundle\Mapper\Helper\ConfigHelper;

--- a/app/bundles/ConfigBundle/Tests/Mapper/Helper/RestrictionHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Mapper/Helper/RestrictionHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Mapper\Helper;
 
 use Mautic\ConfigBundle\Mapper\Helper\RestrictionHelper;

--- a/app/bundles/ConfigBundle/Tests/Service/ConfigChangeLoggerTest.php
+++ b/app/bundles/ConfigBundle/Tests/Service/ConfigChangeLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ConfigBundle\Tests\Service;
 
 use Mautic\ConfigBundle\Service\ConfigChangeLogger;

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Test;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;

--- a/app/bundles/CoreBundle/Test/EventListener/MaintenanceSubscriberTest.php
+++ b/app/bundles/CoreBundle/Test/EventListener/MaintenanceSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Test\EventListener;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
+++ b/app/bundles/CoreBundle/Test/MauticMysqlTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Test;
 
 use Doctrine\DBAL\Exception as DBALException;

--- a/app/bundles/CoreBundle/Tests/CommonMocks.php
+++ b/app/bundles/CoreBundle/Tests/CommonMocks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/RequestTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Form;
 
 use Mautic\CoreBundle\Form\RequestTrait;

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Functional\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Functional\Entity;
 
 use Mautic\CoreBundle\Entity\IpAddress;

--- a/app/bundles/CoreBundle/Tests/Service/FlashBagTest.php
+++ b/app/bundles/CoreBundle/Tests/Service/FlashBagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Service;
 
 use Mautic\CoreBundle\Model\NotificationModel;

--- a/app/bundles/CoreBundle/Tests/Twig/Extension/LanguageExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/Extension/LanguageExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Extension\LanguageExtension;

--- a/app/bundles/CoreBundle/Tests/Twig/ThemesExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/ThemesExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Twig;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Command;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Command;
 
 use Mautic\CoreBundle\Command\ModeratedCommand;

--- a/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/BundleMetadataBuilderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/BundleMetadataBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Builder;
 
 use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadataBuilder;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/BundleMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/BundleMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Builder;
 
 use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadata;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/ConfigMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/ConfigMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Builder\Metadata;
 
 use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadata;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/EntityMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/EntityMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Builder\Metadata;
 
 use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadata;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/PermissionClassMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/PermissionClassMetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Builder\Metadata;
 
 use Mautic\AssetBundle\Security\Permissions\AssetPermissions;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/IntNullableProcessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\EnvProcessor;
 
 use Mautic\CoreBundle\DependencyInjection\EnvProcessor\IntNullableProcessor;

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/NullableProcessorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/EnvProcessor/NullableProcessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\EnvProcessor;
 
 use Mautic\CoreBundle\DependencyInjection\EnvProcessor\NullableProcessor;

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Doctrine\Mapping;
 
 use Doctrine\DBAL\Types\Types;

--- a/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Entity;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/CoreBundle/Tests/Unit/Entity/IpAddressTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Entity/IpAddressTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Entity;
 
 use Mautic\CoreBundle\Entity\IpAddress;

--- a/app/bundles/CoreBundle/Tests/Unit/Event/CustomTemplateEventTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Event/CustomTemplateEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Event;
 
 use Mautic\CoreBundle\Event\CustomTemplateEvent;

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\EventListener;
 
 use Mautic\CoreBundle\EventListener\RequestSubscriber;

--- a/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Factory;
 
 use Mautic\CoreBundle\Factory\ModelFactory;

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Form\Type;
 
 use Mautic\CoreBundle\Factory\IpLookupFactory;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ArrayHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\ArrayHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/DateRangeUnitTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/DateRangeUnitTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Chart;
 
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/LineChartTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/LineChartTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Chart;
 
 use Mautic\CoreBundle\Helper\Chart\LineChart;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ClickthroughHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ClickthroughHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\ClickthroughHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ColorHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ColorHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\ColorHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\CookieHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CsvHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CsvHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\CsvHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTime/DateTokenHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTime/DateTokenHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\DateTime;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/DateTimeHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\FileHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileUploaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileUploaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Exception\FilePathException;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\InputHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use DeviceDetector\DeviceDetector;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Language/InstallerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Language;
 
 use Mautic\CoreBundle\Helper\Language\Installer;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/RandomHelper/RandomHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/RandomHelper/RandomHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\RandomHelper;
 
 use Mautic\CoreBundle\Helper\RandomHelper\RandomHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/TrailingSlashHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/TrailingSlashHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Update/Github/ReleaseParserTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Update/Github/ReleaseParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Update\Github;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Update\PreUpdateChecks;
 
 use Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckDatabaseDriverAndVersion;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckPhpVersionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckPhpVersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper\Update\PreUpdateChecks;
 
 use Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckPhpVersion;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\UrlHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/ExtemeIpLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/ExtemeIpLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/GeobytesLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/GeobytesLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/GeoipsLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/GeoipsLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/IpinfodbLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/IpinfodbLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/IpstackLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/IpstackLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use Mautic\CoreBundle\Exception\BadConfigurationException;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindDownloadLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindDownloadLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use Mautic\CoreBundle\IpLookup\MaxmindDownloadLookup;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/TelizeLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/TelizeLookupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\IpLookup;
 
 use GuzzleHttp\Client;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ApiEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ApiEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\ApiEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ConfigEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ConfigEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\ConfigEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ElFinderEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/ElFinderEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\ElFinderEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/MigrationEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/MigrationEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\MigrationsEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SAMLEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SAMLEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\SAMLEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SessionEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SessionEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\SessionEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SiteUrlEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/SiteUrlEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\SiteUrlEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/TwigEnvVarsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/EnvVars/TwigEnvVarsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader\EnvVars;
 
 use Mautic\CoreBundle\Loader\EnvVars\TwigEnvVars;

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Loader;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;

--- a/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Model/IteratorExportDataModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Model;
 
 use Mautic\CoreBundle\Entity\CommonRepository;

--- a/app/bundles/CoreBundle/Tests/Unit/Monolog/Handler/FileLogHandlerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Monolog/Handler/FileLogHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Monolog\Handler;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Release/MetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Release/MetadataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Release;
 
 use Mautic\CoreBundle\Release\Metadata;

--- a/app/bundles/CoreBundle/Tests/Unit/Release/ThisReleaseTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Release/ThisReleaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Release;
 
 use Mautic\CoreBundle\Release\ThisRelease;

--- a/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/RememberMeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ConfigHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ConfigHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Twig\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ContentHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ContentHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Twig\Helper;
 
 use Mautic\CoreBundle\Twig\Helper\ContentHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Twig\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/AbstractStepTestCase.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/AbstractStepTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use PHPUnit\Framework\MockObject\MockObject;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/DeleteCacheStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/DeleteCacheStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Mautic\CoreBundle\Helper\CacheHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Mautic\CoreBundle\Helper\AppVersion;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Mautic\CoreBundle\Exception\UpdateFailedException;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Mautic\CoreBundle\Helper\PathsHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand as MigrateCommand;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update\Step;
 
 use Mautic\CoreBundle\Helper\LanguageHelper;

--- a/app/bundles/CoreBundle/Tests/Unit/Update/StepProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/StepProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\CoreBundle\Tests\Unit\Update;
 
 use Mautic\CoreBundle\Update\Step\StepInterface;

--- a/app/bundles/DashboardBundle/Tests/Entity/WidgetTest.php
+++ b/app/bundles/DashboardBundle/Tests/Entity/WidgetTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\DashboardBundle\Tests\Entity;
 
 use Mautic\DashboardBundle\Entity\Widget;

--- a/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
+++ b/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\DashboardBundle\Tests\Event;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\DynamicContentBundle\Tests\Unit\EventListener;
 
 use Mautic\AssetBundle\Helper\TokenHelper as AssetTokenHelper;

--- a/app/bundles/DynamicContentBundle/Tests/Validator/Constraints/SlotNameTypeValidatorTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Validator/Constraints/SlotNameTypeValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\DynamicContentBundle\Tests\Validator\Constraints;
 
 use Mautic\DynamicContentBundle\Entity\DynamicContent;

--- a/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Event/EmailSendEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Event;
 
 use Mautic\EmailBundle\Event\EmailSendEvent;

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignConditionSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailToUserSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailToUserSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\EmailBundle\EventListener\EmailToUserSubscriber;

--- a/app/bundles/EmailBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/FormSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Helper;
 
 use Mautic\EmailBundle\EmailEvents;

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Helper;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/EmailBundle/Tests/Helper/PointEventHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PointEventHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Helper;
 
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Helper;
 
 use Mautic\EmailBundle\Helper\UrlMatcher;

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Model;
 
 use Mautic\CoreBundle\Event\TokenReplacementEvent;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Accessor/ConfigAccessorTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Accessor/ConfigAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Accessor;
 
 use Mautic\EmailBundle\MonitoredEmail\Accessor\ConfigAccessor;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/FetcherTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/FetcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Organizer/MailboxContainerTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Organizer/MailboxContainerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Organizer;
 
 use Mautic\EmailBundle\MonitoredEmail\Accessor\ConfigAccessor;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Organizer/MailboxOrganizerTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Organizer/MailboxOrganizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Organizer;
 
 use Mautic\EmailBundle\Event\ParseEmailEvent;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/AddressTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/AddressTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
 use Mautic\EmailBundle\MonitoredEmail\Processor\Address;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/BodyParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/BodyParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Bounce;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\BounceNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Bounce;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\BounceNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapperTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Bounce\Mapper;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\CategoryNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/ParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Bounce;
 
 use Mautic\EmailBundle\MonitoredEmail\Message;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoop/ParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoop/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\FeedbackLoop;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\FeedbackLoopNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoopTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoopTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Reply/ParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Reply/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Reply;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\ReplyNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/UnsubscribeTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/UnsubscribeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Unsubscription/ParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Unsubscription/ParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Processor\Unsubscription;
 
 use Mautic\EmailBundle\MonitoredEmail\Exception\UnsubscriptionNotFound;

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Search/ContactFinderTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Search/ContactFinderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\MonitoredEmail\Search;
 
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/EmailBundle/Tests/OptionsAccessor/EmailToUserAccessorTest.php
+++ b/app/bundles/EmailBundle/Tests/OptionsAccessor/EmailToUserAccessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\OptionsAccessor;
 
 use Mautic\EmailBundle\OptionsAccessor\EmailToUserAccessor;

--- a/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\EmailBundle\Tests\Stat;
 
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Asset;

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Entity\IpAddress;

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\EventListener;
 
 use Doctrine\DBAL\Query\QueryBuilder;

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Model;
 
 use Doctrine\DBAL\Schema\Column;

--- a/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Model;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Model;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/FormBundle/Tests/ProgressiveProfiling/DisplayManagerTest.php
+++ b/app/bundles/FormBundle/Tests/ProgressiveProfiling/DisplayManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\ProgressiveProfiling;
 
 use Mautic\FormBundle\Entity\Field;

--- a/app/bundles/FormBundle/Tests/Validator/UploadFieldValidatorTest.php
+++ b/app/bundles/FormBundle/Tests/Validator/UploadFieldValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\FormBundle\Tests\Validator;
 
 use Mautic\CoreBundle\Exception\FileInvalidException;

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\InstallBundle\Tests\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\InstallBundle\Tests\Install;
 
 use Doctrine\DBAL\Connection;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/AbstractIntegrationTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/AbstractIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\IntegrationsBundle\Tests\Unit;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\IntegrationsBundle\Tests\Unit\Entity;
 
 use Doctrine\DBAL\Query\QueryBuilder;

--- a/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Command;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/LeadBundle/Tests/Command/ImportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/ImportCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Command;
 
 use Mautic\CoreBundle\Model\NotificationModel;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Doctrine\DBAL\Schema\Column;

--- a/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Illuminate\Support\Collection;

--- a/app/bundles/LeadBundle/Tests/Deduplicate/CompanyDeduperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/CompanyDeduperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Deduplicate;
 
 use Mautic\LeadBundle\Deduplicate\CompanyDeduper;

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Deduplicate;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/Helper/MergeValueHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Deduplicate\Helper;
 
 use Mautic\LeadBundle\Deduplicate\Exception\ValueNotMergeableException;

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;

--- a/app/bundles/LeadBundle/Tests/Entity/CustomFieldRepositoryTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CustomFieldRepositoryTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\LeadBundle\Entity\LeadRepository;

--- a/app/bundles/LeadBundle/Tests/Entity/DoNotContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/DoNotContactTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\LeadBundle\Entity\DoNotContact;

--- a/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\LeadBundle\Entity\Import;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Entity\IpAddress;

--- a/app/bundles/LeadBundle/Tests/Entity/TagRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/TagRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/TagTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/TagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Entity;
 
 use Mautic\LeadBundle\Entity\Tag;

--- a/app/bundles/LeadBundle/Tests/Event/ChannelSubscriptionChangeTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/ChannelSubscriptionChangeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\DoNotContact;

--- a/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/CompanyEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\Company;

--- a/app/bundles/LeadBundle/Tests/Event/LeadEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadListEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\CategoryBundle\Entity\Category;

--- a/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/LeadTimelineEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Event;
 
 use Mautic\LeadBundle\Event\LeadTimelineEvent;

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CompanySubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/LeadBundle/Tests/EventListener/DoNotContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/DoNotContactSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\Entity\Campaign;

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/LeadBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/PointSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\Company;

--- a/app/bundles/LeadBundle/Tests/Field/FieldsWithUniqueIdentifierTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/FieldsWithUniqueIdentifierTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Field;
 
 use Mautic\LeadBundle\Field\FieldList;

--- a/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Form;
 
 use Mautic\CoreBundle\Form\Type\BooleanType;

--- a/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Form/Type/HtmlTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/HtmlTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Form\Type;
 
 use Mautic\LeadBundle\Form\Type\HtmlType;

--- a/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Form\Validator\Constraints;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Functional\Command;
 
 use Doctrine\DBAL\Schema\Column;

--- a/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Functional/SearchWithSpecialCharactersInFieldTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/SearchWithSpecialCharactersInFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Functional;
 
 use Symfony\Component\DomCrawler\Crawler;

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldValueHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldValueHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\LeadBundle\Helper\CustomFieldValueHelper;

--- a/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\LeadBundle\Entity\LeadField;

--- a/app/bundles/LeadBundle/Tests/Helper/IdentifyCompanyHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/IdentifyCompanyHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\LeadBundle\Helper\IdentifyCompanyHelper;

--- a/app/bundles/LeadBundle/Tests/Helper/LeadChangeEventDispatcherTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/LeadChangeEventDispatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\LeadBundle\Entity\DoNotContact;

--- a/app/bundles/LeadBundle/Tests/Helper/PrimaryCompanyHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/PrimaryCompanyHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Test\ReflectionHelper;

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelCustomFieldsFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelCustomFieldsFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Doctrine\DBAL\Logging\SQLLogger;

--- a/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/IpAddressModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\Serializer;

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Doctrine\DBAL\Exception as DBALException;

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/LeadBundle/Tests/Report/FieldsBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Report/FieldsBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Report;
 
 use Mautic\FormBundle\Entity\Field;

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment;
 
 use Mautic\LeadBundle\Entity\LeadList;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/BaseDecoratorTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/BaseDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/CustomMappedDecoratorTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/CustomMappedDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date;
 
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTodayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayTomorrowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Day/DateDayYesterdayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthLastTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthNextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Month/DateMonthThisTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateAnniversaryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateDefaultTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateDefaultTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Other/DateRelativeIntervalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Other;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekLastTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekNextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Week/DateWeekThisTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearLastTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearLastTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearNextTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearNextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearThisTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/Year/DateYearThisTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
 use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;

--- a/app/bundles/LeadBundle/Tests/Segment/IntegrationCampaign/IntegrationCampaignPartsTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/IntegrationCampaign/IntegrationCampaignPartsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Segment\IntegrationCampaign;
 
 use Mautic\LeadBundle\Segment\IntegrationCampaign\IntegrationCampaignParts;

--- a/app/bundles/LeadBundle/Tests/Services/ContactSegmentFilterDictionaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Services/ContactSegmentFilterDictionaryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Services;
 
 use Mautic\LeadBundle\Event\SegmentDictionaryGenerationEvent;

--- a/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
+++ b/app/bundles/LeadBundle/Tests/StandardImportTestHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/LeadBundle/Tests/Tracker/DeviceTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/DeviceTrackerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Tracker;
 
 use Mautic\CacheBundle\Cache\CacheProvider;

--- a/app/bundles/LeadBundle/Tests/Twig/DncReasonHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Twig/DncReasonHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Twig;
 
 use Mautic\LeadBundle\Entity\DoNotContact;

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Validator\Constraints;
 
 use Mautic\LeadBundle\Form\Validator\Constraints\EmailAddress;

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Validator\Constraints;
 
 use Mautic\LeadBundle\Validator\Constraints\Length;

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/LengthValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\LeadBundle\Tests\Validator\Constraints;
 
 use Mautic\LeadBundle\Validator\Constraints\Length;

--- a/app/bundles/MessengerBundle/Tests/Message/EmailHitNotificationTest.php
+++ b/app/bundles/MessengerBundle/Tests/Message/EmailHitNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\MessengerBundle\Tests\Message;
 
 use Mautic\MessengerBundle\Message\EmailHitNotification;

--- a/app/bundles/MessengerBundle/Tests/Message/PageHitNotificationTest.php
+++ b/app/bundles/MessengerBundle/Tests/Message/PageHitNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\MessengerBundle\Tests\Message;
 
 use Mautic\MessengerBundle\Message\PageHitNotification;

--- a/app/bundles/MessengerBundle/Tests/MessageHandler/EmailHitNotificationHandlerTest.php
+++ b/app/bundles/MessengerBundle/Tests/MessageHandler/EmailHitNotificationHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\MessengerBundle\Tests\MessageHandler;
 
 use Doctrine\DBAL\Exception\RetryableException;

--- a/app/bundles/MessengerBundle/Tests/MessageHandler/PageHitNotificationHandlerTest.php
+++ b/app/bundles/MessengerBundle/Tests/MessageHandler/PageHitNotificationHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\MessengerBundle\Tests\MessageHandler;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\Lead;

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\EventListener;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;

--- a/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;

--- a/app/bundles/PageBundle/Tests/Form/Type/RedirectListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/RedirectListTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Form\Type;
 
 use Mautic\PageBundle\Form\Type\RedirectListType;

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/PageBundle/Tests/Model/Tracking404ModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/Tracking404ModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -61,7 +61,7 @@ abstract class PageTestAbstract extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockTrackingId = hash('sha1', uniqid(mt_rand(), true));
+        $this->mockTrackingId = hash('sha1', uniqid((string) mt_rand(), true));
     }
 
     protected function getPageModel(bool $transliterationEnabled = true, bool $validatePageHitRequiredData = true): PageModel

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Tests;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PluginBundle\Tests;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/PluginBundle/Tests/Entity/PluginTest.php
+++ b/app/bundles/PluginBundle/Tests/Entity/PluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PluginBundle\Tests\Entity;
 
 use Mautic\PluginBundle\Entity\Plugin;

--- a/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PluginBundle\Tests\Helper;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTestCase.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PluginBundle\Tests\Integration;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PointBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PointBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/ReportBundle/Tests/Adapter/ReportDataAdapterTest.php
+++ b/app/bundles/ReportBundle/Tests/Adapter/ReportDataAdapterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Adapter;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Controller;
 
 use Doctrine\ORM\Exception\NotSupported;

--- a/app/bundles/ReportBundle/Tests/Entity/ReportTest.php
+++ b/app/bundles/ReportBundle/Tests/Entity/ReportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Entity;
 
 use Mautic\ReportBundle\Entity\Report;

--- a/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
+++ b/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Entity;
 
 use Doctrine\ORM\AbstractQuery;

--- a/app/bundles/ReportBundle/Tests/EventListener/SchedulerSubscriberTest.php
+++ b/app/bundles/ReportBundle/Tests/EventListener/SchedulerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\EventListener;
 
 use Mautic\ReportBundle\Entity\Report;

--- a/app/bundles/ReportBundle/Tests/Model/CsvExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/CsvExporterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/ReportBundle/Tests/Model/ExportHandlerTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ExportHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\CoreBundle\Exception\FilePathException;

--- a/app/bundles/ReportBundle/Tests/Model/ExportResponseTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ExportResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\ReportBundle\Model\ExportResponse;

--- a/app/bundles/ReportBundle/Tests/Model/ReportCleanupTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportCleanupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\ReportBundle\Model\ReportCleanup;

--- a/app/bundles/ReportBundle/Tests/Model/ReportExportOptionsTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportExportOptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\CoreBundle\Event\JobExtendTimeEvent;

--- a/app/bundles/ReportBundle/Tests/Model/ReportFileWriterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportFileWriterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/ReportBundle/Tests/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/app/bundles/ReportBundle/Tests/Model/ScheduleModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ScheduleModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Builder;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerDailyBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerDailyBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Builder;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerDailyBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerMonthBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerMonthBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Builder;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerMonthBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerWeeklyBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Builder/SchedulerWeeklyBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Builder;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerWeeklyBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Date/DateBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Date/DateBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Date;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/EventListener/ReportSchedulerSubscriberTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/EventListener/ReportSchedulerSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\EventListener;
 
 use Mautic\ReportBundle\Entity\Report;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Factory/SchedulerTemplateFactoryTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Factory/SchedulerTemplateFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Factory;
 
 use Mautic\ReportBundle\Scheduler\Builder\SchedulerDailyBuilder;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Model;
 
 use Mautic\ReportBundle\Entity\Report;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/SchedulerPlannerTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/SchedulerPlannerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Model;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/SendScheduleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Model;
 
 use Mautic\EmailBundle\Helper\MailHelper;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Option/ExportOptionTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Option/ExportOptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Option;
 
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;

--- a/app/bundles/ReportBundle/Tests/Scheduler/Validator/ScheduleIsValidValidatorTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Validator/ScheduleIsValidValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\ReportBundle\Tests\Scheduler\Validator;
 
 use Mautic\ReportBundle\Entity\Report;

--- a/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
+++ b/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\DependencyInjection\Compiler;
 
 use Mautic\PluginBundle\Helper\IntegrationHelper;

--- a/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Event\TokenReplacementEvent;

--- a/app/bundles/SmsBundle/Tests/EventListener/StopSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/StopSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\EventListener;
 
 use Mautic\LeadBundle\Entity\DoNotContact;

--- a/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\EventListener;
 
 use Mautic\EmailBundle\Entity\Email;

--- a/app/bundles/SmsBundle/Tests/Helper/ReplyHelperTest.php
+++ b/app/bundles/SmsBundle/Tests/Helper/ReplyHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\Helper;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\Integration\Twilio;
 
 use Mautic\PluginBundle\Entity\Integration;

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioCallbackTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioCallbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\SmsBundle\Tests\Integration\Twilio;
 
 use Mautic\SmsBundle\Helper\ContactHelper;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/CalculatorTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/CalculatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection;
 
 use Mautic\StatsBundle\Aggregate\Calculator;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/CollectorTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/CollectorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection;
 
 use Mautic\StatsBundle\Aggregate\Collector;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/DAO/StatsDAOTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/DAO/StatsDAOTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\DAO;
 
 use Mautic\StatsBundle\Aggregate\Collection\DAO\StatsDAO;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/DayStatTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/DayStatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\Stats;
 
 use Mautic\StatsBundle\Aggregate\Collection\Stats\DayStat;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/HourStatTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/HourStatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\Stats;
 
 use Mautic\StatsBundle\Aggregate\Collection\Stats\HourStat;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/MonthStatTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/MonthStatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\Stats;
 
 use Mautic\StatsBundle\Aggregate\Collection\Stats\DayStat;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/WeekStatTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/WeekStatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\Stats;
 
 use Mautic\StatsBundle\Aggregate\Collection\Stats\WeekStat;

--- a/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/YearStatTest.php
+++ b/app/bundles/StatsBundle/Tests/Aggregate/Collection/Stats/YearStatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\StatsBundle\Tests\Aggregate\Collection\Stats;
 
 use Mautic\StatsBundle\Aggregate\Collection\Stats\MonthStat;

--- a/app/bundles/UserBundle/Tests/Entity/UserTest.php
+++ b/app/bundles/UserBundle/Tests/Entity/UserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Entity;
 
 use Mautic\UserBundle\Entity\User;

--- a/app/bundles/UserBundle/Tests/Event/LoginEventTest.php
+++ b/app/bundles/UserBundle/Tests/Event/LoginEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Event;
 
 use Mautic\UserBundle\Entity\User;

--- a/app/bundles/UserBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\EventListener;
 
 use Mautic\ConfigBundle\Event\ConfigEvent;

--- a/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\EventListener;
 
 use Mautic\UserBundle\EventListener\SAMLSubscriber;

--- a/app/bundles/UserBundle/Tests/EventListener/SecuritySubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/SecuritySubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Model;
 
 use Doctrine\ORM\EntityManager;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Security\SAML\Store;
 
 use LightSaml\Credential\X509Credential;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/EntityDescriptorStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/EntityDescriptorStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Security\SAML\Store;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/IdStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/IdStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Security\SAML\Store;
 
 use Doctrine\Persistence\ObjectManager;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/TrustOptionsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/TrustOptionsStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Security\SAML\Store;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;

--- a/app/bundles/UserBundle/Tests/Security/SAML/User/UserMapperTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/User/UserMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\UserBundle\Tests\Security\SAML\User;
 
 use LightSaml\Model\Assertion\Assertion;

--- a/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Functional\Model;
 
 use Doctrine\Common\Collections\Order;

--- a/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Functional;
 
 use Doctrine\ORM\EntityRepository;

--- a/app/bundles/WebhookBundle/Tests/Unit/Entity/WebhookTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Entity/WebhookTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Unit\Entity;
 
 use Mautic\WebhookBundle\Entity\Webhook;

--- a/app/bundles/WebhookBundle/Tests/Unit/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/EventListener/WebhookSubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Unit\EventListener;
 
 use Mautic\CoreBundle\Helper\IpLookupHelper;

--- a/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Unit\Helper;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/app/bundles/WebhookBundle/Tests/Unit/Http/ClientTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Http/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Unit\Http;
 
 use GuzzleHttp\Client as GuzzleClient;

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\WebhookBundle\Tests\Unit\Model;
 
 use Doctrine\ORM\EntityManager;

--- a/plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/ConnectwiseApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Api;
 
 use MauticPlugin\MauticCrmBundle\Api\ConnectwiseApi;

--- a/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/Zoho/MapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Api\Zoho;
 
 use MauticPlugin\MauticCrmBundle\Api\Zoho\Exception\MatchingKeyNotFoundException;

--- a/plugins/MauticCrmBundle/Tests/CrmAbstractIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/CrmAbstractIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests;
 
 use Mautic\EmailBundle\Helper\EmailValidator;

--- a/plugins/MauticCrmBundle/Tests/DynamicsApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/DynamicsApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests;
 
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;

--- a/plugins/MauticCrmBundle/Tests/DynamicsIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/DynamicsIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests;
 
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;

--- a/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
 
 use Mautic\PluginBundle\Model\IntegrationEntityModel;

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/FetcherTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/FetcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\CampaignMember;
 
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/OrganizerTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/CampaignMember/OrganizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\CampaignMember;
 
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember\Organizer;

--- a/plugins/MauticCrmBundle/Tests/Integration/Salesforce/Helper/StateValidationHelperTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/Salesforce/Helper/StateValidationHelperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration\Salesforce\Helper;
 
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Helper\StateValidationHelper;

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
 
 use Mautic\CoreBundle\Entity\AuditLogRepository;

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticSocialBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
 
 use Mautic\CoreBundle\Translation\Translator;

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticTagManagerBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticTagManagerBundle\Tests\Functional\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;

--- a/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticTagManagerBundle\Tests\Unit\Integration;
 
 use MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration;

--- a/plugins/MauticTagManagerBundle/Tests/Unit/Security/Permissions/TagManagerPermissionsTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Unit/Security/Permissions/TagManagerPermissionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticTagManagerBundle\Tests\Unit\Security\Permissions;
 
 use MauticPlugin\MauticTagManagerBundle\Security\Permissions\TagManagerPermissions;


### PR DESCRIPTION
Some test can assert float/int/string values, and convert result to miss-matching type. 
This makes sure the scalar values are tested strictly :+1: 