### PR TITLE
Fix stale pending count from cache in email overview

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -828,6 +828,34 @@ class EmailRepository extends CommonRepository
             ->andWhere('lc.manually_removed = 1');
     }
 
+    /**
+     * @return int[]
+     */
+    public function getSegmentEmailIdsByListId(int $listId): array
+    {
+        $connection = $this->getEntityManager()->getConnection();
+
+        $includedIds = $connection->createQueryBuilder()
+            ->select('DISTINCT xref.email_id')
+            ->from(MAUTIC_TABLE_PREFIX.'email_list_xref', 'xref')
+            ->innerJoin('xref', MAUTIC_TABLE_PREFIX.'emails', 'e', 'e.id = xref.email_id')
+            ->where('xref.leadlist_id = :listId')
+            ->andWhere("e.email_type = 'list'")
+            ->setParameter('listId', $listId)
+            ->fetchFirstColumn();
+
+        $excludedIds = $connection->createQueryBuilder()
+            ->select('DISTINCT excl.email_id')
+            ->from(MAUTIC_TABLE_PREFIX.'email_list_excluded', 'excl')
+            ->innerJoin('excl', MAUTIC_TABLE_PREFIX.'emails', 'e', 'e.id = excl.email_id')
+            ->where('excl.leadlist_id = :listId')
+            ->andWhere("e.email_type = 'list'")
+            ->setParameter('listId', $listId)
+            ->fetchFirstColumn();
+
+        return array_values(array_unique(array_map('intval', [...$includedIds, ...$excludedIds])));
+    }
+
     private function getExcludedListQuery(int $emailId): ?QueryBuilder
     {
         $connection = $this->getEntityManager()

--- a/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\EventListener;
+
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Event\ListChangeEvent;
+use Mautic\LeadBundle\LeadEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SegmentSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private EmailModel $emailModel,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LeadEvents::LEAD_LIST_CHANGE       => ['onListChange', 0],
+            LeadEvents::LEAD_LIST_BATCH_CHANGE => ['onListChange', 0],
+        ];
+    }
+
+    public function onListChange(ListChangeEvent $event): void
+    {
+        $this->emailModel->invalidatePendingCountCacheForList($event->getList()->getId());
+    }
+}

--- a/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\LeadBundle\Event\ListChangeEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SegmentSubscriber implements EventSubscriberInterface
+final class SegmentSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private EmailModel $emailModel,

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -2354,13 +2354,38 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * @throws \Psr\Cache\InvalidArgumentException
      */
