### PR TITLE
[tests] add string-names method fetch type in tests to assigns using var

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -42,6 +42,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         $translator = static::getContainer()->get('translator');
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
+        /** @var CoreParametersHelper $coreParametersHelper */
         $coreParametersHelper = static::getContainer()->get('mautic.helper.core_parameters');
         $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');
@@ -114,6 +115,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         $translator = static::getContainer()->get('translator');
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
+        /** @var CoreParametersHelper $coreParametersHelper */
         $coreParametersHelper = static::getContainer()->get('mautic.helper.core_parameters');
         $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -408,6 +408,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
 
         // Set new permissions
         $role->setIsAdmin(false);
+        /** @var RoleModel $roleModel */
         $roleModel = static::getContainer()->get('mautic.user.model.role');
         $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -6,6 +6,7 @@ namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\AssetBundle\Tests\Asset\AbstractAssetTestCase;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\HttpFoundation\Response;
 
 final class PublicControllerFunctionalTest extends AbstractAssetTestCase
@@ -135,6 +136,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
     {
         $this->logoutUser();
         $asset                = $this->createAsset(['title' => 'Missing Local File Asset']);
+        /** @var CoreParametersHelper $coreParametersHelper */
         $coreParametersHelper = static::getContainer()->get('mautic.helper.core_parameters');
         $asset->setUploadDir($coreParametersHelper->get('upload_dir'));
         $this->em->flush();

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
@@ -46,6 +46,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
 
         $expectedUrl = 'https://localhost/asset/'.$slug.$expectedQuery;
 
+        /** @var AssetModel $assetModel */
         $assetModel = static::getContainer()->get('mautic.asset.model.asset');
         $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, $absolute, $clickthrough, $stream);
@@ -116,6 +117,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
         $this->assertNull($asset->getUuid());
         $this->assertSame('1:the-alias', $asset->getSlug());
 
+        /** @var AssetModel $assetModel */
         $assetModel = static::getContainer()->get('mautic.asset.model.asset');
         $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, true, []);

--- a/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Tests\Command\Api;
 
