### PR TITLE
[php 8.1] make use of readonly properties and first class callables

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class CampaignListType extends AbstractType
 {
-    private bool $canViewOther;
+    private readonly bool $canViewOther;
 
     public function __construct(
         private readonly CampaignModel $model,

--- a/app/bundles/CampaignBundle/Tests/Entity/EventFake.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventFake.php
@@ -12,7 +12,7 @@ use Mautic\CampaignBundle\Entity\Event;
 final class EventFake extends Event
 {
     public function __construct(
-        private ?int $id = null,
+        private readonly ?int $id = null,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Fixtures/FixtureHelper.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Fixtures/FixtureHelper.php
@@ -15,7 +15,7 @@ use Mautic\LeadBundle\Entity\Lead;
 final class FixtureHelper
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -153,8 +153,8 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->dispatcher->addSubscriber($campaignSubscriber);
-        $this->dispatcher->addListener(EmailEvents::ON_CAMPAIGN_BATCH_ACTION, [$this, 'sendMarketingMessageEmail']);
-        $this->dispatcher->addListener(SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION, [$this, 'sendMarketingMessageSms']);
+        $this->dispatcher->addListener(EmailEvents::ON_CAMPAIGN_BATCH_ACTION, $this->sendMarketingMessageEmail(...));
+        $this->dispatcher->addListener(SmsEvents::ON_CAMPAIGN_TRIGGER_ACTION, $this->sendMarketingMessageSms(...));
     }
 
     public function testCorrectChannelIsUsed(): void

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1419,7 +1419,7 @@ class CommonRepository extends ServiceEntityRepository
             foreach ($selects as $alias => $columns) {
                 if ($isOrm) {
                     if ($columns = array_intersect($columns, $ormColumns)) {
-                        $columns    = array_map([$this, 'sanitize'], $columns);
+                        $columns    = array_map($this->sanitize(...), $columns);
                         $partials[] = 'partial '.$alias.'.{'.implode(',', $columns).'}';
                     }
                 } else {

--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -162,7 +162,7 @@ class ConfigType extends AbstractType
                             'message' => 'mautic.core.value.required',
                         ]
                     ),
-                    new Callback([$this, 'validateImagePath']),
+                    new Callback($this->validateImagePath(...)),
                 ],
             ]
         );

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -432,7 +432,7 @@ class ThemeHelper implements ThemeHelperInterface
 
             $this->sandboxEnv->addRuntimeLoader(new class($this->twig) implements RuntimeLoaderInterface {
                 public function __construct(
-                    private Environment $twig,
+                    private readonly Environment $twig,
                 ) {
                 }
 

--- a/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
+++ b/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
@@ -238,7 +238,7 @@ class DBALMocker
 
             $mock->expects(new AnyInvokedCount())
                 ->method('executeQuery')
-                ->willReturnCallback([$this, 'getMockResultStatement']);
+                ->willReturnCallback($this->getMockResultStatement(...));
 
             $this->mockQueryBuilder = $mock;
         }

--- a/app/bundles/CoreBundle/Test/Extensions/DbPrefix/Subscriber/Subscriber.php
+++ b/app/bundles/CoreBundle/Test/Extensions/DbPrefix/Subscriber/Subscriber.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Test\Extensions\DbPrefix\DbPrefix;
 abstract class Subscriber
 {
     public function __construct(
-        private DbPrefix $dbPrefix,
+        private readonly DbPrefix $dbPrefix,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Test/Extensions/SeparateProcess/Subscriber/Subscriber.php
+++ b/app/bundles/CoreBundle/Test/Extensions/SeparateProcess/Subscriber/Subscriber.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Test\Extensions\SeparateProcess\SeparateProcess;
 abstract class Subscriber
 {
     public function __construct(
-        private SeparateProcess $separateProcess,
+        private readonly SeparateProcess $separateProcess,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Test/Extensions/SlowTest/Subscriber/Subscriber.php
+++ b/app/bundles/CoreBundle/Test/Extensions/SlowTest/Subscriber/Subscriber.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Test\Extensions\SlowTest\SlowTest;
 abstract class Subscriber
 {
     public function __construct(
-        private SlowTest $slowTest,
+        private readonly SlowTest $slowTest,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Test/Session/InMemoryTokenStorage.php
+++ b/app/bundles/CoreBundle/Test/Session/InMemoryTokenStorage.php
@@ -22,7 +22,7 @@ class InMemoryTokenStorage implements ClearableTokenStorageInterface
     private array $store = [];
 
     public function __construct(
-        private string $namespace = SessionTokenStorage::SESSION_NAMESPACE,
+        private readonly string $namespace = SessionTokenStorage::SESSION_NAMESPACE,
     ) {
         $this->store[$this->namespace] = [];
     }

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -16,7 +16,7 @@ final class DateHelper
     /**
      * @api cannot be readonly, as changed in tests via reflection
      */
-    private readonly DateTimeHelper $helper;
+    private DateTimeHelper $helper;
 
     /**
      * @param string $dateFullFormat

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -16,7 +16,7 @@ final class DateHelper
     /**
      * @api cannot be readonly, as changed in tests via reflection
      */
-    private DateTimeHelper $helper;
+    private readonly DateTimeHelper $helper;
 
     /**
      * @param string $dateFullFormat

--- a/app/bundles/CoreBundle/Twig/Helper/EntityHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/EntityHelper.php
@@ -21,8 +21,8 @@ class EntityHelper extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('getEntity', [$this, 'getEntity']),
-            new TwigFunction('getEntities', [$this, 'getEntities']),
+            new TwigFunction('getEntity', $this->getEntity(...)),
+            new TwigFunction('getEntities', $this->getEntities(...)),
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SegmentSubscriber.php
@@ -12,7 +12,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 final class SegmentSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private EmailModel $emailModel,
+        private readonly EmailModel $emailModel,
     ) {
     }
 

--- a/app/bundles/EmailBundle/Helper/PlainTextHelper.php
+++ b/app/bundles/EmailBundle/Helper/PlainTextHelper.php
@@ -286,7 +286,7 @@ class PlainTextHelper
         $this->convertBlockquotes($text);
         $this->convertPre($text);
         $text = preg_replace($this->search, $this->replace, $text);
-        $text = preg_replace_callback($this->callbackSearch, [$this, 'pregCallback'], $text);
+        $text = preg_replace_callback($this->callbackSearch, $this->pregCallback(...), $text);
         $text = strip_tags($text);
         $text = preg_replace($this->entSearch, $this->entReplace, $text);
         $text = html_entity_decode($text, ENT_QUOTES, self::ENCODING);
@@ -368,7 +368,7 @@ class PlainTextHelper
             // Run our defined tags search-and-replace with callback
             $this->preContent = preg_replace_callback(
                 $this->callbackSearch,
-                [$this, 'pregCallback'],
+                $this->pregCallback(...),
                 $this->preContent
             );
 
@@ -381,7 +381,7 @@ class PlainTextHelper
             // replace the content (use callback because content can contain $0 variable)
             $text = preg_replace_callback(
                 '/<pre[^>]*>.*<\/pre>/ismU',
-                [$this, 'pregPreCallback'],
+                $this->pregPreCallback(...),
                 $text,
                 1
             );

--- a/app/bundles/EmailBundle/Tests/Functional/Fixtures/EmailFixturesHelper.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Fixtures/EmailFixturesHelper.php
@@ -16,7 +16,7 @@ use Mautic\PageBundle\Entity\Trackable;
 final class EmailFixturesHelper
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Transport/TestTransport.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Transport/TestTransport.php
@@ -15,7 +15,7 @@ use Symfony\Component\Mime\RawMessage;
 
 class TestTransport implements TransportInterface, BounceProcessorInterface, UnsubscriptionProcessorInterface
 {
-    private NullTransport $nullTransport;
+    private readonly NullTransport $nullTransport;
 
     public function __construct()
     {

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FormListType extends AbstractType
 {
-    private bool $viewOther;
+    private readonly bool $viewOther;
 
     private readonly \Mautic\FormBundle\Entity\FormRepository $repo;
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/TestExamples/Integration/ExampleIntegration.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/TestExamples/Integration/ExampleIntegration.php
@@ -18,7 +18,7 @@ final class ExampleIntegration extends BasicIntegration implements IntegrationIn
     public const NAME = 'Example';
 
     public function __construct(
-        private ExampleSyncDataExchange $syncDataExchange,
+        private readonly ExampleSyncDataExchange $syncDataExchange,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/TestExamples/Sync/SyncDataExchange/ExampleSyncDataExchange.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/TestExamples/Sync/SyncDataExchange/ExampleSyncDataExchange.php
@@ -47,7 +47,7 @@ class ExampleSyncDataExchange implements SyncDataExchangeInterface
 
     private array $payload = ['create' => [], 'update' => []];
 
-    private ValueNormalizer $valueNormalizer;
+    private readonly ValueNormalizer $valueNormalizer;
 
     public function __construct()
     {

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -226,7 +226,7 @@ class FieldType extends AbstractType
                 'required'    => false,
                 'disabled'    => $disableDefaultValue,
                 'constraints' => [
-                    new Assert\Callback([$this, 'validateDefaultValue']),
+                    new Assert\Callback($this->validateDefaultValue(...)),
                 ],
             ]
         );
@@ -245,7 +245,7 @@ class FieldType extends AbstractType
             switch ($type) {
                 case 'select':
                 case 'lookup':
-                    $constraints = new Assert\Callback([$this, 'validateDefaultValue']);
+                    $constraints = new Assert\Callback($this->validateDefaultValue(...));
                     // no break
                 case 'multiselect':
                     $cleaningRules['defaultValue'] = 'raw';
@@ -406,7 +406,7 @@ class FieldType extends AbstractType
                 case 'tel':
                 case 'url':
                 case 'email':
-                    $constraints = new Assert\Callback([$this, 'validateDefaultValue']);
+                    $constraints = new Assert\Callback($this->validateDefaultValue(...));
                     // no break
                 case 'number':
                     $form->add(

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
@@ -12,8 +12,8 @@ use Mautic\LeadBundle\Model\ListModel;
 class LoadSegmentsData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private ListModel $listModel,
-        private LeadModel $contactModel,
+        private readonly ListModel $listModel,
+        private readonly LeadModel $contactModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -29,7 +29,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     {
         /** @var EventDispatcher $eventDispatcher */
         $eventDispatcher = static::getContainer()->get('event_dispatcher');
-        $eventDispatcher->addListener(LeadEvents::LEAD_POST_SAVE, [$this, 'addPointsListener']);
+        $eventDispatcher->addListener(LeadEvents::LEAD_POST_SAVE, $this->addPointsListener(...));
 
         /** @var LeadModel $model */
         $model = static::getContainer()->get('mautic.lead.model.lead');

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
@@ -49,7 +49,7 @@ final class ListControllerTest extends MauticMysqlTestCase
                 'Mautic Do Not Contact Extras Bundle',
             ],
             array_map(
-                fn (string $dirtyPackageName): string => trim($dirtyPackageName),
+                trim(...),
                 $crawler->filter('#marketplace-packages-table .package-name a')->extract(['_text'])
             )
         );
@@ -80,7 +80,7 @@ final class ListControllerTest extends MauticMysqlTestCase
                 'Mautic Referrals Bundle',
             ],
             array_map(
-                fn (string $dirtyPackageName): string => trim($dirtyPackageName),
+                trim(...),
                 $crawler->filter('#marketplace-packages-table .package-name a')->extract(['_text'])
             )
         );

--- a/app/bundles/PageBundle/Form/Type/PageListType.php
+++ b/app/bundles/PageBundle/Form/Type/PageListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PageListType extends AbstractType
 {
-    private bool $canViewOther;
+    private readonly bool $canViewOther;
 
     public function __construct(
         private readonly PageModel $model,

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -39,7 +39,7 @@ class PageType extends AbstractType
 {
     private readonly ?\Mautic\UserBundle\Entity\User $user;
 
-    private bool $canViewOther;
+    private readonly bool $canViewOther;
 
     public function __construct(
         private readonly EntityManager $em,

--- a/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
+++ b/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PreferenceCenterListType extends AbstractType
 {
-    private bool $canViewOther;
+    private readonly bool $canViewOther;
 
     public function __construct(
         private readonly PageModel $model,

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -16,7 +16,7 @@ class oAuthHelper
 
     private $accessToken;
 
-    private string $accessTokenSecret;
+    private readonly string $accessTokenSecret;
 
     private $callback;
 

--- a/app/bundles/PluginBundle/Tests/Integration/ClientFactory.php
+++ b/app/bundles/PluginBundle/Tests/Integration/ClientFactory.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Client;
 class ClientFactory
 {
     public function __construct(
-        private Client $httpClient,
+        private readonly Client $httpClient,
     ) {
     }
 

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -234,7 +234,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
                 'eventDetails' => $eventDetails,
             ];
 
-            $callback = $settings['callback'] ?? [\Mautic\PointBundle\Helper\EventHelper::class, 'engagePointAction'];
+            $callback = $settings['callback'] ?? \Mautic\PointBundle\Helper\EventHelper::engagePointAction(...);
 
             if (is_callable($callback)) {
                 $object = null;

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
@@ -155,7 +155,7 @@ final class FileManagerControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertNotEmpty($content['data']);
 
         $assetList         = $content['data'];
-        $uploadedFileNames = array_map([$this, 'getFileNameFromUrl'], $uploadedFiles);
+        $uploadedFileNames = array_map($this->getFileNameFromUrl(...), $uploadedFiles);
 
         // Check if the first 'IMAGE_COUNT' assets in the list are the recently uploaded files
         for ($i = 0; $i < self::IMAGE_COUNT; ++$i) {

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -492,7 +492,7 @@ class SalesforceApi extends CrmApi
      */
     public function getCompaniesByName(array $names, $requiredFieldString)
     {
-        $names     = array_map([$this, 'escapeQueryValue'], $names);
+        $names     = array_map($this->escapeQueryValue(...), $names);
         $queryUrl  = $this->integration->getQueryUrl();
         $findQuery = 'select Id, '.$requiredFieldString.' from Account where isDeleted = false and Name in (\''.implode("','", $names).'\')';
 

--- a/plugins/MauticFocusBundle/Form/Type/FocusListType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FocusListType extends AbstractType
 {
-    private FocusRepository $repo;
+    private readonly FocusRepository $repo;
 
     public function __construct(
         protected FocusModel $focusModel,

--- a/rector.php
+++ b/rector.php
@@ -20,7 +20,7 @@ return RectorConfig::configure()
         __DIR__.'/plugins',
     ])
     ->withPreparedSets(deadCode: true, typeDeclarations: true)
-    ->withPhpSets(php80: true)
+    ->withPhpSets(php81: true)
     ->withCache(__DIR__.'/var/cache/rector')
     ->withTypeGuardedClasses([
         Mautic\CoreBundle\Controller\AbstractStandardFormController::class,

--- a/rector.php
+++ b/rector.php
@@ -81,7 +81,11 @@ return RectorConfig::configure()
         Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class => [
             __DIR__.'/app/bundles/EmailBundle/Entity/EmailDraft.php',
             __DIR__.'/app/bundles/EmailBundle/Helper/MailHelper.php',
+            __DIR__.'/app/bundles/CoreBundle/Twig/Helper/DateHelper.php',
         ],
+
+        // from upcoming PHP 8.1
+        Rector\CodingStyle\Rector\FuncCall\FunctionFirstClassCallableRector::class,
 
         // too many changes
         Rector\CodingStyle\Rector\Stmt\NewlineAfterStatementRector::class,


### PR DESCRIPTION
Let's move the codebase toward PHP 8.2 version :+1: 