### PR TITLE
Fix manually adding lead to segment via campaign

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -710,12 +710,14 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 $dispatchEvents[] = $listId;
             }
 
-            if (!$isAlreadyCounted) {
-                if ($this->coreParametersHelper->get('update_segment_contact_count_in_background', false)) {
-                    $this->segmentCountCacheHelper->invalidateSegmentContactCount($listId);
-                } else {
-                    $this->segmentCountCacheHelper->incrementSegmentContactCount($listId);
-                }
+            if ($isAlreadyCounted) {
+                continue;
+            }
+
+            if ($this->coreParametersHelper->get('update_segment_contact_count_in_background', false)) {
+                $this->segmentCountCacheHelper->invalidateSegmentContactCount($listId);
+            } else {
+                $this->segmentCountCacheHelper->incrementSegmentContactCount($listId);
             }
         }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -683,8 +683,11 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 );
             }
 
+            $isAlreadyCounted = false;
+
             if (null != $listLead) {
                 if ($manuallyAdded && ($listLead->wasManuallyRemoved() || !$listLead->wasManuallyAdded())) {
+                    $isAlreadyCounted = !$listLead->wasManuallyRemoved();
                     $listLead->setManuallyRemoved(false);
                     $listLead->setManuallyAdded($manuallyAdded);
 
@@ -707,10 +710,12 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 $dispatchEvents[] = $listId;
             }
 
-            if ($this->coreParametersHelper->get('update_segment_contact_count_in_background', false)) {
-                $this->segmentCountCacheHelper->invalidateSegmentContactCount($listId);
-            } else {
-                $this->segmentCountCacheHelper->incrementSegmentContactCount($listId);
+            if (!$isAlreadyCounted) {
+                if ($this->coreParametersHelper->get('update_segment_contact_count_in_background', false)) {
+                    $this->segmentCountCacheHelper->invalidateSegmentContactCount($listId);
+                } else {
+                    $this->segmentCountCacheHelper->incrementSegmentContactCount($listId);
+                }
             }
         }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -684,7 +684,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             }
 
             if (null != $listLead) {
-                if ($manuallyAdded && $listLead->wasManuallyRemoved()) {
+                if ($manuallyAdded && ($listLead->wasManuallyRemoved() || !$listLead->wasManuallyAdded())) {
                     $listLead->setManuallyRemoved(false);
                     $listLead->setManuallyAdded($manuallyAdded);
 

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -168,9 +168,9 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
             'lead' => $contact,
             'list' => $segment,
         ]);
-        self::assertNotNull($listLead);
-        self::assertFalse($listLead->wasManuallyAdded());
-        self::assertFalse($listLead->wasManuallyRemoved());
+        $this->assertInstanceOf(ListLead::class, $listLead);
+        $this->assertFalse($listLead->wasManuallyAdded());
+        $this->assertFalse($listLead->wasManuallyRemoved());
 
         $segmentModel->addLead($contact, $segment, true);
 
@@ -180,9 +180,9 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
             'list' => $segment,
         ]);
 
-        self::assertNotNull($listLead);
-        self::assertTrue($listLead->wasManuallyAdded());
-        self::assertFalse($listLead->wasManuallyRemoved());
+        $this->assertInstanceOf(ListLead::class, $listLead);
+        $this->assertTrue($listLead->wasManuallyAdded());
+        $this->assertFalse($listLead->wasManuallyRemoved());
     }
 
     private function createLeadList(User $user, string $name, bool $isGlobal): LeadList

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -150,7 +150,7 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
     public function testManuallyAddContactWhoWasAutomaticallyAddedToSegmentBefore(): void
     {
         /** @var ListModel $segmentModel */
-        $segmentModel = static::getContainer()->get('mautic.lead.model.list');
+        $segmentModel = static::getContainer()->get(ListModel::class);
 
         /** @var LeadRepository $contactRepository */
         $contactRepository = $this->em->getRepository(Lead::class);

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -150,7 +150,7 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
     public function testManuallyAddContactWhoWasAutomaticallyAddedToSegmentBefore(): void
     {
         /** @var ListModel $segmentModel */
-        $segmentModel = static::getContainer()->get(ListModel::class);
+        $segmentModel = self::getContainer()->get(ListModel::class);
 
         /** @var LeadRepository $contactRepository */
         $contactRepository = $this->em->getRepository(Lead::class);
@@ -168,9 +168,9 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
             'lead' => $contact,
             'list' => $segment,
         ]);
-        Assert::assertNotNull($listLead);
-        Assert::assertFalse($listLead->wasManuallyAdded());
-        Assert::assertFalse($listLead->wasManuallyRemoved());
+        self::assertNotNull($listLead);
+        self::assertFalse($listLead->wasManuallyAdded());
+        self::assertFalse($listLead->wasManuallyRemoved());
 
         $segmentModel->addLead($contact, $segment, true);
 
@@ -180,9 +180,9 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
             'list' => $segment,
         ]);
 
-        Assert::assertNotNull($listLead);
-        Assert::assertTrue($listLead->wasManuallyAdded());
-        Assert::assertFalse($listLead->wasManuallyRemoved());
+        self::assertNotNull($listLead);
+        self::assertTrue($listLead->wasManuallyAdded());
+        self::assertFalse($listLead->wasManuallyRemoved());
     }
 
     private function createLeadList(User $user, string $name, bool $isGlobal): LeadList

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
@@ -144,6 +145,44 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
         Assert::assertSame(1, (int) end($data['datasets'][0]['data'])); // Added for today.
         Assert::assertSame(1, (int) end($data['datasets'][1]['data'])); // Removed for today.
         Assert::assertSame(0, (int) end($data['datasets'][2]['data'])); // Total for today.
+    }
+
+    public function testManuallyAddContactWhoWasAutomaticallyAddedToSegmentBefore(): void
+    {
+        /** @var ListModel $segmentModel */
+        $segmentModel = static::getContainer()->get('mautic.lead.model.list');
+
+        /** @var LeadRepository $contactRepository */
+        $contactRepository = $this->em->getRepository(Lead::class);
+
+        $segment = new LeadList();
+        $segment->setName('Test Segment');
+        $segmentModel->saveEntity($segment);
+
+        $contact = new Lead();
+        $contactRepository->saveEntities([$contact]);
+
+        $segmentModel->addLead($contact, $segment, false);
+
+        $listLead = $this->em->getRepository(ListLead::class)->findOneBy([
+            'lead' => $contact,
+            'list' => $segment,
+        ]);
+        Assert::assertNotNull($listLead);
+        Assert::assertFalse($listLead->wasManuallyAdded());
+        Assert::assertFalse($listLead->wasManuallyRemoved());
+
+        $segmentModel->addLead($contact, $segment, true);
+
+        $this->em->clear();
+        $listLead = $this->em->getRepository(ListLead::class)->findOneBy([
+            'lead' => $contact,
+            'list' => $segment,
+        ]);
+
+        Assert::assertNotNull($listLead);
+        Assert::assertTrue($listLead->wasManuallyAdded());
+        Assert::assertFalse($listLead->wasManuallyRemoved());
     }
 
     private function createLeadList(User $user, string $name, bool $isGlobal): LeadList


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR solves issue https://github.com/mautic/mautic/issues/16473
It makes sure that when a contact is added to a segment via campaign, manually_added is set to 1 in the lead_lists_leads entry (even if the lead was automatically added before via segments update)


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Add a lead to a segment via campaign rebuild
3. Create a campaign which adds the lead to the same segment
4. Add the lead to the campaign and trigger it
5. See that manually_added in table lead_lists_leads has changed to 1

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->