### PR TITLE
Fix token picker in dynamic content variation modal

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/11.editor.js
+++ b/app/bundles/CoreBundle/Assets/js/11.editor.js
@@ -221,12 +221,38 @@ Mautic.getCKEditorFonts = function(fonts) {
     return CKEditorFonts;
 }
 
+Mautic.getDynamicContentCkEditorToolbar = function() {
+    return [
+        'undo', 'redo', '|', 'bold', 'italic', 'underline', 'heading', 'fontfamily', 'fontsize',
+        'fontColor', 'fontBackgroundColor', 'alignment', 'numberedList', 'bulletedList', 'blockQuote',
+        'removeFormat', 'link', 'ckfinder', 'mediaEmbed', 'insertTable', 'TokenPlugin', 'sourceEditing',
+    ];
+};
+
+Mautic.ensureDynamicContentEditorAttributes = function(textarea) {
+    if (!textarea.attr('data-token-callback')) {
+        const method = typeof Mautic.getBuilderTokensMethod === 'function'
+            ? Mautic.getBuilderTokensMethod()
+            : 'email:getBuilderTokens';
+        textarea.attr('data-token-callback', method);
+    }
+};
+
 Mautic.ConvertFieldToCkeditor  = function(textarea, ckEditorToolbarOptions) {
     if (ckEditors.has( textarea[0] ))
     {
         ckEditors.get( textarea[0] ).destroy();
         ckEditors.delete( textarea[0] )
     }
+
+    if (textarea.hasClass('editor-dynamic-content')) {
+        Mautic.ensureDynamicContentEditorAttributes(textarea);
+
+        if (!ckEditorToolbarOptions || !ckEditorToolbarOptions.length) {
+            ckEditorToolbarOptions = Mautic.getDynamicContentCkEditorToolbar();
+        }
+    }
+
     const tokenCallback = textarea.attr('data-token-callback');
     Mautic.InitCkEditor(textarea, Mautic.GetCkEditorConfigOptions(ckEditorToolbarOptions, tokenCallback, textarea));
 }

--- a/app/bundles/CoreBundle/Assets/js/1a.content.js
+++ b/app/bundles/CoreBundle/Assets/js/1a.content.js
@@ -732,22 +732,10 @@ Mautic.onPageLoad = function (container, response, inModal) {
 Mautic.setDynamicContentEditors = function(container) {
     // The editor for dynamic content should only be initialized when the modal is opened due to conflicts and not being able to edit content otherwise
     if (mQuery(container + ' textarea.editor-dynamic-content').length) {
-        console.log('[Builder] Using CKEditor for the Dynamic Content editor');
         mQuery(container + ' textarea.editor-dynamic-content').each(function () {
             const textarea = mQuery(this);
-            const maxButtons = ['undo', 'redo', '|', 'bold', 'italic', 'underline', 'heading', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', 'alignment', 'numberedList', 'bulletedList', 'blockQuote', 'removeFormat', 'link', 'ckfinder', 'mediaEmbed', 'insertTable', 'TokenPlugin', 'sourceEditing'];
-            let minButtons = ['undo', 'redo', '|', 'bold', 'italic', 'underline'];
-
-            if (textarea.hasClass('editor-dynamic-content') || textarea.hasClass('editor-basic')) {
-                minButtons = ['undo', 'redo', '|', 'bold', 'italic', 'underline', 'heading', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', 'alignment', 'numberedList', 'bulletedList', 'blockQuote', 'removeFormat', 'link', 'ckfinder', 'mediaEmbed', 'insertTable', 'sourceEditing'];
-            }
-
-            let ckEditorToolbar = minButtons;
-            if (textarea.hasClass('editor-advanced') || textarea.hasClass('editor-basic-fullpage')) {
-                ckEditorToolbar = maxButtons;
-            }
-
-            Mautic.ConvertFieldToCkeditor(textarea, ckEditorToolbar);
+            Mautic.ensureDynamicContentEditorAttributes(textarea);
+            Mautic.ConvertFieldToCkeditor(textarea, Mautic.getDynamicContentCkEditorToolbar());
         });
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #16201 

## Description

When adding dynamic content to an email from the sidebar block, the modal used to configure the dynamic content variations does not offer the tokens dropdown. Typing `{` in the variation content also does not trigger the token popup.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Open the email builder.
3. Add a dynamic content block from the sidebar.
4. Open the modal to configure the dynamic content variations.
5. Try to insert a token in a variation.
6. Type { in the variation content field.