+use Mautic\CacheBundle\Cache\CacheProvider;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
@@ -23,6 +24,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
+        /** @var CacheProvider $cacheProvider */
         $cacheProvider = self::getContainer()->get('mautic.cache.provider');
         if ($fromCache) {
             $contactCountDetail = [

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
@@ -6,6 +6,7 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CampaignBundle\Tests\Functional\Fixtures\FixtureHelper;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Tests\Functional\Fixtures\EmailFixturesHelper;
@@ -115,6 +116,7 @@ final class CampaignMetricsControllerFunctionalTest extends MauticMysqlTestCase
         Assert::assertCount(3, $hoursDatasets);  // Assuming there are 3 datasets: Email sent, Email read, Email clicked
 
         // Get the time format from CoreParametersHelper
+        /** @var CoreParametersHelper $coreParametersHelper */
         $coreParametersHelper = self::getContainer()->get('mautic.helper.core_parameters');
         $timeFormat           = $coreParametersHelper->get('date_format_timeonly');
 

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
@@ -33,6 +33,7 @@ final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('dataGetContactPendingEventsConsidersCampaignPublishUpAndDown')]
     public function testGetContactPendingEventsConsidersCampaignPublishUpAndDown(?\DateTime $publishUp, ?\DateTime $publishDown, int $expectedCount): void
     {
+        /** @var EventRepository $repository */
         $repository = static::getContainer()->get('mautic.campaign.repository.event');
         $this->assertInstanceOf(EventRepository::class, $repository);
 
@@ -51,6 +52,7 @@ final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testSetEventsAsDeletedWithRedirectUpdatesChains(): void
     {
+        /** @var EventRepository $repository */
         $repository = static::getContainer()->get('mautic.campaign.repository.event');
         $this->assertInstanceOf(EventRepository::class, $repository);
 
@@ -152,6 +154,7 @@ final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // 4. Call the method under test
+        /** @var EventRepository $repository */
         $repository   = self::getContainer()->get('mautic.campaign.repository.event');
         $this->assertInstanceOf(EventRepository::class, $repository);
         $resultEmails = $repository->getCampaignEmailEvents($campaign->getId());

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -12,6 +12,7 @@ use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,6 +45,7 @@ final class CampaignRotationTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
+        /** @var ContactTracker $contactTracker */
         $contactTracker               = static::getContainer()->get('mautic.tracker.contact');
         $this->campaignLeadRepository = static::getContainer()->get('mautic.campaign.repository.lead');
         $this->leadEventLogRepository = static::getContainer()->get('mautic.campaign.repository.lead_event_log');

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 
 use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Symfony\Component\DomCrawler\Crawler;
@@ -88,6 +89,7 @@ final class CampaignAuditLogTest extends MauticMysqlTestCase
         $this->assertTrue($responseData['success'], print_r(json_decode($response->getContent(), true), true));
 
         // 2.c Save campaign through CampaignModel to trigger audit log creation
+        /** @var CampaignModel $campaignModel */
         $campaignModel = static::getContainer()->get('mautic.campaign.model.campaign');
         $campaign      = $campaignModel->getEntity($campaignId);
         $event         = $this->em->find(Event::class, $eventId);

--- a/app/bundles/CoreBundle/Controller/FormThemeTrait.php
+++ b/app/bundles/CoreBundle/Controller/FormThemeTrait.php
@@ -4,6 +4,7 @@ namespace Mautic\CoreBundle\Controller;
 
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Twig\Environment;
 
 trait FormThemeTrait
@@ -14,7 +15,7 @@ trait FormThemeTrait
      * @param FormInterface<mixed> $form
      * @param mixed                $themes
      *
-     * @return \Symfony\Component\Form\FormView
+     * @return FormView
      */
     protected function setFormTheme(FormInterface $form, Environment $twig, $themes = null)
     {
@@ -22,7 +23,7 @@ trait FormThemeTrait
 
         // Extract form theme from options if applicable
         $fieldThemes = [];
-        $findThemes  = function ($form, $formView) use ($twig, &$findThemes, &$fieldThemes): void {
+        $findThemes  = function (FormInterface $form, FormView $formView) use ($twig, &$findThemes, &$fieldThemes): void {
             /** @var Form $field */
             foreach ($form as $name => $field) {
                 $fieldView = $formView[$name];

--- a/app/bundles/CoreBundle/Tests/Command/GenerateProductionAssetsCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/GenerateProductionAssetsCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Command;
 
 use Mautic\CoreBundle\Helper\Filesystem;
+use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 
 final class GenerateProductionAssetsCommandTest extends MauticMysqlTestCase
@@ -22,6 +23,7 @@ final class GenerateProductionAssetsCommandTest extends MauticMysqlTestCase
         parent::setUp();
 
         $this->filesystem = self::getContainer()->get('mautic.filesystem');
+        /** @var PathsHelper $pathHelper */
         $pathHelper       = self::getContainer()->get('mautic.helper.paths');
 
         $this->ckeditorFilePath = $pathHelper->getVendorRootPath().'/media/libraries/ckeditor/';

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
@@ -19,6 +19,7 @@ final class SystemThemeTemplatePathPassTest extends MauticMysqlTestCase
 
         // This test require cache to be cleared
         // as the template override must exist before the cache is generated.
+        /** @var PathsHelper $pathsHelper */
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');
         $this->assertInstanceOf(PathsHelper::class, $pathsHelper);
         $cacheDir    = $pathsHelper->getCachePath();

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
@@ -77,6 +77,7 @@ final class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
         $field->setAlias('custom_field_test');
         $field->setCharLengthLimit(64);
 
+        /** @var FieldModel $fieldModel */
         $fieldModel = $this->getContainer()->get('mautic.lead.model.field');
         $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $fieldModel->saveEntity($field);

--- a/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
@@ -27,6 +27,7 @@ final class CorePermissionsTest extends MauticMysqlTestCase
     {
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'sales']);
         $this->loginUser($user);
+        /** @var CorePermissions $permissions */
         $permissions = self::getContainer()->get('mautic.security');
         $this->assertInstanceOf(CorePermissions::class, $permissions);
         $permissions->setPermissionObject($this->createVirtualPermission($grant));

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -18,6 +18,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
 
     protected function beforeTearDown(): void
     {
+        /** @var PathsHelper $pathsHelper */
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');
         $folderPath  = "{$pathsHelper->getImagePath()}/$this->folderName";
 

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -159,6 +159,7 @@ final class DashboardControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $contact = new Lead();
         $contact->setFirstName('John');
+        /** @var LeadModel $contactModel */
         $contactModel = self::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntity($contact);

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Test\ReflectionHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadCategoryData;
 use Mautic\LeadBundle\Entity\Lead;
@@ -18,6 +19,7 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +44,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
     private function setUpMailer(): void
     {
+        /** @var MailHelper $mailHelper */
         $mailHelper = static::getContainer()->get('mautic.helper.mailer');
         $transport  = new SmtpTransport();
         $mailer     = new Mailer($transport);
@@ -54,6 +57,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
     protected function beforeTearDown(): void
     {
         // Clear owners cache (to leave a clean environment for future tests):
+        /** @var MailHelper $mailHelper */
         $mailHelper = static::getContainer()->get('mautic.helper.mailer');
         ReflectionHelper::setValue($mailHelper, 'leadOwners', []);
     }
@@ -834,6 +838,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
      */
     private function setPermission(Role $role, array $permissions): void
     {
+        /** @var RoleModel $roleModel */
         $roleModel = $this->getContainer()->get('mautic.user.model.role');
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -21,6 +21,7 @@ use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\ProjectBundle\Entity\Project;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
@@ -1499,6 +1500,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
      */
     private function setPermission(Role $role, array $permissions): void
     {
+        /** @var RoleModel $roleModel */
         $roleModel = $this->getContainer()->get('mautic.user.model.role');
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\Controller;
 
 use Doctrine\ORM\ORMException;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
@@ -497,6 +498,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $lead->setEmail($rightEmail);
         $this->em->persist($lead);
         // Email hash
+        /** @var CoreParametersHelper $coreParametersHelper */
         $coreParametersHelper   = self::getContainer()->get('mautic.helper.core_parameters');
         $configSecretEmailHash  = $coreParametersHelper->get('secret_key');
         $rightHashForWrongEmail = hash_hmac('sha256', $wrongEmail, $configSecretEmailHash);

--- a/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
@@ -58,6 +58,7 @@ final class PendingQueryFunctionalTest extends MauticMysqlTestCase
             $contacts[] = $contact;
         }
 
+        /** @var LeadModel $contactModel */
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);

--- a/app/bundles/EmailBundle/Tests/Functional/EmailTokenTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailTokenTest.php
@@ -11,6 +11,8 @@ use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
@@ -173,7 +175,9 @@ final class EmailTokenTest extends MauticMysqlTestCase
 
     private function createLeadWithAllFields(): Lead
     {
+        /** @var LeadModel $leadModel */
         $leadModel  = self::getContainer()->get('mautic.lead.model.lead');
+        /** @var FieldModel $fieldModel */
         $fieldModel = self::getContainer()->get('mautic.lead.model.field');
 
         $lead = new Lead();

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -44,6 +44,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         $this->configParams['email_frequency_time']   = 'MONTH';
         parent::setUp();
 
+        /** @var EmailModel $emailModel */
         $emailModel = static::getContainer()->get('mautic.email.model.email');
         $this->assertInstanceOf(EmailModel::class, $emailModel);
         $this->emailModel = $emailModel;
@@ -138,6 +139,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
             $contacts[] = $contact;
         }
 
+        /** @var LeadModel $contactModel */
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
@@ -30,6 +30,7 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
         $this->assertStringContainsString('10 total events(s) to be processed in batches', $commandResult->getDisplay());
         $this->em->clear();
 
+        /** @var EmailModel $emailModel */
         $emailModel = static::getContainer()->get('mautic.email.model.email');
         $this->assertInstanceOf(EmailModel::class, $emailModel);
 
@@ -62,6 +63,7 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
      */
     private function createContacts(): array
     {
+        /** @var LeadModel $contactModel */
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $contactModel);
 

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Mautic\FormBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Helper\FormUploader;
+use Mautic\FormBundle\Model\FieldModel;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,7 +17,9 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testDownloadFileByFileNameAction(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel   = static::getContainer()->get('mautic.form.model.field');
+        /** @var FormUploader $formUploader */
         $formUploader = static::getContainer()->get('mautic.form.helper.form_uploader');
         $fileName     = 'image.png';
 

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -12,6 +12,7 @@ use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
+use Mautic\FormBundle\Model\SubmissionModel;
 use Mautic\FormBundle\Tests\FormTestHelperTrait;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\PageBundle\Entity\Page;
@@ -1389,6 +1390,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         // Deleting the submission decrements the counter symmetrically (via the postRemove listener).
         $submissionId    = $finalSubmissionsData['submissions'][0]['id'];
+        /** @var SubmissionModel $submissionModel */
         $submissionModel = static::getContainer()->get('mautic.form.model.submission');
         $submission      = $submissionModel->getEntity($submissionId);
         $submissionModel->deleteEntity($submission);

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -10,6 +10,8 @@ use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Tests\Helper\ConditionalFieldOrderTestData;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -206,6 +208,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
     {
         $multiselectFieldId = $this->createMultiselectLeadField();
 
+        /** @var FieldModel $fieldModel */
         $fieldModel       = $this->getContainer()->get('mautic.lead.model.field');
         $multiselectField = $fieldModel->getEntity($multiselectFieldId);
         $fieldAlias       = $multiselectField->getAlias();
@@ -221,6 +224,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
 
         $this->logoutUser();
 
+        /** @var ContactTracker $contactTracker */
         $contactTracker = $this->getContainer()->get('mautic.tracker.contact');
         $contactTracker->setTrackedContact($lead);
 
@@ -286,7 +290,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
 
     private function createMultiselectLeadField(): int
     {
-        /** @var \Mautic\LeadBundle\Model\FieldModel $fieldModel */
+        /** @var FieldModel $fieldModel */
         $fieldModel = $this->getContainer()->get('mautic.lead.model.field');
         $alias      = 'test_multiselect_'.uniqid();
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/SyncServiceTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/SyncServiceTest.php
@@ -7,6 +7,7 @@ namespace Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService;
 use Doctrine\DBAL\Connection;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\InstallBundle\InstallFixtures\ORM\LeadFieldData;
+use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncService\SyncService;
 use Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService\TestExamples\Integration\ExampleIntegration;
@@ -40,6 +41,7 @@ final class SyncServiceTest extends MauticMysqlTestCase
         $settings->setIsPublished(true);
         $exampleIntegration->setIntegrationConfiguration($settings);
 
+        /** @var SyncIntegrationsHelper $syncIntegrationsHelper */
         $syncIntegrationsHelper = $this->getContainer()->get('mautic.integrations.helper.sync_integrations');
         $syncIntegrationsHelper->addIntegration($exampleIntegration);
 

--- a/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Command\CleanupExportedFilesCommand;
 use Mautic\LeadBundle\Command\ContactScheduledExportCommand;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -71,6 +72,7 @@ final class CleanupExportedFilesCommandFunctionalTest extends MauticMysqlTestCas
             $contacts[] = $contact;
         }
 
+        /** @var LeadModel $leadModel */
         $leadModel = self::getContainer()->get('mautic.lead.model.lead');
         $leadModel->saveEntities($contacts);
     }

--- a/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Command;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\DeduplicateCommand;
+use Mautic\LeadBundle\Deduplicate\ContactDeduper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use PHPUnit\Framework\Assert;
@@ -28,6 +29,7 @@ final class DeduplicateCommandFunctionalTest extends MauticMysqlTestCase
     {
         $contactRepository = $this->em->getRepository(Lead::class);
 
+        /** @var ContactDeduper $contactDeduper */
         $contactDeduper = static::getContainer()->get('mautic.lead.deduper');
 
         Assert::assertSame(0, $contactRepository->count([]), 'Some contacts were forgotten to remove from other tests');

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
 use Symfony\Component\HttpFoundation\Request;
 
 final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
@@ -30,6 +31,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
 
         // Check segment cached contact count using the SegmentCountCacheHelper directly
+        /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
         $segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
         self::assertEquals(5, $count, "Expected segment $segmentId to have 5 contacts");
@@ -43,6 +45,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
 
         // Check segment cached contact count using the SegmentCountCacheHelper directly
+        /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
         $segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
         self::assertEquals(4, $count, "Expected segment $segmentId to have 4 contacts");

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -121,6 +122,7 @@ final class SegmentFiltersFunctionalTest extends MauticMysqlTestCase
                         ],
                     ],
                 ]);
+                /** @var LeadModel $leadModel */
                 $leadModel = static::getContainer()->get('mautic.lead.model.lead');
                 $leadModel->setFieldValues($contact, [self::FIELD_NAME => [$cars[$i % 3]]]);
             }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
@@ -635,6 +636,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
+        /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
         $segmentCountCacheHelper = self::getContainer()->get('mautic.helper.segment.count.cache');
         $segmentCountCacheHelper->setSegmentContactCount($segment->getId(), 2);
 

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -75,6 +75,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $crawler                = $this->client->request('GET', '/s/companies/view/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
+        /** @var CompanyModel $model */
         $model                  = self::getContainer()->get('mautic.lead.model.company');
         $company                = $model->getEntity($this->company1Id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
@@ -111,6 +112,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $crawler                = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
+        /** @var CompanyModel $model */
         $model                  = self::getContainer()->get('mautic.lead.model.company');
         $company                = $model->getEntity($this->company1Id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
@@ -137,9 +139,11 @@ final class CompanyControllerTest extends MauticMysqlTestCase
     /* Get company contacts list */
     public function testListCompanyContacts(): void
     {
+        /** @var CompanyModel $companyModel */
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
+        /** @var LeadModel $leadModel */
         $leadModel = self::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $leadModel);
 
@@ -367,6 +371,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $buttonCrawler = $crawler->selectButton('Save & Close');
         $form          = $buttonCrawler->form();
 
+        /** @var CompanyModel $companyModel */
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
@@ -400,6 +405,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
 
         $content = $clientResponse->getContent();
 
+        /** @var CompanyModel $companyModel */
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
         $company1 = $companyModel->getEntity($this->company1Id);
@@ -426,6 +432,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
+        /** @var CompanyModel $companyModel */
         $companyModel = self::getContainer()->get('mautic.lead.model.company');
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
 

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +20,7 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('provideFieldLength')]
     public function testNewFieldVarcharFieldLength(int $expectedLength, ?int $inputLength = null): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
         $field      = $this->createField('a', 'text', [], $inputLength);
         $fieldModel->saveEntity($field);
@@ -30,6 +32,7 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
 
     public function testNewMultiSelectField(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
         $field      = $this->createField('s', 'select', ['properties' => ['list' => ['choice_a' => 'Choice A']]]);
         $fieldModel->saveEntity($field);
@@ -62,6 +65,7 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
 
     public function testFieldDeleteValidationUsedInSegment(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel       = static::getContainer()->get('mautic.lead.model.field');
         $field_first      = $this->createField('First');
         $fieldModel->saveEntity($field_first);

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Controller;
 
+use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\ImportCommand;
 use Mautic\LeadBundle\Entity\Company;
@@ -449,6 +450,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
 
     private function addCancellationNotification(?Import $import = null): void
     {
+        /** @var NotificationModel $notificationModel */
         $notificationModel = static::getContainer()->get('mautic.core.model.notification');
         $translator        = static::getContainer()->get('translator');
 

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -45,6 +45,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(ListModel::class, $this->listModel);
         $this->listRepo = $this->listModel->getRepository();
         $this->assertInstanceOf(LeadListRepository::class, $this->listRepo);
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $leadModel);
         $this->segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
@@ -17,9 +17,11 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
 {
     public function testMergedContactFound(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $model);
 
+        /** @var ContactMerger $merger */
         $merger = static::getContainer()->get('mautic.lead.merger');
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
@@ -71,12 +73,14 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
 
     public function testMergedContactsPointsAreAccurate(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $model);
 
         $em = static::getContainer()->get('doctrine.orm.entity_manager');
         $this->assertInstanceOf(EntityManager::class, $em);
 
+        /** @var ContactMerger $merger */
         $merger = static::getContainer()->get('mautic.lead.merger');
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
@@ -138,15 +142,19 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
 
     public function testMergedContactKeepsCompanyAssociations(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $model);
 
+        /** @var CompanyModel $companyModel */
         $companyModel = static::getContainer()->get('mautic.lead.model.company');
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
+        /** @var ContactMerger $merger */
         $merger = static::getContainer()->get('mautic.lead.merger');
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
+        /** @var CompanyLeadRepository $companyLeadRepository */
         $companyLeadRepository = static::getContainer()->get('mautic.lead.repository.company_lead');
         $this->assertInstanceOf(CompanyLeadRepository::class, $companyLeadRepository);
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Entity;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\HttpFoundation\Request;
 
 final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
@@ -22,6 +23,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testPointsAreAdded(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
 
         $this->lead->adjustPoints(100);
@@ -36,6 +38,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testPointsAreSubtracted(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
 
         $this->lead->adjustPoints(100, Lead::POINTS_SUBTRACT);
@@ -50,6 +53,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testPointsAreMultiplied(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
 
         $this->lead->adjustPoints(2, Lead::POINTS_MULTIPLY);
@@ -64,6 +68,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testPointsAreDivided(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
 
         $this->lead->adjustPoints(2, Lead::POINTS_DIVIDE);
@@ -78,6 +83,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testMixedOperatorPointsAreCalculated(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
 
         $this->lead->adjustPoints(100, Lead::POINTS_SUBTRACT);
@@ -95,6 +101,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testMixedModelAndRepositorySavesDoNotDoublePoints(): void
     {
+        /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');
         $this->lead->adjustPoints(120, Lead::POINTS_ADD);
         $model->saveEntity($this->lead);

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Tests\Traits\LeadFieldTestTrait;
@@ -435,6 +436,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $lead3      = $this->createContact('test_true_'.uniqid().'@example.com');
         $contactId3 = $lead3->getId();
 
+        /** @var LeadModel $leadModel */
         $leadModel = $this->getContainer()->get('mautic.lead.model.lead');
 
         $leadModel->setFieldValues($lead1, [
@@ -1087,6 +1089,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
         // Create a contact and set the custom field value
         $contact   = $this->createContact('john.doe@example.com');
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $leadModel->setFieldValues($contact, ['test_date' => $fieldValue]);
         $leadModel->saveEntity($contact);
@@ -1123,6 +1126,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->assertSame($expectedResult, $event->getResult(), 'Regex operator should not cause exception and should match as expected.');
 
         // Clean up
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
         $field      = $fieldModel->getEntityByAlias('test_date');
         if ($field) {

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -23,6 +23,7 @@ final class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('normalizeData')]
     public function testOnReportDisplay(string $value, string $type, array $properties, string $expected): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
         $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $field = new LeadField();

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -38,6 +38,7 @@ final class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
         $contactRepository = $this->em->getRepository(Lead::class);
         $this->assertInstanceOf(LeadRepository::class, $contactRepository);
 
+        /** @var ListModel $segmentModel */
         $segmentModel = static::getContainer()->get('mautic.lead.model.list');
         $this->assertInstanceOf(ListModel::class, $segmentModel);
 

--- a/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Functional;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,6 +26,7 @@ final class ContactExportLimitFunctionalTest extends MauticMysqlTestCase
         $this->loadFixtures([LoadLeadData::class]);
 
         // Create additional contacts to exceed the limit
+        /** @var LeadModel $contactModel */
         $contactModel = self::getContainer()->get('mautic.lead.model.lead');
         for ($i = 0; $i < 3; ++$i) {
             $contact = new Lead();

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
@@ -11,6 +11,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\Tag;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\ImportModel;
+use Mautic\LeadBundle\Model\TagModel;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -347,6 +350,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $field->setName($alias);
         $field->setProperties($properties);
 
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
         $fieldModel->saveEntity($field);
     }
@@ -402,6 +406,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         $this->getContainer()->get('mautic.security.user_token_setter')->setUser($import->getCreatedBy());
+        /** @var ImportModel $importModel */
         $importModel = static::getContainer()->get('mautic.lead.model.import');
         $importModel->saveEntity($import);
 
@@ -460,6 +465,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $tag = new Tag();
         $tag->setTag($tagName);
 
+        /** @var TagModel $tagModel */
         $tagModel = static::getContainer()->get('mautic.lead.model.tag');
         $tagModel->saveEntity($tag);
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\ContactScheduledExportCommand;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
@@ -91,6 +92,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
             $contacts[] = $contact;
         }
 
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $leadModel->saveEntities($contacts);
     }

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
@@ -85,6 +85,7 @@ final class SendEmailToContactTest extends MauticMysqlTestCase
 
     public function testSMimeWithEncryptedPrivateKey(): void
     {
+        /** @var EncryptionHelper $encryptionHelper */
         $encryptionHelper = self::getContainer()->get('mautic.helper.encryption');
         $this->assertInstanceOf(EncryptionHelper::class, $encryptionHelper);
 

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Tests\Functional\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Test\ReflectionHelper;
+use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Tests\Helper\Transport\SmtpTransport;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
@@ -29,6 +30,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
     protected function beforeTearDown(): void
     {
         // Clear owners cache (to leave a clean environment for future tests):
+        /** @var MailHelper $mailHelper */
         $mailHelper = static::getContainer()->get('mautic.helper.mailer');
         ReflectionHelper::setValue($mailHelper, 'leadOwners', []);
     }
@@ -157,6 +159,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
 
     private function setUpMailer(): void
     {
+        /** @var MailHelper $mailHelper */
         $mailHelper = static::getContainer()->get('mautic.helper.mailer');
         $transport  = new SmtpTransport();
         $mailer     = new Mailer($transport);

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
@@ -10,6 +10,8 @@ use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
 
@@ -30,6 +32,7 @@ final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
         $company = new Company();
         $company->setName('Test company');
         $company->setOwner($user);
+        /** @var CompanyModel $companyModel */
         $companyModel = static::getContainer()->get('mautic.lead.model.company');
         $companyModel->saveEntity($company);
 
@@ -45,11 +48,13 @@ final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
     {
         $company = new Company();
         $company->setName('Test Delete Company');
+        /** @var CompanyModel $companyModel */
         $companyModel = static::getContainer()->get('mautic.lead.model.company');
         $companyModel->saveEntity($company);
 
         $lead = new Lead();
         $lead->setFirstname('Test name');
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $leadModel->saveEntity($lead);
         $companyModel->addLeadToCompany($company, $lead);

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -103,6 +103,7 @@ final class SegmentSubscriberTest extends MauticMysqlTestCase
         // Run segments update command.
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segmentId]);
 
+        /** @var ListModel $listModel */
         $listModel = $this->getContainer()->get('mautic.lead.model.list');
         $this->assertInstanceOf(ListModel::class, $listModel);
 

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -98,6 +98,7 @@ final class FieldModelTest extends MauticMysqlTestCase
 
     public function testSingleContactFieldIsCreatedAndDeleted(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
 
         $field = new LeadField();
@@ -114,6 +115,7 @@ final class FieldModelTest extends MauticMysqlTestCase
 
     public function testSingleCompanyFieldIsCreatedAndDeleted(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
 
         $field = new LeadField();
@@ -130,6 +132,7 @@ final class FieldModelTest extends MauticMysqlTestCase
 
     public function testMultipleFieldsAreCreatedAndDeleted(): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = static::getContainer()->get('mautic.lead.model.field');
 
         $leadField = new LeadField();
@@ -294,6 +297,7 @@ final class FieldModelTest extends MauticMysqlTestCase
         };
 
         $this->connection->getConfiguration()->setSQLLogger($stack); /** @phpstan-ignore-line SQLLogger is deprecated */
+        /** @var FieldModel $fieldModel */
         $fieldModel = $this->getContainer()->get('mautic.lead.model.field');
 
         // Ensure the index exists

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\LeadEvents;
+use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -120,7 +121,9 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
 
     public function testGetCustomLeadFieldLength(): void
     {
+        /** @var LeadModel $leadModel */
         $leadModel  = $this->getContainer()->get('mautic.lead.model.lead');
+        /** @var FieldModel $fieldModel */
         $fieldModel = $this->getContainer()->get('mautic.lead.model.field');
 
         // Create a lead field.
@@ -171,6 +174,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     {
         $this->expectException(DBALException::class);
 
+        /** @var LeadModel $leadModel */
         $leadModel  = $this->getContainer()->get('mautic.lead.model.lead');
         $leadModel->getCustomLeadFieldLength(['unknown_field']);
     }
@@ -181,6 +185,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('fieldValueProvider')]
     public function testSelectFieldSavesOnlyAllowedValuesInDB(string $selectFieldValue, ?string $expectedValue): void
     {
+        /** @var FieldModel $fieldModel */
         $fieldModel = self::getContainer()->get('mautic.lead.model.field');
 
         // Create a lead field.
@@ -197,6 +202,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
         $fieldModel->saveEntity($selectField);
         $this->em->clear();
 
+        /** @var LeadModel $leadModel */
         $leadModel  = self::getContainer()->get('mautic.lead.model.lead');
 
         $fields = [

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Tests\Segment\Query\Filter;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Assert;
 
 final class SegmentReferenceFilterQueryBuilderGlueTest extends MauticMysqlTestCase
@@ -66,6 +67,7 @@ final class SegmentReferenceFilterQueryBuilderGlueTest extends MauticMysqlTestCa
 
         $this->testSymfonyCommand('mautic:segments:update', ['--list-id' => $segmentD->getId()]);
 
+        /** @var ListModel $listModel */
         $listModel = static::getContainer()->get('mautic.lead.model.list');
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentD->getId());

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -35,6 +35,7 @@ final class PageControllerTest extends MauticMysqlTestCase
             'template' => 'blank',
         ];
 
+        /** @var PageModel $model */
         $model = static::getContainer()->get('mautic.page.model.page');
         $page  = new Page();
         $page->setTitle($pageData['title'])
@@ -201,6 +202,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/s/pages/view/'.$this->id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
+        /** @var PageModel $model */
         $model                  = static::getContainer()->get('mautic.page.model.page');
         $page                   = $model->getEntity($this->id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
@@ -12,6 +12,7 @@ use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Model\RedirectModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -228,6 +229,7 @@ final class PageModelTest extends MauticMysqlTestCase
         $this->em->persist($redirect);
         $this->em->flush();
 
+        /** @var RedirectModel $redirectModel */
         $redirectModel = $this->getContainer()->get('mautic.page.model.redirect');
         $redirectURL   = $redirectModel->generateRedirectUrl($redirect, $clickThrough);
         // Send Request

--- a/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\PointBundle\Tests\Functional;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\ReportBundle\Entity\Report;
@@ -163,6 +164,7 @@ final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
 
     private function createTestContactWithGroupPoints(): void
     {
+        /** @var LeadModel $contactModel */
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
 
         $groupA = $this->createGroup('Group A');

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -63,6 +63,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
     public function testCreatingDuplicateProject(): void
     {
+        /** @var ProjectModel $projectModel */
         $projectModel = self::getContainer()->get('mautic.project.model.project');
         $this->assertInstanceOf(ProjectModel::class, $projectModel);
 
@@ -123,6 +124,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('xssPayloadsProvider')]
     public function testProjectNamesAreEscapedInAjaxResponse(string $xssPayload, string $dangerousSubstring): void
     {
+        /** @var ProjectModel $projectModel */
         $projectModel = self::getContainer()->get('mautic.project.model.project');
         $this->assertInstanceOf(ProjectModel::class, $projectModel);
 
@@ -225,6 +227,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('specialCharacterProjectNamesProvider')]
     public function testProjectNamesWithSpecialCharactersAreEscapedAndFunctional(string $projectName): void
     {
+        /** @var ProjectModel $projectModel */
         $projectModel = self::getContainer()->get('mautic.project.model.project');
         $this->assertInstanceOf(ProjectModel::class, $projectModel);
 

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -95,6 +95,7 @@ final class ReportApiControllerTest extends MauticMysqlTestCase
 
         // Set new permissions
         $role->setIsAdmin(false);
+        /** @var RoleModel $roleModel */
         $roleModel = static::getContainer()->get('mautic.user.model.role');
         $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -9,8 +9,10 @@ use Doctrine\Persistence\Mapping\MappingException;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Model\PageModel;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Entity\SchedulerRepository;
 use Mautic\ReportBundle\Model\ReportFileWriter;
@@ -37,6 +39,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $query->from(MAUTIC_TABLE_PREFIX.'page_hits', 'ph');
         $query->leftJoin('ph', MAUTIC_TABLE_PREFIX.'pages', 'p', 'ph.page_id = p.id');
 
+        /** @var PageModel $pageModel */
         $pageModel = self::getContainer()->get('mautic.page.model.page');
         $res       = $pageModel->getHitRepository()->getMostVisited($query);   // $this->em->getRepository(Hit::class);
 
@@ -181,6 +184,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testEmailReportWithAggregatedColumnsAndTotals(): void
     {
+        /** @var LeadModel $contactModel */
         $contactModel = static::getContainer()->get('mautic.lead.model.lead');
 
         // Create and save contacts
@@ -286,6 +290,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testContactReportNotLikeExpression(): void
     {
+        /** @var LeadModel $contactModel */
         $contactModel = self::getContainer()->get('mautic.lead.model.lead');
 
         // Create and save contacts

--- a/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\ReportBundle\Entity\Report;
+use Mautic\ReportBundle\Model\ReportModel;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -52,6 +53,7 @@ final class ReportModelTest extends MauticMysqlTestCase
         /** @var RequestStack $requestStack */
         $requestStack = self::getContainer()->get('request_stack');
         $requestStack->push($request);
+        /** @var ReportModel $reportModel */
         $reportModel = self::getContainer()->get('mautic.report.model.report');
 
         $aDayAgoBeginningOfTheDay = (clone $aDayAgo)->setTime(0, 0, 0);

--- a/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
@@ -28,9 +28,11 @@ final class SmsSubscriberTokenTest extends MauticMysqlTestCase
     public function testSmsTokenReplacement(): void
     {
         $transport = $this->configureTwilioWithArrayTransport();
+        /** @var SmsModel $smsModel */
         $smsModel  = $this->getContainer()->get('mautic.sms.model.sms');
         $this->assertInstanceOf(SmsModel::class, $smsModel);
 
+        /** @var LeadModel $contactModel */
         $contactModel = $this->getContainer()->get('mautic.lead.model.lead');
         $this->assertInstanceOf(LeadModel::class, $contactModel);
 

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
@@ -18,6 +18,7 @@ final class TwilioConfigurationFunctionalTest extends MauticMysqlTestCase
     {
         $this->configureTwilioWithArrayTransport();
 
+        /** @var TwilioIntegration $integration */
         $integration = $this->getContainer()->get('mautic.integration.twilio');
         $this->assertInstanceOf(TwilioIntegration::class, $integration);
 

--- a/plugins/MauticFocusBundle/Tests/Functional/Model/FocusFormAutoFillTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Model/FocusFormAutoFillTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Tracker\ContactTracker;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 
 final class FocusFormAutoFillTest extends MauticMysqlTestCase
@@ -78,6 +79,7 @@ final class FocusFormAutoFillTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Step 4: Track the contact using setSystemContact (bypasses HTTP request requirement)
+        /** @var ContactTracker $contactTracker */
         $contactTracker = self::getContainer()->get('mautic.tracker.contact');
         $contactTracker->setSystemContact($contact);
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -8,6 +8,8 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Model\TagModel;
 
 final class BatchControllerTest extends MauticMysqlTestCase
 {
@@ -33,7 +35,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
             'tag4',
         ];
 
-        /** @var \Mautic\LeadBundle\Model\TagModel $tagModel */
+        /** @var TagModel $tagModel */
         $tagModel            = static::getContainer()->get('mautic.lead.model.tag');
         $this->tagRepository = $tagModel->getRepository();
         $this->tags          = $this->addTags($tags);
@@ -62,6 +64,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('3 contacts affected', $this->client->getResponse()->getContent());
 
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $lead1     = $leadModel->getEntity($this->leads[0]->getId());
         $this->assertContains($this->tags[0], $lead1->getTags()->toArray());
@@ -71,6 +74,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
 
     public function testAddAndRemoveBatchSetAction(): void
     {
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $this->leads[0]->addTag($this->tags[1]);
         $this->leads[0]->addTag($this->tags[2]);
@@ -112,6 +116,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
      */
     public function addLeads(): array
     {
+        /** @var LeadModel $leadModel */
         $leadModel = static::getContainer()->get('mautic.lead.model.lead');
         $lead      = $leadModel->getEntity();
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
+use Mautic\LeadBundle\Model\TagModel;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\ReportBundle\Entity\Report;
@@ -32,6 +33,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        /** @var TagModel $tagModel */
         $tagModel            = static::getContainer()->get('mautic.lead.model.tag');
         $this->tagRepository = $tagModel->getRepository();
 
@@ -351,6 +353,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         Assert::assertSame(2, $this->countLeadTagAssociations($secondaryTagId));
 
         // Test the actual merge functionality by calling the model directly
+        /** @var TagModel $tagModel */
         $tagModel = static::getContainer()->get('mautic.lead.model.tag');
         $tagModel->tagMerge($primaryTag, $secondaryTag);
 
@@ -390,6 +393,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $pointTriggerEventId   = (int) $pointTriggerEvent->getId();
         $reportId              = (int) $report->getId();
 
+        /** @var TagModel $tagModel */
         $tagModel = static::getContainer()->get('mautic.lead.model.tag');
         $tagModel->tagMerge($primaryTag, $secondaryTag);
 

--- a/rector.php
+++ b/rector.php
@@ -39,7 +39,6 @@ return RectorConfig::configure()
         ClassPropertyAssignToConstructorPromotionRector::class,
         SimplifyUselessVariableRector::class,
         UnserializeToSerializerDecodeRector::class,
-        ReturnTypeFromGetRepositoryDocblockRector::class,
     ])
     ->reportUnusedSkips()
     ->withCodingStyleLevel(3)


### PR DESCRIPTION
I've noticed couple unknown methods in IDE in tests, because named-based service from container has no generic return type.
This should fix it :+1: 