+    public function invalidatePendingCountCache(int $emailId): void
+    {
+        $this->cacheStorageHelper->delete(sprintf('%s|%s|%s', 'email', $emailId, 'pending'));
+    }
+
+    /**
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function invalidatePendingCountCacheForList(int $listId): void
+    {
+        foreach ($this->getRepository()->getSegmentEmailIdsByListId($listId) as $emailId) {
+            $this->invalidatePendingCountCache($emailId);
+        }
+    }
+
+    /**
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
     protected function setCachedCount(mixed $entity): void
     {
-        $queued  = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'queued'));
-        $pending = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'pending'));
+        $queued = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'queued'));
 
         if (false !== $queued) {
             $entity->setQueuedCount($queued);
+        }
+
+        $pending = $this->cacheStorageHelper->get(sprintf('%s|%s|%s', 'email', $entity->getId(), 'pending'));
+
+        if (false === $pending && $entity instanceof Email && $entity->isSegmentEmail() && null !== $entity->getId()) {
+            $entity->setPendingCount($this->getPendingLeads($entity, null, true));
+
+            return;
         }
 
         if (false !== $pending) {

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\LeadEvents;
+
+class SegmentSubscriberFunctionalTest extends MauticMysqlTestCase
+{
+    public function testLeadListChangeEventHasListeners(): void
+    {
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+
+        $this->assertTrue($dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE));
+        $this->assertTrue($dispatcher->hasListeners(LeadEvents::LEAD_LIST_BATCH_CHANGE));
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
@@ -7,7 +7,7 @@ namespace Mautic\EmailBundle\Tests\EventListener;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\LeadEvents;
 
-class SegmentSubscriberFunctionalTest extends MauticMysqlTestCase
+final class SegmentSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testLeadListChangeEventHasListeners(): void
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\EmailBundle\EventListener\SegmentSubscriber;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Event\ListChangeEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SegmentSubscriberTest extends TestCase
+{
+    /**
+     * @var MockObject&EmailModel
+     */
+    private MockObject $emailModel;
+
+    private SegmentSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->emailModel  = $this->createMock(EmailModel::class);
+        $this->subscriber  = new SegmentSubscriber($this->emailModel);
+    }
+
+    public function testOnListChangeInvalidatesPendingCountCacheForList(): void
+    {
+        $segment = new LeadList();
+        $segment->setId(42);
+
+        $this->emailModel->expects($this->once())
+            ->method('invalidatePendingCountCacheForList')
+            ->with(42);
+
+        $this->subscriber->onListChange(new ListChangeEvent(new Lead(), $segment));
+    }
+}

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -12,7 +12,7 @@ use Mautic\LeadBundle\Event\ListChangeEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class SegmentSubscriberTest extends TestCase
+final class SegmentSubscriberTest extends TestCase
 {
     /**
      * @var MockObject&EmailModel

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -17,7 +17,10 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\LeadBundle\Event\ListChangeEvent;
+use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
@@ -528,5 +531,99 @@ class EmailModelFunctionalTest extends MauticMysqlTestCase
 
         $this->assertArrayHasKey('companies', $result);
         $this->assertEmpty($result['companies']);
+    }
+
+    public function testGetEntityReturnsFreshPendingCountAfterPendingCacheInvalidation(): void
+    {
+        $contacts = $this->generateContacts(5);
+        $segment  = $this->createSegment();
+        $this->addContactsToSegment(array_slice($contacts, 0, 2), $segment);
+        $email = $this->createEmail($segment);
+
+        $this->emailModel->getPendingLeads($email, null, true);
+
+        $this->addContactsToSegment(array_slice($contacts, 2, 3), $segment);
+        $this->emailModel->invalidatePendingCountCacheForList($segment->getId());
+
+        $loadedEmail = $this->emailModel->getEntity($email->getId());
+        \assert($loadedEmail instanceof Email);
+
+        $this->assertEquals(5, $loadedEmail->getPendingCount());
+    }
+
+    public function testGetEntityReturnsFreshPendingCountAfterSegmentListChangeEvent(): void
+    {
+        $contacts = $this->generateContacts(5);
+        $segment  = $this->createSegment();
+        $this->addContactsToSegment(array_slice($contacts, 0, 2), $segment);
+        $email = $this->createEmail($segment);
+
+        $this->emailModel->getPendingLeads($email, null, true);
+
+        $this->addContactsToSegment(array_slice($contacts, 2, 3), $segment);
+
+        static::getContainer()->get('event_dispatcher')->dispatch(
+            new ListChangeEvent($contacts[2], $segment, true),
+            LeadEvents::LEAD_LIST_CHANGE
+        );
+
+        $loadedEmail = $this->emailModel->getEntity($email->getId());
+        \assert($loadedEmail instanceof Email);
+
+        $this->assertEquals(5, $loadedEmail->getPendingCount());
+    }
+
+    public function testGetEntityReturnsFreshPendingCountForSegmentEmail(): void
+    {
+        $contacts = $this->generateContacts(5);
+        $segment  = $this->createSegment();
+        $this->addContactsToSegment(array_slice($contacts, 0, 2), $segment);
+        $email = $this->createEmail($segment);
+
+        $this->emailModel->getPendingLeads($email, null, true);
+
+        $listModel = static::getContainer()->get('mautic.lead.model.list');
+        \assert($listModel instanceof ListModel);
+
+        foreach (array_slice($contacts, 2, 3) as $contact) {
+            $listModel->addLead($contact, $segment, true);
+        }
+
+        $loadedEmail = $this->emailModel->getEntity($email->getId());
+        \assert($loadedEmail instanceof Email);
+
+        $this->assertEquals(5, $loadedEmail->getPendingCount());
+    }
+
+    public function testGetEntitiesReturnsFreshPendingCountForSegmentEmail(): void
+    {
+        $contacts = $this->generateContacts(5);
+        $segment  = $this->createSegment();
+        $this->addContactsToSegment(array_slice($contacts, 0, 2), $segment);
+        $email = $this->createEmail($segment);
+
+        $this->emailModel->getPendingLeads($email, null, true);
+
+        $listModel = static::getContainer()->get('mautic.lead.model.list');
+        \assert($listModel instanceof ListModel);
+
+        foreach (array_slice($contacts, 2, 3) as $contact) {
+            $listModel->addLead($contact, $segment, true);
+        }
+
+        $entities = $this->emailModel->getEntities([
+            'ids'              => [$email->getId()],
+            'ignore_paginator' => true,
+        ]);
+
+        $loadedEmail = null;
+        foreach ($entities as $entity) {
+            $loadedEmail = $entity;
+            break;
+        }
+
+        \assert($loadedEmail instanceof Email);
+
+        $this->assertEquals(5, $loadedEmail->getPendingCount());
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #16196 

## Description

Email overview shows stale pending count from cache when segment membership changes.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2.  Create broadcast email linked to segment
3. Modify segment (add/remove contacts)
4. Overview shows correct pending count
