### PR TITLE
Do not send email translation children as independent broadcasts

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -834,6 +834,12 @@ class EmailRepository extends CommonRepository
             $qb->expr()->eq($this->getTableAlias().'.emailType', $qb->expr()->literal('list'))
         );
 
+        // Translation children must not be broadcast independently. They are sent
+        // by the parent's broadcast to the contacts with a matching preferred locale.
+        $expr->add(
+            $qb->expr()->isNull($this->getTableAlias().'.translationParent')
+        );
+
         if (null !== $id && 0 !== $id) {
             $expr->add(
                 $qb->expr()->eq($this->getTableAlias().'.id', (int) $id)

--- a/app/bundles/EmailBundle/Tests/Functional/BroadcastTranslationTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/BroadcastTranslationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Functional;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailRepository;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Assert;
+
+final class BroadcastTranslationTest extends MauticMysqlTestCase
+{
+    /**
+     * Disabled so the kernel can be rebooted mid-test to simulate consecutive cron runs.
+     */
+    protected $useCleanupRollback = false;
+
+    public function testTranslationChildrenAreNotBroadcastIndependently(): void
+    {
+        $segment = $this->createSegment();
+        $parent  = $this->createEmail('Email EN', 'en', $segment);
+        $this->createEmail('Email PT', 'pt_PT', $segment, $parent);
+        $this->em->clear();
+
+        $repository = $this->em->getRepository(Email::class);
+        \assert($repository instanceof EmailRepository);
+
+        $broadcastIds = [];
+        foreach ($repository->getPublishedBroadcastsIterable() as $email) {
+            $broadcastIds[] = $email->getId();
+        }
+
+        Assert::assertSame([$parent->getId()], $broadcastIds);
+    }
+
+    public function testBroadcastSendsTranslationByPreferredLocale(): void
+    {
+        // Contacts are created before the segment because LeadModel::saveEntity()
+        // clears the entity manager; a detached segment would get cascade-persisted
+        // as a duplicate when the emails are flushed.
+        $contacts = [
+            $this->createContact('en-locale@example.com', 'en'),
+            $this->createContact('no-locale-1@example.com', null),
+            $this->createContact('pt-locale@example.com', 'pt_PT'),
+            $this->createContact('no-locale-2@example.com', null),
+        ];
+        $segment = $this->createSegment();
+        $this->addContactsToSegment($contacts, $segment);
+
+        $parent = $this->createEmail('Email EN', 'en', $segment);
+        $child  = $this->createEmail('Email PT', 'pt_PT', $segment, $parent);
+        $this->em->clear();
+
+        // A limit lower than the segment size ensures a single broadcast cannot
+        // drain the whole segment in one run, which is the scenario where
+        // translation children used to be sent as independent broadcasts.
+        $commandTester = $this->testSymfonyCommand('mautic:broadcasts:send', ['--limit' => 2]);
+        Assert::assertSame(0, $commandTester->getStatusCode());
+
+        // Reboot the kernel to simulate the next cron run happening in a fresh process.
+        $this->setUpSymfony($this->configParams);
+
+        $commandTester = $this->testSymfonyCommand('mautic:broadcasts:send', ['--limit' => 2]);
+        Assert::assertSame(0, $commandTester->getStatusCode());
+
+        $stats = $this->em->getConnection()->fetchAllAssociative(
+            'SELECT email_address, email_id FROM '.MAUTIC_TABLE_PREFIX.'email_stats'
+        );
+
+        Assert::assertCount(4, $stats, 'Every contact must receive exactly one email.');
+
+        $sentEmailIdByAddress = [];
+        foreach ($stats as $stat) {
+            $sentEmailIdByAddress[$stat['email_address']] = (int) $stat['email_id'];
+        }
+        ksort($sentEmailIdByAddress);
+
+        Assert::assertSame(
+            [
+                'en-locale@example.com'   => $parent->getId(),
+                'no-locale-1@example.com' => $parent->getId(),
+                'no-locale-2@example.com' => $parent->getId(),
+                'pt-locale@example.com'   => $child->getId(),
+            ],
+            $sentEmailIdByAddress,
+            'Contacts must receive the translation matching their preferred locale and the parent otherwise.'
+        );
+    }
+
+    private function createSegment(): LeadList
+    {
+        $segment = new LeadList();
+        $segment->setName('Segment A');
+        $segment->setPublicName('Segment A');
+        $segment->setAlias('segment-a');
+        $this->em->persist($segment);
+        $this->em->flush();
+
+        return $segment;
+    }
+
+    private function createContact(string $emailAddress, ?string $preferredLocale): Lead
+    {
+        $contact = new Lead();
+        $contact->setEmail($emailAddress);
+
+        if (null !== $preferredLocale) {
+            $contact->addUpdatedField('preferred_locale', $preferredLocale);
+        }
+
+        $contactModel = static::getContainer()->get('mautic.lead.model.lead');
+        \assert($contactModel instanceof LeadModel);
+        $contactModel->saveEntity($contact);
+
+        return $contact;
+    }
+
+    /**
+     * @param Lead[] $contacts
+     */
+    private function addContactsToSegment(array $contacts, LeadList $segment): void
+    {
+        foreach ($contacts as $contact) {
+            $reference = new ListLead();
+            $reference->setLead($contact);
+            $reference->setList($segment);
+            // Segment membership must predate the emails' publish up date, otherwise
+            // the contacts are not considered pending (see EmailModel::getPendingLeads()
+            // passing the publish up date as the send stop date).
+            $reference->setDateAdded(new \DateTime('-1 week'));
+            $this->em->persist($reference);
+        }
+
+        $this->em->flush();
+    }
+
+    private function createEmail(string $name, string $language, LeadList $segment, ?Email $translationParent = null): Email
+    {
+        $email = new Email();
+        $email->setName($name);
+        $email->setSubject($name.' Subject');
+        $email->setCustomHtml($name.' content');
+        $email->setEmailType('list');
+        $email->setLanguage($language);
+        $email->setPublishUp(new \DateTime('-1 day'));
+        $email->setIsPublished(true);
+        $email->addList($segment);
+
+        if (null !== $translationParent) {
+            $email->setTranslationParent($translationParent);
+            $translationParent->addTranslationChild($email);
+        }
+
+        $this->em->persist($email);
+        $this->em->flush();
+
+        return $email;
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #16491

## Description

`EmailRepository::getPublishedBroadcastsQuery()` only filters on published-by-date and `emailType = 'list'`, so a translation child of a segment email is picked up by `mautic:broadcasts:send` as its own independent broadcast targeting the same segments.

When the child is broadcast on its own, the language map built by `EmailModel::getEmailSettings()` contains only the child (`getTranslations()` returns children only, and the `default` entry points to the email currently being broadcast). As a result, every contact in the child's batch receives the translation regardless of `preferred_locale`, including contacts with an empty locale or a locale matching the parent. Which language a contact receives becomes a race between the two broadcast jobs. See #16491 for full details.

On 7.x the impact is worse than wrong-language sends: once both broadcasts drain the segment, the next `mautic:broadcasts:send` run crashes with `ORMInvalidArgumentException` ("A new entity was found through the relationship 'Email#translationParent'"), because the parent is detached by `BroadcastSubscriber` after it is processed and the child's auto-unpublish save then flushes against it.

This PR excludes emails with a `translationParent` from the broadcast query. With only the parent processed as a broadcast, the existing locale grouping in `EmailModel::sendEmail()` routes contacts with a matching preferred locale to the translation and everyone else to the parent, which matches the documented behaviour. The auto-unpublish check ("no more pending contacts") also applies to the translation family as a whole via the parent.

Includes a functional test covering both the repository query and an end-to-end `mautic:broadcasts:send` run with a translated segment email, batch limits, and contacts with different preferred locales.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a segment **S** with 4 contacts: one with `preferred_locale = pt_PT`, one with `en`, two with no locale set.
3. Create segment email **A** (language `en`), assign segment S, publish.
4. From email A, create a translation **B** (language `pt_PT`) and publish it.
5. Run `bin/console mautic:broadcasts:send --limit=2` twice (the limit forces the scenario where the segment is not drained in one run).
6. Check Contacts > (each contact) > History, or the `email_stats` table: the `pt_PT` contact must have received B; the other three contacts must have received A. Before this fix, contacts processed under B's broadcast all received B regardless of locale.
7. Run the automated test: `bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist app/bundles/EmailBundle/Tests/Functional/BroadcastTranslationTest.php`

