### PR TITLE
Fix GrapesJS CKEditor paragraph splitting for inline spans

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/builder.service.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/builder.service.js
@@ -1198,6 +1198,18 @@ export default class BuilderService {
     const inlineElements = BuilderService.getInlineElements();
     const emailCkEditorOptions = BuilderService.getCkeConf('email:getBuilderTokens');
     const emailInlineOptions = BuilderService.buildInlineCkeConf(emailCkEditorOptions);
+    const allowedTextInnerChildTags = [
+      'a',
+      'b',
+      'em',
+      'i',
+      'small',
+      'span',
+      'strong',
+      'sub',
+      'sup',
+      'u',
+    ];
 
     this.editor = grapesjs.init({
       selectorManager: {
@@ -1212,8 +1224,18 @@ export default class BuilderService {
         styles,
       },
       domComponents: {
-        // disable all except link components
-        disableTextInnerChilds: (child) => !child.is('link'), // https://github.com/GrapesJS/grapesjs/releases/tag/v0.21.2
+        // Keep inline phrasing content inside paragraph text components. If
+        // spans are disallowed here, GrapesJS reparses them as siblings of the
+        // paragraph and MJML renders extra line breaks.
+        disableTextInnerChilds: (child) => {
+          if (child.is('link')) {
+            return false;
+          }
+
+          const tagName = `${child.get('tagName') || ''}`.toLowerCase();
+
+          return !allowedTextInnerChildTags.includes(tagName);
+        },
       },
       storageManager: false,
       assetManager: this.getAssetManagerConf(),


### PR DESCRIPTION

| Q                                      | A |
| -------------------------------------- | --- |
| Bug fix? (use the a.b branch)          | ✔️ |
| New feature/enhancement? (use the a.x branch) | ❌ |
| Deprecations?                          | ❌ |
| BC breaks? (use the c.x branch)        | ❌ |
| Automated tests included?              | ❌ |
| Related user documentation PR URL      | N/A |
| Related developer documentation PR URL | N/A |
| Issue(s) addressed                     |  |

## Description

Fixes GrapesJS MJML email editing where CKEditor initialization split inline `<span>` content out of a `<p>`, causing extra newlines and changing the visual layout.

https://github.com/user-attachments/assets/309ce18f-3bf5-4038-a514-5533bd10062e

The MJML builder now keeps common inline phrasing elements, including `span` and `strong`, inside paragraph text components.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an email theme containing `<p><span style="color:#fa6c3d;"><strong>-</strong></span><strong>Test header</strong></p>` inside `mj-text`.
3. Open the email in GrapesJS and edit the text with CKEditor.
4. Confirm the inline span remains inside the paragraph and no extra newline appears before `Test header`.