### PR TITLE
Fix segment emails with no publish up date never being broadcast

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -848,8 +848,12 @@ class EmailRepository extends CommonRepository
 
     private function getPublishedBroadcastsQuery(?int $id = null): Query
     {
+        // The last argument allows a null publish up date so that a published segment
+        // email without a start date is broadcast immediately, consistent with how it
+        // is shown as active in the UI (see FormEntity::getPublishStatus()). A future
+        // publish up date still holds the email back until the scheduled start.
         $qb   = $this->createQueryBuilder($this->getTableAlias());
-        $expr = $this->getPublishedByDateOrmExpression($qb, null, true, true, false);
+        $expr = $this->getPublishedByDateOrmExpression($qb, null, true, true, true);
 
         $expr->add(
             $qb->expr()->eq($this->getTableAlias().'.emailType', $qb->expr()->literal('list'))

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -203,6 +203,63 @@ final class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
+     * A published segment (list) email that has no publish up date must still be
+     * picked up for broadcast. Previously such an email was shown as active in the
+     * UI but silently excluded from sending because a publish up date was required.
+     *
+     * @see https://github.com/mautic/mautic/issues/16165
+     */
+    public function testGetPublishedBroadcastsIncludesSegmentEmailWithoutPublishUp(): void
+    {
+        // Published segment email without any start date - should be broadcast now.
+        $noPublishUp = $this->createSegmentEmail('No publish up', true, null);
+
+        // Published segment email whose start date is already in the past - should be broadcast.
+        $pastPublishUp = $this->createSegmentEmail('Past publish up', true, new \DateTime('-1 day'));
+
+        // Published segment email scheduled to start in the future - must be held back.
+        $futurePublishUp = $this->createSegmentEmail('Future publish up', true, new \DateTime('+1 day'));
+
+        // Unpublished segment email without a start date - must not be broadcast.
+        $unpublished = $this->createSegmentEmail('Unpublished', false, null);
+
+        // Template email without a start date - must not be broadcast.
+        $template = $this->createSegmentEmail('Template', true, null);
+        $template->setEmailType('template');
+        $this->em->persist($template);
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $broadcastIds = [];
+        foreach ($this->emailRepository->getPublishedBroadcastsIterable() as $email) {
+            $broadcastIds[] = $email->getId();
+        }
+        sort($broadcastIds);
+
+        $expectedIds = [$noPublishUp->getId(), $pastPublishUp->getId()];
+        sort($expectedIds);
+
+        Assert::assertSame($expectedIds, $broadcastIds);
+        Assert::assertNotContains($futurePublishUp->getId(), $broadcastIds);
+        Assert::assertNotContains($unpublished->getId(), $broadcastIds);
+        Assert::assertNotContains($template->getId(), $broadcastIds);
+    }
+
+    private function createSegmentEmail(string $name, bool $isPublished, ?\DateTimeInterface $publishUp): Email
+    {
+        $email = new Email();
+        $email->setName($name);
+        $email->setSubject($name);
+        $email->setEmailType('list');
+        $email->setIsPublished($isPublished);
+        $email->setPublishUp($publishUp);
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    /**
      * @throws ORMException
      */
     private function createLead(string $lastName): Lead

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -240,10 +240,10 @@ final class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
         $expectedIds = [$noPublishUp->getId(), $pastPublishUp->getId()];
         sort($expectedIds);
 
-        Assert::assertSame($expectedIds, $broadcastIds);
-        Assert::assertNotContains($futurePublishUp->getId(), $broadcastIds);
-        Assert::assertNotContains($unpublished->getId(), $broadcastIds);
-        Assert::assertNotContains($template->getId(), $broadcastIds);
+        $this->assertSame($expectedIds, $broadcastIds);
+        $this->assertNotContains($futurePublishUp->getId(), $broadcastIds);
+        $this->assertNotContains($unpublished->getId(), $broadcastIds);
+        $this->assertNotContains($template->getId(), $broadcastIds);
     }
 
     private function createSegmentEmail(string $name, bool $isPublished, ?\DateTimeInterface $publishUp): Email


### PR DESCRIPTION
### What & why

A published segment (list) email with **no publish up date** is shown as **active** in the UI — `FormEntity::getPublishStatus()` treats a null publish up as published — but it is never actually sent: `EmailRepository::getPublishedBroadcastsQuery()` builds its date expression with `getPublishedByDateExpression()` disallowing a null publish up, so those emails are silently excluded from the broadcast query.

This bit users after the "Schedule sending for emails" feature (#14254) reframed publish up as an *optional start date* for segment emails: it's now normal to have an active segment email with no start date that looks active but never delivers (the report in #16165 hit it with double-opt-in confirmation newsletters).

The fix aligns the broadcast query with the publish state the UI shows: allow a null publish up date in `getPublishedBroadcastsQuery()`. A **future** publish up date still holds the email back until its scheduled start, and unpublished emails stay excluded — only the null case changes.

### Tests

Adds `testGetPublishedBroadcastsIncludesSegmentEmailWithoutPublishUp` to `EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php`, covering five cases: null publish up (now broadcast), past publish up (broadcast), future publish up (held back), unpublished (excluded), and template-type email (excluded). The null-publish-up assertion fails on current code and passes with this change.

```
bin/phpunit app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
```

### Manual test steps

**Reproduce (before):**
1. Create a segment email, leave "Publish at (date/time)" empty, publish it. It shows as active (green).
2. Wait for the `mautic:broadcasts:send` cron (or run it manually) → the email is never sent, no error anywhere.

**Verify (after):**
1. Same setup, run `bin/console mautic:broadcasts:send` → the email is picked up and sent to the segment.
2. Set a future publish up date on another segment email → it is not sent until that time passes.

Closes #16165
