### PR TITLE
[docblock] use generics of collection, union in mock object + avoid type breaking changes by new withTypeGuardedClasses() Rector config option

### DIFF
--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -811,10 +811,8 @@ class Asset extends FormEntity implements UuidInterface
 
     /**
      * Returns absolute path to the file.
-     *
-     * @return string
      */
-    public function getAbsolutePath()
+    public function getAbsolutePath(): ?string
     {
         return null === $this->path
             ? null
@@ -823,10 +821,8 @@ class Asset extends FormEntity implements UuidInterface
 
     /**
      * Returns absolute path to temporary file.
-     *
-     * @return string
      */
-    public function getAbsoluteTempPath()
+    public function getAbsoluteTempPath(): ?string
     {
         return null === $this->tempId || null === $this->tempName
             ? null
@@ -835,10 +831,8 @@ class Asset extends FormEntity implements UuidInterface
 
     /**
      * Returns absolute path to temporary file.
-     *
-     * @return string
      */
-    public function getAbsoluteTempDir()
+    public function getAbsoluteTempDir(): ?string
     {
         return null === $this->tempId
             ? null

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -564,7 +564,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     }
 
     /**
-     * @return Lead[]|Collection
+     * @return Collection<int, Lead>
      */
     public function getLeads(): Collection
     {

--- a/app/bundles/CampaignBundle/Event/AbstractLogCollectionEvent.php
+++ b/app/bundles/CampaignBundle/Event/AbstractLogCollectionEvent.php
@@ -54,7 +54,7 @@ abstract class AbstractLogCollectionEvent extends \Symfony\Contracts\EventDispat
     /**
      * Return an array of Lead entities keyed by LeadEventLog ID.
      *
-     * @return Lead[]|ArrayCollection
+     * @return ArrayCollection<int, Lead>
      */
     public function getContacts()
     {

--- a/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
+++ b/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
@@ -26,7 +26,7 @@ class DecisionResultsEvent extends Event
     }
 
     /**
-     * @return ArrayCollection|LeadEventLog[]
+     * @return ArrayCollection<int, LeadEventLog>
      */
     public function getLogs(): ArrayCollection
     {

--- a/app/bundles/CampaignBundle/Event/PendingEvent.php
+++ b/app/bundles/CampaignBundle/Event/PendingEvent.php
@@ -41,7 +41,7 @@ class PendingEvent extends AbstractLogCollectionEvent
     }
 
     /**
-     * @return LeadEventLog[]|ArrayCollection
+     * @return ArrayCollection<int, LeadEventLog>
      */
     public function getPending()
     {
@@ -212,7 +212,7 @@ class PendingEvent extends AbstractLogCollectionEvent
     }
 
     /**
-     * @return LeadEventLog[]|ArrayCollection
+     * @return ArrayCollection<int, LeadEventLog>
      */
     public function getFailures(): ArrayCollection
     {
@@ -220,7 +220,7 @@ class PendingEvent extends AbstractLogCollectionEvent
     }
 
     /**
-     * @return LeadEventLog[]|ArrayCollection
+     * @return ArrayCollection<int, LeadEventLog>
      */
     public function getSuccessful(): ArrayCollection
     {

--- a/app/bundles/CampaignBundle/Executioner/Result/EvaluatedContacts.php
+++ b/app/bundles/CampaignBundle/Executioner/Result/EvaluatedContacts.php
@@ -28,7 +28,7 @@ class EvaluatedContacts
     }
 
     /**
-     * @return ArrayCollection|Lead[]
+     * @return ArrayCollection<int, Lead>
      */
     public function getPassed(): ArrayCollection
     {
@@ -36,7 +36,7 @@ class EvaluatedContacts
     }
 
     /**
-     * @return ArrayCollection|Lead[]
+     * @return ArrayCollection<int, Lead>
      */
     public function getFailed(): ArrayCollection
     {

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -68,7 +68,7 @@ class ChannelPreferences
     /**
      * @param int $priority
      *
-     * @return ArrayCollection|LeadEventLog[]
+     * @return ArrayCollection<int, LeadEventLog>
      */
     public function getLogsByPriority($priority)
     {

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -242,7 +242,7 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return Event|\PHPUnit\Framework\MockObject\MockObject
+     * @return Event&\PHPUnit\Framework\MockObject\MockObject
      */
     private function getEvent(): \PHPUnit\Framework\MockObject\MockObject
     {

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -37,10 +37,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
 
         private $mainLogger;
 
-        /**
-         * @var string
-         */
-        private static $root;
+        private static string|false $root;
 
         public function __construct()
         {
@@ -510,7 +507,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
                 ]);
                 $twig               = new \Twig\Environment($loader);
                 // This is the same filter Located at Mautic\CoreBundle\Twig\Extension\ExceptionExtension;
-                $twig->addFunction(new \Twig\TwigFunction('getRootPath', fn () => realpath(__DIR__.'/../../../../')));
+                $twig->addFunction(new \Twig\TwigFunction('getRootPath', fn (): string|false => realpath(__DIR__.'/../../../../')));
 
                 if ($loader->exists('custom_offline.html.twig')) {
                     $content = $twig->render('custom_offline.html.twig', ['error' => $error]);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -32,7 +32,7 @@ final class PathsHelperTest extends TestCase
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $this->coreParametersHelper->method('get')
             ->willReturnCallback(
-                fn (string $key) => match ($key) {
+                fn (string $key): string => match ($key) {
                     'image_path' => 'media/images',
                     'tmp_path'   => __DIR__.'/resource/paths/tmp',
                     default      => '',
@@ -105,7 +105,7 @@ final class PathsHelperTest extends TestCase
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $this->coreParametersHelper->method('get')
             ->willReturnCallback(
-                fn (string $key) => match ($key) {
+                fn (string $key): string => match ($key) {
                     'import_campaigns_dir' => $campaignImportPath,
                     'image_path'           => 'media/images',
                     'tmp_path'             => __DIR__.'/resource/paths/tmp',
@@ -129,7 +129,7 @@ final class PathsHelperTest extends TestCase
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelper->method('get')
             ->willReturnCallback(
-                fn (string $key) => match ($key) {
+                fn (string $key): string => match ($key) {
                     'tmp_path' => $tempPath,
                     default    => '',
                 }
@@ -164,7 +164,7 @@ final class PathsHelperTest extends TestCase
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
         $coreParametersHelper->method('get')
             ->willReturnCallback(
-                fn (string $key) => match ($key) {
+                fn (string $key): string => match ($key) {
                     'dashboard_import_dir' => $dashboardDir,
                     default                => '',
                 }

--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -590,7 +590,7 @@ class Stat
     }
 
     /**
-     * @return ArrayCollection|EmailReply[]
+     * @return ArrayCollection<int, EmailReply>
      */
     public function getReplies()
     {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1815,13 +1815,11 @@ class MailHelper
 
     /**
      * Clean the name - if empty, set as null to ensure pretty headers.
-     *
-     * @return string|null
      */
-    protected function cleanName($name)
+    protected function cleanName(?string $name): ?string
     {
         if (null === $name) {
-            return $name;
+            return null;
         }
 
         $name = trim(html_entity_decode($name, ENT_QUOTES));

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -280,7 +280,7 @@ final class BuilderSubscriberTest extends TestCase
 
         $emailHash = hash_hmac('sha256', 'lukas.sykora@acquia.com', 'secret');
         $this->emailModel->method('buildUrl')
-            ->willReturnCallback(fn ($route) => match ($route) {
+            ->willReturnCallback(fn ($route): ?string => match ($route) {
                 'mautic_email_unsubscribe' => '/email/unsubscribe/hash/lukas.sykora@acquia.com/'.$emailHash,
                 'mautic_email_webview'     => '/email/webview/'.$emailHash,
                 'mautic_email_preview'     => '/email/preview/111',

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -686,7 +686,7 @@ class Form extends FormEntity implements UuidInterface
     }
 
     /**
-     * @return Collection|Submission[]
+     * @return Collection<int, Submission>
      */
     public function getSubmissions(): Collection
     {

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMappingRepository.php
@@ -131,8 +131,6 @@ class ObjectMappingRepository extends CommonRepository
 
     /**
      * @param string[]|string $objectIds
-     *
-     * @return \Doctrine\DBAL\Driver\Statement|int
      */
     public function markAsDeleted(string $integration, string $objectName, $objectIds): int
     {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
@@ -60,7 +60,7 @@ final class FieldFilterHelperTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|ConfigFormSyncInterface
+     * @return \PHPUnit\Framework\MockObject\MockObject&ConfigFormSyncInterface
      */
     private function getIntegrationObject(): \PHPUnit\Framework\MockObject\MockObject
     {

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -18,6 +18,9 @@ class OwnerSubscriber implements EventSubscriberInterface
 
     private string $ownerFieldSprintf = '{ownerfield=%s}';
 
+    /**
+     * @var array<int, mixed>|null
+     */
     private ?array $owners = null;
 
     public function __construct(
@@ -137,9 +140,9 @@ class OwnerSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @return array|null
+     * @return mixed[]|null
      */
-    private function getOwner($ownerId)
+    private function getOwner(int $ownerId)
     {
         if (!isset($this->owners[$ownerId])) {
             $this->owners[$ownerId] = $this->leadModel->getRepository()->getLeadOwner($ownerId);

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberTest.php
@@ -229,7 +229,7 @@ final class ReportDevicesSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return ReportGeneratorEvent|\PHPUnit\Framework\MockObject\MockObject
+     * @return ReportGeneratorEvent&\PHPUnit\Framework\MockObject\MockObject
      */
     private function getReportGeneratorEventMock(): \PHPUnit\Framework\MockObject\MockObject
     {
@@ -244,7 +244,7 @@ final class ReportDevicesSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return QueryBuilder|\PHPUnit\Framework\MockObject\MockObject
+     * @return QueryBuilder&\PHPUnit\Framework\MockObject\MockObject
      */
     private function getQueryBuilderMock(): \PHPUnit\Framework\MockObject\MockObject
     {

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
@@ -218,7 +218,7 @@ final class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return ReportGeneratorEvent|\PHPUnit\Framework\MockObject\MockObject
+     * @return ReportGeneratorEvent&\PHPUnit\Framework\MockObject\MockObject
      */
     private function getReportGeneratorEventMock(): \PHPUnit\Framework\MockObject\MockObject
     {
@@ -233,7 +233,7 @@ final class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return QueryBuilder|\PHPUnit\Framework\MockObject\MockObject
+     * @return QueryBuilder&\PHPUnit\Framework\MockObject\MockObject
      */
     private function getQueryBuilderMock(): \PHPUnit\Framework\MockObject\MockObject
     {

--- a/app/bundles/PageBundle/Helper/TrackingHelper.php
+++ b/app/bundles/PageBundle/Helper/TrackingHelper.php
@@ -40,10 +40,7 @@ class TrackingHelper
         return $result;
     }
 
-    /**
-     * @return string|null
-     */
-    private function getCacheKey()
+    private function getCacheKey(): ?string
     {
         $lead = $this->contactTracker->getContact();
 

--- a/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
+++ b/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
@@ -30,7 +30,7 @@ final class SchedulerRepositoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return QueryBuilder|MockObject
+     * @return QueryBuilder&MockObject
      */
     private function getQueryBuilderMock(): MockObject
     {

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -426,7 +426,7 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
     }
 
     /**
-     * @return ArrayCollection|LeadList[]
+     * @return ArrayCollection<int, LeadList>
      */
     public function getLists()
     {

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -11,7 +11,6 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserCreator implements UserCreatorInterface
 {

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -34,9 +34,6 @@ class UserCreator implements UserCreatorInterface
         $this->defaultRole   = (int) $defaultRole;
     }
 
-    /**
-     * @return UserInterface|null
-     */
     public function createUser(Response $response): User
     {
         if (empty($this->defaultRole)) {

--- a/composer.lock
+++ b/composer.lock
@@ -17738,12 +17738,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "867d8cbc74bad66f28f79c44467080e240bf4798"
+                "reference": "64bb26c9c565824b73bb5798d9ef23b7a6ab3ca3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/867d8cbc74bad66f28f79c44467080e240bf4798",
-                "reference": "867d8cbc74bad66f28f79c44467080e240bf4798",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/64bb26c9c565824b73bb5798d9ef23b7a6ab3ca3",
+                "reference": "64bb26c9c565824b73bb5798d9ef23b7a6ab3ca3",
                 "shasum": ""
             },
             "require": {
@@ -17791,7 +17791,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-30T12:07:29+00:00"
+            "time": "2026-07-01T22:00:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -870,7 +870,7 @@ final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
     }
 
     /**
-     * @return SalesforceIntegration|MockObject
+     * @return SalesforceIntegration&MockObject
      */
     protected function getSalesforceIntegration(int $maxUpdate = 100, int $maxCreate = 200, int $maxSfLeads = 25, int $maxSfContacts = 25, ?string $updateObject = null): MockObject
     {

--- a/rector.php
+++ b/rector.php
@@ -9,18 +9,8 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Cast\RecastingRemovalRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictStringReturnsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
-
-$extendableClasses = [
-    __DIR__.'/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php',
-    __DIR__.'/app/bundles/CoreBundle/Controller/CommonController.php',
-    __DIR__.'/app/bundles/CoreBundle/Controller/FormController.php',
-    __DIR__.'/app/bundles/CoreBundle/Entity/CommonRepository.php',
-    __DIR__.'/app/bundles/CoreBundle/Model/FormModel.php',
-];
 
 return RectorConfig::configure()
     ->withPaths([
@@ -30,8 +20,15 @@ return RectorConfig::configure()
     ->withPreparedSets(deadCode: true)
     ->withPhpSets(php80: true)
     ->withCache(__DIR__.'/var/cache/rector')
+    ->withTypeGuardedClasses([
+        Mautic\CoreBundle\Controller\AbstractStandardFormController::class,
+        Mautic\CoreBundle\Controller\CommonController::class,
+        Mautic\CoreBundle\Controller\AbstractFormController::class,
+    ])
     ->withRules([
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
+        Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector::class,
+        Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ChangeMockObjectReturnUnionToIntersectionRector::class,
 
         TypedPropertyFromAssignsRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,
@@ -62,8 +59,6 @@ return RectorConfig::configure()
         // too many changes
         Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector::class,
         Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector::class,
-        // soon to be deprecated
-        Rector\CodeQuality\Rector\Concat\JoinStringConcatRector::class,
 
         Rector\Renaming\Rector\FuncCall\RenameFunctionRector::class,
 
@@ -81,26 +76,17 @@ return RectorConfig::configure()
             __DIR__.'/app/bundles/CoreBundle/Tests/Unit/Doctrine/ArrayTypeTest.php',
         ],
 
-        // designed to be overriden by 3rd party, adding return type will break BC
-        Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictScalarReturnsRector::class => [
-            ...$extendableClasses,
-        ],
-        ReturnTypeFromStrictTypedCallRector::class => [
-            ...$extendableClasses,
-        ],
         StringReturnTypeFromStrictStringReturnsRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Entity/FormEntity.php',
         ],
-        ReturnTypeFromStrictTypedPropertyRector::class => [
-            __DIR__.'/app/bundles/CoreBundle/Controller/FormController.php',
-            // handle mocks later
-            __DIR__.'/app/bundles/IntegrationsBundle/Sync/DAO/DateRange.php',
-            __DIR__.'/app/bundles/CampaignBundle/Executioner/EventExecutioner.php',
-        ],
         Rector\TypeDeclaration\Rector\ClassMethod\ReturnNullableTypeRector::class => [
             __DIR__.'/app/bundles/IntegrationsBundle/Sync/DAO/DateRange.php',
-            // can be overriden, BC
-            ...$extendableClasses,
+        ],
+
+        Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector::class => [
+            // date times
+            __DIR__.'/app/bundles/CampaignBundle/Executioner/EventExecutioner.php',
+            __DIR__.'/app/bundles/IntegrationsBundle/Sync/DAO/DateRange.php',
         ],
 
         TypedPropertyFromAssignsRector::class => [


### PR DESCRIPTION
Make use of experimental feature to avoid inwatend param/return type declaration overrides :+1: 
https://github.com/rectorphp/rector-src/pull/8135