### PR TITLE
[rector] add type declarations to helpers, listeners, integrations

### DIFF
--- a/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
@@ -29,7 +29,7 @@ final class EntityResultHelperTest extends TestCase
 
         $this->assertEquals($results, $arrayResult);
 
-        $arrayResult = $resultHelper->getArray($results, function ($entity): void {
+        $arrayResult = $resultHelper->getArray($results, function (Lead $entity): void {
             $this->modifyEntityData($entity);
         });
 
@@ -65,7 +65,7 @@ final class EntityResultHelperTest extends TestCase
 
         $this->assertEquals($results, $arrayResult);
 
-        $arrayResult = $resultHelper->getArray($results, function ($entity): void {
+        $arrayResult = $resultHelper->getArray($results, function (Lead $entity): void {
             $this->modifyEntityData($entity);
         });
 
@@ -99,7 +99,7 @@ final class EntityResultHelperTest extends TestCase
             $this->assertEquals($entity->getTitle(), 'Title '.$entity->getId());
         }
 
-        $arrayResult = $resultHelper->getArray($data, function ($entity): void {
+        $arrayResult = $resultHelper->getArray($data, function (Lead $entity): void {
             $this->modifyEntityData($entity);
         });
 

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
@@ -144,7 +144,7 @@ class LegacyEventDispatcher
         }
     }
 
-    private function dispatchEventName($eventName, array $settings, LeadEventLog $log): CampaignExecutionEvent
+    private function dispatchEventName(string $eventName, array $settings, LeadEventLog $log): CampaignExecutionEvent
     {
         @trigger_error('eventName is deprecated. Convert to using batchEventName.', E_USER_DEPRECATED);
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -180,7 +180,7 @@ class Interval implements ScheduleModeInterface
      * @return \DateTimeInterface
      */
     private function getGroupExecutionDateTime(
-        $eventId,
+        int $eventId,
         Lead $contact,
         \DateTimeInterface $compareFromDateTime,
         ?\DateTimeInterface $hour = null,
@@ -244,7 +244,7 @@ class Interval implements ScheduleModeInterface
     /**
      * @return \DateTimeInterface
      */
-    private function getExecutionDateTimeFromHour(Lead $contact, \DateTimeInterface $hour, $eventId, \DateTimeInterface $compareFromDateTime)
+    private function getExecutionDateTimeFromHour(Lead $contact, \DateTimeInterface $hour, int $eventId, \DateTimeInterface $compareFromDateTime)
     {
         /** @var \DateTime $groupHour */
         $groupHour = clone $hour;
@@ -272,7 +272,7 @@ class Interval implements ScheduleModeInterface
         Lead $contact,
         \DateTimeInterface $startTime,
         \DateTimeInterface $endTime,
-        $eventId,
+        int $eventId,
         \DateTimeInterface $compareFromDateTime,
     ) {
         /* @var \DateTime $startTime */

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -118,11 +118,10 @@ namespace Mautic\CoreBundle\ErrorHandler {
         /**
          * @param string $file
          * @param int    $line
-         * @param array  $context
          *
          * @throws \ErrorException
          */
-        public function handleError($level, $message, $file = 'unknown', $line = 0, $context = []): bool
+        public function handleError($level, $message, $file = 'unknown', $line = 0, array $context = []): bool
         {
             $errorReporting = ('dev' === self::$environment) ? -1 : error_reporting();
             if ($level & $errorReporting) {
@@ -372,10 +371,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
             return $this;
         }
 
-        /**
-         * @param array $context
-         */
-        protected function log($logLevel, $message, $context = [], $debugTrace = null)
+        protected function log($logLevel, $message, array $context = [], $debugTrace = null)
         {
             $message = strip_tags($message);
             if ($this->logger) {

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -245,7 +245,7 @@ class CoreSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function addRouteToCollection(RouteCollection $collection, $type, $name, $details): void
+    private function addRouteToCollection(RouteCollection $collection, $type, string $name, $details): void
     {
         // Set defaults and controller
         $defaults = (!empty($details['defaults'])) ? $details['defaults'] : [];

--- a/app/bundles/CoreBundle/Factory/ModelFactory.php
+++ b/app/bundles/CoreBundle/Factory/ModelFactory.php
@@ -51,7 +51,7 @@ class ModelFactory
     /**
      * Check if a model exists.
      */
-    public function hasModel($modelNameKey): bool
+    public function hasModel(string $modelNameKey): bool
     {
         try {
             $this->getModel($modelNameKey);

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -244,7 +244,7 @@ class AssetGenerationHelper
      * @param string $env
      * @param array  $assets
      */
-    protected function findAssets($dir, $ext, $env, &$assets): array
+    protected function findAssets(string|array $dir, $ext, $env, &$assets): array
     {
         $rootPath    = str_replace('\\', '/', $this->pathsHelper->getSystemPath('assets_root').'/');
         $directories = new Finder();

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -239,12 +239,11 @@ class AssetGenerationHelper
     /**
      * Finds directory assets.
      *
-     * @param string $dir
-     * @param string $ext
-     * @param string $env
-     * @param array  $assets
+     * @param array $assets
+     *
+     * @return array<string, mixed>
      */
-    protected function findAssets(string|array $dir, $ext, $env, &$assets): array
+    protected function findAssets(string $dir, string $ext, string $env, &$assets): array
     {
         $rootPath    = str_replace('\\', '/', $this->pathsHelper->getSystemPath('assets_root').'/');
         $directories = new Finder();

--- a/app/bundles/CoreBundle/Helper/Chart/LineChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/LineChart.php
@@ -35,8 +35,8 @@ class LineChart extends AbstractChart implements ChartInterface
      */
     public function __construct(
         ?string $unit = null,
-        $dateFrom = null,
-        $dateTo = null,
+        ?\DateTimeInterface $dateFrom = null,
+        ?\DateTimeInterface $dateTo = null,
         protected $dateFormat = null,
     ) {
         $this->unit       = $unit ?? $this->getTimeUnitFromDateRange($dateFrom, $dateTo);

--- a/app/bundles/CoreBundle/Helper/CoreParametersHelper.php
+++ b/app/bundles/CoreBundle/Helper/CoreParametersHelper.php
@@ -45,10 +45,7 @@ class CoreParametersHelper
         return $this->parameters->get($name, $default);
     }
 
-    /**
-     * @param string $name
-     */
-    public function has($name): bool
+    public function has(string $name): bool
     {
         return $this->parameters->has($this->stripMauticPrefix($name));
     }

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -35,7 +35,7 @@ class DateTimeHelper
      * @param string|null               $fromFormat Format the string is in
      * @param string|null               $timezone   Timezone the string is in
      */
-    public function __construct($string = '', ?string $fromFormat = self::FORMAT_DB, string $timezone = 'UTC')
+    public function __construct($string = '', ?string $fromFormat = self::FORMAT_DB, ?string $timezone = 'UTC')
     {
         $this->setDefaultTimezone();
         $this->setDateTime($string, $fromFormat, $timezone);

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -35,7 +35,7 @@ class DateTimeHelper
      * @param string|null               $fromFormat Format the string is in
      * @param string|null               $timezone   Timezone the string is in
      */
-    public function __construct($string = '', $fromFormat = self::FORMAT_DB, $timezone = 'UTC')
+    public function __construct($string = '', ?string $fromFormat = self::FORMAT_DB, string $timezone = 'UTC')
     {
         $this->setDefaultTimezone();
         $this->setDateTime($string, $fromFormat, $timezone);

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -97,12 +97,9 @@ class FormModel extends AbstractCommonModel
     /**
      * Create/edit entity.
      *
-     * @param object $entity
-     * @param bool   $unlock
-     *
-     * @phpstan-param T $entity
+     * @param T $entity
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity(object $entity, bool $unlock = true): void
     {
         $isNew = $this->isNewEntity($entity);
 

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -113,12 +113,10 @@ class AssetExtension extends AbstractExtension
     }
 
     /**
-     * @param string|null $packageName
-     * @param string|null $version
-     * @param bool        $absolute
-     * @param bool        $ignorePrefix
+     * @param bool $absolute
+     * @param bool $ignorePrefix
      */
-    public function getAssetUrl(string $path, $packageName = null, $version = null, $absolute = false, $ignorePrefix = false): string
+    public function getAssetUrl(string $path, ?string $packageName = null, ?string $version = null, $absolute = false, $ignorePrefix = false): string
     {
         return $this->assetsHelper->getUrl($path, $packageName, $version, $absolute, $ignorePrefix);
     }

--- a/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
@@ -65,12 +65,10 @@ class DateExtension extends AbstractExtension
      * Returns date and time concat eg 2014-08-02 5:00am.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toFullConcat($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toFullConcat($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->dateHelper->toFullConcat($datetime, $timezone, $fromFormat);
     }

--- a/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
@@ -108,13 +108,11 @@ final class AssetsHelper
     /**
      * Set asset url path.
      *
-     * @param string      $path
-     * @param string|null $packageName
-     * @param string|null $version
-     * @param bool|false  $absolute
-     * @param bool|false  $ignorePrefix
+     * @param string     $path
+     * @param bool|false $absolute
+     * @param bool|false $ignorePrefix
      */
-    public function getUrl($path, $packageName = null, $version = null, $absolute = false, $ignorePrefix = false): string
+    public function getUrl($path, ?string $packageName = null, ?string $version = null, $absolute = false, $ignorePrefix = false): string
     {
         // if we have http in the url it is absolute and we can just return it
         if (str_starts_with($path, 'http')) {

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -44,12 +44,10 @@ final class DateHelper
 
     /**
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    private function format(string $type, $datetime, $timezone, $fromFormat)
+    private function format(string $type, $datetime, string $timezone, ?string $fromFormat)
     {
         if (empty($datetime)) {
             return '';
@@ -65,12 +63,10 @@ final class DateHelper
      * Returns full date. eg. October 8, 2014 21:19.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toFull($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toFull($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->format('datetime', $datetime, $timezone, $fromFormat);
     }
@@ -79,12 +75,10 @@ final class DateHelper
      * Returns date and time concat eg 2014-08-02 5:00am.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toFullConcat($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toFullConcat($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         $this->helper->setDateTime($datetime, $fromFormat, $timezone);
 
@@ -97,12 +91,10 @@ final class DateHelper
      * Returns short date format eg Sun, Oct 8.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toShort($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toShort($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->format('short', $datetime, $timezone, $fromFormat);
     }
@@ -111,12 +103,10 @@ final class DateHelper
      * Returns date only e.g. 2014-08-09.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toDate($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toDate($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->format('date', $datetime, $timezone, $fromFormat);
     }
@@ -125,12 +115,10 @@ final class DateHelper
      * Returns time only e.g. 21:19.
      *
      * @param \DateTime|string $datetime
-     * @param string           $timezone
-     * @param string           $fromFormat
      *
      * @return string
      */
-    public function toTime($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s')
+    public function toTime($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->format('time', $datetime, $timezone, $fromFormat);
     }
@@ -139,11 +127,9 @@ final class DateHelper
      * Returns date/time like Today, 10:00 AM.
      *
      * @param string|int<min, -1>|int<1, max>|\DateTime $datetime
-     * @param string                                    $timezone
-     * @param string                                    $fromFormat
      * @param bool                                      $forceDateForNonText If true, return as full date/time rather than "29 days ago"
      */
-    public function toText($datetime, $timezone = 'local', $fromFormat = 'Y-m-d H:i:s', $forceDateForNonText = false): string
+    public function toText($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s', $forceDateForNonText = false): string
     {
         if (empty($datetime)) {
             return '';

--- a/app/bundles/CoreBundle/Twig/Helper/SecurityHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/SecurityHelper.php
@@ -74,10 +74,8 @@ final readonly class SecurityHelper
 
     /**
      * Returns CSRF token string for an intention.
-     *
-     * @param string $intention
      */
-    public function getCsrfToken($intention): string
+    public function getCsrfToken(string $intention): string
     {
         return $this->tokenManager->getToken($intention)->getValue();
     }

--- a/app/bundles/CoreBundle/Validator/FileUploadValidator.php
+++ b/app/bundles/CoreBundle/Validator/FileUploadValidator.php
@@ -15,15 +15,13 @@ class FileUploadValidator
     }
 
     /**
-     * @param int    $fileSize          In bytes
+     * @param int    $fileSize      In bytes
      * @param string $fileExtension
-     * @param int    $maxUploadSize     In bytes
-     * @param string $extensionErrorMsg
-     * @param string $sizeErrorMsg
+     * @param int    $maxUploadSize In bytes
      *
      * @throws FileInvalidException
      */
-    public function validate($fileSize, $fileExtension, $maxUploadSize, array $allowedExtensions, $extensionErrorMsg, $sizeErrorMsg): void
+    public function validate($fileSize, $fileExtension, $maxUploadSize, array $allowedExtensions, string $extensionErrorMsg, string $sizeErrorMsg): void
     {
         $errors = [];
 
@@ -47,11 +45,10 @@ class FileUploadValidator
 
     /**
      * @param string $extension
-     * @param string $extensionErrorMsg
      *
      * @throws FileInvalidException
      */
-    public function checkExtension($extension, array $allowedExtensions, $extensionErrorMsg = 'mautic.asset.asset.error.file.extension'): void
+    public function checkExtension($extension, array $allowedExtensions, string $extensionErrorMsg = 'mautic.asset.asset.error.file.extension'): void
     {
         $extension         = strtolower($extension);
         $allowedExtensions = array_map(strtolower(...), $allowedExtensions);
@@ -67,11 +64,10 @@ class FileUploadValidator
     /**
      * @param int    $fileSize
      * @param string $maxUploadSizeMB Max file size in MB
-     * @param string $sizeErrorMsg
      *
      * @throws FileInvalidException
      */
-    public function checkFileSize($fileSize, $maxUploadSizeMB, $sizeErrorMsg = 'mautic.asset.asset.error.file.size'): void
+    public function checkFileSize($fileSize, $maxUploadSizeMB, string $sizeErrorMsg = 'mautic.asset.asset.error.file.size'): void
     {
         if (!$maxUploadSizeMB) {
             return;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -720,12 +720,11 @@ class MailHelper
      * Use a template as the body.
      *
      * @param string $template
-     * @param array  $vars
      * @param bool   $returnContent
      *
      * @return void|string
      */
-    public function setTemplate($template, $vars = [], $returnContent = false, $charset = null)
+    public function setTemplate($template, array $vars = [], $returnContent = false, $charset = null)
     {
         $content = $this->twig->render($template, $vars);
 
@@ -1105,9 +1104,8 @@ class MailHelper
      * Sets FROM for the mailer which can overwrite the system default.
      *
      * @param string|array $fromEmail
-     * @param string       $fromName
      */
-    public function setFrom($fromEmail, $fromName = null): void
+    public function setFrom($fromEmail, ?string $fromName = null): void
     {
         if (is_array($fromEmail)) {
             $this->from = AddressDTO::fromAddressArray($fromEmail);

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -499,7 +499,7 @@ class FieldType extends AbstractType
                     ChoiceType::class,
                     [
                         'choices'     => $fields->toChoices(),
-                        'choice_attr' => function ($val) use ($fields): array {
+                        'choice_attr' => function (string $val) use ($fields): array {
                             try {
                                 $field = $fields->getFieldByKey($val);
                                 if ($field->isListType()) {

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Notifier.php
@@ -26,12 +26,11 @@ class Notifier
 
     /**
      * @param NotificationDAO[] $notifications
-     * @param string            $integrationHandler
      *
      * @throws HandlerNotSupportedException
      * @throws IntegrationNotFoundException
      */
-    public function noteMauticSyncIssue(array $notifications, $integrationHandler = MauticSyncDataExchange::NAME): void
+    public function noteMauticSyncIssue(array $notifications, string $integrationHandler = MauticSyncDataExchange::NAME): void
     {
         foreach ($notifications as $notification) {
             $handler = $this->handlerContainer->getHandler($integrationHandler, $notification->getMauticObject());

--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -9,10 +9,9 @@ use Mautic\LeadBundle\Model\CompanyModel;
 class IdentifyCompanyHelper
 {
     /**
-     * @param array $data
      * @param mixed $lead
      */
-    public static function identifyLeadsCompany($data, $lead, CompanyModel $companyModel): array
+    public static function identifyLeadsCompany(array $data, $lead, CompanyModel $companyModel): array
     {
         $addContactToCompany = true;
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -454,9 +454,8 @@ class LeadModel extends FormModel
 
     /**
      * @param Lead $entity
-     * @param bool $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity(object $entity, bool $unlock = true): void
     {
         $companyFieldMatches = [];
         $fields              = $entity->getFields();

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -36,7 +36,7 @@ final class SegmentSubscriberTest extends MauticMysqlTestCase
         /** @var TranslatorInterface $translator */
         $translator = $this->getContainer()->get('translator');
 
-        $expectedTranslationString = implode(' ', array_map(fn ($trans) => $translator->trans($trans), $expectedTranslations));
+        $expectedTranslationString = implode(' ', array_map(fn (string $trans) => $translator->trans($trans), $expectedTranslations));
 
         $crawlerText = $crawler->filter('#leadlist_filters_0_properties')->filter('.alert')->text();
         $this->assertStringContainsString($expectedTranslationString, $crawlerText);

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1395,7 +1395,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
          * @param $mauticFields
          * @param $fieldType
          */
-        $cleanup = function (&$mappedFields, $integrationFields, $mauticFields, $fieldType) use (&$missingRequiredFields, &$featureSettings): void {
+        $cleanup = function (&$mappedFields, array $integrationFields, $mauticFields, $fieldType) use (&$missingRequiredFields, &$featureSettings): void {
             $updateKey    = ('companyFields' === $fieldType) ? 'update_mautic_company' : 'update_mautic';
             $removeFields = array_keys(array_diff_key($mappedFields, $integrationFields));
 
@@ -2150,7 +2150,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return array
      */
-    protected function dispatchIntegrationKeyEvent($eventName, $keys = [])
+    protected function dispatchIntegrationKeyEvent(?string $eventName, $keys = [])
     {
         /** @var PluginIntegrationKeyEvent $event */
         $event = $this->dispatcher->dispatch(

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -113,11 +113,9 @@ class ReportBuilderEvent extends AbstractReportEvent
     /**
      * Returns standard form fields such as id, name, publish_up, etc.
      *
-     * @param string $prefix
-     *
      * @return array<string,array<string,string>>
      */
-    public function getStandardColumns($prefix, $removeColumns = [], $idLink = null): array
+    public function getStandardColumns(string $prefix, array $removeColumns = [], $idLink = null): array
     {
         return $this->reportHelper->getStandardColumns($prefix, $removeColumns, (string) $idLink);
     }

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -113,6 +113,8 @@ class ReportBuilderEvent extends AbstractReportEvent
     /**
      * Returns standard form fields such as id, name, publish_up, etc.
      *
+     * @param string[] $removeColumns
+     *
      * @return array<string,array<string,string>>
      */
     public function getStandardColumns(string $prefix, array $removeColumns = [], $idLink = null): array

--- a/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGeneratorEvent.php
@@ -243,13 +243,9 @@ class ReportGeneratorEvent extends AbstractReportEvent
     /**
      * Apply date filters to the query.
      *
-     * @param string $dateColumn
-     * @param string $tablePrefix
-     * @param bool   $dateOnly
-     *
      * @throws \Exception
      */
-    public function applyDateFilters(QueryBuilder $queryBuilder, $dateColumn, $tablePrefix = 't', $dateOnly = false): ReportGeneratorEvent
+    public function applyDateFilters(QueryBuilder $queryBuilder, string $dateColumn, string $tablePrefix = 't', bool $dateOnly = false): ReportGeneratorEvent
     {
         $this->setDateRangeQueryFilters(
             $queryBuilder, $tablePrefix, $dateOnly, $dateColumn,

--- a/app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
+++ b/app/bundles/SmsBundle/Integration/Twilio/TwilioTransport.php
@@ -40,10 +40,9 @@ class TwilioTransport implements TransportInterface, MMSTransportInterface
     }
 
     /**
-     * @param string       $content
      * @param array<mixed> $media
      */
-    private function sendMessage(Lead $lead, $content, array $media = []): bool|string
+    private function sendMessage(Lead $lead, string $content, array $media = []): bool|string
     {
         $number = $lead->getLeadPhoneNumber();
 

--- a/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
@@ -160,7 +160,7 @@ final class CampaignSubscriberTest extends TestCase
             {
             }
 
-            public function saveEntity($entity, $unlock = true): void
+            public function saveEntity(object $entity, bool $unlock = true): void
             {
             }
         };
@@ -398,7 +398,7 @@ final class CampaignSubscriberTest extends TestCase
             {
             }
 
-            public function saveEntity($entity, $unlock = true): void
+            public function saveEntity(object $entity, bool $unlock = true): void
             {
             }
         };

--- a/app/bundles/UserBundle/Security/Provider/UserProvider.php
+++ b/app/bundles/UserBundle/Security/Provider/UserProvider.php
@@ -31,10 +31,7 @@ class UserProvider implements UserProviderInterface
     ) {
     }
 
-    /**
-     * @param string $username
-     */
-    public function loadUserByUsername($username): User
+    public function loadUserByUsername(string $username): User
     {
         return $this->loadUserByIdentifier($username);
     }

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -70,13 +70,12 @@ class CampaignHelper
     }
 
     /**
-     * @param string $method
-     * @param int    $timeout
+     * @param int $timeout
      *
      * @throws \InvalidArgumentException
      * @throws \OutOfRangeException
      */
-    private function makeRequest(string $url, $method, $timeout, array $headers, array $payload): void
+    private function makeRequest(string $url, string $method, $timeout, array $headers, array $payload): void
     {
         switch ($method) {
             case 'get':

--- a/plugins/MauticCrmBundle/Api/DynamicsApi.php
+++ b/plugins/MauticCrmBundle/Api/DynamicsApi.php
@@ -85,13 +85,17 @@ class DynamicsApi extends CrmApi
     }
 
     /**
-     * @param Lead $lead
+     * @param mxied[] $data
+     * @param Lead    $lead
      */
     public function createLead(array $data, $lead, $object = 'contacts'): ResponseInterface
     {
         return $this->request('', $data, 'POST', $object);
     }
 
+    /**
+     * @param mixed[] $data
+     */
     public function updateLead(array $data, $objectId): ResponseInterface
     {
         //        $settings['headers']['If-Match'] = '*'; // prevent create new contact

--- a/plugins/MauticCrmBundle/Api/DynamicsApi.php
+++ b/plugins/MauticCrmBundle/Api/DynamicsApi.php
@@ -87,12 +87,12 @@ class DynamicsApi extends CrmApi
     /**
      * @param Lead $lead
      */
-    public function createLead($data, $lead, $object = 'contacts'): ResponseInterface
+    public function createLead(array $data, $lead, $object = 'contacts'): ResponseInterface
     {
         return $this->request('', $data, 'POST', $object);
     }
 
-    public function updateLead($data, $objectId): ResponseInterface
+    public function updateLead(array $data, $objectId): ResponseInterface
     {
         //        $settings['headers']['If-Match'] = '*'; // prevent create new contact
         return $this->request(sprintf('contacts(%s)', $objectId), $data, 'PATCH', 'contacts', []);

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -787,7 +787,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         if ('company' == $object) {
             $priority = parent::getPriorityFieldsForMautic($config, $object, 'mautic_company');
@@ -885,7 +885,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         return false;
     }
 
-    public function saveCampaignMembers($allCampaignMembers, $campaignMemberObject, $campaignId): void
+    public function saveCampaignMembers($allCampaignMembers, IntegrationObject $campaignMemberObject, $campaignId): void
     {
         if (empty($allCampaignMembers)) {
             return;

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -469,11 +469,11 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return array
      */
-    protected function getPriorityFieldsForMautic(array $config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $entityObject = null, string $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 1),
@@ -482,11 +482,11 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return array
      */
-    protected function getPriorityFieldsForIntegration(array $config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $entityObject = null, string $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 0),
@@ -495,11 +495,11 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return array
      */
-    protected function getFieldsByPriority(array $config, $priorityObject, $direction)
+    protected function getFieldsByPriority(array $config, string $priorityObject, $direction)
     {
         return isset($config['update_'.$priorityObject]) ? array_keys($config['update_'.$priorityObject], $direction) : array_keys($config['leadFields'] ?? []);
     }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -473,7 +473,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return array
      */
-    protected function getPriorityFieldsForMautic($config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $entityObject = null, $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 1),
@@ -486,7 +486,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return array
      */
-    protected function getPriorityFieldsForIntegration($config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $entityObject = null, $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 0),

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1895,7 +1895,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 
@@ -1907,7 +1907,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForIntegration($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForIntegration($config, $object, $priorityObject);
         unset($fields['Contact']['Id'], $fields['Lead']['Id']);
@@ -2495,12 +2495,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param string $sfObject
-     * @param string $sfFieldString
-     *
      * @throws ApiErrorException
      */
-    public function getDncHistory($sfObject, $sfFieldString): mixed
+    public function getDncHistory(string $sfObject, string $sfFieldString): mixed
     {
         return $this->getDoNotContactHistory($sfObject, $sfFieldString, 'DESC');
     }

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1891,11 +1891,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, string $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 
@@ -1903,11 +1903,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForIntegration(array $config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $object = null, string $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForIntegration($config, $object, $priorityObject);
         unset($fields['Contact']['Id'], $fields['Lead']['Id']);

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1164,11 +1164,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $params
-     *
      * @return mixed[]
      */
-    public function pushLeads($params = []): array
+    public function pushLeads(array $params = []): array
     {
         [$fromDate, $toDate]     = $this->getSyncTimeframeDates($params);
         $limit                   = $params['limit'];
@@ -1693,7 +1691,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1687,11 +1687,11 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param mixed[] $config
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, string $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 

--- a/rector.php
+++ b/rector.php
@@ -37,7 +37,7 @@ return RectorConfig::configure()
         UnserializeToSerializerDecodeRector::class,
     ])
     ->reportUnusedSkips()
-    ->withTypeCoverageLevel(36)
+    ->withTypeCoverageLevel(42)
     ->withCodingStyleLevel(3)
     ->withCodeQualityLevel(27)
     ->withSkip([
@@ -46,15 +46,22 @@ return RectorConfig::configure()
             __DIR__.'/app/bundles/UserBundle/Tests/Entity/UserTest.php',
         ],
 
-        Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector::class => [
-            __DIR__.'/app/bundles/SmsBundle/Controller/AjaxController.php',
-        ],
-
         Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector::class,
         // modified with reflection
         Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class => [
             __DIR__.'/app/bundles/EmailBundle/Entity/EmailDraft.php',
             __DIR__.'/app/bundles/EmailBundle/Helper/MailHelper.php',
+        ],
+
+        Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector::class => [
+            // investigate
+            __DIR__.'/app/bundles/CoreBundle/Helper/ArrayHelper.php',
+            __DIR__.'/app/bundles/SmsBundle/Controller/AjaxController.php',
+        ],
+
+        // buggy, fixed in dev-main rector
+        Rector\TypeDeclaration\Rector\ClassMethod\NarrowObjectReturnTypeRector::class => [
+            __DIR__.'/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php',
         ],
 
         // too many changes


### PR DESCRIPTION
Adds param/return type declarations across helpers, twig extensions, event listeners, integrations and rector.php.

Split from a larger rector type-declaration branch. Companion PRs: controllers (#16437), repositories (#16438), models (#16440), entities (#16441).