### PR TITLE
[rector] add type declarations to controllers

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -45,10 +45,8 @@ class ClientController extends AbstractStandardFormController
 
     /**
      * Generate's default client list.
-     *
-     * @param int $page
      */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         if (!$this->security->isGranted('api:clients:view')) {
             $this->throwAccessDenied();

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -405,6 +405,10 @@ class CommonApiController extends FetchCommonApiController
         return $parameters;
     }
 
+    /**
+     * @param mixed[] $errors
+     * @param mixed[] $entities
+     */
     protected function processBatchForm(Request $request, $key, $entity, $params, $method, array &$errors, array &$entities)
     {
         $this->inBatchMode = true;

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -409,7 +409,7 @@ class CommonApiController extends FetchCommonApiController
      * @param mixed[] $errors
      * @param mixed[] $entities
      */
-    protected function processBatchForm(Request $request, $key, $entity, $params, $method, array &$errors, array &$entities)
+    protected function processBatchForm(Request $request, $key, $entity, $params, $method, &$errors, &$entities)
     {
         $this->inBatchMode = true;
         $formResponse      = $this->processForm($request, $entity, $params, $method);

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -405,7 +405,7 @@ class CommonApiController extends FetchCommonApiController
         return $parameters;
     }
 
-    protected function processBatchForm(Request $request, $key, $entity, $params, $method, &$errors, &$entities)
+    protected function processBatchForm(Request $request, $key, $entity, $params, $method, array &$errors, array &$entities)
     {
         $this->inBatchMode = true;
         $formResponse      = $this->processForm($request, $entity, $params, $method);

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -374,11 +374,9 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 403 Access Denied.
      *
-     * @param string $msg
-     *
      * @return Response
      */
-    protected function accessDenied($msg = 'mautic.core.error.accessdenied')
+    protected function accessDenied(string $msg = 'mautic.core.error.accessdenied')
     {
         return $this->returnError($msg, Response::HTTP_FORBIDDEN);
     }
@@ -391,11 +389,9 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 400 Bad Request.
      *
-     * @param string $msg
-     *
      * @return Response
      */
-    protected function badRequest($msg = 'mautic.core.error.badrequest')
+    protected function badRequest(string $msg = 'mautic.core.error.badrequest')
     {
         return $this->returnError($msg, Response::HTTP_BAD_REQUEST);
     }
@@ -440,7 +436,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      *
      * @return mixed[]
      */
-    protected function getBatchEntities($parameters, &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
+    protected function getBatchEntities($parameters, array &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
     {
         $idHelper = new BatchIdToEntityHelper($parameters, $requestIdColumn);
 
@@ -581,7 +577,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     {
         return $this->prepareEntityResultsToArray(
             $results,
-            function ($entity): void {
+            function (object $entity): void {
                 $this->preSerializeEntity($entity);
             }
         );

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -374,9 +374,11 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 403 Access Denied.
      *
+     * @param string $msg
+     *
      * @return Response
      */
-    protected function accessDenied(string $msg = 'mautic.core.error.accessdenied')
+    protected function accessDenied($msg = 'mautic.core.error.accessdenied')
     {
         return $this->returnError($msg, Response::HTTP_FORBIDDEN);
     }
@@ -389,9 +391,11 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 400 Bad Request.
      *
+     * @param string $msg
+     *
      * @return Response
      */
-    protected function badRequest(string $msg = 'mautic.core.error.badrequest')
+    protected function badRequest($msg = 'mautic.core.error.badrequest')
     {
         return $this->returnError($msg, Response::HTTP_BAD_REQUEST);
     }
@@ -436,7 +440,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      *
      * @return mixed[]
      */
-    protected function getBatchEntities($parameters, array &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
+    protected function getBatchEntities($parameters, &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
     {
         $idHelper = new BatchIdToEntityHelper($parameters, $requestIdColumn);
 
@@ -464,10 +468,10 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
         $idHelper->setIsAssociative(true);
 
         [$entities, $total] = $prepareForSerialization
-                ?
-                $this->prepareEntitiesForView($entities)
-                :
-                $this->prepareEntityResultsToArray($entities);
+            ?
+            $this->prepareEntitiesForView($entities)
+            :
+            $this->prepareEntityResultsToArray($entities);
 
         // Set errors
         if ($idHelper->hasErrors()) {
@@ -577,7 +581,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     {
         return $this->prepareEntityResultsToArray(
             $results,
-            function (object $entity): void {
+            function ($entity): void {
                 $this->preSerializeEntity($entity);
             }
         );

--- a/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
@@ -203,6 +203,8 @@ class EventLogApiController extends FetchCommonApiController
             return $valid;
         }
 
+        $errors= [];
+
         $events   = $this->getBatchEntities($parameters, $errors, false, 'eventId', $this->getModel('campaign.event'), false);
         $contacts = $this->getBatchEntities($parameters, $errors, false, 'contactId', $this->getModel('lead'), false);
 

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -15,7 +15,7 @@ abstract class AbstractFormController extends CommonController
     /**
      * @return mixed
      */
-    public function unlockAction(Request $request, $objectId, $objectModel)
+    public function unlockAction(Request $request, $objectId, string $objectModel)
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);
@@ -58,12 +58,11 @@ abstract class AbstractFormController extends CommonController
      *
      * @param array  $postActionVars
      * @param object $entity
-     * @param string $model
      * @param bool   $batch          Flag if a batch action is being performed
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse|array
      */
-    protected function isLocked($postActionVars, $entity, $model, $batch = false)
+    protected function isLocked($postActionVars, $entity, string $model, $batch = false)
     {
         $date                   = $entity->getCheckedOut();
         $postActionVars         = $this->refererPostActionVars($postActionVars);

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -13,7 +13,6 @@ abstract class AbstractFormController extends CommonController
     protected ?string $permissionBase = null;
 
     /**
-     * @param string $objectModel
      * @return mixed
      */
     public function unlockAction(Request $request, $objectId, $objectModel)
@@ -59,11 +58,12 @@ abstract class AbstractFormController extends CommonController
      *
      * @param array  $postActionVars
      * @param object $entity
+     * @param string $model
      * @param bool   $batch          Flag if a batch action is being performed
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse|array
      */
-    protected function isLocked($postActionVars, $entity, string $model, $batch = false)
+    protected function isLocked($postActionVars, $entity, $model, $batch = false)
     {
         $date                   = $entity->getCheckedOut();
         $postActionVars         = $this->refererPostActionVars($postActionVars);

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -13,9 +13,10 @@ abstract class AbstractFormController extends CommonController
     protected ?string $permissionBase = null;
 
     /**
+     * @param string $objectModel
      * @return mixed
      */
-    public function unlockAction(Request $request, $objectId, string $objectModel)
+    public function unlockAction(Request $request, $objectId, $objectModel)
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -70,7 +70,7 @@ class WidgetApiController extends CommonApiController
      *
      * @return Response
      */
-    public function getDataAction(Request $request, $type)
+    public function getDataAction(Request $request, string $type)
     {
         $start      = microtime(true);
         $timezone   = InputHelper::clean($request->get('timezone'));

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -36,7 +36,7 @@ class AjaxController extends CommonAjaxController
             $request,
             $emailModel,
             fn ($formType, $formOptions): \Symfony\Component\Form\FormInterface => $formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
-            fn ($form): string                                                  => $this->renderView('@MauticEmail/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticEmail/AbTest/form.html.twig', '@MauticEmail/FormTheme/Email/layout.html.twig'])]),
+            fn (\Symfony\Component\Form\FormInterface $form): string            => $this->renderView('@MauticEmail/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticEmail/AbTest/form.html.twig', '@MauticEmail/FormTheme/Email/layout.html.twig'])]),
             'email_abtest_settings',
             'emailform'
         ));

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -686,7 +686,7 @@ class PublicController extends CommonFormController
         return $repo->getLeadByEmail($email);
     }
 
-    public function getUnsubscribeMessage($idHash, $model, $stat, $translator): string
+    public function getUnsubscribeMessage(string $idHash, $model, $stat, TranslatorInterface $translator): string
     {
         $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -52,10 +52,7 @@ class FormController extends CommonFormController
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(

--- a/app/bundles/LeadBundle/Controller/AuditlogController.php
+++ b/app/bundles/LeadBundle/Controller/AuditlogController.php
@@ -14,7 +14,7 @@ class AuditlogController extends CommonController
     use LeadAccessTrait;
     use LeadDetailsTrait;
 
-    public function indexAction(Request $request, $leadId, $page = 1)
+    public function indexAction(Request $request, $leadId, int $page = 1)
     {
         if (empty($leadId)) {
             $this->throwAccessDenied();

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -24,10 +24,7 @@ class CompanyController extends FormController
 {
     use LeadDetailsTrait;
 
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, CompanyColumnsDictionary $companyColumnsDictionary, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, CompanyColumnsDictionary $companyColumnsDictionary, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -35,7 +35,7 @@ trait FrequencyRuleTrait
      *
      * @return true|FormInterface
      */
-    protected function getFrequencyRuleForm($lead, &$viewParameters = [], &$data = null, $isPublic = false, $action = null, $isPreferenceCenter = false)
+    protected function getFrequencyRuleForm(Lead $lead, &$viewParameters = [], &$data = null, $isPublic = false, $action = null, $isPreferenceCenter = false)
     {
         /** @var LeadModel $model */
         $model = $this->getModel('lead');

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -2252,7 +2252,7 @@ class LeadController extends FormController
         $iterator = new IteratorExportDataModel(
             $model,
             $args,
-            fn ($contact): array => $exportHelper->parseLeadToExport($contact)
+            fn (Lead $contact): array => $exportHelper->parseLeadToExport($contact)
         );
         $response = $this->exportResultsAs($iterator, $fileType, 'contacts', $exportHelper);
 

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -14,10 +14,7 @@ trait LeadDetailsTrait
 {
     private ?RequestStack $requestStack = null;
 
-    /**
-     * @param int $page
-     */
-    protected function getAllEngagements(array $leads, ?array $filters = null, ?array $orderBy = null, $page = 1, $limit = 25): array
+    protected function getAllEngagements(array $leads, ?array $filters = null, ?array $orderBy = null, int $page = 1, $limit = 25): array
     {
         $session = $this->requestStack->getCurrentRequest()->getSession();
 
@@ -251,11 +248,7 @@ trait LeadDetailsTrait
         ];
     }
 
-    /**
-     * @param int $page
-     * @param int $limit
-     */
-    protected function getEngagements(Lead $lead, ?array $filters = null, ?array $orderBy = null, $page = 1, $limit = 25): array
+    protected function getEngagements(Lead $lead, ?array $filters = null, ?array $orderBy = null, int $page = 1, int $limit = 25): array
     {
         $session = $this->requestStack->getCurrentRequest()->getSession();
 

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -14,7 +14,7 @@ class TimelineController extends CommonController
     use LeadAccessTrait;
     use LeadDetailsTrait;
 
-    public function indexAction(Request $request, $leadId, $page = 1)
+    public function indexAction(Request $request, $leadId, int $page = 1)
     {
         if (empty($leadId)) {
             $this->throwAccessDenied();
@@ -63,7 +63,7 @@ class TimelineController extends CommonController
         );
     }
 
-    public function pluginIndexAction(Request $request, $integration, $page = 1)
+    public function pluginIndexAction(Request $request, $integration, int $page = 1)
     {
         $limit = 25;
         $leads = $this->checkAllAccess('view', $limit);
@@ -125,7 +125,7 @@ class TimelineController extends CommonController
         );
     }
 
-    public function pluginViewAction(Request $request, $integration, $leadId, $page = 1)
+    public function pluginViewAction(Request $request, $integration, $leadId, int $page = 1)
     {
         if (empty($leadId)) {
             return $this->notFound();

--- a/app/bundles/PageBundle/Controller/AjaxController.php
+++ b/app/bundles/PageBundle/Controller/AjaxController.php
@@ -22,7 +22,7 @@ class AjaxController extends CommonAjaxController
             $request,
             $pageModel,
             fn ($formType, $formOptions): \Symfony\Component\Form\FormInterface => $formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
-            fn ($form): string                                                  => $this->renderView('@MauticPage/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticPage/AbTest/form.html.twig', 'MauticPageBundle:FormTheme\Page'])]),
+            fn (\Symfony\Component\Form\FormInterface $form): string            => $this->renderView('@MauticPage/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticPage/AbTest/form.html.twig', 'MauticPageBundle:FormTheme\Page'])]),
             'page_abtest_settings',
             'page'
         ));

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -30,10 +30,7 @@ class PageController extends FormController
 {
     use FormErrorMessagesTrait;
 
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageConfig $pageConfig, PageHelperFactoryInterface $pageHelperFactory, PageModel $model, $page = 1): Response
+    public function indexAction(Request $request, PageConfig $pageConfig, PageHelperFactoryInterface $pageHelperFactory, PageModel $model, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted([

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -13,10 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PointController extends AbstractFormController
 {
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted([

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -14,10 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TriggerController extends FormController
 {
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted([

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -22,10 +22,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ReportController extends FormController
 {
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         /* @type \Mautic\ReportBundle\Model\ReportModel $model */
         $model = $this->getModel('report');
@@ -156,7 +153,7 @@ class ReportController extends FormController
      *
      * @return array<string, string|array<string, string>>|bool|HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, int $objectId)
     {
         $page      = $request->getSession()->get('mautic.report.page', 1);
         $returnUrl = $this->generateUrl('mautic_report_index', ['page' => $page]);
@@ -293,7 +290,7 @@ class ReportController extends FormController
      *
      * @return HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false)
+    public function editAction(Request $request, int $objectId, $ignorePost = false)
     {
         $model = $this->getModel('report');
         \assert($model instanceof ReportModel);

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -86,7 +86,7 @@ class AjaxController extends CommonAjaxController
      *
      * @return array<string, string>
      */
-    protected function getBuilderTokens($query): array
+    protected function getBuilderTokens(string $query): array
     {
         /** @var EmailModel $model */
         $model        = $this->getModel('email');

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -80,9 +80,7 @@ class AjaxController extends CommonAjaxController
     }
 
     /**
-     * Just selected get tokens from email  builder.
-     *
-     * @param string|null $query
+     * Just selected get tokens from email builder.
      *
      * @return array<string, string>
      */

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -13,10 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StageController extends AbstractFormController
 {
-    /**
-     * @param int $page
-     */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -30,10 +30,8 @@ class RoleController extends FormController
 
     /**
      * Generate's default role list view.
-     *
-     * @param int $page
      */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $page = 1): Response
+    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
     {
         if (!$this->security->isGranted('user:roles:view')) {
             $this->throwAccessDenied();

--- a/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+++ b/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
@@ -163,7 +163,7 @@ class GrapesJsController extends CommonController
         }
 
         // Replace short codes to emoji
-        $content = array_map(fn ($text): string => EmojiHelper::toEmoji($text, 'short'), $content);
+        $content = array_map(fn (string $text): string => EmojiHelper::toEmoji($text, 'short'), $content);
 
         $renderedTemplate =  $themeHelper->renderThemeTemplate(
             $logicalName,


### PR DESCRIPTION
Adds param/return type declarations to controllers (PHPStan levels rector run).

Split from a larger rector type-declaration branch. Companion PRs: repositories, models/helpers/entities.