### PR TITLE
[tests] unite calls to $this->assert*() method calls

### DIFF
--- a/app/bundles/ApiBundle/Tests/Extension/OwnershipScopedCollectionExtensionTest.php
+++ b/app/bundles/ApiBundle/Tests/Extension/OwnershipScopedCollectionExtensionTest.php
@@ -125,7 +125,7 @@ final class OwnershipScopedCollectionExtensionTest extends TestCase
 
     public function testNoFilterAppliedWhenOperationHasNoSecurityExpression(): void
     {
-        $this->security->expects(self::never())->method('isGranted');
+        $this->security->expects($this->never())->method('isGranted');
 
         $queryBuilder = $this->createQueryBuilderExpectingNoCalls();
 
@@ -139,7 +139,7 @@ final class OwnershipScopedCollectionExtensionTest extends TestCase
 
     public function testNoFilterAppliedWhenSecurityExpressionHasNoOwnPermission(): void
     {
-        $this->security->expects(self::never())->method('isGranted');
+        $this->security->expects($this->never())->method('isGranted');
 
         $queryBuilder = $this->createQueryBuilderExpectingNoCalls();
 
@@ -153,7 +153,7 @@ final class OwnershipScopedCollectionExtensionTest extends TestCase
 
     public function testNoFilterAppliedWhenOperationIsNull(): void
     {
-        $this->security->expects(self::never())->method('isGranted');
+        $this->security->expects($this->never())->method('isGranted');
 
         $queryBuilder = $this->createQueryBuilderExpectingNoCalls();
 
@@ -192,8 +192,8 @@ final class OwnershipScopedCollectionExtensionTest extends TestCase
     private function createQueryBuilderExpectingNoCalls(): QueryBuilder&MockObject
     {
         $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->expects(self::never())->method('andWhere');
-        $queryBuilder->expects(self::never())->method('setParameter');
+        $queryBuilder->expects($this->never())->method('andWhere');
+        $queryBuilder->expects($this->never())->method('setParameter');
 
         return $queryBuilder;
     }

--- a/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
@@ -158,7 +158,7 @@ final class Oauth2Test extends MauticMysqlTestCase
     public function testUserBoundBearerTokenAuthenticatesOnApiV1AndApiV2(): void
     {
         $adminUser = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
-        self::assertInstanceOf(User::class, $adminUser);
+        $this->assertInstanceOf(User::class, $adminUser);
 
         $accessToken = $this->createUserBoundAccessToken($adminUser);
 
@@ -216,7 +216,7 @@ final class Oauth2Test extends MauticMysqlTestCase
         $this->em->clear();
 
         $reloadedToken = $this->em->getRepository(AccessToken::class)->findOneBy(['token' => 'test_user_bound_bearer_token']);
-        self::assertInstanceOf(AccessToken::class, $reloadedToken);
+        $this->assertInstanceOf(AccessToken::class, $reloadedToken);
 
         return $reloadedToken;
     }

--- a/app/bundles/ApiBundle/Tests/Functional/OwnershipScopedSecurityMetadataTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/OwnershipScopedSecurityMetadataTest.php
@@ -76,10 +76,7 @@ final class OwnershipScopedSecurityMetadataTest extends MauticMysqlTestCase
             }
         }
 
-        self::assertEmpty(
-            $violations,
-            "The following ownership-scoped item operations are missing ', object)' in their security expression:\n"
-            .implode("\n", $violations)
-        );
+        $this->assertEmpty($violations, "The following ownership-scoped item operations are missing ', object)' in their security expression:\n"
+        .implode("\n", $violations));
     }
 }

--- a/app/bundles/AssetBundle/Tests/DataFixtures/LoadAssetDataTest.php
+++ b/app/bundles/AssetBundle/Tests/DataFixtures/LoadAssetDataTest.php
@@ -17,19 +17,19 @@ final class LoadAssetDataTest extends MauticMysqlTestCase
             ['title' => '@TOCHANGE: Asset1 Title'],
             ['id' => 'DESC']
         );
-        self::assertInstanceOf(Asset::class, $asset);
-        self::assertSame('asset1', $asset->getAlias());
-        self::assertEquals('@TOCHANGE: Asset1 Original File Name', $asset->getOriginalFileName());
-        self::assertEquals('fdb8e28357b02d12d068de3e5661832e21bc08ec.doc', $asset->getPath());
-        self::assertEquals(1, $asset->getDownloadCount());
-        self::assertEquals(1, $asset->getUniqueDownloadCount());
-        self::assertEquals(1, $asset->getRevision());
-        self::assertEquals('en', $asset->getLanguage());
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertSame('asset1', $asset->getAlias());
+        $this->assertEquals('@TOCHANGE: Asset1 Original File Name', $asset->getOriginalFileName());
+        $this->assertEquals('fdb8e28357b02d12d068de3e5661832e21bc08ec.doc', $asset->getPath());
+        $this->assertEquals(1, $asset->getDownloadCount());
+        $this->assertEquals(1, $asset->getUniqueDownloadCount());
+        $this->assertEquals(1, $asset->getRevision());
+        $this->assertEquals('en', $asset->getLanguage());
     }
 
     public function testLoadFixturesOrder(): void
     {
         $loadAssetData = new LoadAssetData();
-        self::assertSame(10, $loadAssetData->getOrder());
+        $this->assertSame(10, $loadAssetData->getOrder());
     }
 }

--- a/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
+++ b/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
@@ -42,8 +42,8 @@ final class AssetRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($repository, $qb, $filter);
 
-        self::assertSame($expected, (string) $expr);
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame($expected, (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     /**
@@ -59,7 +59,7 @@ final class AssetRepositoryTest extends TestCase
     {
         $repository = $this->getRepository();
         $commands   = $repository->getSearchCommands();
-        self::assertContains('mautic.asset.asset.searchcommand.isexpired', $commands);
-        self::assertContains('mautic.asset.asset.searchcommand.ispending', $commands);
+        $this->assertContains('mautic.asset.asset.searchcommand.isexpired', $commands);
+        $this->assertContains('mautic.asset.asset.searchcommand.ispending', $commands);
     }
 }

--- a/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
@@ -94,7 +94,7 @@ final class DashboardSubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber->onWidgetDetailGenerate($event);
 
         $templateData = $event->getTemplateData();
-        self::assertArrayHasKey('chartData', $templateData);
+        $this->assertArrayHasKey('chartData', $templateData);
     }
 
     public function testUniqueVsRepetitiveDownloadsPassesFilterArrayAndPermissionFlagToAssetModel(): void
@@ -133,7 +133,7 @@ final class DashboardSubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber->onWidgetDetailGenerate($event);
 
         $templateData = $event->getTemplateData();
-        self::assertArrayHasKey('chartData', $templateData);
+        $this->assertArrayHasKey('chartData', $templateData);
     }
 
     public function testPopularAssetsPassesFilterArrayAndPermissionFlagToAssetModel(): void
@@ -178,6 +178,6 @@ final class DashboardSubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber->onWidgetDetailGenerate($event);
 
         $templateData = $event->getTemplateData();
-        self::assertArrayHasKey('bodyItems', $templateData);
+        $this->assertArrayHasKey('bodyItems', $templateData);
     }
 }

--- a/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -37,10 +37,10 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
         // timeline twig from erroring on a missing href key. The DownloadRepository
         // LEFT JOINs assets, so a.title resolves to NULL once asset_id is NULL;
         // the subscriber falls back to a localized "Deleted asset" placeholder.
-        self::assertIsString($event['eventLabel']);
-        self::assertNotEmpty($event['eventLabel']);
-        self::assertNull($event['extra']['asset']);
-        self::assertNull($event['extra']['assetDownloadUrl']);
+        $this->assertIsString($event['eventLabel']);
+        $this->assertNotEmpty($event['eventLabel']);
+        $this->assertNull($event['extra']['asset']);
+        $this->assertNull($event['extra']['assetDownloadUrl']);
     }
 
     /**
@@ -54,11 +54,11 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 
         $event = $this->getFirstAssetDownloadEvent($leadId);
 
-        self::assertIsArray($event['eventLabel']);
-        self::assertArrayHasKey('href', $event['eventLabel']);
-        self::assertSame('Live asset', $event['eventLabel']['label']);
-        self::assertInstanceOf(Asset::class, $event['extra']['asset']);
-        self::assertNotNull($event['extra']['assetDownloadUrl']);
+        $this->assertIsArray($event['eventLabel']);
+        $this->assertArrayHasKey('href', $event['eventLabel']);
+        $this->assertSame('Live asset', $event['eventLabel']['label']);
+        $this->assertInstanceOf(Asset::class, $event['extra']['asset']);
+        $this->assertNotNull($event['extra']['assetDownloadUrl']);
     }
 
     /**
@@ -108,7 +108,7 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
             $payload['events'],
             static fn (array $event): bool => 'asset.download' === ($event['event'] ?? null),
         ));
-        self::assertCount(1, $assetDownloadEvents);
+        $this->assertCount(1, $assetDownloadEvents);
 
         return $assetDownloadEvents[0];
     }

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -145,8 +145,8 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         $downloads = $data['member'];
-        self::assertCount(1, $downloads, 'Expected exactly 1 download (only the one for the owned asset)');
-        self::assertSame($ownDownload->getId(), $downloads[0]['id']);
+        $this->assertCount(1, $downloads, 'Expected exactly 1 download (only the one for the owned asset)');
+        $this->assertSame($ownDownload->getId(), $downloads[0]['id']);
     }
 
     public function testViewOwnCollectionReportsOwnedTotalAcrossPagesOnApiV2(): void
@@ -222,9 +222,9 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertArrayHasKey('member', $page1Data);
-        self::assertArrayHasKey('totalItems', $page1Data);
-        self::assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned downloads');
-        self::assertCount(4, $page1Data['member'], 'Should return all 4 owned downloads on single page');
+        $this->assertArrayHasKey('member', $page1Data);
+        $this->assertArrayHasKey('totalItems', $page1Data);
+        $this->assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned downloads');
+        $this->assertCount(4, $page1Data['member'], 'Should return all 4 owned downloads on single page');
     }
 }

--- a/app/bundles/AssetBundle/Tests/Functional/Entity/DownloadRepositoryFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/Entity/DownloadRepositoryFunctionalTest.php
@@ -43,10 +43,10 @@ final class DownloadRepositoryFunctionalTest extends MauticMysqlTestCase
             new \DateTime('2026-03-01 00:00:00', new \DateTimeZone('UTC'))
         );
 
-        self::assertArrayHasKey((string) $page->getId(), $result);
-        self::assertSame('1', (string) $result[(string) $page->getId()]['count']);
-        self::assertSame('Landing page', $result[(string) $page->getId()]['name']);
-        self::assertSame('77', (string) $result[(string) $page->getId()]['total']);
+        $this->assertArrayHasKey((string) $page->getId(), $result);
+        $this->assertSame('1', (string) $result[(string) $page->getId()]['count']);
+        $this->assertSame('Landing page', $result[(string) $page->getId()]['name']);
+        $this->assertSame('77', (string) $result[(string) $page->getId()]['total']);
     }
 
     public function testGetDownloadCountsByEmailRespectsFromDateFilter(): void
@@ -69,10 +69,10 @@ final class DownloadRepositoryFunctionalTest extends MauticMysqlTestCase
             new \DateTime('2026-03-01 00:00:00', new \DateTimeZone('UTC'))
         );
 
-        self::assertArrayHasKey((string) $email->getId(), $result);
-        self::assertSame('1', (string) $result[(string) $email->getId()]['count']);
-        self::assertSame('AB subject', $result[(string) $email->getId()]['name']);
-        self::assertSame('25', (string) $result[(string) $email->getId()]['total']);
+        $this->assertArrayHasKey((string) $email->getId(), $result);
+        $this->assertSame('1', (string) $result[(string) $email->getId()]['count']);
+        $this->assertSame('AB subject', $result[(string) $email->getId()]['name']);
+        $this->assertSame('25', (string) $result[(string) $email->getId()]['total']);
     }
 
     private function createDownload(

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -551,13 +551,13 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1]);
 
         $count = $this->segmentCountCacheHelper->getSegmentContactCount(1);
-        self::assertSame(0, $count);
+        $this->assertSame(0, $count);
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
 
         // Segment cache count should be 50.
         $count = $this->segmentCountCacheHelper->getSegmentContactCount(1);
-        self::assertSame(50, $count);
+        $this->assertSame(50, $count);
     }
 
     public function testCampaignActionChangeMembership(): void
@@ -772,7 +772,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1]);
         // Segment cache count should be 50.
         $count = $this->segmentCountCacheHelper->getSegmentContactCount(1);
-        self::assertSame(50, $count);
+        $this->assertSame(50, $count);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -359,11 +359,11 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns/view/%d', $campaign->getId()));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Campaign ABC', (string) $response->getContent());
-        self::assertSame('', trim($crawler->filter('#decisions-container')->text()));
-        self::assertSame('', trim($crawler->filter('#actions-container')->text()));
-        self::assertSame('', trim($crawler->filter('#conditions-container')->text()));
-        self::assertSame('', trim($crawler->filter('#campaign-graph-div')->text()));
+        $this->assertStringContainsString('Campaign ABC', (string) $response->getContent());
+        $this->assertSame('', trim($crawler->filter('#decisions-container')->text()));
+        $this->assertSame('', trim($crawler->filter('#actions-container')->text()));
+        $this->assertSame('', trim($crawler->filter('#conditions-container')->text()));
+        $this->assertSame('', trim($crawler->filter('#campaign-graph-div')->text()));
     }
 
     public function testCampaignViewEvents(): void
@@ -375,8 +375,8 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $body     = json_decode($response->getContent(), true);
-        self::assertCount(2, $body);
+        $this->assertCount(2, $body);
         self::arrayHasKey('actions');
-        self::assertStringContainsString('100% 2 0 Event A mautic.campaign.type.a 100% 2 0 Event B mautic.campaign.type.b', (string) preg_replace('/\s+/', ' ', strip_tags($body['actions'])));
+        $this->assertStringContainsString('100% 2 0 Event A mautic.campaign.type.a 100% 2 0 Event B mautic.campaign.type.b', (string) preg_replace('/\s+/', ' ', strip_tags($body['actions'])));
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
@@ -43,11 +43,8 @@ final class CampaignRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($this->repository, $qb, $filter);
 
-        self::assertSame(
-            '(c.isPublished = :par1) AND (c.publishDown IS NOT NULL) AND (c.publishDown <> \'\') AND (c.publishDown < CURRENT_TIMESTAMP())',
-            (string) $expr
-        );
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame('(c.isPublished = :par1) AND (c.publishDown IS NOT NULL) AND (c.publishDown <> \'\') AND (c.publishDown < CURRENT_TIMESTAMP())', (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     public function testAddSearchCommandWhereClauseHandlesPendingFilters(): void
@@ -59,17 +56,14 @@ final class CampaignRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($this->repository, $qb, $filter);
 
-        self::assertSame(
-            '(c.isPublished = :par1) AND (c.publishUp IS NOT NULL) AND (c.publishUp <> \'\') AND (c.publishUp > CURRENT_TIMESTAMP())',
-            (string) $expr
-        );
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame('(c.isPublished = :par1) AND (c.publishUp IS NOT NULL) AND (c.publishUp <> \'\') AND (c.publishUp > CURRENT_TIMESTAMP())', (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     public function testGetSearchCommandsContainsExpirationFilters(): void
     {
         $commands = $this->repository->getSearchCommands();
-        self::assertContains('mautic.campaign.campaign.searchcommand.isexpired', $commands);
-        self::assertContains('mautic.campaign.campaign.searchcommand.ispending', $commands);
+        $this->assertContains('mautic.campaign.campaign.searchcommand.isexpired', $commands);
+        $this->assertContains('mautic.campaign.campaign.searchcommand.ispending', $commands);
     }
 }

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
@@ -33,7 +33,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
         // Schedule the first campaign event.
         $commandTester = $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
         $output        = $commandTester->getDisplay();
-        self::assertStringContainsString('150 total events were executed', $output);
+        $this->assertStringContainsString('150 total events were executed', $output);
 
         // Force the campaign failure events manually
         // Reload campaign to get the event
@@ -56,7 +56,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
                     'message' => "{$campaign->getName()} / Send email to user",
                 ]
             );
-        self::assertCount(1, $notifications);
+        $this->assertCount(1, $notifications);
 
         // Let's try dispatching the event again and verify that we have a second notification
         // (verifying that notifications aren't deduplicated)
@@ -70,7 +70,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
             ]);
 
         // There should be exactly two notifications created (no deduplication)
-        self::assertCount(2, $notifications);
+        $this->assertCount(2, $notifications);
     }
 
     /**
@@ -90,7 +90,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->client->request('POST', '/api/contacts/batch/new', $contacts);
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $contacts = $response['contacts'];
-        self::assertCount(150, $contacts);
+        $this->assertCount(150, $contacts);
         self::assertResponseStatusCodeSame(201, $this->client->getResponse()->getContent());
 
         return $contacts;

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -120,8 +120,8 @@ final class CampaignEventSubscriberTest extends TestCase
 
         $this->fixture->onCampaignPreSave(new CampaignEvent($campaign));
 
-        self::assertNotNull($campaign->getPublishUp());
-        self::assertSame('00', $campaign->getPublishUp()->format('s'));
+        $this->assertInstanceOf(\DateTimeInterface::class, $campaign->getPublishUp());
+        $this->assertSame('00', $campaign->getPublishUp()->format('s'));
     }
 
     public function testFailedEventGeneratesANotification(): void

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -49,13 +49,10 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        self::assertSame(
-            [
-                CampaignEvents::CAMPAIGN_POST_SAVE     => ['onCampaignPostSave', 0],
-                CampaignEvents::CAMPAIGN_POST_DELETE   => ['onCampaignDelete', 0],
-            ],
-            CampaignSubscriber::getSubscribedEvents()
-        );
+        $this->assertSame([
+            CampaignEvents::CAMPAIGN_POST_SAVE     => ['onCampaignPostSave', 0],
+            CampaignEvents::CAMPAIGN_POST_DELETE   => ['onCampaignDelete', 0],
+        ], CampaignSubscriber::getSubscribedEvents());
     }
 
     public function testOnCampaignPostSaveNothingHappened(): void

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
@@ -111,14 +111,14 @@ final class ActionDispatcherTest extends \PHPUnit\Framework\TestCase
                         $event->pass($logs->get(1));
                         $event->fail($logs->get(2), 'just because');
                     } elseif (2 === $dispatcCounter) {
-                        self::assertInstanceOf(ExecutedEvent::class, $event);
-                        self::assertSame(CampaignEvents::ON_EVENT_EXECUTED, $eventName);
+                        $this->assertInstanceOf(ExecutedEvent::class, $event);
+                        $this->assertSame(CampaignEvents::ON_EVENT_EXECUTED, $eventName);
                     } elseif (3 === $dispatcCounter) {
-                        self::assertInstanceOf(ExecutedBatchEvent::class, $event);
-                        self::assertSame(CampaignEvents::ON_EVENT_EXECUTED_BATCH, $eventName);
+                        $this->assertInstanceOf(ExecutedBatchEvent::class, $event);
+                        $this->assertSame(CampaignEvents::ON_EVENT_EXECUTED_BATCH, $eventName);
                     } elseif (4 === $dispatcCounter) {
-                        self::assertInstanceOf(FailedEvent::class, $event);
-                        self::assertSame(CampaignEvents::ON_EVENT_FAILED, $eventName);
+                        $this->assertInstanceOf(FailedEvent::class, $event);
+                        $this->assertSame(CampaignEvents::ON_EVENT_FAILED, $eventName);
                     } else {
                         self::fail('Unknown event called.');
                     }

--- a/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
+++ b/app/bundles/CoreBundle/Test/Event/TokenReplacementEventTest.php
@@ -14,14 +14,14 @@ final class TokenReplacementEventTest extends TestCase
     {
         $passthrough = ['passthrough'];
         $event       = new TokenReplacementEvent('', null, [], $passthrough);
-        self::assertSame($passthrough, $event->getPassthrough());
+        $this->assertSame($passthrough, $event->getPassthrough());
     }
 
     public function testGetSetContent(): void
     {
         $content = 'content';
         $event   = new TokenReplacementEvent($content);
-        self::assertSame($content, $event->getContent());
+        $this->assertSame($content, $event->getContent());
     }
 
     public function testAddGetTokens(): void
@@ -31,17 +31,14 @@ final class TokenReplacementEventTest extends TestCase
         $token1 = 'token1';
         $value1 = 'value1';
         $event  = new TokenReplacementEvent('');
-        self::assertSame([], $event->getTokens());
+        $this->assertSame([], $event->getTokens());
         $event->addToken($token, $value);
-        self::assertSame([$token => $value], $event->getTokens());
+        $this->assertSame([$token => $value], $event->getTokens());
         $event->addToken($token1, $value1);
-        self::assertSame(
-            [
-                $token  => $value,
-                $token1 => $value1,
-            ],
-            $event->getTokens()
-        );
+        $this->assertSame([
+            $token  => $value,
+            $token1 => $value1,
+        ], $event->getTokens());
     }
 
     public function testGetClickthrough(): void
@@ -50,37 +47,25 @@ final class TokenReplacementEventTest extends TestCase
         $leadEntity['id'] = $leadId;
         $clickthrough     = ['lead' => $leadEntity];
         $event            = new TokenReplacementEvent('', $leadEntity, $clickthrough);
-        self::assertSame(
-            ['lead' => 1],
-            $event->getClickthrough()
-        );
+        $this->assertSame(['lead' => 1], $event->getClickthrough());
 
         $leadEntity   = new Lead();
 
         $clickthrough = ['lead', $leadEntity];
         $event        = new TokenReplacementEvent('', $leadEntity, $clickthrough);
-        self::assertSame(
-            $clickthrough,
-            $event->getClickthrough()
-        );
+        $this->assertSame($clickthrough, $event->getClickthrough());
 
         $leadEntity->setId($leadId);
         $clickthrough = ['lead' => $leadEntity];
         $event        = new TokenReplacementEvent('', $leadEntity, $clickthrough);
-        self::assertSame(
-            ['lead' => 1],
-            $event->getClickthrough()
-        );
+        $this->assertSame(['lead' => 1], $event->getClickthrough());
     }
 
     public function testGetEntity(): void
     {
         $lead  = new Lead();
         $event = new TokenReplacementEvent($lead);
-        self::assertSame(
-            $lead,
-            $event->getEntity()
-        );
+        $this->assertSame($lead, $event->getEntity());
     }
 
     public function testSetClickthrough(): void
@@ -90,17 +75,17 @@ final class TokenReplacementEventTest extends TestCase
         $clickthrough = ['clickthrough'];
         $event->setClickthrough($clickthrough);
 
-        self::assertSame($clickthrough, $event->getClickthrough());
+        $this->assertSame($clickthrough, $event->getClickthrough());
     }
 
     public function testGetLead(): void
     {
         $lead  = null;
         $event = new TokenReplacementEvent('', $lead);
-        self::assertSame($lead, $event->getLead());
+        $this->assertSame($lead, $event->getLead());
         $lead  = new Lead();
         $event = new TokenReplacementEvent('', $lead);
-        self::assertSame($lead, $event->getLead());
+        $this->assertSame($lead, $event->getLead());
     }
 
     public function testSetContent(): void
@@ -108,6 +93,6 @@ final class TokenReplacementEventTest extends TestCase
         $content1 = 'content1';
         $event    = new TokenReplacementEvent('');
         $event->setContent($content1);
-        self::assertSame($content1, $event->getContent());
+        $this->assertSame($content1, $event->getContent());
     }
 }

--- a/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
@@ -20,12 +20,12 @@ final class UnusedIpDeleteCommandFunctionalTest extends MauticMysqlTestCase
         $ipAddressRepo = $this->em->getRepository(IpAddress::class);
         $ipAddressRepo->saveEntity(new IpAddress('127.0.0.1'));
         $count = $ipAddressRepo->count(['ipAddress' => '127.0.0.1']);
-        self::assertSame(1, $count);
+        $this->assertSame(1, $count);
 
         // Delete unused IP address.
         $this->testSymfonyCommand('mautic:unusedip:delete');
 
         $count = $ipAddressRepo->count(['ipAddress' => '127.0.0.1']);
-        self::assertSame(0, $count);
+        $this->assertSame(0, $count);
     }
 }

--- a/app/bundles/CoreBundle/Tests/EventListener/CoreSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/EventListener/CoreSubscriberTest.php
@@ -13,14 +13,11 @@ final class CoreSubscriberTest extends TestCase
 {
     public function testGetSubscribedEvents(): void
     {
-        self::assertSame(
-            [
-                CoreEvents::BUILD_MENU            => ['onBuildMenu', 9999],
-                CoreEvents::BUILD_ROUTE           => ['onBuildRoute', 0],
-                CoreEvents::FETCH_ICONS           => ['onFetchIcons', 9999],
-                SecurityEvents::INTERACTIVE_LOGIN => ['onSecurityInteractiveLogin', 0],
-            ],
-            CoreSubscriber::getSubscribedEvents()
-        );
+        $this->assertSame([
+            CoreEvents::BUILD_MENU            => ['onBuildMenu', 9999],
+            CoreEvents::BUILD_ROUTE           => ['onBuildRoute', 0],
+            CoreEvents::FETCH_ICONS           => ['onFetchIcons', 9999],
+            SecurityEvents::INTERACTIVE_LOGIN => ['onSecurityInteractiveLogin', 0],
+        ], CoreSubscriber::getSubscribedEvents());
     }
 }

--- a/app/bundles/CoreBundle/Tests/EventListener/DashboardSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/EventListener/DashboardSubscriberTest.php
@@ -74,12 +74,12 @@ final class DashboardSubscriberTest extends TestCase
         $this->event->expects($this->once())
             ->method('getType')
             ->willReturn('random');
-        $this->event->expects(self::never())
+        $this->event->expects($this->never())
             ->method('isCached');
-        $this->event->expects(self::never())
+        $this->event->expects($this->never())
             ->method('setTemplate');
 
-        $this->auditLogModel->expects(self::never())
+        $this->auditLogModel->expects($this->never())
             ->method('getLogForObject');
 
         $subscriber = new DashboardSubscriber(
@@ -106,7 +106,7 @@ final class DashboardSubscriberTest extends TestCase
         $this->event->expects($this->once())
             ->method('stopPropagation');
 
-        $this->auditLogModel->expects(self::never())
+        $this->auditLogModel->expects($this->never())
             ->method('getLogForObject');
 
         $subscriber = new DashboardSubscriber(
@@ -206,7 +206,7 @@ final class DashboardSubscriberTest extends TestCase
             ->with(789)
             ->willThrowException($this->createStub(\Exception::class));
 
-        $this->modelFactory->expects(self::exactly(7))
+        $this->modelFactory->expects($this->exactly(7))
             ->method('getModel')
             ->willReturnMap([
                 ['null.object', $nullObjectModel],
@@ -220,7 +220,7 @@ final class DashboardSubscriberTest extends TestCase
 
         $route           = $this->createStub(Route::class);
         $routeCollection = $this->createMock(RouteCollection::class);
-        $matcher         = self::exactly(5);
+        $matcher         = $this->exactly(5);
         $routeCollection->expects($matcher) // no null object and  exception object
             ->method('get')->willReturnCallback(function (...$parameters) use ($matcher, $route): ?\PHPUnit\Framework\MockObject\Stub {
                 if (1 === $matcher->numberOfInvocations()) {
@@ -252,10 +252,10 @@ final class DashboardSubscriberTest extends TestCase
                 throw new \PHPUnit\Framework\Exception(sprintf('Method not be called for %dth time', $matcher->numberOfInvocations()));
             });
 
-        $this->router->expects(self::exactly(5))
+        $this->router->expects($this->exactly(5))
             ->method('getRouteCollection')
             ->willReturn($routeCollection);
-        $this->router->expects(self::exactly(3))
+        $this->router->expects($this->exactly(3))
             ->method('generate')
             ->willReturnMap([
                 ['mautic_model_action', ['objectAction' => 'view', 'objectId' => 345], UrlGeneratorInterface::ABSOLUTE_PATH, '/not-getter'],

--- a/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
@@ -40,7 +40,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => 'user@example.com', 'cc' => '', 'bcc' => '']);
 
-        self::assertTrue($form->isValid());
+        $this->assertTrue($form->isValid());
     }
 
     public function testCommaSeparatedValidEmailsPasses(): void
@@ -48,7 +48,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => 'user1@example.com,user2@example.com', 'cc' => '', 'bcc' => '']);
 
-        self::assertTrue($form->isValid());
+        $this->assertTrue($form->isValid());
     }
 
     public function testCommaSeparatedEmailsWithSpacesPasses(): void
@@ -56,7 +56,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => 'user1@example.com, user2@example.com', 'cc' => '', 'bcc' => '']);
 
-        self::assertTrue($form->isValid());
+        $this->assertTrue($form->isValid());
     }
 
     public function testEmptyValuePasses(): void
@@ -64,7 +64,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => '', 'cc' => '', 'bcc' => '']);
 
-        self::assertTrue($form->isValid());
+        $this->assertTrue($form->isValid());
     }
 
     public function testInvalidEmailFails(): void
@@ -72,7 +72,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => 'notanemail', 'cc' => '', 'bcc' => '']);
 
-        self::assertFalse($form->isValid());
+        $this->assertFalse($form->isValid());
     }
 
     public function testZeroValueFails(): void
@@ -80,7 +80,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => '0', 'cc' => '', 'bcc' => '']);
 
-        self::assertFalse($form->isValid());
+        $this->assertFalse($form->isValid());
     }
 
     public function testOneInvalidEmailInListFails(): void
@@ -88,7 +88,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => 'valid@example.com,notanemail', 'cc' => '', 'bcc' => '']);
 
-        self::assertFalse($form->isValid());
+        $this->assertFalse($form->isValid());
     }
 
     public function testCcAndBccFieldsAlsoValidate(): void
@@ -96,7 +96,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
         $form = $this->factory->create(ToBcBccStubFormType::class);
         $form->submit(['to' => '', 'cc' => 'invalid', 'bcc' => 'also-invalid']);
 
-        self::assertFalse($form->isValid());
+        $this->assertFalse($form->isValid());
     }
 }
 

--- a/app/bundles/CoreBundle/Tests/Form/Type/LookupTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/Type/LookupTypeTest.php
@@ -19,7 +19,7 @@ final class LookupTypeTest extends TypeTestCase
         $form = $this->factory->create(LookupType::class, null, ['attr' => $attributes]);
         $view = $form->createView();
 
-        self::assertSame($expected, $view->vars['attr']);
+        $this->assertSame($expected, $view->vars['attr']);
     }
 
     public static function provideLookupAttributes(): \Generator

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
@@ -183,7 +183,7 @@ final class MessageOfTheDayCommandTest extends MauticMysqlTestCase
         touch($this->cachePath, time() - 7200);
 
         $httpClient = static::getContainer()->get(HttpClientInterface::class);
-        self::assertInstanceOf(MockHttpClient::class, $httpClient);
+        $this->assertInstanceOf(MockHttpClient::class, $httpClient);
         $httpClient->setResponseFactory([
             new MockResponse('', ['http_code' => 500]),
         ]);

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -511,17 +511,14 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         $content = \json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
-        self::assertCount(2, $content, $response->getContent());
-        self::assertArrayHasKey('success', $content);
-        self::assertSame(0, $content['success']);
-        self::assertArrayHasKey('error', $content);
+        $this->assertCount(2, $content, $response->getContent());
+        $this->assertArrayHasKey('success', $content);
+        $this->assertSame(0, $content['success']);
+        $this->assertArrayHasKey('error', $content);
         // Check the logged/displayed URL has no auth details.
-        self::assertStringStartsWith(
-            'Automatically fetching the IP lookup data failed. Download https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz, extract if necessary, and upload to',
-            $content['error']
-        );
+        $this->assertStringStartsWith('Automatically fetching the IP lookup data failed. Download https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz, extract if necessary, and upload to', $content['error']);
 
-        self::assertCount(0, $mockHandler);
+        $this->assertCount(0, $mockHandler);
     }
 
     public function testGetIpLookupForm(): void
@@ -542,13 +539,13 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         $content = \json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
-        self::assertCount(2, $content);
-        self::assertArrayHasKey('attribution', $content);
-        self::assertArrayHasKey('html', $content);
-        self::assertIsString($content['html']);
-        self::assertStringContainsString('ip_lookup_config', $content['html']);
+        $this->assertCount(2, $content);
+        $this->assertArrayHasKey('attribution', $content);
+        $this->assertArrayHasKey('html', $content);
+        $this->assertIsString($content['html']);
+        $this->assertStringContainsString('ip_lookup_config', $content['html']);
 
-        self::assertStringNotContainsString('_token', $content['html']);
+        $this->assertStringNotContainsString('_token', $content['html']);
     }
 
     private function loginOtherUser(string $name): void

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -66,7 +66,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
         /** @var PathsHelper $pathsHelper */
         $pathsHelper = static::getContainer()->get('mautic.helper.paths');
         $folderPath  = "{$pathsHelper->getImagePath()}/{$this->folderName}";
-        self::assertDirectoryExists($folderPath);
-        self::assertSame('777', substr(sprintf('%o', fileperms($folderPath)), -3));
+        $this->assertDirectoryExists($folderPath);
+        $this->assertSame('777', substr(sprintf('%o', fileperms($folderPath)), -3));
     }
 }

--- a/app/bundles/CoreBundle/Tests/IpLookup/MaxmindDownloadLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/IpLookup/MaxmindDownloadLookupTest.php
@@ -21,7 +21,7 @@ final class MaxmindDownloadLookupTest extends TestCase
 
         $lookup = new MaxmindDownloadLookup($auth, logger: $logger);
 
-        self::assertSame('', $lookup->getRemoteDateStoreDownloadUrl());
+        $this->assertSame('', $lookup->getRemoteDateStoreDownloadUrl());
     }
 
     public static function provideMissingOrWrongAuth(): \Generator
@@ -41,7 +41,7 @@ final class MaxmindDownloadLookupTest extends TestCase
 
         $lookup = new MaxmindDownloadLookup($auth, logger: $logger);
 
-        self::assertSame('https://'.$auth.'@download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz', $lookup->getRemoteDateStoreDownloadUrl());
+        $this->assertSame('https://'.$auth.'@download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz', $lookup->getRemoteDateStoreDownloadUrl());
     }
 
     public static function provideProperAuth(): \Generator

--- a/app/bundles/CoreBundle/Tests/Twig/StringExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/StringExtensionTest.php
@@ -33,34 +33,34 @@ final class StringExtensionTest extends TestCase
     {
         $result = $this->extension->createUnicodeString('Hello World');
 
-        self::assertSame('Hello World', $result->toString());
+        $this->assertSame('Hello World', $result->toString());
     }
 
     public function testUFilterInTwig(): void
     {
         $result = $this->twig->render('upper');
 
-        self::assertSame('HELLO WORLD', $result);
+        $this->assertSame('HELLO WORLD', $result);
     }
 
     public function testTruncateInTwig(): void
     {
         $result = $this->twig->render('truncate');
 
-        self::assertSame('This is...', $result);
+        $this->assertSame('This is...', $result);
     }
 
     public function testSlugFilter(): void
     {
         $result = $this->twig->render('slug');
 
-        self::assertSame('Hello-World', $result);
+        $this->assertSame('Hello-World', $result);
     }
 
     public function testGetFiltersContainsUFilter(): void
     {
         $filterNames = array_map(static fn (\Twig\TwigFilter $filter): string => $filter->getName(), $this->extension->getFilters());
 
-        self::assertContains('u', $filterNames);
+        $this->assertContains('u', $filterNames);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
@@ -179,7 +179,7 @@ final class CommonRepositoryTest extends \PHPUnit\Framework\TestCase
         ];
 
         foreach ($expectedValues as $expectedValue) {
-            self::assertSame($expectedValue, $this->repo->generateRandomParameterName());
+            $this->assertSame($expectedValue, $this->repo->generateRandomParameterName());
         }
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/ErrorHandler/ErrorHandlerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/ErrorHandler/ErrorHandlerTest.php
@@ -56,15 +56,15 @@ final class ErrorHandlerTest extends TestCase
 
         $content = $handler->handleException(new \RuntimeException('boom'), true);
 
-        self::assertIsString($content);
+        $this->assertIsString($content);
         // With the buggy relative paths, Twig's FilesystemLoader would have
         // thrown a LoaderError before any template was rendered, and the
         // catch block in generateResponse would have returned that message.
-        self::assertStringContainsString('<!DOCTYPE html>', $content);
-        self::assertStringContainsString('<div class="container">', $content);
-        self::assertStringContainsString('<div class="alert alert-danger">', $content);
-        self::assertStringContainsString('<div id="previous"></div>', $content);
-        self::assertStringNotContainsString(\Twig\Error\LoaderError::class, $content);
-        self::assertStringNotContainsString('directory does not exist', $content);
+        $this->assertStringContainsString('<!DOCTYPE html>', $content);
+        $this->assertStringContainsString('<div class="container">', $content);
+        $this->assertStringContainsString('<div class="alert alert-danger">', $content);
+        $this->assertStringContainsString('<div id="previous"></div>', $content);
+        $this->assertStringNotContainsString(\Twig\Error\LoaderError::class, $content);
+        $this->assertStringNotContainsString('directory does not exist', $content);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -96,7 +96,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
 
     public function testGetBlockPrefix(): void
     {
-        self::assertSame('content_preview_settings', $this->form->getBlockPrefix());
+        $this->assertSame('content_preview_settings', $this->form->getBlockPrefix());
     }
 
     public function testBuildFormWithTranslationAndVariantFieldNotAvailable(): void
@@ -111,7 +111,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                 'children' => [],
             ],
         ];
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
 
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {
@@ -136,7 +136,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             ->willReturnCallback(
                 function (...$parameters) use ($matcher, $builder): MockObject {
                     if (1 === $matcher->numberOfInvocations()) {
-                        self::assertEquals($this->contactFieldDefinition, $parameters);
+                        $this->assertEquals($this->contactFieldDefinition, $parameters);
                     }
 
                     return $builder;
@@ -146,7 +146,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
         $this->security->expects($this->once())
             ->method('isAdmin')
             ->willReturn(true);
-        $this->security->expects(self::never())
+        $this->security->expects($this->never())
             ->method('hasEntityAccess');
 
         $this->form->buildForm($builder, $options);
@@ -185,7 +185,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             ->willReturn(false);
 
         $builder = $this->createMock(FormBuilderInterface::class);
-        $builder->expects(self::never())
+        $builder->expects($this->never())
             ->method('add');
         $this->form->buildForm($builder, $options);
     }
@@ -206,9 +206,9 @@ final class ContentPreviewSettingsTypeTest extends TestCase
         $this->security->expects($this->once())
             ->method('isAdmin')
             ->willReturn(true);
-        $this->security->expects(self::never())
+        $this->security->expects($this->never())
             ->method('hasEntityAccess');
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
 
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {
@@ -233,7 +233,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             ->willReturnCallback(
                 function (...$parameters) use ($matcher, $builder): MockObject {
                     if (1 === $matcher->numberOfInvocations()) {
-                        self::assertEquals($this->contactFieldDefinition, $parameters);
+                        $this->assertEquals($this->contactFieldDefinition, $parameters);
                     }
 
                     return $builder;
@@ -274,7 +274,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             ->method('hasEntityAccess')
             ->with('lead:leads:viewown', 'lead:leads:viewother', $userId)
             ->willReturn(true);
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
 
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {
@@ -299,7 +299,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             ->willReturnCallback(
                 function (...$parameters) use ($matcher, $builder): MockObject {
                     if (1 === $matcher->numberOfInvocations()) {
-                        self::assertEquals($this->contactFieldDefinition, $parameters);
+                        $this->assertEquals($this->contactFieldDefinition, $parameters);
                     }
 
                     return $builder;
@@ -368,9 +368,9 @@ final class ContentPreviewSettingsTypeTest extends TestCase
         $this->security->expects($this->once())
             ->method('isAdmin')
             ->willReturn(true);
-        $this->security->expects(self::never())
+        $this->security->expects($this->never())
             ->method('hasEntityAccess');
-        $matcher = self::exactly(4);
+        $matcher = $this->exactly(4);
 
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {
@@ -399,7 +399,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
             });
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
-        $matcher     = self::exactly(3);
+        $matcher     = $this->exactly(3);
         $formBuilder->expects($matcher)
             ->method('add')->willReturnCallback(function (...$parameters) use ($matcher, $expectedTranslationChoices, $parentEmailId, $expectedVariantChoices, $formBuilder): MockObject {
                 if (1 === $matcher->numberOfInvocations()) {
@@ -427,7 +427,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                     ], $parameters[2]);
                 }
                 if (3 === $matcher->numberOfInvocations()) {
-                    self::assertEquals($this->contactFieldDefinition, $parameters);
+                    $this->assertEquals($this->contactFieldDefinition, $parameters);
                 }
 
                 return $formBuilder;

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/DynamicContentFilterEntryFiltersTypeTest.php
@@ -28,7 +28,7 @@ final class DynamicContentFilterEntryFiltersTypeTest extends TestCase
     public function testBuildForm(): void
     {
         $builder = $this->createMock(FormBuilderInterface::class);
-        $matcher = self::exactly(4);
+        $matcher = $this->exactly(4);
         $builder->expects($matcher)
             ->method('add')->willReturnCallback(function (...$parameters) use ($matcher, $builder): MockObject {
                 if (1 === $matcher->numberOfInvocations()) {
@@ -82,7 +82,7 @@ final class DynamicContentFilterEntryFiltersTypeTest extends TestCase
 
     public function testGetBlockPrefix(): void
     {
-        self::assertSame('dynamic_content_filter_entry_filters', $this->form->getBlockPrefix());
+        $this->assertSame('dynamic_content_filter_entry_filters', $this->form->getBlockPrefix());
     }
 
     public function testConfigureOptions(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
@@ -302,10 +302,7 @@ final class ChartQueryTest extends TestCase
     private function assertTimeDataWithoutSqlOrder(array $expectedResult, array $data): void
     {
         $this->createChartQuery();
-        self::assertSame(
-            $expectedResult,
-            $this->chartQuery->completeTimeData($data)
-        );
+        $this->assertSame($expectedResult, $this->chartQuery->completeTimeData($data));
     }
 
     public function testPrepareTimeDataQueryWithLeadEventLog(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
@@ -128,8 +128,8 @@ final class ImportHelperTest extends TestCase
         $zipFilePath   = $this->exportHelper->writeToZipFile($jsonOutput, $assetList, '');
         $this->paths[] = $zipFilePath;
 
-        self::assertFileExists($zipFilePath);
+        $this->assertFileExists($zipFilePath);
 
-        self::assertSame($jsonData, $this->importHelper->readZipFile($zipFilePath));
+        $this->assertSame($jsonData, $this->importHelper->readZipFile($zipFilePath));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UrlHelperTest.php
@@ -111,7 +111,7 @@ final class UrlHelperTest extends \PHPUnit\Framework\TestCase
     #[DataProvider('provideUrlsForSanitizeQueryParameters')]
     public function testSanitizeQueryParameters(string $url, string $expected): void
     {
-        self::assertSame($expected, UrlHelper::sanitizeAbsoluteUrl($url));
+        $this->assertSame($expected, UrlHelper::sanitizeAbsoluteUrl($url));
     }
 
     public static function provideUrlsForSanitizeQueryParameters(): \Generator

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
@@ -215,7 +215,7 @@ final class DashboardControllerTest extends \PHPUnit\Framework\TestCase
             ->with((int) $widgetId)
             ->willReturn(null);
 
-        $this->containerMock->expects(self::never())
+        $this->containerMock->expects($this->never())
             ->method('get');
 
         $this->expectException(NotFoundHttpException::class);
@@ -247,6 +247,6 @@ final class DashboardControllerTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->controller->widgetAction($this->requestMock, $widgetService, $twig, $widgetId);
 
-        self::assertSame('{"success":1,"widgetId":"1","widgetHtml":"lfsadkdhf\u016fasfjds","widgetWidth":null,"widgetHeight":null}', $response->getContent());
+        $this->assertSame('{"success":1,"widgetId":"1","widgetHtml":"lfsadkdhf\u016fasfjds","widgetWidth":null,"widgetHeight":null}', $response->getContent());
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -81,7 +81,7 @@ final class AjaxControllerTest extends \PHPUnit\Framework\TestCase
             ->method('has')
             ->with('parameter_bag')
             ->willReturn(true);
-        $containerMock->expects(self::once())
+        $containerMock->expects($this->once())
             ->method('get')
             ->with('parameter_bag')
             ->willReturn($parameterBag);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -266,7 +266,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/new');
         $html    = $crawler->filterXPath("//select[@id='emailform_segmentTranslationParent']//optgroup")->html();
-        self::assertSame('<option value="'.$email->getId().'">'.$email->getName().' ('.$email->getId().')</option>', trim($html));
+        $this->assertSame('<option value="'.$email->getId().'">'.$email->getName().' ('.$email->getId().')</option>', trim($html));
     }
 
     public function testSegmentEmailVariationChildrenParents(): void

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -66,7 +66,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        self::assertCount(1, $formCrawler);
+        $this->assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues(['example_send[emails][list][0]' => 'admin@yoursite.com']);
         $this->client->submit($form);
@@ -138,7 +138,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         $crawler     = $this->client->request(Request::METHOD_GET, "/s/emails/sendExample/{$email->getId()}");
         $formCrawler = $crawler->filter('form[name=example_send]');
-        self::assertCount(1, $formCrawler);
+        $this->assertCount(1, $formCrawler);
         $form = $formCrawler->form();
         $form->setValues(['example_send[emails][list][0]' => 'admin@yoursite.com']);
         $this->client->submit($form);
@@ -146,7 +146,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         self::assertResponseStatusCodeSame(Response::HTTP_OK, verbose: true);
 
         $message = self::getMailerMessagesByToAddress('admin@yoursite.com')[0];
-        self::assertInstanceOf(MauticMessage::class, $message);
+        $this->assertInstanceOf(MauticMessage::class, $message);
 
         Assert::assertSame('[TEST] [TEST] Email subject', $message->getSubject());
         Assert::assertStringContainsString('Contact emails is [Email]. Company details: [Company Name], [City].', $message->getBody()->toString());
@@ -169,7 +169,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         );
         $response = $this->client->getResponse()->getContent();
         self::assertResponseStatusCodeSame(201, $response);
-        self::assertJson($response);
+        $this->assertJson($response);
 
         // Create email with dynamic content variant
         $email          = $this->createEmail();
@@ -241,7 +241,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         );
         $response = $this->client->getResponse()->getContent();
         self::assertResponseStatusCodeSame(201, $response);
-        self::assertJson($response);
+        $this->assertJson($response);
 
         // Create email with dynamic content variant
         $email          = $this->createEmail();
@@ -333,7 +333,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
         );
         $response = $this->client->getResponse()->getContent();
         self::assertResponseStatusCodeSame(201, $response);
-        self::assertJson($response);
+        $this->assertJson($response);
 
         // Create email with dynamic content variant
         $email          = $this->createEmail();

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -104,7 +104,7 @@ final class EmailSendFunctionalTest extends MauticMysqlTestCase
 
         // malform click through parameter
         parse_str($urlParts['query'], $queryParams);
-        self::assertArrayHasKey('ct', $queryParams);
+        $this->assertArrayHasKey('ct', $queryParams);
         $queryParams['ct'] = substr($queryParams['ct'], 0, -5);
 
         $this->requestUrl($urlParts['path'], $queryParams);
@@ -116,7 +116,7 @@ final class EmailSendFunctionalTest extends MauticMysqlTestCase
         $urlParts = $this->sendEmailToContact('https://localhost/email-{contactfield=email}/link');
 
         parse_str($urlParts['query'], $queryParams);
-        self::assertArrayHasKey('ct', $queryParams);
+        $this->assertArrayHasKey('ct', $queryParams);
 
         $this->requestUrl($urlParts['path'], $queryParams);
         self::assertResponseRedirects('/email-contact-flood-0@doe.com/link');

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -59,7 +59,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, $url);
         self::assertResponseIsSuccessful();
         foreach ($expectedContents as $expectedContent) {
-            self::assertStringContainsString($expectedContent, $crawler->text());
+            $this->assertStringContainsString($expectedContent, $crawler->text());
         }
     }
 
@@ -147,7 +147,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
             ]
         );
         self::assertResponseStatusCodeSame(201);
-        self::assertJson($this->client->getResponse()->getContent());
+        $this->assertJson($this->client->getResponse()->getContent());
 
         // Create some contacts
         $this->client->request(
@@ -245,7 +245,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
     {
         $crawler = $this->client->request(Request::METHOD_GET, '/email/preview/5009');
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
-        self::assertStringContainsString('404 Not Found - Requested URL not found: /email/preview/5009', $crawler->text());
+        $this->assertStringContainsString('404 Not Found - Requested URL not found: /email/preview/5009', $crawler->text());
     }
 
     private function createSegment(string $name = 'Segment 1'): LeadList

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -27,27 +27,18 @@ final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
         $mainPageId = $emailMain->getId();
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/emails');
-        self::assertStringContainsString($emailMain->getName(), $crawler->text());
+        $this->assertStringContainsString($emailMain->getName(), $crawler->text());
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/view/{$mainPageId}");
 
         // Translation choice is not visible
-        self::assertCount(
-            0,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]')
-        );
+        $this->assertCount(0, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]'));
 
         // Variant choice is not visible
-        self::assertCount(
-            0,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]')
-        );
+        $this->assertCount(0, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]'));
 
         // Contact lookup is not visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_contact"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_contact"]'));
 
         $emailTranslated = new Email();
         $emailTranslated->setIsPublished(true);
@@ -82,31 +73,16 @@ final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/view/{$mainPageId}");
 
         // Translation choice is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]'));
 
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]/option[@value="'.$emailTranslated->getId().'"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]/option[@value="'.$emailTranslated->getId().'"]'));
 
         // Variant choice is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]'));
 
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]/option[@value="'.$emailVariant->getId().'"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]/option[@value="'.$emailVariant->getId().'"]'));
 
         // Contact lookup is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_contact"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_contact"]'));
     }
 }

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -95,7 +95,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
 
-        self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
+        $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
     }
 
     public function testContactPreferencesLandingPageTracking(): void
@@ -159,7 +159,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
+        $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
         $this->assertResponseIsSuccessful();
     }
 
@@ -173,7 +173,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        self::assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
+        $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
         $this->assertResponseIsSuccessful();
     }
 
@@ -187,7 +187,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        self::assertStringNotContainsString('form/submit?formId=', $crawler->html());
+        $this->assertStringNotContainsString('form/submit?formId=', $crawler->html());
         $this->assertResponseIsSuccessful();
     }
 

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -306,11 +306,8 @@ final class EmailRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($this->repo, $qb, $filter);
 
-        self::assertSame(
-            '(e.isPublished = :par1 AND e.publishDown IS NOT NULL AND e.publishDown <> \'\' AND e.publishDown < CURRENT_TIMESTAMP())',
-            (string) $expr
-        );
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame('(e.isPublished = :par1 AND e.publishDown IS NOT NULL AND e.publishDown <> \'\' AND e.publishDown < CURRENT_TIMESTAMP())', (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     public function testAddSearchCommandWhereClauseHandlesPendingFilters(): void
@@ -322,17 +319,14 @@ final class EmailRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($this->repo, $qb, $filter);
 
-        self::assertSame(
-            '(e.isPublished = :par1 AND e.publishUp IS NOT NULL AND e.publishUp <> \'\' AND e.publishUp > CURRENT_TIMESTAMP())',
-            (string) $expr
-        );
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame('(e.isPublished = :par1 AND e.publishUp IS NOT NULL AND e.publishUp <> \'\' AND e.publishUp > CURRENT_TIMESTAMP())', (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     public function testGetSearchCommandsContainsExpirationFilters(): void
     {
         $commands = $this->repo->getSearchCommands();
-        self::assertContains('mautic.email.email.searchcommand.isexpired', $commands);
-        self::assertContains('mautic.email.email.searchcommand.ispending', $commands);
+        $this->assertContains('mautic.email.email.searchcommand.isexpired', $commands);
+        $this->assertContains('mautic.email.email.searchcommand.ispending', $commands);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Entity/StatRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatRepositoryFunctionalTest.php
@@ -32,7 +32,7 @@ final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->createStat($childEmail, '2026-03-20 09:00:00');
         $this->em->flush();
 
-        self::assertSame('2026-03-20 09:00:00', $this->statRepository->getEmailSentLastDate((int) $parentEmail->getId()));
+        $this->assertSame('2026-03-20 09:00:00', $this->statRepository->getEmailSentLastDate((int) $parentEmail->getId()));
     }
 
     public function testGetEmailSentLastDateReturnsNullWithoutStats(): void
@@ -40,7 +40,7 @@ final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
         $email = $this->createEmail('No stats email', 'No stats subject');
         $this->em->flush();
 
-        self::assertNull($this->statRepository->getEmailSentLastDate((int) $email->getId()));
+        $this->assertNull($this->statRepository->getEmailSentLastDate((int) $email->getId()));
     }
 
     private function createEmail(string $name, string $subject): Email

--- a/app/bundles/EmailBundle/Tests/Entity/StatRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatRepositoryTest.php
@@ -126,12 +126,12 @@ final class StatRepositoryTest extends \PHPUnit\Framework\TestCase
         $this->connection->expects($this->once())
             ->method('executeQuery')
             ->willReturnCallback(function (string $sql, array $params = [], array $types = []) {
-                self::assertStringContainsString('SELECT s.id AS id, s.lead_id AS lead_id, s.email_address AS email_address, s.is_read AS is_read, s.email_id AS email_id, s.date_sent AS date_sent, s.date_read AS date_read, e.name AS email_name, c.id AS company_id, c.companyname AS company_name, campaign.id AS campaign_id, campaign.name AS campaign_name, ll.id AS segment_id, ll.name AS segment_name, COUNT(ph.id) AS link_hits', $sql);
-                self::assertStringContainsString('LEFT JOIN test_companies_leads cl ON s.lead_id = cl.lead_id AND cl.is_primary = 1', $sql);
-                self::assertStringContainsString('GROUP BY s.id, s.lead_id, s.email_address, s.is_read, s.email_id, s.date_sent, s.date_read, e.name, c.id, c.companyname, campaign.id, campaign.name, ll.id, ll.name', $sql);
-                self::assertStringNotContainsString('GROUP BY s.id AS', $sql);
-                self::assertSame('2026-03-01 00:00:00', $params['dateFrom']);
-                self::assertSame('2026-03-31 23:59:59', $params['dateTo']);
+                $this->assertStringContainsString('SELECT s.id AS id, s.lead_id AS lead_id, s.email_address AS email_address, s.is_read AS is_read, s.email_id AS email_id, s.date_sent AS date_sent, s.date_read AS date_read, e.name AS email_name, c.id AS company_id, c.companyname AS company_name, campaign.id AS campaign_id, campaign.name AS campaign_name, ll.id AS segment_id, ll.name AS segment_name, COUNT(ph.id) AS link_hits', $sql);
+                $this->assertStringContainsString('LEFT JOIN test_companies_leads cl ON s.lead_id = cl.lead_id AND cl.is_primary = 1', $sql);
+                $this->assertStringContainsString('GROUP BY s.id, s.lead_id, s.email_address, s.is_read, s.email_id, s.date_sent, s.date_read, e.name, c.id, c.companyname, campaign.id, campaign.name, ll.id, ll.name', $sql);
+                $this->assertStringNotContainsString('GROUP BY s.id AS', $sql);
+                $this->assertSame('2026-03-01 00:00:00', $params['dateFrom']);
+                $this->assertSame('2026-03-31 23:59:59', $params['dateTo']);
 
                 return $this->result;
             });

--- a/app/bundles/EmailBundle/Tests/EventListener/BroadcastSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BroadcastSubscriberFunctionalTest.php
@@ -67,7 +67,7 @@ final class BroadcastSubscriberFunctionalTest extends MauticMysqlTestCase
         $event->setMaxThreads(1);
 
         $subscriber = self::getContainer()->get(BroadcastSubscriber::class);
-        self::assertInstanceOf(BroadcastSubscriber::class, $subscriber);
+        $this->assertInstanceOf(BroadcastSubscriber::class, $subscriber);
 
         $subscriber->onBroadcast($event);
         $results = $event->getResults();

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -270,7 +270,7 @@ CONTENT,
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $coreParametersHelper->method('get')

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -130,11 +130,11 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $this->filter[0]['operator'] = 'startsWith';
         $this->filter[0]['filter']   = 'my';
 
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
 
         $this->lead['custom'] = 'another text';
 
-        self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
 
     public function testDWCContactWithRegex(): void
@@ -143,7 +143,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $this->filter[0]['operator'] = 'regexp';
         $this->filter[0]['filter']   = '(13357|04249|20363)';
 
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
 
     public function testDWCContactEndWidth(): void
@@ -151,11 +151,11 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $this->filter[0]['operator'] = 'endsWith';
         $this->filter[0]['filter']   = 'text';
 
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
 
         $this->lead['custom'] = 'another words';
 
-        self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
 
     public function testDWCContactContains(): void
@@ -163,11 +163,11 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $this->filter[0]['operator'] = 'contains';
         $this->filter[0]['filter']   = 'custom';
 
-        self::assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertTrue($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
 
         $this->lead['custom'] = 'another words';
 
-        self::assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
+        $this->assertFalse($this->matchFilterForLeadTrait->match($this->filter, $this->lead));
     }
 
     public function testMatchFilterForLeadWithNumberType(): void
@@ -318,7 +318,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     /**
@@ -517,7 +517,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidIn(): void
@@ -550,7 +550,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidNotIn(): void
@@ -583,7 +583,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidInAll(): void
@@ -616,7 +616,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidNotInAll(): void
@@ -649,7 +649,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $trait = new MatchFilterForLeadTraitTestable();
         $trait->setRepository($segmentRepository);
 
-        self::assertTrue($trait->match($filter, $lead));
+        $this->assertTrue($trait->match($filter, $lead));
     }
 
     public function testIsContactSegmentRelationshipValidInvalidOperator(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/PointSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/PointSubscriberFunctionalTest.php
@@ -49,8 +49,8 @@ final class PointSubscriberFunctionalTest extends MauticMysqlTestCase
         $event = new EmailSendEvent(null, ['email' => $email, 'lead' => $leadArray]);
 
         $dispatcher = self::getContainer()->get('event_dispatcher');
-        self::assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
-        self::assertSame($deletedLeadId, $event->getLead()['id']);
+        $this->assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
+        $this->assertSame($deletedLeadId, $event->getLead()['id']);
 
         $dispatcher->dispatch($event, EmailEvents::EMAIL_ON_SEND);
     }

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -57,7 +57,7 @@ final class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $requestStack = new RequestStack();
         $themeHelper  = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $mailHashHelper = new MailHashHelper($coreParametersHelper);

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -51,7 +51,7 @@ final class ExampleSendTypeTest extends TestCase
     {
         $userId  = 37;
         $builder = $this->createMock(FormBuilderInterface::class);
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
         $builder->expects($matcher)
             ->method('add')->willReturnCallback(function (...$parameters) use ($matcher, $builder): MockObject {
                 if (1 === $matcher->numberOfInvocations()) {
@@ -101,7 +101,7 @@ final class ExampleSendTypeTest extends TestCase
     public function testBuildFormWithContact(): void
     {
         $userId  = 37;
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {
                 if (1 === $matcher->numberOfInvocations()) {
@@ -119,7 +119,7 @@ final class ExampleSendTypeTest extends TestCase
             });
 
         $builder = $this->createMock(FormBuilderInterface::class);
-        $matcher = self::exactly(4);
+        $matcher = $this->exactly(4);
         $builder->expects($matcher)
             ->method('add')->willReturnCallback(function (...$parameters) use ($matcher, $builder): MockObject {
                 if (1 === $matcher->numberOfInvocations()) {

--- a/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
@@ -60,9 +60,9 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         $emails = $data['member'];
-        self::assertCount(1, $emails, 'Expected exactly 1 email');
-        self::assertSame($restrictedUserEmail->getId(), $emails[0]['id']);
-        self::assertSame('Restricted User Email', $emails[0]['name']);
+        $this->assertCount(1, $emails, 'Expected exactly 1 email');
+        $this->assertSame($restrictedUserEmail->getId(), $emails[0]['id']);
+        $this->assertSame('Restricted User Email', $emails[0]['name']);
     }
 
     public function testViewOwnCollectionReportsOwnedTotalAcrossPagesOnApiV2(): void
@@ -121,14 +121,14 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertArrayHasKey('member', $page1Data);
-        self::assertArrayHasKey('totalItems', $page1Data);
-        self::assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned emails');
-        self::assertCount(4, $page1Data['member'], 'Should return all 4 owned emails on single page');
+        $this->assertArrayHasKey('member', $page1Data);
+        $this->assertArrayHasKey('totalItems', $page1Data);
+        $this->assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned emails');
+        $this->assertCount(4, $page1Data['member'], 'Should return all 4 owned emails on single page');
 
         // Verify all items belong to restricted user
         foreach ($page1Data['member'] as $email) {
-            self::assertStringStartsWith('Restricted User Email', $email['name']);
+            $this->assertStringStartsWith('Restricted User Email', $email['name']);
         }
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -625,17 +625,14 @@ final class MailHelperTest extends TestCase
 
         $mailer->flushQueue([]);
 
-        self::assertEmpty($mailer->getErrors()['failures']);
+        $this->assertEmpty($mailer->getErrors()['failures']);
 
         $fromAddresses = $transport->getFromAddresses();
         $metadatas     = $transport->getMetadatas();
 
         $this->assertCount(3, $fromAddresses);
         $this->assertCount(3, $metadatas);
-        self::assertSame(
-            ['owner1@owner.com', 'nobody@nowhere.com', 'owner2@owner.com'],
-            $fromAddresses
-        );
+        $this->assertSame(['owner1@owner.com', 'nobody@nowhere.com', 'owner2@owner.com'], $fromAddresses);
     }
 
     public function testGlobalFromThatAllFromAddressesAreTheSame(): void
@@ -1532,20 +1529,17 @@ final class MailHelperTest extends TestCase
             $realHeaders[$header->getName()] = $header->getBodyAsString();
         }
 
-        self::assertSame(
-            $realHeaders,
-            [
-                'To'                    => 'contact1@somewhere.com',
-                'From'                  => 'No Body <nobody@nowhere.com>',
-                'Sender'                => 'No Body <nobody@nowhere.com>',
-                'Reply-To'              => 'nobody@nowhere.com',
-                'Subject'               => 'Test',
-                'X-Mautic-Test-2'       => MailHelper::getBlankPixel(),
-                'X-Mautic-Test-1'       => MailHelper::getBlankPixel(),
-                'List-Unsubscribe'      => '<{unsubscribe_url}>',
-                'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
-            ]
-        );
+        $this->assertSame($realHeaders, [
+            'To'                    => 'contact1@somewhere.com',
+            'From'                  => 'No Body <nobody@nowhere.com>',
+            'Sender'                => 'No Body <nobody@nowhere.com>',
+            'Reply-To'              => 'nobody@nowhere.com',
+            'Subject'               => 'Test',
+            'X-Mautic-Test-2'       => MailHelper::getBlankPixel(),
+            'X-Mautic-Test-1'       => MailHelper::getBlankPixel(),
+            'List-Unsubscribe'      => '<{unsubscribe_url}>',
+            'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
+        ]);
     }
 
     public function testThatHtmlIsCorrectlyProcessedWhenTheAreEmbeddedImages(): void
@@ -2075,7 +2069,7 @@ final class MailHelperTest extends TestCase
         $mailer->addTo($this->contacts[0]['email']);
 
         $onSendDispatchCount = 0;
-        $eventDispatcher->expects(self::atLeastOnce())
+        $eventDispatcher->expects($this->atLeastOnce())
             ->method('dispatch')
             ->willReturnCallback(function (object $event, ?string $eventName = null) use (&$onSendDispatchCount): object {
                 if ($event instanceof EmailSendEvent && EmailEvents::EMAIL_ON_SEND === $eventName) {

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
@@ -22,6 +22,6 @@ final class EmailModelBuildUrlTest extends MauticMysqlTestCase
         $idHash     = uniqid();
         $url        = $emailModel->buildUrl('mautic_email_unsubscribe', ['idHash' => $idHash]);
 
-        self::assertSame('https://foo.bar.com/email/unsubscribe/'.$idHash, $url);
+        $this->assertSame('https://foo.bar.com/email/unsubscribe/'.$idHash, $url);
     }
 }

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -270,8 +270,8 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         $parentEmail->setName('Test change');
         $this->emailModel->saveEntity($parentEmail);
 
-        self::assertSame($customHtmlParent, $parentEmail->getCustomHtml());
-        self::assertSame($customHtmlChildren, $childrenEmail->getCustomHtml());
+        $this->assertSame($customHtmlParent, $parentEmail->getCustomHtml());
+        $this->assertSame($customHtmlChildren, $childrenEmail->getCustomHtml());
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -999,8 +999,8 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->getEmailListStats($lists);
 
-        self::assertCount(1, $result['datasets']);
-        self::assertEquals(self::SEGMENT_A, $result['datasets'][0]['label']);
+        $this->assertCount(1, $result['datasets']);
+        $this->assertEquals(self::SEGMENT_A, $result['datasets'][0]['label']);
     }
 
     public function testGetEmailListStatsTwoSegments(): void
@@ -1015,9 +1015,9 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->getEmailListStats($lists);
 
-        self::assertCount(3, $result['datasets']);
-        self::assertEquals(self::SEGMENT_A, $result['datasets'][1]['label']);
-        self::assertEquals(self::SEGMENT_B, $result['datasets'][2]['label']);
+        $this->assertCount(3, $result['datasets']);
+        $this->assertEquals(self::SEGMENT_A, $result['datasets'][1]['label']);
+        $this->assertEquals(self::SEGMENT_B, $result['datasets'][2]['label']);
     }
 
     /**

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -250,7 +250,7 @@ final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         );
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
@@ -383,7 +383,7 @@ final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $mailHelper = $this->getMockBuilder(MailHelper::class)
@@ -466,7 +466,7 @@ final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
             ->willReturn(new AddressDTO('someone@somewhere.com'));
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
@@ -584,7 +584,7 @@ final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $routerMock = $this->createStub(Router::class);
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
@@ -689,7 +689,7 @@ final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
         $twig = $this->createStub(Environment::class);
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $coreParametersHelper->expects($this->atLeast(3))->method('get')

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -93,7 +93,7 @@ final class ReplyTest extends \PHPUnit\Framework\TestCase
         $this->emailStatModel->expects($this->once())
             ->method('saveEntity');
 
-        $this->leadRepository->expects(self::atLeastOnce())
+        $this->leadRepository->expects($this->atLeastOnce())
             ->method('detachEntity');
 
         $this->contactFinder->method('findByHash')

--- a/app/bundles/FormBundle/Tests/DTO/TokenDtoTest.php
+++ b/app/bundles/FormBundle/Tests/DTO/TokenDtoTest.php
@@ -49,6 +49,6 @@ final class TokenDtoTest extends TestCase
     public function testToString(string $name, string|int $value, string $expected): void
     {
         $tokenDto = new TokenDto($name, $value);
-        self::assertSame($expected, $tokenDto->toString());
+        $this->assertSame($expected, $tokenDto->toString());
     }
 }

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -103,7 +103,7 @@ New line',
             ->setFields($this->getFormFields())
             ->setAction($action);
 
-        $this->mailer->expects(self::never())
+        $this->mailer->expects($this->never())
             ->method('send');
 
         $this->subscriber->onFormSubmitActionSendEmail($submissionEvent);
@@ -227,7 +227,7 @@ New line',
         $this->mailer->expects($this->once())
             ->method('send');
 
-        $this->mailer->expects(self::never())
+        $this->mailer->expects($this->never())
             ->method('setTo');
         $this->mailer->expects($this->once())
             ->method('setCc')
@@ -415,11 +415,11 @@ New line',
             ->setFields($this->getFormFields())
             ->setAction($action);
 
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('reset');
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('send');
-        $matcher = self::exactly(3);
+        $matcher = $this->exactly(3);
 
         $this->mailer->expects($matcher)
             ->method('setTo')->willReturnCallback(function (...$parameters) use ($matcher, $to, $leadEmail, $ownerEmail): true {
@@ -441,20 +441,20 @@ New line',
         $this->mailer->expects($this->once())
             ->method('setBcc')
             ->with([$bcc => null]);
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('setSubject')
             ->with($subject);
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('setBody')
             ->with($message);
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('parsePlainText')
             ->with($message);
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('addTokens')
             ->with($emailTokens);
 
-        $this->mailer->expects(self::exactly(3))
+        $this->mailer->expects($this->exactly(3))
             ->method('setLead');
 
         $this->subscriber->onFormSubmitActionSendEmail($submissionEvent);

--- a/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
@@ -49,8 +49,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
     }
 
     public function testFailsWhenNoSelectionsProvided(): void
@@ -67,8 +67,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, []);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
     }
 
     public function testFailsWhenValueIsNull(): void
@@ -85,8 +85,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, null);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('You must select at least 1 options.', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('You must select at least 1 options.', $event->getInvalidReason());
     }
 
     public function testFailsWhenAboveMaximum(): void
@@ -103,8 +103,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a', 'b', 'c', 'd']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('You cannot select more than 3 options.', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('You cannot select more than 3 options.', $event->getInvalidReason());
     }
 
     public function testValidWithinRange(): void
@@ -116,7 +116,7 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a', 'b']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertTrue($event->isValid());
+        $this->assertTrue($event->isValid());
     }
 
     public function testUsesCustomMinimumMessage(): void
@@ -131,8 +131,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('Custom minimum message', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('Custom minimum message', $event->getInvalidReason());
     }
 
     public function testUsesCustomMaximumMessage(): void
@@ -147,8 +147,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a', 'b', 'c']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('Custom maximum message', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('Custom maximum message', $event->getInvalidReason());
     }
 
     public function testFallsBackToDefaultMessageWhenCustomMessageEmpty(): void
@@ -168,8 +168,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, ['a']);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame(self::MINIMUM_TWO_OPTIONS_MESSAGE, $event->getInvalidReason());
     }
 
     public function testEmailDonotSubmitDomainPatternTriggersFailure(): void
@@ -194,8 +194,8 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, $email);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('Cannot be sent with this email', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('Cannot be sent with this email', $event->getInvalidReason());
     }
 
     public function testEmailBlockedFreeProviderTriggersFailure(): void
@@ -220,7 +220,7 @@ final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
         $event = new ValidationEvent($field, $email);
         $this->subscriber->onFormValidate($event);
 
-        self::assertFalse($event->isValid());
-        self::assertSame('Blocked free email provider', $event->getInvalidReason());
+        $this->assertFalse($event->isValid());
+        $this->assertSame('Blocked free email provider', $event->getInvalidReason());
     }
 }

--- a/app/bundles/FormBundle/Tests/Finder/Tokens/RedirectUrlTokensFinderTest.php
+++ b/app/bundles/FormBundle/Tests/Finder/Tokens/RedirectUrlTokensFinderTest.php
@@ -346,13 +346,13 @@ final class RedirectUrlTokensFinderTest extends TestCase
     #[DataProvider('provideUrlToCheck')]
     public function testHasTokens(string $url, bool $expected): void
     {
-        self::assertSame($expected, $this->redirectUrlTokensFinder->hasTokens($url));
+        $this->assertSame($expected, $this->redirectUrlTokensFinder->hasTokens($url));
     }
 
     #[DataProvider('provideUrlToReplace')]
     public function testReplaceTokensWithDummyData(string $url, string $expected): void
     {
-        self::assertSame($expected, $this->redirectUrlTokensFinder->replaceTokensWithDummyData($url));
+        $this->assertSame($expected, $this->redirectUrlTokensFinder->replaceTokensWithDummyData($url));
     }
 
     protected function setUp(): void

--- a/app/bundles/FormBundle/Tests/Helper/BlockedFreeEmailProvidersHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/BlockedFreeEmailProvidersHelperTest.php
@@ -14,9 +14,9 @@ final class BlockedFreeEmailProvidersHelperTest extends TestCase
     {
         $providers = BlockedFreeEmailProvidersHelper::load();
 
-        self::assertIsArray($providers);
-        self::assertNotEmpty($providers);
-        self::assertContainsOnly('string', $providers);
+        $this->assertIsArray($providers);
+        $this->assertNotEmpty($providers);
+        $this->assertContainsOnly('string', $providers);
     }
 
     public function testLoadReturnsArrayOfStrings(): void
@@ -24,8 +24,8 @@ final class BlockedFreeEmailProvidersHelperTest extends TestCase
         $providers = BlockedFreeEmailProvidersHelper::load();
 
         foreach ($providers as $provider) {
-            self::assertIsString($provider);
-            self::assertNotEmpty($provider);
+            $this->assertIsString($provider);
+            $this->assertNotEmpty($provider);
         }
     }
 
@@ -34,6 +34,6 @@ final class BlockedFreeEmailProvidersHelperTest extends TestCase
         $providers = BlockedFreeEmailProvidersHelper::load();
 
         // The JSON file should contain providers
-        self::assertGreaterThan(0, count($providers));
+        $this->assertGreaterThan(0, count($providers));
     }
 }

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -43,8 +43,8 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $reloaded = $formModel->getEntity($formId);
-        self::assertNotNull($reloaded);
-        self::assertSame(ConditionalFieldOrderTestData::getExpectedChildLabels(), $this->getConditionalChildLabels($reloaded));
+        $this->assertInstanceOf(Form::class, $reloaded);
+        $this->assertSame(ConditionalFieldOrderTestData::getExpectedChildLabels(), $this->getConditionalChildLabels($reloaded));
 
         $resaveSessionFields = [];
         foreach ($reloaded->getFields() as $field) {
@@ -61,8 +61,8 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $savedAgain = $formModel->getEntity($formId);
-        self::assertNotNull($savedAgain);
-        self::assertSame(ConditionalFieldOrderTestData::getExpectedChildLabels(), $this->getConditionalChildLabels($savedAgain));
+        $this->assertInstanceOf(Form::class, $savedAgain);
+        $this->assertSame(ConditionalFieldOrderTestData::getExpectedChildLabels(), $this->getConditionalChildLabels($savedAgain));
 
         $formModel->deleteEntity($savedAgain);
     }
@@ -91,26 +91,26 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
             "/s/forms/preview/{$formId}?email=testform@test.com&firstname=test&description=test-test&checkbox=val1|val3"
         );
         $inputValue = $crawler->filter('input[type=email]')->attr('value');
-        self::assertSame('testform@test.com', $inputValue);
+        $this->assertSame('testform@test.com', $inputValue);
         $inputValue = $crawler->filter('input[type=text]')->attr('value');
-        self::assertSame('test', $inputValue);
+        $this->assertSame('test', $inputValue);
         $inputValue = $crawler->filter('textarea[name^=mauticform]')->html();
-        self::assertSame('test-test', $inputValue);
+        $this->assertSame('test-test', $inputValue);
         $inputValue = $crawler->filter('textarea[name^=mauticform]')->html();
-        self::assertSame('test-test', $inputValue);
+        $this->assertSame('test-test', $inputValue);
         $inputValue = $crawler->filter('input[value^=val1]')->attr('checked');
-        self::assertNotNull($inputValue, $crawler->html());
+        $this->assertNotNull($inputValue, $crawler->html());
         $inputValue = $crawler->filter('input[value^=val2]')->attr('checked');
-        self::assertNull($inputValue);
+        $this->assertNull($inputValue);
         $inputValue = $crawler->filter('input[value^=val3]')->attr('checked');
-        self::assertNotNull($inputValue);
+        $this->assertNotNull($inputValue);
 
         $this->createPage($formId);
         $crawler    = $this->client->request(Request::METHOD_GET, '/test-page?email=test%2Bpage@test.com&firstname=test');
         $inputValue = $crawler->filter('input[type=email]')->attr('value');
-        self::assertSame('test+page@test.com', $inputValue);
+        $this->assertSame('test+page@test.com', $inputValue);
         $inputValue = $crawler->filter('input[type=text]')->attr('value');
-        self::assertSame('test', $inputValue);
+        $this->assertSame('test', $inputValue);
     }
 
     private function createForm(): int

--- a/app/bundles/IntegrationsBundle/Tests/Unit/AbstractIntegrationTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/AbstractIntegrationTest.php
@@ -40,7 +40,7 @@ final class AbstractIntegrationTest extends TestCase
 JSON;
 
         $json = $integrationDouble->parseCallbackResponse($jsonString);
-        self::assertArrayHasKey('webinars', $json);
+        $this->assertArrayHasKey('webinars', $json);
     }
 
     private function buildAbstractIntegrationDouble(): AbstractIntegration

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Event/ConfigSaveEventTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Event/ConfigSaveEventTest.php
@@ -20,7 +20,7 @@ final class ConfigSaveEventTest extends TestCase
             ->method('getName')
             ->willReturn($name);
 
-        self::assertSame($integration, $event->getIntegrationConfiguration());
-        self::assertSame($name, $event->getIntegration());
+        $this->assertSame($integration, $event->getIntegrationConfiguration());
+        $this->assertSame($name, $event->getIntegration());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Event/KeysSaveEventTest.php
@@ -20,8 +20,8 @@ final class KeysSaveEventTest extends TestCase
 
         $event = new KeysSaveEvent($integration, $keys);
 
-        self::assertSame($integration, $event->getIntegrationConfiguration());
-        self::assertSame($keys, $event->getOldKeys());
-        self::assertSame($keys, $event->getNewKeys());
+        $this->assertSame($integration, $event->getIntegrationConfiguration());
+        $this->assertSame($keys, $event->getOldKeys());
+        $this->assertSame($keys, $event->getNewKeys());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
@@ -340,7 +340,7 @@ final class CompanyObjectSubscriberTest extends TestCase
             ->with(1)
             ->willReturn($companyObj);
         $this->subscriber->findCompanyById($event);
-        self::assertSame($companyObj, $event->getEntity());
+        $this->assertSame($companyObj, $event->getEntity());
     }
 
     public function testFindCompanyByIdWithNoIdSet(): void
@@ -349,7 +349,7 @@ final class CompanyObjectSubscriberTest extends TestCase
         $this->companyObjectHelper->expects($this->never())
             ->method('findObjectById');
         $this->subscriber->findCompanyById($event);
-        self::assertNull($event->getEntity());
+        $this->assertNull($event->getEntity());
     }
 
     public function testFindCompanyByIdWithNoCompany(): void
@@ -361,6 +361,6 @@ final class CompanyObjectSubscriberTest extends TestCase
             ->with(1)
             ->willReturn(null);
         $this->subscriber->findCompanyById($event);
-        self::assertNull($event->getEntity());
+        $this->assertNull($event->getEntity());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
@@ -343,7 +343,7 @@ final class ContactObjectSubscriberTest extends TestCase
             ->with(1)
             ->willReturn($contactObj);
         $this->subscriber->findContactById($event);
-        self::assertSame($contactObj, $event->getEntity());
+        $this->assertSame($contactObj, $event->getEntity());
     }
 
     /**
@@ -355,7 +355,7 @@ final class ContactObjectSubscriberTest extends TestCase
         $this->contactObjectHelper->expects($this->never())
             ->method('findObjectById');
         $this->subscriber->findContactById($event);
-        self::assertNull($event->getEntity());
+        $this->assertNull($event->getEntity());
     }
 
     /**
@@ -370,6 +370,6 @@ final class ContactObjectSubscriberTest extends TestCase
             ->with(1)
             ->willReturn(null);
         $this->subscriber->findContactById($event);
-        self::assertNull($event->getEntity());
+        $this->assertNull($event->getEntity());
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -194,7 +194,7 @@ final class CompanyObjectHelperTest extends TestCase
             ->with(1)
             ->willReturn($company);
 
-        self::assertSame($company, $this->getObjectHelper()->findObjectById(1));
+        $this->assertSame($company, $this->getObjectHelper()->findObjectById(1));
     }
 
     public function testFindObjectByIdReturnsNull(): void
@@ -203,7 +203,7 @@ final class CompanyObjectHelperTest extends TestCase
             ->method('getEntity')
             ->with(1);
 
-        self::assertNull($this->getObjectHelper()->findObjectById(1));
+        $this->assertNotInstanceOf(Company::class, $this->getObjectHelper()->findObjectById(1));
     }
 
     public function testSetFieldValues(): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -321,7 +321,7 @@ final class ContactObjectHelperTest extends TestCase
             ->with(1)
             ->willReturn($contact);
 
-        self::assertSame($contact, $this->getObjectHelper()->findObjectById(1));
+        $this->assertSame($contact, $this->getObjectHelper()->findObjectById(1));
     }
 
     public function testFindObjectByIdReturnsNull(): void
@@ -330,7 +330,7 @@ final class ContactObjectHelperTest extends TestCase
             ->method('getEntity')
             ->with(1);
 
-        self::assertNull($this->getObjectHelper()->findObjectById(1));
+        $this->assertNotInstanceOf(Lead::class, $this->getObjectHelper()->findObjectById(1));
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
@@ -183,7 +183,7 @@ final class MauticSyncProcessTest extends TestCase
             ->willThrowException(new ObjectDeletedException());
 
         $syncOrder = $this->createMauticSyncProcess($mappingManual)->getSyncOrder($syncReport);
-        self::assertSame([], $syncOrder->getIdentifiedObjects());
+        $this->assertSame([], $syncOrder->getIdentifiedObjects());
     }
 
     public function testGetSyncOrderObjectSkipped(): void
@@ -223,7 +223,7 @@ final class MauticSyncProcessTest extends TestCase
 
         $syncOrder = $this->createMauticSyncProcess($mappingManual)->getSyncOrder($syncReport);
 
-        self::assertSame([], $syncOrder->getIdentifiedObjects());
+        $this->assertSame([], $syncOrder->getIdentifiedObjects());
     }
 
     public function testThatItDoesntSyncOtherEntityTypesWhenIDsForSomeEntityAreSpecified(): void

--- a/app/bundles/LeadBundle/Tests/Command/DeleteContactSecondaryCompaniesCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteContactSecondaryCompaniesCommandTest.php
@@ -23,18 +23,18 @@ final class DeleteContactSecondaryCompaniesCommandTest extends MauticMysqlTestCa
         $companyLeadRepo  = $this->em->getRepository(CompanyLead::class);
 
         $contactCompanies = $companyLeadRepo->getCompaniesByLeadId($contact->getId());
-        self::assertCount(2, $contactCompanies);
+        $this->assertCount(2, $contactCompanies);
 
         $this->testSymfonyCommand(DeleteContactSecondaryCompaniesCommand::NAME);
 
         $contactCompanies = $companyLeadRepo->getCompaniesByLeadId($contact->getId());
-        self::assertCount(2, $contactCompanies);
+        $this->assertCount(2, $contactCompanies);
 
         $this->setUpSymfony(['contact_allow_multiple_companies' => 0]);
         $this->testSymfonyCommand(DeleteContactSecondaryCompaniesCommand::NAME);
 
         $contactCompanies = $companyLeadRepo->getCompaniesByLeadId($contact->getId());
-        self::assertCount(1, $contactCompanies);
+        $this->assertCount(1, $contactCompanies);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
@@ -33,25 +33,25 @@ final class DeleteLeadListsCommandFunctionalTest extends MauticMysqlTestCase
         /** @var ListModel $listModel */
         $listModel = $this->getContainer()->get('mautic.lead.model.list');
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentId);
-        self::assertSame(5, $leadCount);
+        $this->assertSame(5, $leadCount);
 
         $listModel->deleteEntity($segment);
         $this->em->flush();
         $this->em->refresh($segment);
 
-        self::assertNull($listModel->getEntity($segmentId));
+        $this->assertNotInstanceOf(LeadList::class, $listModel->getEntity($segmentId));
 
         $deletedEntity = $listModel->getSoftDeletedEntity($segmentId);
         $this->assertInstanceOf(LeadList::class, $deletedEntity);
-        self::assertSame($segmentId, $deletedEntity->getId());
+        $this->assertSame($segmentId, $deletedEntity->getId());
 
         $this->testSymfonyCommand(DeleteLeadListsCommand::COMMAND_NAME, ['list-id' => $segmentId]);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentId);
-        self::assertSame(0, $leadCount);
+        $this->assertSame(0, $leadCount);
 
         $deletedEntity = $listModel->getSoftDeletedEntity($segmentId);
-        self::assertNull($deletedEntity);
+        $this->assertNotInstanceOf(LeadList::class, $deletedEntity);
     }
 
     public function testSegmentDeleteCommandWithoutArgs(): void
@@ -68,7 +68,7 @@ final class DeleteLeadListsCommandFunctionalTest extends MauticMysqlTestCase
         /** @var ListModel $listModel */
         $listModel = $this->getContainer()->get('mautic.lead.model.list');
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentBId);
-        self::assertSame(5, $leadCount);
+        $this->assertSame(5, $leadCount);
 
         // Test segments delete command without ids
         $listModel->deleteEntities([$segmentBId, $segmentCId]);
@@ -76,19 +76,19 @@ final class DeleteLeadListsCommandFunctionalTest extends MauticMysqlTestCase
         $this->em->refresh($segmentB);
         $this->em->refresh($segmentC);
 
-        self::assertNull($listModel->getEntity($segmentBId));
+        $this->assertNotInstanceOf(LeadList::class, $listModel->getEntity($segmentBId));
 
         $deletedEntity = $listModel->getSoftDeletedEntity($segmentBId);
         $this->assertInstanceOf(LeadList::class, $deletedEntity);
-        self::assertSame($segmentBId, $deletedEntity->getId());
+        $this->assertSame($segmentBId, $deletedEntity->getId());
         // command without  args --list-id
         $this->testSymfonyCommand(DeleteLeadListsCommand::COMMAND_NAME);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentBId);
-        self::assertSame(0, $leadCount);
+        $this->assertSame(0, $leadCount);
 
         $deletedEntity = $listModel->getSoftDeletedEntity($segmentBId);
-        self::assertNull($deletedEntity);
+        $this->assertNotInstanceOf(LeadList::class, $deletedEntity);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -34,7 +34,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
         $segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
-        self::assertEquals(5, $count, "Expected segment {$segmentId} to have 5 contacts");
+        $this->assertEquals(5, $count, "Expected segment {$segmentId} to have 5 contacts");
 
         // Delete 1 contact.
         $contact = $contacts[0];
@@ -48,7 +48,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
         /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
         $segmentCountCacheHelper = static::getContainer()->get('mautic.helper.segment.count.cache');
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
-        self::assertEquals(4, $count, "Expected segment {$segmentId} to have 4 contacts");
+        $this->assertEquals(4, $count, "Expected segment {$segmentId} to have 4 contacts");
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -20,13 +20,13 @@ final class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCa
 
         // Run segments update command.
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segmentAId]);
-        self::assertCount(5, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentAId]));
+        $this->assertCount(5, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentAId]));
 
         $segmentB   = $this->saveSegmentB($segmentAId);
         $segmentBId = $segmentB->getId();
         // Run segments update command.
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segmentBId]);
-        self::assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentBId]));
+        $this->assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segmentBId]));
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterWithRelativeTimeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterWithRelativeTimeFunctionalTest.php
@@ -22,7 +22,7 @@ final class SegmentFilterWithRelativeTimeFunctionalTest extends MauticMysqlTestC
         $segment = $this->saveSegment($hours);
 
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
-        self::assertCount($hours, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment->getId()]));
+        $this->assertCount($hours, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment->getId()]));
     }
 
     /**
@@ -93,11 +93,7 @@ final class SegmentFilterWithRelativeTimeFunctionalTest extends MauticMysqlTestC
         try {
             $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
 
-            self::assertCount(
-                1,
-                $this->em->getRepository(ListLead::class)->findBy(['list' => $segment->getId()]),
-                'Contact last active 30 min ago must be included in the "-1 hour" segment even when the system timezone is non-UTC.'
-            );
+            $this->assertCount(1, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment->getId()]), 'Contact last active 30 min ago must be included in the "-1 hour" segment even when the system timezone is non-UTC.');
         } finally {
             ReflectionHelper::setStaticValue(DateTimeHelper::class, 'defaultLocalTimezone', $originalCachedTimezone);
         }

--- a/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
@@ -62,7 +62,7 @@ final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlT
         $this->em->flush();
 
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
-        self::assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
+        $this->assertCount(3, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
     }
 
     public function testSegmentNuberFilterWithRegexCommand(): void
@@ -97,6 +97,6 @@ final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlT
         $this->em->flush();
 
         $this->testSymfonyCommand('mautic:segments:update', ['-i' => $segment->getId()]);
-        self::assertCount(2, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
+        $this->assertCount(2, $this->em->getRepository(ListLead::class)->findBy(['list' => $segment]));
     }
 }

--- a/app/bundles/LeadBundle/Tests/Command/SegmentStressTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentStressTest.php
@@ -48,7 +48,7 @@ final class SegmentStressTest extends MauticMysqlTestCase
         $segmentAId = $segmentA->getId();
         $this->em->clear();
         $commandTester = $this->testSymfonyCommand(UpdateLeadListsCommand::NAME, ['-i' => $segmentAId]);
-        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode(), $commandTester->getDisplay());
+        $this->assertSame(Command::SUCCESS, $commandTester->getStatusCode(), $commandTester->getDisplay());
     }
 
     private function saveContacts(): void

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -492,10 +492,10 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         /** @var User $adminUser */
         $adminUser = $userRepository->findOneBy(['username' => 'admin']);
-        self::assertInstanceOf(User::class, $adminUser);
+        $this->assertInstanceOf(User::class, $adminUser);
 
         $salesUser = $userRepository->findOneBy(['username' => 'sales']);
-        self::assertInstanceOf(User::class, $salesUser);
+        $this->assertInstanceOf(User::class, $salesUser);
 
         $leads = [];
 
@@ -526,10 +526,10 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $data       = json_decode($response->getContent(), true);
         $foundNames = array_column($data, 'value');
 
-        self::assertCount(4, $foundNames);
+        $this->assertCount(4, $foundNames);
 
         foreach ($foundNames as $key => $name) {
-            self::assertSame('User '.($key + 1), $name);
+            $this->assertSame('User '.($key + 1), $name);
         }
     }
 
@@ -539,7 +539,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $userRepository = $this->em->getRepository(User::class);
 
         $adminUser = $userRepository->findOneBy(['username' => 'admin']);
-        self::assertInstanceOf(User::class, $adminUser);
+        $this->assertInstanceOf(User::class, $adminUser);
 
         $leads = [];
 
@@ -610,9 +610,9 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $data       = json_decode($response->getContent(), true);
         $foundNames = array_column($data, 'value');
 
-        self::assertCount(2, $foundNames);
-        self::assertSame('User 3', $foundNames[0]);
-        self::assertSame('User 4', $foundNames[1]);
+        $this->assertCount(2, $foundNames);
+        $this->assertSame('User 3', $foundNames[0]);
+        $this->assertSame('User 4', $foundNames[1]);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -219,12 +219,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('bramborak|makovec', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('bramborak|makovec', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
 
         // Test patch and values should be updated
         $updatedValues = [
@@ -238,12 +238,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $responseJson   = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('halusky', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('halusky', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
 
         // Test empty patch and values should be updated
         $updatedValues = [
@@ -258,12 +258,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $responseJson   = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
     }
 
     /**
@@ -331,12 +331,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('makovec', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('makovec', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
 
         // Test patch and values should be updated
         $updatedValues = [
@@ -350,12 +350,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $responseJson   = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('halusky', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('halusky', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
 
         // Test empty patch and values should be updated
         $updatedValues = [
@@ -370,12 +370,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         );
         $clientResponse = $this->client->getResponse();
         $responseJson   = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        self::assertArrayHasKey('contact', $responseJson);
-        self::assertArrayHasKey('fields', $responseJson['contact']);
-        self::assertArrayHasKey('core', $responseJson['contact']['fields']);
-        self::assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
-        self::assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
-        self::assertSame('', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
+        $this->assertArrayHasKey('contact', $responseJson);
+        $this->assertArrayHasKey('fields', $responseJson['contact']);
+        $this->assertArrayHasKey('core', $responseJson['contact']['fields']);
+        $this->assertArrayHasKey($fieldAlias, $responseJson['contact']['fields']['core']);
+        $this->assertArrayHasKey('value', $responseJson['contact']['fields']['core'][$fieldAlias]);
+        $this->assertSame('', $responseJson['contact']['fields']['core'][$fieldAlias]['value']);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -1119,7 +1119,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $response = json_decode($clientResponse->getContent(), true);
 
-        self::assertCount(3, $response['contacts']);
+        $this->assertCount(3, $response['contacts']);
 
         $this->assertEquals(Response::HTTP_OK, $response['statusCodes'][0]);
         $this->assertSame($contact1->getId(), $response['contacts'][0]['id']);

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -101,8 +101,8 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $engagementData = $datasets[0]['data'] ?? [];
         $totalContacts  = array_sum($engagementData);
 
-        self::assertStringContainsString('Engagements', (string) $response->getContent());
-        self::assertSame(1, $totalContacts);
+        $this->assertStringContainsString('Engagements', (string) $response->getContent());
+        $this->assertSame(1, $totalContacts);
     }
 
     /**
@@ -221,12 +221,12 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $companyB = $companyModel->getEntity($companyB->getId());
         $companyC = $companyModel->getEntity($companyC->getId());
 
-        self::assertInstanceOf(Company::class, $companyA);
-        self::assertInstanceOf(Company::class, $companyB);
-        self::assertInstanceOf(Company::class, $companyC);
-        self::assertSame('Retail', $companyA->getIndustry());
-        self::assertSame('Retail', $companyB->getIndustry());
-        self::assertSame('Services', $companyC->getIndustry());
+        $this->assertInstanceOf(Company::class, $companyA);
+        $this->assertInstanceOf(Company::class, $companyB);
+        $this->assertInstanceOf(Company::class, $companyC);
+        $this->assertSame('Retail', $companyA->getIndustry());
+        $this->assertSame('Retail', $companyB->getIndustry());
+        $this->assertSame('Services', $companyC->getIndustry());
 
         $response = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('closeModal', $response, 'The response does not contain the `closeModal` param.');
@@ -279,20 +279,20 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $companyF = $companyModel->getEntity($companyF->getId());
         $companyG = $companyModel->getEntity($companyG->getId());
 
-        self::assertInstanceOf(Company::class, $companyA);
-        self::assertInstanceOf(Company::class, $companyB);
-        self::assertInstanceOf(Company::class, $companyC);
-        self::assertInstanceOf(Company::class, $companyD);
-        self::assertInstanceOf(Company::class, $companyE);
-        self::assertInstanceOf(Company::class, $companyF);
-        self::assertInstanceOf(Company::class, $companyG);
-        self::assertSame('Retail', $companyA->getIndustry());
-        self::assertSame('Retail', $companyB->getIndustry());
-        self::assertSame('Goods', $companyC->getIndustry());
-        self::assertSame('Services', $companyD->getIndustry());
-        self::assertSame('Retail', $companyE->getIndustry());
-        self::assertSame('Retail', $companyF->getIndustry());
-        self::assertSame('Retail', $companyG->getIndustry());
+        $this->assertInstanceOf(Company::class, $companyA);
+        $this->assertInstanceOf(Company::class, $companyB);
+        $this->assertInstanceOf(Company::class, $companyC);
+        $this->assertInstanceOf(Company::class, $companyD);
+        $this->assertInstanceOf(Company::class, $companyE);
+        $this->assertInstanceOf(Company::class, $companyF);
+        $this->assertInstanceOf(Company::class, $companyG);
+        $this->assertSame('Retail', $companyA->getIndustry());
+        $this->assertSame('Retail', $companyB->getIndustry());
+        $this->assertSame('Goods', $companyC->getIndustry());
+        $this->assertSame('Services', $companyD->getIndustry());
+        $this->assertSame('Retail', $companyE->getIndustry());
+        $this->assertSame('Retail', $companyF->getIndustry());
+        $this->assertSame('Retail', $companyG->getIndustry());
 
         $response = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('closeModal', $response, 'The response does not contain the `closeModal` param.');

--- a/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
@@ -18,6 +18,6 @@ final class LeadCompanyControllerTest extends MauticMysqlTestCase
     {
         $crawler     = $this->client->request('GET', 's/contacts/new/');
         $multiple    = $crawler->filterXPath('//*[@id="lead_companies"]')->attr('multiple');
-        self::assertNull($multiple);
+        $this->assertNull($multiple);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -767,8 +767,8 @@ EMAIL;
         self::assertResponseStatusCodeSame(Response::HTTP_OK);
 
         $errorContainer = $crawler->filter('form[name="lead"] .has-error .help-block');
-        self::assertCount(1, $errorContainer);
-        self::assertSame('This field must be unique.', $errorContainer->text(null, true));
+        $this->assertCount(1, $errorContainer);
+        $this->assertSame('This field must be unique.', $errorContainer->text(null, true));
     }
 
     public function testEditRendersErrorOnEmailDuplicate(): void
@@ -1145,7 +1145,7 @@ EMAIL;
     {
         $crawler     = $this->client->request('GET', 's/contacts/new/');
         $multiple    = $crawler->filterXPath('//*[@id="lead_companies"]')->attr('multiple');
-        self::assertSame('multiple', $multiple);
+        $this->assertSame('multiple', $multiple);
     }
 
     public function testCompanyMergeList(): void

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -145,19 +145,19 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $manualSegmentId = $manualSegment->getId();
 
         // Verify last built date is not set.
-        self::assertNull($segment->getLastBuiltDate());
+        $this->assertNotInstanceOf(\DateTimeInterface::class, $segment->getLastBuiltDate());
 
         // Check segment count UI for no contacts for manual segment.
         // And check the filtered segment is Building
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('Building', $html);
-        self::assertSame('label label-info col-count', $spClass);
+        $this->assertSame('Building', $html);
+        $this->assertSame('label label-info col-count', $spClass);
         $html    = $this->getSegmentCountHtml($crawler, $manualSegmentId);
         $spClass = $this->getSegmentCountClass($crawler, $manualSegmentId);
-        self::assertSame('No Contacts', $html);
-        self::assertSame('label label-gray col-count', $spClass);
+        $this->assertSame('No Contacts', $html);
+        $this->assertSame('label label-gray col-count', $spClass);
 
         // Add 4 contacts.
         $contacts   = $this->saveContacts();
@@ -170,7 +170,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->detach($segment);
         $segment = $this->listRepo->find($segmentId);
         $this->assertInstanceOf(LeadList::class, $segment);
-        self::assertNotNull($segment->getLastBuiltDate());
+        $this->assertInstanceOf(\DateTimeInterface::class, $segment->getLastBuiltDate());
         $this->assertInstanceOf(LeadList::class, $segment);
 
         // Set last built date in the future to allow testing without waiting.
@@ -182,68 +182,68 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('View 4 Contacts', $html);
-        self::assertSame('label label-gray col-count', $spClass);
+        $this->assertSame('View 4 Contacts', $html);
+        $this->assertSame('label label-gray col-count', $spClass);
 
         // Remove 1 contact from segment.
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contact/'.$contact1Id.'/remove');
-        self::assertSame('{"success":1}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         // Check segment count UI for 3 contacts.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('View 3 Contacts', $html);
-        self::assertSame('label label-gray col-count', $spClass);
+        $this->assertSame('View 3 Contacts', $html);
+        $this->assertSame('label label-gray col-count', $spClass);
 
         // Add 1 contact back to segment.
         $parameters = ['ids' => [$contact1Id]];
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contacts/add', $parameters);
-        self::assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         // Check segment count UI for 4 contacts.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('View 4 Contacts', $html);
-        self::assertSame('label label-gray col-count', $spClass);
+        $this->assertSame('View 4 Contacts', $html);
+        $this->assertSame('label label-gray col-count', $spClass);
 
         // Check segment count AJAX for 4 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 4 Contacts', $response['content']['html']);
-        self::assertSame('label label-gray col-count', $response['content']['className']);
-        self::assertSame(4, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 4 Contacts', $response['content']['html']);
+        $this->assertSame('label label-gray col-count', $response['content']['className']);
+        $this->assertSame(4, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
 
         // Remove 1 contact from segment.
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contact/'.$contact1Id.'/remove');
-        self::assertSame('{"success":1}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         // Check segment count AJAX for 3 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 3 Contacts', $response['content']['html']);
-        self::assertSame('label label-gray col-count', $response['content']['className']);
-        self::assertSame(3, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 3 Contacts', $response['content']['html']);
+        $this->assertSame('label label-gray col-count', $response['content']['className']);
+        $this->assertSame(3, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
 
         // Add 1 contact back to segment.
         $parameters = ['ids' => [$contact1Id]];
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contacts/add', $parameters);
-        self::assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         // Check segment count AJAX for 4 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 4 Contacts', $response['content']['html']);
-        self::assertSame('label label-gray col-count', $response['content']['className']);
-        self::assertSame(4, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 4 Contacts', $response['content']['html']);
+        $this->assertSame('label label-gray col-count', $response['content']['className']);
+        $this->assertSame(4, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
 
         // Save filtered segment again to trigger rebuild label, setting last built date in the past.
         $this->em->detach($segment);
@@ -258,16 +258,16 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('Building (4 Contacts)', $html);
-        self::assertSame('label label-info col-count', $spClass);
+        $this->assertSame('Building (4 Contacts)', $html);
+        $this->assertSame('label label-info col-count', $spClass);
 
         // Check segment count AJAX for building 4 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('Building (4 Contacts)', $response['content']['html']);
-        self::assertSame('label label-info col-count', $response['content']['className']);
-        self::assertSame(4, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('Building (4 Contacts)', $response['content']['html']);
+        $this->assertSame('label label-info col-count', $response['content']['className']);
+        $this->assertSame(4, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
     }
 
     /**
@@ -298,7 +298,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
-        self::assertSame('No Contacts', $html);
+        $this->assertSame('No Contacts', $html);
 
         // Add 4 contacts.
         $contacts   = $this->saveContacts();
@@ -312,11 +312,11 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Check segment count UI for 4 contacts.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
-        self::assertSame('View 4 Contacts', $html);
+        $this->assertSame('View 4 Contacts', $html);
 
         // Remove 1 contact from segment.
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contact/'.$contact1Id.'/remove');
-        self::assertSame('{"success":1}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1}', $this->client->getResponse()->getContent());
         self::assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
@@ -324,12 +324,12 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Check segment count UI for 3 contacts.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
-        self::assertSame('View 3 Contacts', $html);
+        $this->assertSame('View 3 Contacts', $html);
 
         // Add 1 contact back to segment.
         $parameters = ['ids' => [$contact1Id]];
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contacts/add', $parameters);
-        self::assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
         self::assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
@@ -337,18 +337,18 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Check segment count UI for 4 contacts.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
-        self::assertSame('View 4 Contacts', $html);
+        $this->assertSame('View 4 Contacts', $html);
 
         // Check segment count AJAX for 4 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 4 Contacts', $response['content']['html']);
-        self::assertSame(4, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 4 Contacts', $response['content']['html']);
+        $this->assertSame(4, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
 
         // Remove 1 contact from segment.
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contact/'.$contact1Id.'/remove');
-        self::assertSame('{"success":1}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
@@ -356,14 +356,14 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Check segment count AJAX for 3 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 3 Contacts', $response['content']['html']);
-        self::assertSame(3, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 3 Contacts', $response['content']['html']);
+        $this->assertSame(3, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
 
         // Add 1 contact back to segment.
         $parameters = ['ids' => [$contact1Id]];
         $this->client->request(Request::METHOD_POST, '/api/segments/'.$segmentId.'/contacts/add', $parameters);
-        self::assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
+        $this->assertSame('{"success":1,"details":{"'.$contact1Id.'":{"success":true}}}', $this->client->getResponse()->getContent());
         $this->assertResponseIsSuccessful();
 
         $this->testSymfonyCommand(SegmentCountCacheCommand::COMMAND_NAME);
@@ -371,9 +371,9 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         // Check segment count AJAX for 4 contacts.
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('View 4 Contacts', $response['content']['html']);
-        self::assertSame(4, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('View 4 Contacts', $response['content']['html']);
+        $this->assertSame(4, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
     }
 
     public function testSegmentClone(): void
@@ -431,9 +431,9 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $parameter = ['id' => 'ABC'];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
 
-        self::assertSame('No Contacts', $response['content']['html']);
-        self::assertSame(0, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_NOT_FOUND, $response['statusCode']);
+        $this->assertSame('No Contacts', $response['content']['html']);
+        $this->assertSame(0, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response['statusCode']);
     }
 
     public function testUnpublishUsedSegment(): void
@@ -731,16 +731,16 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments');
         $html    = $this->getSegmentCountHtml($crawler, $segmentId);
         $spClass = $this->getSegmentCountClass($crawler, $segmentId);
-        self::assertSame('No Contacts', $html);
-        self::assertSame('label label-gray col-count', $spClass);
+        $this->assertSame('No Contacts', $html);
+        $this->assertSame('label label-gray col-count', $spClass);
 
         // Check segment count AJAX - should also show "No Contacts"
         $parameter = ['id' => $segmentId];
         $response  = $this->callGetLeadCountAjaxRequest($parameter);
-        self::assertSame('No Contacts', $response['content']['html']);
-        self::assertSame('label label-gray col-count', $response['content']['className']);
-        self::assertSame(0, $response['content']['leadCount']);
-        self::assertSame(Response::HTTP_OK, $response['statusCode']);
+        $this->assertSame('No Contacts', $response['content']['html']);
+        $this->assertSame('label label-gray col-count', $response['content']['className']);
+        $this->assertSame(0, $response['content']['leadCount']);
+        $this->assertSame(Response::HTTP_OK, $response['statusCode']);
     }
 
     public function testSegmentWarningIcon(): void

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -73,12 +73,12 @@ final class ListControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', sprintf('/s/segments/view/%d', $segment->getId()));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('MySeg', (string) $response->getContent());
+        $this->assertStringContainsString('MySeg', (string) $response->getContent());
         // Make sure that contact grid is not loaded synchronously
-        self::assertStringNotContainsString('Kane', (string) $response->getContent());
-        self::assertStringNotContainsString('Jacques', (string) $response->getContent());
+        $this->assertStringNotContainsString('Kane', (string) $response->getContent());
+        $this->assertStringNotContainsString('Jacques', (string) $response->getContent());
         // Make sure the data-target-url is not an absolute URL
-        self::assertStringContainsString(sprintf('data-target-url="/s/segment/view/%s/contact/1"', $segment->getId()), (string) $response->getContent());
+        $this->assertStringContainsString(sprintf('data-target-url="/s/segment/view/%s/contact/1"', $segment->getId()), (string) $response->getContent());
     }
 
     public function testSegmentContactGrid(): void
@@ -89,8 +89,8 @@ final class ListControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', sprintf('/s/segment/view/%d/contact/%d', $segment->getId(), $pageId));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
-        self::assertStringContainsString('Kane', (string) $response->getContent());
-        self::assertStringContainsString('Jacques', (string) $response->getContent());
+        $this->assertStringContainsString('Kane', (string) $response->getContent());
+        $this->assertStringContainsString('Jacques', (string) $response->getContent());
     }
 
     private function createList(string $suffix = 'A'): LeadList
@@ -189,7 +189,7 @@ final class ListControllerTest extends MauticMysqlTestCase
 
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200.');
-        self::assertStringContainsString('Segment clone', (string) $clientResponse->getContent());
+        $this->assertStringContainsString('Segment clone', (string) $clientResponse->getContent());
     }
 
     public function testSegmentSearchFilters(): void

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -367,10 +367,7 @@ final class LeadFieldRepositoryTest extends TestCase
             ->method('getOneOrNullResult')
             ->willReturn($leadField);
 
-        self::assertSame(
-            $leadField,
-            $this->repository->getFieldThatIsMissingColumn()
-        );
+        $this->assertSame($leadField, $this->repository->getFieldThatIsMissingColumn());
     }
 
     private function createQueryMock(): MockObject

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -45,28 +45,28 @@ final class LeadListRepositoryTest extends TestCase
     {
         $contactId = 1;
         $this->mockIsContactInAnySegment($contactId, []);
-        self::assertFalse($this->repository->isContactInAnySegment($contactId));
+        $this->assertFalse($this->repository->isContactInAnySegment($contactId));
     }
 
     public function testIsContactInAnySegmentTrue(): void
     {
         $contactId = 1;
         $this->mockIsContactInAnySegment($contactId, [1]);
-        self::assertTrue($this->repository->isContactInAnySegment($contactId));
+        $this->assertTrue($this->repository->isContactInAnySegment($contactId));
     }
 
     public function testIsNotContactInAnySegmentTrue(): void
     {
         $contactId = 1;
         $this->mockIsContactInAnySegment($contactId, []);
-        self::assertTrue($this->repository->isNotContactInAnySegment($contactId));
+        $this->assertTrue($this->repository->isNotContactInAnySegment($contactId));
     }
 
     public function testIsNotContactInAnySegmentFalse(): void
     {
         $contactId = 1;
         $this->mockIsContactInAnySegment($contactId, [1]);
-        self::assertFalse($this->repository->isNotContactInAnySegment($contactId));
+        $this->assertFalse($this->repository->isNotContactInAnySegment($contactId));
     }
 
     public function testIsContactInSegmentsNone(): void
@@ -75,7 +75,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1];
         $queryResult        = [];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsContactInSegmentsOne(): void
@@ -84,7 +84,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsContactInSegmentsAll(): void
@@ -93,7 +93,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1, 2];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsNotContactInSegmentsNone(): void
@@ -102,7 +102,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1];
         $queryResult        = [0];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertTrue($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertTrue($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsNotContactInSegmentsOne(): void
@@ -111,7 +111,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsNotContactInSegmentsAll(): void
@@ -120,7 +120,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1, 2];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isNotContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsContactInAllSegmentsNoSegments(): void
@@ -129,7 +129,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1];
         $queryResult        = [];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isContactInAllSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isContactInAllSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsContactInAllSegmentsDoesNotMatch(): void
@@ -138,7 +138,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isContactInAllSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isContactInAllSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsContactInAllSegmentsMatches(): void
@@ -147,7 +147,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1, 2];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
+        $this->assertTrue($this->repository->isContactInSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsNotContactInAllSegmentsMatches(): void
@@ -156,7 +156,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1];
         $queryResult        = [];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertTrue($this->repository->isNotContactInAllSegments($contactId, $expectedSegmentIds));
+        $this->assertTrue($this->repository->isNotContactInAllSegments($contactId, $expectedSegmentIds));
     }
 
     public function testIsNotContactInAllSegmentsDoesNotMatch(): void
@@ -165,7 +165,7 @@ final class LeadListRepositoryTest extends TestCase
         $expectedSegmentIds = [1, 2];
         $queryResult        = [1, 2];
         $this->mockIsContactInSegments($contactId, $expectedSegmentIds, $queryResult);
-        self::assertFalse($this->repository->isNotContactInAllSegments($contactId, $expectedSegmentIds));
+        $this->assertFalse($this->repository->isNotContactInAllSegments($contactId, $expectedSegmentIds));
     }
 
     /**
@@ -258,7 +258,7 @@ SQL;
             ['listIds', $listIds, ArrayParameterType::INTEGER],
             ['false', false, 'boolean'],
         ];
-        $this->queryBuilderMock->expects(self::exactly(2))
+        $this->queryBuilderMock->expects($this->exactly(2))
             ->method('setParameter')
             ->willReturnCallback(function (...$parameters) use (&$expectedCalls): MockObject {
                 $this->assertSame(array_shift($expectedCalls), $parameters);
@@ -266,7 +266,7 @@ SQL;
                 return $this->queryBuilderMock;
             });
 
-        self::assertSame(array_combine($listIds, $counts), $this->repository->getLeadCount($listIds));
+        $this->assertSame(array_combine($listIds, $counts), $this->repository->getLeadCount($listIds));
     }
 
     public function testGetSingleLeadCount(): void
@@ -292,7 +292,7 @@ SQL;
         $this->queryBuilderMock->expects($this->once())
             ->method('getQueryPart')
             ->willReturn($fromPart);
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
 
         $this->queryBuilderMock->expects($matcher)
             ->method('from')->willReturnCallback(function (...$parameters) use ($matcher) {
@@ -309,7 +309,7 @@ SQL;
                     return $this->queryBuilderMock;
                 }
             });
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
 
         $this->expressionMock->expects($matcher)
             ->method('eq')->willReturnCallback(function (...$parameters) use ($matcher, $listIds): MockObject {
@@ -325,7 +325,7 @@ SQL;
                 return $this->expressionMock;
             });
 
-        self::assertSame($counts[0], $this->repository->getLeadCount($listIds));
+        $this->assertSame($counts[0], $this->repository->getLeadCount($listIds));
     }
 
     /**
@@ -341,7 +341,7 @@ SQL;
             ->with('count(l.lead_id) as thecount, l.leadlist_id')
             ->willReturnSelf();
 
-        $this->queryBuilderMock->expects(self::exactly(2))
+        $this->queryBuilderMock->expects($this->exactly(2))
             ->method('expr')
             ->willReturn($this->expressionMock);
 

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
@@ -163,10 +163,7 @@ final class LeadRepositoryTest extends \PHPUnit\Framework\TestCase
             ->method('createQuery')
             ->willReturn($query);
 
-        self::assertSame(
-            [1, 2],
-            $this->repository->getContactIdsByEmails($emails)
-        );
+        $this->assertSame([1, 2], $this->repository->getContactIdsByEmails($emails));
     }
 
     public function testGetUniqueIdentifiersOperator(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -32,12 +32,9 @@ final class DynamicContentSubscriberTest extends TestCase
 
     public function testGetSubscribedEvents(): void
     {
-        self::assertSame(
-            [
-                DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE => ['onContactFilterEvaluate', 0],
-            ],
-            DynamicContentSubscriber::getSubscribedEvents()
-        );
+        $this->assertSame([
+            DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE => ['onContactFilterEvaluate', 0],
+        ], DynamicContentSubscriber::getSubscribedEvents());
     }
 
     public function testOnContactFilterEvaluateUnknownOperator(): void
@@ -79,8 +76,8 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 
     public function testOnContactFilterEvaluateNotEmpty(): void
@@ -103,8 +100,8 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 
     public function testOnContactFilterEvaluateNotIn(): void
@@ -127,8 +124,8 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 
     public function testOnContactFilterEvaluateNotNotIn(): void
@@ -151,8 +148,8 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 
     public function testOnContactFilterEvaluateNotInAll(): void
@@ -175,8 +172,8 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 
     public function testOnContactFilterEvaluateNotNotInAll(): void
@@ -199,7 +196,7 @@ final class DynamicContentSubscriberTest extends TestCase
             ->willReturn(true);
 
         $this->subscriber->onContactFilterEvaluate($event);
-        self::assertTrue($event->isEvaluated());
-        self::assertTrue($event->isMatched());
+        $this->assertTrue($event->isEvaluated());
+        $this->assertTrue($event->isMatched());
     }
 }

--- a/app/bundles/LeadBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
@@ -28,7 +28,7 @@ final class GeneratedColumnSubscriberTest extends TestCase
     {
         parent::setUp();
         $modelTranslator = $this->createMock(Translator::class);
-        $modelTranslator->expects(self::any())
+        $modelTranslator
             ->method('trans')
             ->willReturnArgument(0);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -269,7 +269,7 @@ final class OwnerSubscriberTest extends TestCase
             );
 
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
@@ -59,9 +59,9 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         $companies = $data['member'];
-        self::assertCount(1, $companies, 'Expected exactly 1 company');
-        self::assertSame($ownerCompany->getId(), $companies[0]['id']);
-        self::assertSame('Owner Company', $companies[0]['name']);
+        $this->assertCount(1, $companies, 'Expected exactly 1 company');
+        $this->assertSame($ownerCompany->getId(), $companies[0]['id']);
+        $this->assertSame('Owner Company', $companies[0]['name']);
     }
 
     public function testViewOwnCollectionReportsOwnedTotalAcrossPagesOnApiV2(): void
@@ -120,14 +120,14 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
 
         $page1Data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertArrayHasKey('member', $page1Data);
-        self::assertArrayHasKey('totalItems', $page1Data);
-        self::assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned companies');
-        self::assertCount(4, $page1Data['member'], 'Should return all 4 owned companies on single page');
+        $this->assertArrayHasKey('member', $page1Data);
+        $this->assertArrayHasKey('totalItems', $page1Data);
+        $this->assertSame(4, $page1Data['totalItems'], 'Should report totalItems 4 owned companies');
+        $this->assertCount(4, $page1Data['member'], 'Should return all 4 owned companies on single page');
 
         // Verify all items belong to restricted user
         foreach ($page1Data['member'] as $company) {
-            self::assertStringStartsWith('Restricted Company', $company['name']);
+            $this->assertStringStartsWith('Restricted Company', $company['name']);
         }
     }
 
@@ -179,12 +179,8 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertCount(
-            1,
-            $data['member'],
-            'New owner should see the reassigned company (owner field takes precedence over createdBy)'
-        );
-        self::assertSame($company->getId(), $data['member'][0]['id']);
+        $this->assertCount(1, $data['member'], 'New owner should see the reassigned company (owner field takes precedence over createdBy)');
+        $this->assertSame($company->getId(), $data['member'][0]['id']);
 
         // Test 2: originalOwner (creator but no longer owner) should NOT see the company
         $originalOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'original.owner']);
@@ -199,10 +195,6 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertCount(
-            0,
-            $data['member'],
-            'Original creator should NOT see the company after reassignment (owner field takes precedence)'
-        );
+        $this->assertCount(0, $data['member'], 'Original creator should NOT see the company after reassignment (owner field takes precedence)');
     }
 }

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -115,33 +115,33 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($legacyCollection);
-        self::assertArrayHasKey('contacts', $legacyCollection);
-        self::assertIsArray($legacyCollection['contacts']);
+        $this->assertIsArray($legacyCollection);
+        $this->assertArrayHasKey('contacts', $legacyCollection);
+        $this->assertIsArray($legacyCollection['contacts']);
 
         $legacyIds = array_map(
             static fn (array $contact): int => (int) $contact['id'],
             array_values($legacyCollection['contacts'])
         );
 
-        self::assertContains((int) $ownContact->getId(), $legacyIds);
-        self::assertNotContains((int) $foreignContact->getId(), $legacyIds);
+        $this->assertContains((int) $ownContact->getId(), $legacyIds);
+        $this->assertNotContains((int) $foreignContact->getId(), $legacyIds);
 
         $this->client->request('GET', '/api/v2/contacts?page=1');
         self::assertResponseIsSuccessful();
 
         $v2Collection = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($v2Collection);
-        self::assertArrayHasKey('member', $v2Collection);
-        self::assertIsArray($v2Collection['member']);
+        $this->assertIsArray($v2Collection);
+        $this->assertArrayHasKey('member', $v2Collection);
+        $this->assertIsArray($v2Collection['member']);
 
         $v2Ids = array_map(
             static fn (array $contact): int => (int) $contact['id'],
             $v2Collection['member']
         );
 
-        self::assertContains((int) $ownContact->getId(), $v2Ids);
-        self::assertNotContains((int) $foreignContact->getId(), $v2Ids);
+        $this->assertContains((int) $ownContact->getId(), $v2Ids);
+        $this->assertNotContains((int) $foreignContact->getId(), $v2Ids);
     }
 
     public function testViewOwnCollectionReportsOwnedTotalAcrossPagesOnApiV2(): void
@@ -182,11 +182,11 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
 
         $firstPage = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($firstPage);
-        self::assertArrayHasKey('member', $firstPage);
-        self::assertArrayHasKey('totalItems', $firstPage);
-        self::assertIsArray($firstPage['member']);
-        self::assertSame(4, (int) $firstPage['totalItems']);
+        $this->assertIsArray($firstPage);
+        $this->assertArrayHasKey('member', $firstPage);
+        $this->assertArrayHasKey('totalItems', $firstPage);
+        $this->assertIsArray($firstPage['member']);
+        $this->assertSame(4, (int) $firstPage['totalItems']);
 
         $firstPageIds = array_map(
             static fn (array $contact): int => (int) $contact['id'],
@@ -194,18 +194,18 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         );
 
         foreach ($firstPageIds as $id) {
-            self::assertContains($id, $ownedContactIds);
+            $this->assertContains($id, $ownedContactIds);
         }
 
         $this->client->request('GET', '/api/v2/contacts?page=2&itemsPerPage=2');
         self::assertResponseIsSuccessful();
 
         $secondPage = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($secondPage);
-        self::assertArrayHasKey('member', $secondPage);
-        self::assertArrayHasKey('totalItems', $secondPage);
-        self::assertIsArray($secondPage['member']);
-        self::assertSame(4, (int) $secondPage['totalItems']);
+        $this->assertIsArray($secondPage);
+        $this->assertArrayHasKey('member', $secondPage);
+        $this->assertArrayHasKey('totalItems', $secondPage);
+        $this->assertIsArray($secondPage['member']);
+        $this->assertSame(4, (int) $secondPage['totalItems']);
 
         $secondPageIds = array_map(
             static fn (array $contact): int => (int) $contact['id'],
@@ -213,7 +213,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         );
 
         foreach ($secondPageIds as $id) {
-            self::assertContains($id, $ownedContactIds);
+            $this->assertContains($id, $ownedContactIds);
         }
     }
 
@@ -266,34 +266,34 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($legacyCollection);
-        self::assertArrayHasKey('contacts', $legacyCollection);
-        self::assertIsArray($legacyCollection['contacts']);
+        $this->assertIsArray($legacyCollection);
+        $this->assertArrayHasKey('contacts', $legacyCollection);
+        $this->assertIsArray($legacyCollection['contacts']);
 
         $legacyIds = array_map(
             static fn (array $contact): int => (int) $contact['id'],
             array_values($legacyCollection['contacts'])
         );
 
-        self::assertContains((int) $ownContact->getId(), $legacyIds);
-        self::assertContains((int) $foreignContact->getId(), $legacyIds);
+        $this->assertContains((int) $ownContact->getId(), $legacyIds);
+        $this->assertContains((int) $foreignContact->getId(), $legacyIds);
 
         $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
         self::assertResponseIsSuccessful();
 
         $collection = json_decode($this->client->getResponse()->getContent(), true);
-        self::assertIsArray($collection);
-        self::assertArrayHasKey('totalItems', $collection);
-        self::assertArrayHasKey('member', $collection);
-        self::assertSame(2, (int) $collection['totalItems'], 'Expected own and foreign contacts');
+        $this->assertIsArray($collection);
+        $this->assertArrayHasKey('totalItems', $collection);
+        $this->assertArrayHasKey('member', $collection);
+        $this->assertSame(2, (int) $collection['totalItems'], 'Expected own and foreign contacts');
 
         $v2Ids = array_map(
             static fn (array $contact): int => (int) $contact['id'],
             $collection['member']
         );
 
-        self::assertContains((int) $ownContact->getId(), $v2Ids);
-        self::assertContains((int) $foreignContact->getId(), $v2Ids);
+        $this->assertContains((int) $ownContact->getId(), $v2Ids);
+        $this->assertContains((int) $foreignContact->getId(), $v2Ids);
     }
 
     public function testViewOwnCollectionRespectsOwnerFieldAfterReassignmentOnApiV2(): void
@@ -346,12 +346,8 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertCount(
-            1,
-            $data['member'],
-            'New owner should see the reassigned contact (owner field takes precedence over createdBy)'
-        );
-        self::assertSame($contact->getId(), $data['member'][0]['id']);
+        $this->assertCount(1, $data['member'], 'New owner should see the reassigned contact (owner field takes precedence over createdBy)');
+        $this->assertSame($contact->getId(), $data['member'][0]['id']);
 
         // Test 2: originalOwner (creator but no longer owner) should NOT see the contact
         $originalOwner = $this->em->getRepository(User::class)->findOneBy(['username' => 'original.contact.owner']);
@@ -366,11 +362,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         self::assertResponseIsSuccessful();
         $data = json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        self::assertCount(
-            0,
-            $data['member'],
-            'Original creator should NOT see the contact after reassignment (owner field takes precedence)'
-        );
+        $this->assertCount(0, $data['member'], 'Original creator should NOT see the contact after reassignment (owner field takes precedence)');
     }
 
     private function createContactOwnedBy(User $owner, string $email): Lead

--- a/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
@@ -39,7 +39,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;
-        $customFieldNotification = self::createMock(CustomFieldNotification::class);
+        $customFieldNotification = $this->createMock(CustomFieldNotification::class);
         $customFieldNotification
             ->expects($this->once())
             ->method('customFieldWasCreated')
@@ -55,7 +55,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
             '--id'   => $leadField->getId(),
         ]);
 
-        self::assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
 
         $leadTableName = $this->em->getClassMetadata(Lead::class)->getTableName();
         $columnsSchema = $this->em->getConnection()->createSchemaManager()->listTableColumns($leadTableName);
@@ -64,7 +64,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
             $columnsSchema
         );
 
-        self::assertContains('custom_field_1', $columnNames);
+        $this->assertContains('custom_field_1', $columnNames);
     }
 
     public function testWithNoArgs(): void
@@ -93,9 +93,9 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;
-        $customFieldNotification = self::createMock(CustomFieldNotification::class);
+        $customFieldNotification = $this->createMock(CustomFieldNotification::class);
         $customFieldNotification
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('customFieldWasCreated')
             ->with(self::isInstanceOf(LeadField::class), self::equalTo($expectedUserId));
         $kernel->getContainer()->set('mautic.lead.field.notification.custom_field', $customFieldNotification);
@@ -106,7 +106,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute([]);
 
-        self::assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
+        $this->assertSame(0, $commandTester->getStatusCode(), $commandTester->getDisplay());
 
         $leadTableName = $this->em->getClassMetadata(Lead::class)->getTableName();
         $columnsSchema = $this->em->getConnection()->createSchemaManager()->listTableColumns($leadTableName);
@@ -115,7 +115,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
             $columnsSchema
         );
 
-        self::assertContains('custom_field_1', $columnNames);
-        self::assertContains('custom_field_2', $columnNames);
+        $this->assertContains('custom_field_1', $columnNames);
+        $this->assertContains('custom_field_2', $columnNames);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -108,18 +108,18 @@ final class SegmentSubscriberTest extends MauticMysqlTestCase
         $this->assertInstanceOf(ListModel::class, $listModel);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentId);
-        self::assertSame(5, $leadCount);
+        $this->assertSame(5, $leadCount);
 
         $listModel->deleteEntity($segment);
         $this->em->flush();
 
-        self::assertNull($listModel->getEntity($segmentId));
+        $this->assertNotInstanceOf(LeadList::class, $listModel->getEntity($segmentId));
 
         $deletedEntity = $listModel->getSoftDeletedEntity($segmentId);
-        self::assertNull($deletedEntity);
+        $this->assertNotInstanceOf(LeadList::class, $deletedEntity);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentId);
-        self::assertSame(0, $leadCount);
+        $this->assertSame(0, $leadCount);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/SegmentCountCacheHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/SegmentCountCacheHelperTest.php
@@ -81,7 +81,7 @@ final class SegmentCountCacheHelperTest extends TestCase
             ->willReturn(false);
 
         $this->cacheProviderMock
-            ->expects(self::never())
+            ->expects($this->never())
             ->method('deleteItem')
             ->with('segment.'.$segmentId.'.lead.recount');
 
@@ -105,13 +105,13 @@ final class SegmentCountCacheHelperTest extends TestCase
             ->willReturn(43200);
 
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('hasItem')
             ->with('segment.'.$segmentId.'.lead.recount')
             ->willReturn(true);
 
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('deleteItem')
             ->with('segment.'.$segmentId.'.lead.recount')
             ->willReturn(true);
@@ -142,7 +142,7 @@ final class SegmentCountCacheHelperTest extends TestCase
     {
         $segmentId = 1;
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('hasItem')
             ->with('segment.'.$segmentId.'.lead')
             ->willReturn(false);
@@ -153,7 +153,7 @@ final class SegmentCountCacheHelperTest extends TestCase
     {
         $segmentId = 1;
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('hasItem')
             ->with('segment.'.$segmentId.'.lead')
             ->willReturn(false);
@@ -164,13 +164,13 @@ final class SegmentCountCacheHelperTest extends TestCase
     {
         $segmentId = 1;
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('hasItem')
             ->with('segment.'.$segmentId.'.lead')
             ->willReturn(true);
 
         $this->cacheProviderMock
-            ->expects(self::exactly(1))
+            ->expects($this->exactly(1))
             ->method('deleteItem')
             ->with('segment.'.$segmentId.'.lead')
             ->willReturn(true);
@@ -214,7 +214,7 @@ final class SegmentCountCacheHelperTest extends TestCase
         $cacheItem = $this->createCacheItem('segment.'.$segmentId.'.lead', 0, true);
 
         $this->cacheProviderMock
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('hasItem')
             ->willReturnCallback(fn (string $key): bool => $key === 'segment.'.$segmentId.'.lead');
         $this->cacheProviderMock

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -74,14 +74,14 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
 
     public function testMultipleAssignedCompany(): void
     {
-        self::assertCount(2, $this->getContactWithAssignTwoCompanies());
+        $this->assertCount(2, $this->getContactWithAssignTwoCompanies());
     }
 
     public function testSignleAssignedCompany(): void
     {
         $this->setUpSymfony(array_merge($this->configParams, ['contact_allow_multiple_companies' => 0]));
 
-        self::assertCount(1, $this->getContactWithAssignTwoCompanies());
+        $this->assertCount(1, $this->getContactWithAssignTwoCompanies());
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -228,7 +228,7 @@ final class ListModelTest extends TestCase
             ->with($leadList)
             ->willReturn($orphanLeadsCount);
 
-        self::assertSame(0, $this->model->rebuildListLeads($leadList));
+        $this->assertSame(0, $this->model->rebuildListLeads($leadList));
 
         $this->segmentCountCacheHelper
             ->expects($this->once())
@@ -238,7 +238,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCountFromCache([$segmentId]);
 
-        self::assertSame([$segmentId => $leadCount], $leadCounts);
+        $this->assertSame([$segmentId => $leadCount], $leadCounts);
     }
 
     public function testRemoveLeadWillDecrementCacheCounter(): void
@@ -258,7 +258,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCountFromCache([$segmentId]);
 
-        self::assertSame([$segmentId => $currentLeadCount - 1], $leadCounts);
+        $this->assertSame([$segmentId => $currentLeadCount - 1], $leadCounts);
     }
 
     public function testGetSegmentContactCountFromCache(): void
@@ -275,7 +275,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCountFromCache([$segmentId]);
 
-        self::assertSame([$segmentId => $leadCount], $leadCounts);
+        $this->assertSame([$segmentId => $leadCount], $leadCounts);
     }
 
     public function testAddLeadWillIncrementCacheCounter(): void
@@ -295,7 +295,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCountFromCache([$segmentId]);
 
-        self::assertSame([$segmentId => $currentLeadCount + 1], $leadCounts);
+        $this->assertSame([$segmentId => $currentLeadCount + 1], $leadCounts);
     }
 
     public function testGetSegmentContactCountFromDatabaseHavingCache(): void
@@ -318,7 +318,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCount([$segmentId]);
 
-        self::assertSame([$segmentId => $leadCount], $leadCounts);
+        $this->assertSame([$segmentId => $leadCount], $leadCounts);
     }
 
     public function testGetSegmentContactCountFromDatabase(): void
@@ -341,7 +341,7 @@ final class ListModelTest extends TestCase
 
         $leadCounts = $this->model->getSegmentContactCount([$segmentId]);
 
-        self::assertSame([$segmentId => $leadCount], $leadCounts);
+        $this->assertSame([$segmentId => $leadCount], $leadCounts);
     }
 
     public function testGetActiveSegmentContactCount(): void
@@ -368,7 +368,7 @@ final class ListModelTest extends TestCase
         $property->setValue($this->model, $doNotContactRepository);
 
         $active = $this->model->getActiveSegmentContactCount($segmentId);
-        self::assertSame($total - $dnc, $active);
+        $this->assertSame($total - $dnc, $active);
     }
 
     public function testLeadListExists(): void
@@ -380,7 +380,7 @@ final class ListModelTest extends TestCase
             ->with($segmentId)
             ->willReturn(true);
 
-        self::assertTrue($this->model->leadListExists($segmentId));
+        $this->assertTrue($this->model->leadListExists($segmentId));
     }
 
     private function mockLeadList(int $id): LeadList

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
@@ -50,7 +50,7 @@ final class ContactSegmentFilterTest extends TestCase
         $this->contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => $type]);
         $filter                          = $this->createContactSegmentFilter();
 
-        self::assertEquals($type, $filter->getType());
+        $this->assertEquals($type, $filter->getType());
     }
 
     public function testGetParameterValue(): void
@@ -64,7 +64,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertEquals($value, $filter->getParameterValue());
+        $this->assertEquals($value, $filter->getParameterValue());
     }
 
     public function testGetTable(): void
@@ -78,7 +78,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertEquals($table, $filter->getTable());
+        $this->assertEquals($table, $filter->getTable());
     }
 
     public function testIsColumnTypeBoolean(): void
@@ -86,12 +86,12 @@ final class ContactSegmentFilterTest extends TestCase
         $this->contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'boolean']);
         $filter                          = $this->createContactSegmentFilter();
 
-        self::assertTrue($filter->isColumnTypeBoolean());
+        $this->assertTrue($filter->isColumnTypeBoolean());
 
         $this->contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => 'something']);
         $filter                          = $this->createContactSegmentFilter();
 
-        self::assertFalse($filter->isColumnTypeBoolean());
+        $this->assertFalse($filter->isColumnTypeBoolean());
     }
 
     public function testGetFilterQueryBuilder(): void
@@ -107,8 +107,8 @@ final class ContactSegmentFilterTest extends TestCase
 
         $parts = $filter->getDoNotContactParts();
 
-        self::assertSame('email', $parts->getChannel());
-        self::assertSame(1, $parts->getParameterType());
+        $this->assertSame('email', $parts->getChannel());
+        $this->assertSame(1, $parts->getParameterType());
     }
 
     public function testGetParameterHolder(): void
@@ -123,7 +123,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertEquals($expectedResult, $filter->getParameterHolder($argument));
+        $this->assertEquals($expectedResult, $filter->getParameterHolder($argument));
     }
 
     public function testGetWhere(): void
@@ -137,7 +137,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->with($this->contactSegmentFilterCrate)
             ->willReturn($where);
 
-        self::assertEquals($where, $filter->getWhere());
+        $this->assertEquals($where, $filter->getWhere());
     }
 
     public function testIsContactSegmentReference(): void
@@ -158,8 +158,8 @@ final class ContactSegmentFilterTest extends TestCase
             }
         });
 
-        self::assertTrue($filter->isContactSegmentReference());
-        self::assertFalse($filter->isContactSegmentReference());
+        $this->assertTrue($filter->isContactSegmentReference());
+        $this->assertFalse($filter->isContactSegmentReference());
     }
 
     public function testGetGlue(): void
@@ -169,7 +169,7 @@ final class ContactSegmentFilterTest extends TestCase
         $this->contactSegmentFilterCrate = new ContactSegmentFilterCrate(['glue' => $glue]);
         $filter                          = $this->createContactSegmentFilter();
 
-        self::assertSame($glue, $filter->getGlue());
+        $this->assertSame($glue, $filter->getGlue());
     }
 
     public function testGetIntegrationCampaignParts(): void
@@ -185,7 +185,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $parts = $filter->getIntegrationCampaignParts();
 
-        self::assertSame($value, $parts->getCampaignId());
+        $this->assertSame($value, $parts->getCampaignId());
     }
 
     public function testApplyQuery(): void
@@ -198,7 +198,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertSame($queryBuilder, $filter->applyQuery($queryBuilder));
+        $this->assertSame($queryBuilder, $filter->applyQuery($queryBuilder));
     }
 
     public function testGetRelationJoinTable(): void
@@ -207,7 +207,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertNull($filter->getRelationJoinTable());
+        $this->assertNull($filter->getRelationJoinTable());
 
         $this->filterDecorator = $this->createMock(CompanyDecorator::class);
         $this->filterDecorator->expects($this->once())
@@ -216,7 +216,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertEquals($table, $filter->getRelationJoinTable());
+        $this->assertEquals($table, $filter->getRelationJoinTable());
     }
 
     public function testGetQueryType(): void
@@ -229,7 +229,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->method('getQueryType')
             ->willReturn($type);
 
-        self::assertSame($type, $filter->getQueryType());
+        $this->assertSame($type, $filter->getQueryType());
     }
 
     public function testGetNullValue(): void
@@ -240,7 +240,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertSame($value, $filter->getNullValue());
+        $this->assertSame($value, $filter->getNullValue());
     }
 
     public function testGetColumnMissingColumn(): void
@@ -253,7 +253,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->method('getCurrentDatabaseName')
             ->willReturn($dbName);
 
-        $this->filterDecorator->expects(self::exactly(2))
+        $this->filterDecorator->expects($this->exactly(2))
             ->method('getTable')
             ->with($this->contactSegmentFilterCrate)
             ->willReturn($tableName);
@@ -263,7 +263,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->with($tableName)
             ->willReturn($columns);
 
-        $this->filterDecorator->expects(self::exactly(2))
+        $this->filterDecorator->expects($this->exactly(2))
             ->method('getField')
             ->willReturn('notExistingColumn');
 
@@ -292,7 +292,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->with($tableName)
             ->willReturn($columns);
 
-        $this->filterDecorator->expects(self::exactly(2))
+        $this->filterDecorator->expects($this->exactly(2))
             ->method('getField')
             ->willReturn('column1');
 
@@ -310,7 +310,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertSame($field, $filter->getField());
+        $this->assertSame($field, $filter->getField());
     }
 
     public function testGetRelationJoinTableField(): void
@@ -319,7 +319,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertNull($filter->getRelationJoinTableField());
+        $this->assertNull($filter->getRelationJoinTableField());
 
         $this->filterDecorator = $this->createMock(CompanyDecorator::class);
         $this->filterDecorator->expects($this->once())
@@ -328,7 +328,7 @@ final class ContactSegmentFilterTest extends TestCase
 
         $filter = $this->createContactSegmentFilter();
 
-        self::assertEquals($field, $filter->getRelationJoinTableField());
+        $this->assertEquals($field, $filter->getRelationJoinTableField());
     }
 
     public function testGetAggregateFunction(): void
@@ -342,7 +342,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->with($this->contactSegmentFilterCrate)
             ->willReturn($function);
 
-        self::assertSame($function, $filter->getAggregateFunction());
+        $this->assertSame($function, $filter->getAggregateFunction());
     }
 
     public function testGetOperator(): void
@@ -356,7 +356,7 @@ final class ContactSegmentFilterTest extends TestCase
             ->with($this->contactSegmentFilterCrate)
             ->willReturn($operator);
 
-        self::assertSame($operator, $filter->getOperator());
+        $this->assertSame($operator, $filter->getOperator());
     }
 
     public function testToString(): void
@@ -403,7 +403,7 @@ final class ContactSegmentFilterTest extends TestCase
         $filter = $this->createContactSegmentFilter();
 
         $result = $filter->__toString();
-        self::assertSame($expectedResult, $result);
+        $this->assertSame($expectedResult, $result);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('dataDoesColumnSupportEmptyValue')]
@@ -412,7 +412,7 @@ final class ContactSegmentFilterTest extends TestCase
         $this->contactSegmentFilterCrate = new ContactSegmentFilterCrate(['type' => $type]);
         $filter                          = $this->createContactSegmentFilter();
 
-        self::assertSame($doesColumnSupportEmptyValue, $filter->doesColumnSupportEmptyValue());
+        $this->assertSame($doesColumnSupportEmptyValue, $filter->doesColumnSupportEmptyValue());
     }
 
     public function testBatchLimitersAreSetCorrectly(): void
@@ -427,7 +427,7 @@ final class ContactSegmentFilterTest extends TestCase
                 'maxId' => 1,
             ]
         );
-        self::assertSame([
+        $this->assertSame([
             'minId' => 1,
             'maxId' => 1,
         ], $filter->getBatchLimiters());

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
@@ -131,7 +131,7 @@ final class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
         // exclude the segment
         $segmentTest3Ref = $this->getReference('segment-test-3');
         $lastRebuiltDate = $segmentTest3Ref->getLastBuiltDate();
-        self::assertNull($lastRebuiltDate);
+        $this->assertNotInstanceOf(\DateTimeInterface::class, $lastRebuiltDate);
 
         $this->testSymfonyCommand(
             UpdateLeadListsCommand::NAME,
@@ -141,7 +141,7 @@ final class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
             ]
         );
 
-        self::assertSame($lastRebuiltDate, $segmentTest3Ref->getLastBuiltDate(), 'Make sure the segment was not executed, if excluded.');
+        $this->assertSame($lastRebuiltDate, $segmentTest3Ref->getLastBuiltDate(), 'Make sure the segment was not executed, if excluded.');
 
         $this->testSymfonyCommand(
             'mautic:segments:update',
@@ -159,7 +159,7 @@ final class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
             'There should be 24 contacts in the segment-test-3 segment after rebuilding from the command line.'
         );
 
-        self::assertNotSame($lastRebuiltDate, $segmentTest3Ref->getLastBuiltDate(), 'Make sure the segment was executed, if not excluded.');
+        $this->assertNotSame($lastRebuiltDate, $segmentTest3Ref->getLastBuiltDate(), 'Make sure the segment was executed, if not excluded.');
 
         // Remove the title from all contacts, rebuild the list, and check that list is updated
         $this->em->getConnection()->executeQuery(sprintf('UPDATE %sleads SET title = NULL;', MAUTIC_TABLE_PREFIX));

--- a/app/bundles/LeadBundle/Tests/Segment/RandomParameterNameTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/RandomParameterNameTest.php
@@ -55,7 +55,7 @@ final class RandomParameterNameTest extends TestCase
         ];
 
         foreach ($expectedValues as $expectedValue) {
-            self::assertSame($expectedValue, $generator->generateRandomParameterName());
+            $this->assertSame($expectedValue, $generator->generateRandomParameterName());
         }
     }
 }

--- a/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
@@ -51,16 +51,16 @@ final class CompanyColumnsDictionaryTest extends TestCase
 
         $columns = $this->dictionary->getColumns();
 
-        self::assertSame(['companywebsite' => 'mautic.company.website', 'companyname' => 'mautic.company.name'], $columns);
+        $this->assertSame(['companywebsite' => 'mautic.company.website', 'companyname' => 'mautic.company.name'], $columns);
     }
 
     public function testGetFieldsMergesCoreAndCompanyCustomFields(): void
     {
         $fields = $this->dictionary->getFields();
 
-        self::assertArrayHasKey('companyname', $fields);
-        self::assertArrayHasKey('leadcount', $fields);
-        self::assertArrayHasKey('annual_revenue', $fields);
-        self::assertSame('Annual Revenue', $fields['annual_revenue']);
+        $this->assertArrayHasKey('companyname', $fields);
+        $this->assertArrayHasKey('leadcount', $fields);
+        $this->assertArrayHasKey('annual_revenue', $fields);
+        $this->assertSame('Annual Revenue', $fields['annual_revenue']);
     }
 }

--- a/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
@@ -59,8 +59,8 @@ final class MobileNotificationDetailsTypeTest extends TypeTestCase
 
         $view = $form->createView();
         // test only field is "additional_data"
-        self::assertCount(1, $view->children);
-        self::assertArrayHasKey('additional_data', $view->children);
+        $this->assertCount(1, $view->children);
+        $this->assertArrayHasKey('additional_data', $view->children);
     }
 
     /**
@@ -76,11 +76,11 @@ final class MobileNotificationDetailsTypeTest extends TypeTestCase
         $form = $this->factory->create(MobileNotificationDetailsType::class);
 
         $view = $form->createView();
-        self::assertCount(1 + count($settings), $view->children);
-        self::assertArrayHasKey('additional_data', $view->children);
+        $this->assertCount(1 + count($settings), $view->children);
+        $this->assertArrayHasKey('additional_data', $view->children);
 
         foreach ($settings as $settingField) {
-            self::assertArrayHasKey($settingField, $view->children);
+            $this->assertArrayHasKey($settingField, $view->children);
         }
     }
 

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
@@ -79,15 +79,15 @@ final class NotificationTypeTest extends TypeTestCase
 
             if (in_array($fieldName, $invalidFields, true)) {
                 ++$errorCount;
-                self::assertCount(1, $errors);
+                $this->assertCount(1, $errors);
                 continue;
             }
 
-            self::assertCount(0, $errors);
+            $this->assertCount(0, $errors);
         }
 
-        self::assertCount($errorCount, $invalidFields);
-        self::assertCount(0, $view->vars['errors']);
+        $this->assertCount($errorCount, $invalidFields);
+        $this->assertCount(0, $view->vars['errors']);
     }
 
     public function testSubmitValidData(): void
@@ -128,9 +128,9 @@ final class NotificationTypeTest extends TypeTestCase
         foreach ($view->children as $fieldName => $child) {
             $errors = $view->children[$fieldName]->vars['errors'];
             $this->assertInstanceOf(FormErrorIterator::class, $errors);
-            self::assertCount(0, $errors);
+            $this->assertCount(0, $errors);
         }
 
-        self::assertCount(0, $view->vars['errors']);
+        $this->assertCount(0, $view->vars['errors']);
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -64,7 +64,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Check for correct preview URL.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$pageId);
-        self::assertStringContainsString('/page/preview/'.$pageId, (string) $crawler->filter('#content_preview_url')->attr('value'));
+        $this->assertStringContainsString('/page/preview/'.$pageId, (string) $crawler->filter('#content_preview_url')->attr('value'));
     }
 
     public function testPreviewPagePublicToggle(): void
@@ -79,7 +79,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         // Check for public preview ON.
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$pageId);
         $toggleElem = $crawler->filter('i.ri-toggle-fill');
-        self::assertCount(1, $toggleElem);
+        $this->assertCount(1, $toggleElem);
 
         // Toggle public preview.
         $parameters = [
@@ -93,7 +93,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         // Check for public preview OFF.
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$pageId);
         $toggleElem = $crawler->filter('i.ri-toggle-line');
-        self::assertCount(1, $toggleElem);
+        $this->assertCount(1, $toggleElem);
 
         // Create landing page with public preview OFF.
         $page = $this->createPage(null, '', true, false);
@@ -105,7 +105,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Check for public preview OFF.
         $crawler = $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$pageId);
-        self::assertCount(1, $crawler->filter('i.ri-toggle-line'));
+        $this->assertCount(1, $crawler->filter('i.ri-toggle-line'));
 
         // Toggle public preview.
         $parameters['id'] = $pageId;
@@ -114,7 +114,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         // Check for public preview ON.
         $crawler    = $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$pageId);
         $toggleElem = $crawler->filter('i.ri-toggle-fill');
-        self::assertCount(1, $toggleElem);
+        $this->assertCount(1, $toggleElem);
     }
 
     public function testPreviewPageWithPublishAndPublicOptions(): void
@@ -129,8 +129,8 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         // Check for public preview ON.
         $this->client->request(Request::METHOD_GET, '/s/logout');
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        self::assertSame('Hello', $crawler->filter('body')->text());
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame('Hello', $crawler->filter('body')->text());
 
         // Create landing page with public preview OFF.
         $page = $this->createPage(null, '', true, false);
@@ -143,11 +143,8 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         // Check public preview without login.
 
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString(
-            'Unauthorized access to requested URL: /page/preview/'.$pageId,
-            $crawler->text()
-        );
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Unauthorized access to requested URL: /page/preview/'.$pageId, $crawler->text());
 
         // Create page with publish OFF.
         $page = $this->createPage(null, '', false);
@@ -159,11 +156,8 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Check for public preview ON.
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString(
-            'Unauthorized access to requested URL: /page/preview/'.$pageId,
-            $crawler->text()
-        );
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Unauthorized access to requested URL: /page/preview/'.$pageId, $crawler->text());
 
         // Create landing page with publish and public preview OFF.
         $page = $this->createPage(null, '', false, false);
@@ -175,19 +169,16 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Check for public preview ON.
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString(
-            'Unauthorized access to requested URL: /page/preview/'.$pageId,
-            $crawler->text()
-        );
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Unauthorized access to requested URL: /page/preview/'.$pageId, $crawler->text());
     }
 
     public function testPreviewPageNotFound(): void
     {
         // Check for non existing landing page preview.
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/20000');
-        self::assertEquals(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString('404 Not Found', $crawler->text());
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('404 Not Found', $crawler->text());
     }
 
     public function testPreviewPageAccess(): void
@@ -205,17 +196,14 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(User::class, $user);
         $this->loginUser($user);
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-        self::assertSame('Hello', $crawler->filter('body')->text());
+        $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame('Hello', $crawler->filter('body')->text());
 
         // Check public preview without login.
         $this->client->request(Request::METHOD_GET, '/s/logout');
         $crawler = $this->client->request(Request::METHOD_GET, '/page/preview/'.$pageId);
-        self::assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString(
-            'Unauthorized access to requested URL: /page/preview/'.$pageId,
-            $crawler->text()
-        );
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Unauthorized access to requested URL: /page/preview/'.$pageId, $crawler->text());
 
         // Check public preview access without permissions
         $this->loginUser($user);
@@ -227,18 +215,15 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
             $page->getCreatedBy()
         )->willReturn(false);
         $this->getContainer()->set('mautic.security', $security);
-        self::assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
-        self::assertStringContainsString(
-            'Unauthorized access to requested URL: /page/preview/'.$pageId,
-            $crawler->text()
-        );
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Unauthorized access to requested URL: /page/preview/'.$pageId, $crawler->text());
     }
 
     private function assertPageContent(string $url, string $expectedContent): void
     {
         $crawler = $this->client->request(Request::METHOD_GET, $url);
         self::assertResponseIsSuccessful();
-        self::assertSame($expectedContent, $crawler->filter('body')->text());
+        $this->assertSame($expectedContent, $crawler->filter('body')->text());
     }
 
     private function createPage(

--- a/app/bundles/PageBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -27,27 +27,18 @@ final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
         $mainPageId = $pageMain->getId();
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/pages');
-        self::assertStringContainsString($pageMain->getTitle(), $crawler->text());
+        $this->assertStringContainsString($pageMain->getTitle(), $crawler->text());
 
         $crawler = $this->client->request(Request::METHOD_GET, "/s/pages/view/{$mainPageId}");
 
         // Translation choice is not visible
-        self::assertCount(
-            0,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]')
-        );
+        $this->assertCount(0, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]'));
 
         // Variant choice is not visible
-        self::assertCount(
-            0,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]')
-        );
+        $this->assertCount(0, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]'));
 
         // Contact lookup is not visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_contact"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_contact"]'));
 
         $pageTranslated = new Page();
         $pageTranslated->setIsPublished(true);
@@ -82,31 +73,16 @@ final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request(Request::METHOD_GET, "/s/pages/view/{$mainPageId}");
 
         // Translation choice is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]'));
 
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_translation"]/option[@value="'.$pageTranslated->getId().'"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_translation"]/option[@value="'.$pageTranslated->getId().'"]'));
 
         // Variant choice is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]'));
 
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_variant"]/option[@value="'.$pageVariant->getId().'"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_variant"]/option[@value="'.$pageVariant->getId().'"]'));
 
         // Contact lookup is visible
-        self::assertCount(
-            1,
-            $crawler->filterXPath('//*[@id="content_preview_settings_contact"]')
-        );
+        $this->assertCount(1, $crawler->filterXPath('//*[@id="content_preview_settings_contact"]'));
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -208,7 +208,7 @@ final class PublicControllerTest extends TestCase
 
         $this->request->attributes->set('ignore_mismatch', true);
         $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects(self::never())
+        $themeHelper->expects($this->never())
             ->method('checkForTwigTemplate');
 
         $controller = new PublicController(
@@ -277,7 +277,7 @@ final class PublicControllerTest extends TestCase
             throw new InvalidDecodedStringException($clickTrough);
         };
 
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects($this->exactly(2))
             ->method('getContactFromQuery')
             ->willReturnCallback($getContactFromRequestCallback);
 
@@ -317,7 +317,7 @@ final class PublicControllerTest extends TestCase
             $redirectId
         );
 
-        self::assertSame('https://someurl.test/', $response->getTargetUrl());
+        $this->assertSame('https://someurl.test/', $response->getTargetUrl());
     }
 
     #[DataProvider('provideRedirectUrls')]
@@ -356,7 +356,7 @@ final class PublicControllerTest extends TestCase
             throw new InvalidDecodedStringException($clickThrough);
         };
 
-        $this->contactRequestHelper->expects(self::exactly(2))
+        $this->contactRequestHelper->expects($this->exactly(2))
             ->method('getContactFromQuery')
             ->willReturnCallback($getContactFromRequestCallback);
 
@@ -396,8 +396,8 @@ final class PublicControllerTest extends TestCase
             $this->pageModel,
             $redirectId
         );
-        self::assertSame($targetUrl, $response->getTargetUrl());
-        self::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        $this->assertSame($targetUrl, $response->getTargetUrl());
+        $this->assertSame(Response::HTTP_FOUND, $response->getStatusCode());
     }
 
     public static function provideRedirectUrls(): \Generator

--- a/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
@@ -42,8 +42,8 @@ final class PageRepositoryTest extends TestCase
 
         [$expr, $params] = $method->invoke($repository, $qb, $filter);
 
-        self::assertSame($expected, (string) $expr);
-        self::assertSame(['par1' => true], $params);
+        $this->assertSame($expected, (string) $expr);
+        $this->assertSame(['par1' => true], $params);
     }
 
     /**
@@ -59,7 +59,7 @@ final class PageRepositoryTest extends TestCase
     {
         $repository = $this->getRepository();
         $commands   = $repository->getSearchCommands();
-        self::assertContains('mautic.page.searchcommand.isexpired', $commands);
-        self::assertContains('mautic.page.searchcommand.ispending', $commands);
+        $this->assertContains('mautic.page.searchcommand.isexpired', $commands);
+        $this->assertContains('mautic.page.searchcommand.ispending', $commands);
     }
 }

--- a/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -126,8 +126,8 @@ final class DetermineWinnerSubscriberTest extends TestCase
         $abTestResults = $event->getAbTestResults();
 
         // Check for lowest bounce rates
-        self::assertSame([1], $abTestResults['winners']);
-        self::assertEquals($expectedData, $abTestResults['support']['data'][$translation]);
+        $this->assertSame([1], $abTestResults['winners']);
+        $this->assertEquals($expectedData, $abTestResults['support']['data'][$translation]);
     }
 
     public function testOnDetermineDwellTimeWinner(): void

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -18,13 +18,10 @@ final class PointSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        self::assertSame(
-            [
-                'mautic.point_on_build' => ['onPointBuild', 0],
-                'mautic.page_on_hit'    => ['onPageHit', 0],
-            ],
-            PointSubscriber::getSubscribedEvents()
-        );
+        $this->assertSame([
+            'mautic.point_on_build' => ['onPointBuild', 0],
+            'mautic.page_on_hit'    => ['onPageHit', 0],
+        ], PointSubscriber::getSubscribedEvents());
     }
 
     public function testPointBuildAddsActions(): void
@@ -32,7 +29,7 @@ final class PointSubscriberTest extends TestCase
         $pointModel        = $this->createStub(PointModel::class);
         $pointBuilderEvent = $this->createMock(PointBuilderEvent::class);
         $pointActionHelper = $this->createStub(PointActionHelper::class);
-        $matcher           = self::exactly(2);
+        $matcher           = $this->exactly(2);
 
         $pointBuilderEvent->expects($matcher)->method('addAction')->willReturnCallback(function (...$parameters) use ($matcher, $pointActionHelper): void {
             if (1 === $matcher->numberOfInvocations()) {

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -89,7 +89,7 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
 
         $crawler = $this->client->request('GET', $unsubscribeUrl);
 
-        self::assertTrue($this->client->getResponse()->isSuccessful(), $this->client->getResponse()->getContent());
+        $this->assertTrue($this->client->getResponse()->isSuccessful(), $this->client->getResponse()->getContent());
 
         $form = $crawler->filter(static::FORM_SELECTOR);
         $html = $form->html();

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -170,7 +170,7 @@ final class PageModelTest extends PageTestAbstract
             ->willReturn(null);
 
         $result = $pageModel->hitPage($redirect, new Request());
-        self::assertFalse($result);
+        $this->assertFalse($result);
     }
 
     /**

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -537,7 +537,7 @@ TEXT;
         // No links so no trackables
         $this->assertEquals($html, $content[0]);
         $token = array_key_first($trackables);
-        self::assertNotNull($token);
+        $this->assertNotNull($token);
 
         $this->assertEquals(str_replace('https://plaintexttest.io', $token, $plainText), $content[1]);
     }
@@ -572,7 +572,7 @@ TEXT;
         // No links so no trackables
         $this->assertEquals($html, $content[0]);
         $token = array_key_first($trackables);
-        self::assertNotNull($token);
+        $this->assertNotNull($token);
 
         $this->assertEquals(str_replace('{contactfield=website}', $token, $plainText), $content[1]);
     }

--- a/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/DetailsTypeTest.php
@@ -33,7 +33,7 @@ final class DetailsTypeTest extends TestCase
         $integrationObject->expects($this->once())
             ->method('decryptApiKeys')
             ->willReturn([]);
-        $integrationObject->expects(self::never())
+        $integrationObject->expects($this->never())
             ->method('isAuthorized');
         $integrationObject->expects($this->once())
             ->method('getSupportedFeatures')
@@ -42,18 +42,18 @@ final class DetailsTypeTest extends TestCase
         $integration = $this->createMock(Integration::class);
         $integration->method('getApiKeys')
             ->willReturn([]);
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getId');
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getSupportedFeatures');
 
         $options['integration_object'] = $integrationObject;
         $options['data']               = $integration;
 
         $calls = 0;
-        $builder->expects(self::never())
+        $builder->expects($this->never())
             ->method('setAction');
-        $builder->expects(self::atLeastOnce())
+        $builder->expects($this->atLeastOnce())
             ->method('add')
             ->willReturnCallback(static function (string $key, string $fieldFQCN, array $options) use (&$calls, $builder): FormBuilderInterface {
                 if ('apiKeys' === $key) {
@@ -81,7 +81,7 @@ final class DetailsTypeTest extends TestCase
         $form = new DetailsType();
         $form->buildForm($builder, $options);
 
-        self::assertSame(1, $calls);
+        $this->assertSame(1, $calls);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('authorizedDataProvider')]
@@ -112,18 +112,18 @@ final class DetailsTypeTest extends TestCase
         $integration = $this->createMock(Integration::class);
         $integration->method('getApiKeys')
             ->willReturn([]);
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getId');
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getSupportedFeatures');
 
         $options['integration_object'] = $integrationObject;
         $options['data']               = $integration;
 
         $calls = 0;
-        $builder->expects(self::never())
+        $builder->expects($this->never())
             ->method('setAction');
-        $builder->expects(self::atLeastOnce())
+        $builder->expects($this->atLeastOnce())
             ->method('add')
             ->willReturnCallback(static function (string $key, string $fieldFQCN, array $options) use ($label, &$calls, $builder): FormBuilderInterface {
                 if ('apiKeys' === $key) {
@@ -154,7 +154,7 @@ final class DetailsTypeTest extends TestCase
         $form = new DetailsType();
         $form->buildForm($builder, $options);
 
-        self::assertSame(2, $calls);
+        $this->assertSame(2, $calls);
     }
 
     public static function authorizedDataProvider(): \Generator
@@ -184,7 +184,7 @@ final class DetailsTypeTest extends TestCase
         $integrationObject->expects($this->once())
             ->method('decryptApiKeys')
             ->willReturn(['decrypted']);
-        $integrationObject->expects(self::never())
+        $integrationObject->expects($this->never())
             ->method('isAuthorized');
         $integrationObject->expects($this->once())
             ->method('getSupportedFeatures')
@@ -204,9 +204,9 @@ final class DetailsTypeTest extends TestCase
         $options['data']               = $integration;
 
         $calls = 0;
-        $builder->expects(self::never())
+        $builder->expects($this->never())
             ->method('setAction');
-        $builder->expects(self::atLeastOnce())
+        $builder->expects($this->atLeastOnce())
             ->method('add')
             ->willReturnCallback(static function (string $key, string $fieldFQCN, array $options) use ($expectedFeatures, &$calls, $builder): FormBuilderInterface {
                 if ('apiKeys' === $key) {
@@ -239,7 +239,7 @@ final class DetailsTypeTest extends TestCase
         $form = new DetailsType();
         $form->buildForm($builder, $options);
 
-        self::assertSame(2, $calls);
+        $this->assertSame(2, $calls);
     }
 
     public static function withFeaturesProvider(): \Generator
@@ -267,7 +267,7 @@ final class DetailsTypeTest extends TestCase
         $integrationObject->expects($this->once())
             ->method('decryptApiKeys')
             ->willReturn(['decrypted']);
-        $integrationObject->expects(self::never())
+        $integrationObject->expects($this->never())
             ->method('isAuthorized');
         $integrationObject->expects($this->once())
             ->method('getSupportedFeatures');
@@ -275,9 +275,9 @@ final class DetailsTypeTest extends TestCase
         $integration = $this->createMock(Integration::class);
         $integration->method('getApiKeys')
             ->willReturn([]);
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getId');
-        $integration->expects(self::never())
+        $integration->expects($this->never())
             ->method('getSupportedFeatures');
 
         $options['integration_object'] = $integrationObject;
@@ -287,7 +287,7 @@ final class DetailsTypeTest extends TestCase
         $builder->expects($this->once())
             ->method('setAction')
             ->with($action);
-        $builder->expects(self::atLeastOnce())
+        $builder->expects($this->atLeastOnce())
             ->method('add')
             ->willReturnCallback(static function (string $key, string $fieldFQCN, array $options) use (&$calls, $builder): FormBuilderInterface {
                 if ('apiKeys' === $key) {
@@ -315,6 +315,6 @@ final class DetailsTypeTest extends TestCase
         $form = new DetailsType();
         $form->buildForm($builder, $options);
 
-        self::assertSame(1, $calls);
+        $this->assertSame(1, $calls);
     }
 }

--- a/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
@@ -29,7 +29,7 @@ final class IntegrationsListTypeTest extends TestCase
         $integration1->expects($this->once())
             ->method('isPublished')
             ->willReturn(false);
-        $integration1->expects(self::never())
+        $integration1->expects($this->never())
             ->method('getPlugin');
 
         $plugin = $this->createMock(Plugin::class);
@@ -134,7 +134,7 @@ final class IntegrationsListTypeTest extends TestCase
             });
 
         $calledCallback = false;
-        $builder->expects(self::exactly(2))
+        $builder->expects($this->exactly(2))
             ->method('addEventListener')
             ->willReturnCallback(static function (string $eventName, callable $callback) use ($formEvent, &$calledCallback, $builder): FormBuilderInterface {
                 self::assertContains($eventName, [FormEvents::PRE_SET_DATA, FormEvents::PRE_SUBMIT]);
@@ -150,8 +150,8 @@ final class IntegrationsListTypeTest extends TestCase
         $integrationsListType = new IntegrationsListType($integrationHelper);
         $integrationsListType->buildForm($builder, ['supported_features' => 'features']);
 
-        self::assertSame(1, $callsBuilder);
-        self::assertSame(2, $callsForm);
+        $this->assertSame(1, $callsBuilder);
+        $this->assertSame(2, $callsForm);
     }
 
     public function testDataHaveIntegration(): void
@@ -162,7 +162,7 @@ final class IntegrationsListTypeTest extends TestCase
         $integration1->expects($this->once())
             ->method('isPublished')
             ->willReturn(false);
-        $integration1->expects(self::never())
+        $integration1->expects($this->never())
             ->method('getPlugin');
 
         $plugin = $this->createMock(Plugin::class);
@@ -247,10 +247,10 @@ final class IntegrationsListTypeTest extends TestCase
         ];
 
         $formEvent = $this->createMock(FormEvent::class);
-        $formEvent->expects(self::exactly(2))
+        $formEvent->expects($this->exactly(2))
             ->method('getForm')
             ->willReturn($form);
-        $formEvent->expects(self::exactly(2))
+        $formEvent->expects($this->exactly(2))
             ->method('getData')
             ->willReturn($data);
 
@@ -275,7 +275,7 @@ final class IntegrationsListTypeTest extends TestCase
             });
 
         $calledCallback = 0;
-        $builder->expects(self::exactly(2))
+        $builder->expects($this->exactly(2))
             ->method('addEventListener')
             ->willReturnCallback(static function (string $eventName, callable $callback) use ($formEvent, &$calledCallback, $builder): FormBuilderInterface {
                 self::assertContains($eventName, [FormEvents::PRE_SET_DATA, FormEvents::PRE_SUBMIT]);
@@ -289,8 +289,8 @@ final class IntegrationsListTypeTest extends TestCase
         $integrationsListType = new IntegrationsListType($integrationHelper);
         $integrationsListType->buildForm($builder, ['supported_features' => 'features']);
 
-        self::assertSame(1, $callsBuilder);
-        self::assertSame(4, $callsForm, 'Because callback is called twice due to coverage.');
-        self::assertSame(2, $calledCallback);
+        $this->assertSame(1, $callsBuilder);
+        $this->assertSame(4, $callsForm, 'Because callback is called twice due to coverage.');
+        $this->assertSame(2, $calledCallback);
     }
 }

--- a/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
+++ b/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
@@ -45,11 +45,11 @@ final class PointEntityValidationTest extends MauticMysqlTestCase
 
         if ($errorMessage) {
             self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
-            self::assertStringContainsString('error', (string) $response->getContent());
-            self::assertStringContainsString($errorMessage, (string) $response->getContent());
+            $this->assertStringContainsString('error', (string) $response->getContent());
+            $this->assertStringContainsString($errorMessage, (string) $response->getContent());
         } else {
             self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
-            self::assertStringNotContainsString('error', (string) $response->getContent());
+            $this->assertStringNotContainsString('error', (string) $response->getContent());
         }
     }
 
@@ -105,9 +105,9 @@ final class PointEntityValidationTest extends MauticMysqlTestCase
         self::assertResponseIsSuccessful();
 
         $response = $this->client->getResponse()->getContent();
-        self::assertStringContainsString($errorMessage, (string) $response);
+        $this->assertStringContainsString($errorMessage, (string) $response);
 
         $pointDetail = $this->em->getRepository(Point::class)->findOneBy(['delta' => $delta]);
-        '' === $errorMessage ? self::assertNotNull($pointDetail) : self::assertNull($pointDetail);
+        '' === $errorMessage ? $this->assertInstanceOf(Point::class, $pointDetail) : $this->assertNotInstanceOf(Point::class, $pointDetail);
     }
 }

--- a/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
@@ -36,10 +36,10 @@ final class EmailTriggerTest extends MauticMysqlTestCase
 
         [$crawler, $form] = $this->fetchForm($trigger, $triggerEvent);
 
-        self::assertEquals($email->getId(), $form->get('pointtriggerevent[properties][useremail][email]')->getValue(), 'Current email should be selected.');
-        self::assertNull($crawler->selectButton('Preview')->attr('disabled'), 'Preview button should not be disabled.');
-        self::assertNull($crawler->selectButton('Edit Email')->attr('disabled'), 'Edit Email button should not be disabled.');
-        self::assertStringContainsString('"origin":"#pointtriggerevent_properties_useremail_email"', (string) $crawler->selectButton('Preview')->attr('onclick'), 'The origin value should be correct.');
+        $this->assertEquals($email->getId(), $form->get('pointtriggerevent[properties][useremail][email]')->getValue(), 'Current email should be selected.');
+        $this->assertNull($crawler->selectButton('Preview')->attr('disabled'), 'Preview button should not be disabled.');
+        $this->assertNull($crawler->selectButton('Edit Email')->attr('disabled'), 'Edit Email button should not be disabled.');
+        $this->assertStringContainsString('"origin":"#pointtriggerevent_properties_useremail_email"', (string) $crawler->selectButton('Preview')->attr('onclick'), 'The origin value should be correct.');
     }
 
     #[\PHPUnit\Framework\Attributes\PreserveGlobalState(false)]
@@ -55,9 +55,9 @@ final class EmailTriggerTest extends MauticMysqlTestCase
 
         [$crawler, $form] = $this->fetchForm($trigger, $triggerEvent);
 
-        self::assertEmpty($form->get('pointtriggerevent[properties][useremail][email]')->getValue(), 'No email should be selected.');
-        self::assertNotNull($crawler->selectButton('Preview')->attr('disabled'), 'Preview button should be disabled.');
-        self::assertNotNull($crawler->selectButton('Edit Email')->attr('disabled'), 'Edit Email button should be disabled.');
+        $this->assertEmpty($form->get('pointtriggerevent[properties][useremail][email]')->getValue(), 'No email should be selected.');
+        $this->assertNotNull($crawler->selectButton('Preview')->attr('disabled'), 'Preview button should be disabled.');
+        $this->assertNotNull($crawler->selectButton('Edit Email')->attr('disabled'), 'Edit Email button should be disabled.');
     }
 
     /**
@@ -66,11 +66,11 @@ final class EmailTriggerTest extends MauticMysqlTestCase
     private function fetchForm(Trigger $trigger, TriggerEvent $triggerEvent): array
     {
         $this->client->request(Request::METHOD_GET, '/s/points/triggers/edit/'.$trigger->getId());
-        self::assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
 
         $uri = sprintf('/s/points/triggers/events/edit/%s?triggerId=%s', $triggerEvent->getId(), $trigger->getId());
         $this->client->xmlHttpRequest(Request::METHOD_GET, $uri);
-        self::assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
 
         $responseData = json_decode($this->client->getResponse()->getContent(), true);
         $crawler      = new Crawler($responseData['newContent'], $this->client->getInternalRequest()->getUri());

--- a/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
@@ -137,17 +137,17 @@ final class PointModelTest extends TestCase
         $repository->expects($this->once())
             ->method('getCompletedLeadActions')
             ->willReturn([]);
-        $repository->expects(self::never())
+        $repository->expects($this->never())
             ->method('saveEntities');
-        $repository->expects(self::never())
+        $repository->expects($this->never())
             ->method('detachEntities');
 
-        $this->dispatcher->expects(self::exactly(2))
+        $this->dispatcher->expects($this->exactly(2))
             ->method('dispatch')
             ->willReturnCallback(function (Event $event, string $eventName) use ($pointActionHelper, $type, $lead, $point): Event {
                 if (PointEvents::POINT_ON_BUILD === $eventName) {
-                    self::assertInstanceOf(PointBuilderEvent::class, $event);
-                    self::assertEquals(new PointBuilderEvent($this->translator), $event);
+                    $this->assertInstanceOf(PointBuilderEvent::class, $event);
+                    $this->assertEquals(new PointBuilderEvent($this->translator), $event);
                     $event->addAction(
                         $type,
                         [
@@ -165,7 +165,7 @@ final class PointModelTest extends TestCase
 
                 if (PointEvents::POINT_ON_ACTION === $eventName) {
                     $pointActionEvent = new PointActionEvent($point, $lead);
-                    self::assertEquals($pointActionEvent, $event);
+                    $this->assertEquals($pointActionEvent, $event);
 
                     return $pointActionEvent;
                 }

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -544,19 +544,19 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(ReportFileWriter::class, $reportFileWriter);
 
         $csvPath = $reportFileWriter->getFilePath($scheduler);
-        self::assertFileExists($csvPath);
+        $this->assertFileExists($csvPath);
 
         // Pretend Mautic has created a ZIP file as in \Mautic\ReportBundle\Scheduler\Model\FileHandler::zipIt
         $zipPath      = str_replace('.csv', '.zip', $csvPath);
         $bytesWritten = file_put_contents($zipPath, 'ZIP');
-        self::assertNotFalse($bytesWritten);
-        self::assertFileExists($zipPath);
+        $this->assertNotFalse($bytesWritten);
+        $this->assertFileExists($zipPath);
 
         $queuedMessage = self::getMailerMessagesByToAddress($toAddress);
 
-        self::assertCount(1, $queuedMessage);
-        self::assertFileExists($csvPath);
-        self::assertFileExists($zipPath);
+        $this->assertCount(1, $queuedMessage);
+        $this->assertFileExists($csvPath);
+        $this->assertFileExists($zipPath);
     }
 
     /**

--- a/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
@@ -91,21 +91,21 @@ final class ReportExporterTest extends \PHPUnit\Framework\TestCase
             ->willReturnCallback(function (Report $report, ReportExportOptions $exportOptions) use ($reportNow, $report2, $report1, $reportDataResult, $invokedCount): ReportDataResult {
                 $invocationCount = $invokedCount->numberOfInvocations();
                 if (0 < $invocationCount && $invocationCount <= 6) {
-                    self::assertSame($report1, $report);
-                    self::assertEquals((new \DateTime())->setTime(0, 0), $exportOptions->getDateFrom());
-                    self::assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
+                    $this->assertSame($report1, $report);
+                    $this->assertEquals((new \DateTime())->setTime(0, 0), $exportOptions->getDateFrom());
+                    $this->assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
                 }
 
                 if (6 < $invocationCount && $invocationCount <= 12) {
-                    self::assertSame($report2, $report);
-                    self::assertEquals((new \DateTime())->setTime(0, 0), $exportOptions->getDateFrom());
-                    self::assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
+                    $this->assertSame($report2, $report);
+                    $this->assertEquals((new \DateTime())->setTime(0, 0), $exportOptions->getDateFrom());
+                    $this->assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
                 }
 
                 if (12 < $invocationCount && $invocationCount <= 18) {
-                    self::assertSame($reportNow, $report);
-                    self::assertEquals((new \DateTime())->setTime(0, 0)->sub(new \DateInterval('P10Y')), $exportOptions->getDateFrom());
-                    self::assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
+                    $this->assertSame($reportNow, $report);
+                    $this->assertEquals((new \DateTime())->setTime(0, 0)->sub(new \DateInterval('P10Y')), $exportOptions->getDateFrom());
+                    $this->assertEquals((new \DateTime('yesterday'))->setTime(23, 59, 59), $exportOptions->getDateTo());
                 }
 
                 return $reportDataResult;

--- a/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
@@ -65,10 +65,10 @@ final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
         $pendingEvent = new PendingEvent(new ActionAccessor([]), $event, new ArrayCollection([$leadLog->getId() => $leadLog]));
 
         $this->subscriber->onCampaignTriggerBatchAction($pendingEvent);
-        self::assertCount(0, $pendingEvent->getFailures());
-        self::assertCount(1, $pendingEvent->getSuccessful());
-        self::assertSame(1, $leadLog->getMetadata()['failed']);
-        self::assertSame('mautic.sms.campaign.failed.missing_entity', $leadLog->getMetadata()['reason']);
+        $this->assertCount(0, $pendingEvent->getFailures());
+        $this->assertCount(1, $pendingEvent->getSuccessful());
+        $this->assertSame(1, $leadLog->getMetadata()['failed']);
+        $this->assertSame('mautic.sms.campaign.failed.missing_entity', $leadLog->getMetadata()['reason']);
     }
 
     public function testSendUnpublishedSms(): void
@@ -103,10 +103,10 @@ final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->subscriber->onCampaignTriggerBatchAction($pendingEvent);
 
-        self::assertCount(0, $pendingEvent->getFailures());
-        self::assertCount(1, $pendingEvent->getSuccessful());
-        self::assertSame(1, $leadLog->getMetadata()['failed']);
-        self::assertSame('mautic.sms.campaign.failed.unpublished', $leadLog->getMetadata()['reason']);
+        $this->assertCount(0, $pendingEvent->getFailures());
+        $this->assertCount(1, $pendingEvent->getSuccessful());
+        $this->assertSame(1, $leadLog->getMetadata()['failed']);
+        $this->assertSame('mautic.sms.campaign.failed.unpublished', $leadLog->getMetadata()['reason']);
     }
 
     public function testOnCampaignTriggerBatchAction(): void

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -122,8 +122,8 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
         $lead = new Lead();
         $lead->setId(1);
         $results = $this->smsModel->sendSms($sms, $lead);
-        self::assertFalse((bool) $results[1]['sent']);
-        self::assertSame('mautic.sms.campaign.failed.unpublished', $results[1]['status']);
+        $this->assertFalse((bool) $results[1]['sent']);
+        $this->assertSame('mautic.sms.campaign.failed.unpublished', $results[1]['status']);
     }
 
     public function testSendSMSTest(): void

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -157,6 +157,6 @@ final class TransportChainTest extends MauticMysqlTestCase
             }
         }
 
-        self::assertSame(2, $sentCount);
+        $this->assertSame(2, $sentCount);
     }
 }

--- a/app/bundles/UserBundle/Tests/EventListener/ApiUserSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/ApiUserSubscriberTest.php
@@ -24,7 +24,7 @@ final class ApiUserSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void
     {
-        self::assertSame([
+        $this->assertSame([
             CheckPassportEvent::class              => ['onCheckPassport', 2048],
             AuthenticationTokenCreatedEvent::class => 'onTokenCreated',
         ], ApiUserSubscriber::getSubscribedEvents());
@@ -37,7 +37,7 @@ final class ApiUserSubscriberTest extends TestCase
             ->method('hasBadge')
             ->with(UserBadge::class)
             ->willReturn(false);
-        $passport->expects(self::never())
+        $passport->expects($this->never())
             ->method('getBadge');
 
         $event = $this->createMock(CheckPassportEvent::class);
@@ -46,10 +46,10 @@ final class ApiUserSubscriberTest extends TestCase
             ->willReturn($passport);
 
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -62,7 +62,7 @@ final class ApiUserSubscriberTest extends TestCase
         $userBadge->expects($this->once())
             ->method('getUserLoader')
             ->willReturn(function (): void {});
-        $userBadge->expects(self::never())
+        $userBadge->expects($this->never())
             ->method('setUserLoader');
 
         $passport = $this->createMock(Passport::class);
@@ -74,7 +74,7 @@ final class ApiUserSubscriberTest extends TestCase
             ->method('getBadge')
             ->with(UserBadge::class)
             ->willReturn($userBadge);
-        $passport->expects(self::never())
+        $passport->expects($this->never())
             ->method('addBadge');
 
         $event = $this->createMock(CheckPassportEvent::class);
@@ -83,10 +83,10 @@ final class ApiUserSubscriberTest extends TestCase
             ->willReturn($passport);
 
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -99,11 +99,11 @@ final class ApiUserSubscriberTest extends TestCase
         $userBadge->expects($this->once())
             ->method('getUserLoader')
             ->willReturn(null);
-        $userBadge->expects(self::never())
+        $userBadge->expects($this->never())
             ->method('setUserLoader');
 
         $passport = $this->createMock(Passport::class);
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('hasBadge')
             ->willReturnCallback(static function (string $className): bool {
                 if (UserBadge::class === $className) {
@@ -120,7 +120,7 @@ final class ApiUserSubscriberTest extends TestCase
             ->method('getBadge')
             ->with(UserBadge::class)
             ->willReturn($userBadge);
-        $passport->expects(self::never())
+        $passport->expects($this->never())
             ->method('addBadge');
 
         $event = $this->createMock(CheckPassportEvent::class);
@@ -129,10 +129,10 @@ final class ApiUserSubscriberTest extends TestCase
             ->willReturn($passport);
 
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -152,7 +152,7 @@ final class ApiUserSubscriberTest extends TestCase
         $accessTokenBadge->method('getAccessToken')->willReturn($accessToken);
 
         $passport = $this->createMock(Passport::class);
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('hasBadge')
             ->willReturnCallback(static function (string $className): bool {
                 if (UserBadge::class === $className) {
@@ -165,7 +165,7 @@ final class ApiUserSubscriberTest extends TestCase
 
                 self::fail('Unknown badge class '.$className);
             });
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('getBadge')
             ->willReturnCallback(function (string $className) use ($accessTokenBadge, $userBadge): BadgeInterface {
                 if (UserBadge::class === $className) {
@@ -179,7 +179,7 @@ final class ApiUserSubscriberTest extends TestCase
                 self::fail('Unknown badge requested '.$className);
             });
         // Not changing any badges.
-        $passport->expects(self::never())
+        $passport->expects($this->never())
             ->method('addBadge');
 
         $event = $this->createMock(CheckPassportEvent::class);
@@ -203,7 +203,7 @@ final class ApiUserSubscriberTest extends TestCase
             // After update to PHP 8.2 change return type to `null`.
             ->willReturnCallback(function (callable $userLoader) use ($userIdentifier): void {
                 $loaderResult = $userLoader($userIdentifier);
-                self::assertNull($loaderResult);
+                $this->assertNull($loaderResult);
             });
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -224,7 +224,7 @@ final class ApiUserSubscriberTest extends TestCase
         $accessTokenBadge->method('getAccessToken')->willReturn($accessToken);
 
         $passport = $this->createMock(Passport::class);
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('hasBadge')
             ->willReturnCallback(static function (string $className): bool {
                 if (UserBadge::class === $className) {
@@ -237,7 +237,7 @@ final class ApiUserSubscriberTest extends TestCase
 
                 self::fail('Unknown badge class '.$className);
             });
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('getBadge')
             ->willReturnCallback(function (string $className) use ($accessTokenBadge, $userBadge): BadgeInterface {
                 if (UserBadge::class === $className) {
@@ -268,14 +268,14 @@ final class ApiUserSubscriberTest extends TestCase
             ->with($userIdentifier)
             ->willReturn($user);
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $userBadge->expects($this->once())
             ->method('setUserLoader')
             ->willReturnCallback(function (callable $userLoader) use ($userIdentifier): void {
                 $loaderResult = $userLoader($userIdentifier);
-                self::assertNotNull($loaderResult);
+                $this->assertNotNull($loaderResult);
             });
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -296,7 +296,7 @@ final class ApiUserSubscriberTest extends TestCase
         $accessTokenBadge->method('getAccessToken')->willReturn($accessToken);
 
         $passport = $this->createMock(Passport::class);
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('hasBadge')
             ->willReturnCallback(static function (string $className): bool {
                 if (UserBadge::class === $className) {
@@ -309,7 +309,7 @@ final class ApiUserSubscriberTest extends TestCase
 
                 self::fail('Unknown badge class '.$className);
             });
-        $passport->expects(self::exactly(2))
+        $passport->expects($this->exactly(2))
             ->method('getBadge')
             ->willReturnCallback(function (string $className) use ($accessTokenBadge, $userBadge): BadgeInterface {
                 if (UserBadge::class === $className) {
@@ -349,7 +349,7 @@ final class ApiUserSubscriberTest extends TestCase
             ->method('setUserLoader')
             ->willReturnCallback(function (callable $userLoader) use ($userIdentifier): void {
                 $loaderResult = $userLoader($userIdentifier);
-                self::assertNotNull($loaderResult);
+                $this->assertNotNull($loaderResult);
             });
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -359,11 +359,11 @@ final class ApiUserSubscriberTest extends TestCase
     public function testTokenCreatedNotOauthToken(): void
     {
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
 
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $passport = $this->createMock(Passport::class);
@@ -376,7 +376,7 @@ final class ApiUserSubscriberTest extends TestCase
         $event->expects($this->once())
             ->method('getPassport')
             ->willReturn($passport);
-        $event->expects(self::never())
+        $event->expects($this->never())
             ->method('getAuthenticatedToken');
 
         $subscriber = new ApiUserSubscriber($userProvider, $tokenPermissions);
@@ -386,11 +386,11 @@ final class ApiUserSubscriberTest extends TestCase
     public function testTokenCreateOauthAlreadyHasAuthenticatedUser(): void
     {
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
 
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $accessTokenBadge = $this->createStub(AccessTokenBadge::class);
@@ -398,7 +398,7 @@ final class ApiUserSubscriberTest extends TestCase
         $authenticatedToken = $this->createMock(OAuthToken::class);
         $authenticatedToken->method('getUser')->willReturn($this->createStub(UserInterface::class));
         // No user was replaced.
-        $authenticatedToken->expects(self::never())
+        $authenticatedToken->expects($this->never())
             ->method('setUser');
 
         $passport = $this->createMock(Passport::class);
@@ -423,11 +423,11 @@ final class ApiUserSubscriberTest extends TestCase
     public function testTokenCreateOauthSetsAuthenticatedUser(): void
     {
         $userProvider = $this->createMock(UserProvider::class);
-        $userProvider->expects(self::never())
+        $userProvider->expects($this->never())
             ->method('loadUserByIdentifier');
 
         $tokenPermissions = $this->createMock(TokenPermissions::class);
-        $tokenPermissions->expects(self::never())
+        $tokenPermissions->expects($this->never())
             ->method('setActivePermissionsOnAuthToken');
 
         $user = $this->createStub(UserInterface::class);

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordStrengthSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordStrengthSubscriberTest.php
@@ -19,7 +19,7 @@ final class PasswordStrengthSubscriberTest extends TestCase
         $passport->method('hasBadge')
             ->with(PasswordCredentials::class)
             ->willReturn(false);
-        $passport->expects(self::never())
+        $passport->expects($this->never())
             ->method('getBadge');
 
         $event = $this->createMock(CheckPassportEvent::class);

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
@@ -94,17 +94,17 @@ final class PluginAuthenticatorTest extends TestCase
 
         $authenticateResult = $authenticateResult->authenticate($request);
         $this->assertInstanceOf(SelfValidatingPassport::class, $authenticateResult);
-        self::assertCount(2, $authenticateResult->getBadges());
+        $this->assertCount(2, $authenticateResult->getBadges());
 
         $userBadge = $authenticateResult->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($userIdentifier, $userBadge->getUserIdentifier());
-        self::assertSame($authenticatedUser, $userBadge->getUser());
+        $this->assertSame($userIdentifier, $userBadge->getUserIdentifier());
+        $this->assertSame($authenticatedUser, $userBadge->getUser());
 
         $pluginBadge = $authenticateResult->getBadge(PluginBadge::class);
         $this->assertInstanceOf(PluginBadge::class, $pluginBadge);
-        self::assertSame($returnedPluginToken, $pluginBadge->getPreAuthenticatedToken());
-        self::assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
+        $this->assertSame($returnedPluginToken, $pluginBadge->getPreAuthenticatedToken());
+        $this->assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
     }
 
     public function testAuthenticateByPreAuthenticationSameToken(): void
@@ -168,17 +168,17 @@ final class PluginAuthenticatorTest extends TestCase
         );
 
         $authenticateResult = $pluginAuthenticator->authenticate($request);
-        self::assertCount(2, $authenticateResult->getBadges());
+        $this->assertCount(2, $authenticateResult->getBadges());
 
         $userBadge = $authenticateResult->getBadge(UserBadge::class);
         \PHPUnit\Framework\Assert::assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($userIdentifier, $userBadge->getUserIdentifier());
-        self::assertSame($authenticatedUser, $userBadge->getUser());
+        $this->assertSame($userIdentifier, $userBadge->getUserIdentifier());
+        $this->assertSame($authenticatedUser, $userBadge->getUser());
 
         $pluginBadge = $authenticateResult->getBadge(PluginBadge::class);
         \PHPUnit\Framework\Assert::assertInstanceOf(PluginBadge::class, $pluginBadge);
-        self::assertEquals(new PluginToken($firewallName, $integration, $authenticatedUser), $pluginBadge->getPreAuthenticatedToken());
-        self::assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
+        $this->assertEquals(new PluginToken($firewallName, $integration, $authenticatedUser), $pluginBadge->getPreAuthenticatedToken());
+        $this->assertSame($authenticatedIntegration, $pluginBadge->getAuthenticatingService());
     }
 
     public function testCreateTokenHasToken(): void
@@ -190,11 +190,11 @@ final class PluginAuthenticatorTest extends TestCase
         $pluginResponse        = new Response();
 
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $dispatcher->expects(self::never())->method('hasListeners');
-        $dispatcher->expects(self::never())->method('dispatch');
+        $dispatcher->expects($this->never())->method('hasListeners');
+        $dispatcher->expects($this->never())->method('dispatch');
 
         $integrationHelper = $this->createMock(IntegrationHelper::class);
-        $integrationHelper->expects(self::never())->method('getIntegrationObjects');
+        $integrationHelper->expects($this->never())->method('getIntegrationObjects');
 
         $userProvider = $this->createStub(UserProviderInterface::class);
 
@@ -237,7 +237,7 @@ final class PluginAuthenticatorTest extends TestCase
             $firewallName
         );
 
-        self::assertEquals($pluginToken, $pluginAuthenticator->createToken($passport, $firewallName));
+        $this->assertEquals($pluginToken, $pluginAuthenticator->createToken($passport, $firewallName));
     }
 
     public function testHappyPathAuthenticationSuccess(): void
@@ -279,7 +279,7 @@ final class PluginAuthenticatorTest extends TestCase
             $firewallName
         );
 
-        self::assertSame($response, $pluginAuthenticator->onAuthenticationSuccess($request, $token, $firewallName));
+        $this->assertSame($response, $pluginAuthenticator->onAuthenticationSuccess($request, $token, $firewallName));
     }
 
     public function testHappyPathAuthenticationFailure(): void
@@ -306,6 +306,6 @@ final class PluginAuthenticatorTest extends TestCase
             $firewallName
         );
 
-        self::assertSame($response, $pluginAuthenticator->onAuthenticationFailure($request, $exception));
+        $this->assertSame($response, $pluginAuthenticator->onAuthenticationFailure($request, $exception));
     }
 }

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
@@ -68,7 +68,7 @@ final class SsoAuthenticatorTest extends TestCase
             }
         }
 
-        self::assertSame($expected, $authenticator->supports($request));
+        $this->assertSame($expected, $authenticator->supports($request));
     }
 
     public static function provideIsPost(): \Generator
@@ -110,7 +110,7 @@ final class SsoAuthenticatorTest extends TestCase
             ->with($request, $path)
             ->willReturn($expected);
 
-        self::assertSame($expected, $authenticator->supports($request));
+        $this->assertSame($expected, $authenticator->supports($request));
     }
 
     public static function provideCheckPath(): \Generator
@@ -152,7 +152,7 @@ final class SsoAuthenticatorTest extends TestCase
             ->with($request, $path)
             ->willReturn(true);
 
-        self::assertSame($expected, $authenticator->supports($request));
+        $this->assertSame($expected, $authenticator->supports($request));
     }
 
     public static function provideFormOnly(): \Generator
@@ -201,7 +201,7 @@ final class SsoAuthenticatorTest extends TestCase
             ->with($request, $path)
             ->willReturn(true);
 
-        self::assertSame($expected, $authenticator->supports($request));
+        $this->assertSame($expected, $authenticator->supports($request));
     }
 
     public static function provideRequestIntegrationParameter(): \Generator
@@ -251,32 +251,32 @@ final class SsoAuthenticatorTest extends TestCase
 
         $passport = $authenticator->authenticate($request);
         $badges   = $passport->getBadges();
-        self::assertCount($enableCsrf ? 4 : 3, $badges);
+        $this->assertCount($enableCsrf ? 4 : 3, $badges);
 
         $userBadge = $passport->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($username, $userBadge->getUserIdentifier());
+        $this->assertSame($username, $userBadge->getUserIdentifier());
 
         $passwordBadge = $passport->getBadge(PasswordCredentials::class);
         $this->assertInstanceOf(PasswordCredentials::class, $passwordBadge);
-        self::assertSame($password, $passwordBadge->getPassword());
+        $this->assertSame($password, $passwordBadge->getPassword());
 
-        self::assertTrue($passport->hasBadge(RememberMeBadge::class));
+        $this->assertTrue($passport->hasBadge(RememberMeBadge::class));
 
         // Badge will be added later by PasswordStrengthSubscriber
         $passwordStrengthBadge = $passport->getBadge(PasswordStrengthBadge::class);
-        self::assertNull($passwordStrengthBadge);
+        $this->assertNotInstanceOf(PasswordStrengthBadge::class, $passwordStrengthBadge);
 
         if (!$enableCsrf) {
-            self::assertFalse($passport->hasBadge(CsrfTokenBadge::class));
+            $this->assertFalse($passport->hasBadge(CsrfTokenBadge::class));
 
             return;
         }
 
         $csrfTokenBadge = $passport->getBadge(CsrfTokenBadge::class);
         $this->assertInstanceOf(CsrfTokenBadge::class, $csrfTokenBadge);
-        self::assertSame($csrfToken, $csrfTokenBadge->getCsrfToken());
-        self::assertSame('authenticate', $csrfTokenBadge->getCsrfTokenId());
+        $this->assertSame($csrfToken, $csrfTokenBadge->getCsrfToken());
+        $this->assertSame('authenticate', $csrfTokenBadge->getCsrfTokenId());
     }
 
     public static function provideEnableCsrf(): \Generator
@@ -340,7 +340,7 @@ final class SsoAuthenticatorTest extends TestCase
 
         $userBadge = $passport->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($username, $userBadge->getUserIdentifier());
+        $this->assertSame($username, $userBadge->getUserIdentifier());
 
         $this->expectException(UserNotFoundException::class);
 
@@ -406,8 +406,8 @@ final class SsoAuthenticatorTest extends TestCase
 
         $userBadge = $passport->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($username, $userBadge->getUserIdentifier());
-        self::assertSame($user, $userBadge->getUser());
+        $this->assertSame($username, $userBadge->getUserIdentifier());
+        $this->assertSame($user, $userBadge->getUser());
     }
 
     public function testAuthenticateListenerForcesFailure(): void
@@ -497,7 +497,7 @@ final class SsoAuthenticatorTest extends TestCase
 
         $userBadge = $passport->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($username, $userBadge->getUserIdentifier());
+        $this->assertSame($username, $userBadge->getUserIdentifier());
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage($failedMessage);
@@ -586,8 +586,8 @@ final class SsoAuthenticatorTest extends TestCase
 
         $userBadge = $passport->getBadge(UserBadge::class);
         $this->assertInstanceOf(UserBadge::class, $userBadge);
-        self::assertSame($username, $userBadge->getUserIdentifier());
+        $this->assertSame($username, $userBadge->getUserIdentifier());
 
-        self::assertSame($user, $userBadge->getUser());
+        $this->assertSame($user, $userBadge->getUser());
     }
 }

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/Request/RequestStateStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/Request/RequestStateStoreTest.php
@@ -70,7 +70,7 @@ final class RequestStateStoreTest extends TestCase
 
     public function testGetNotHit(): void
     {
-        self::assertNull($this->requestStateStore->get($this->stateId));
+        $this->assertNotInstanceOf(RequestState::class, $this->requestStateStore->get($this->stateId));
     }
 
     public function testGetIsHitButNotRequestState(): void
@@ -85,7 +85,7 @@ final class RequestStateStoreTest extends TestCase
         );
         ($setUp)($this->cacheItem);
 
-        self::assertNull($this->requestStateStore->get($this->stateId));
+        $this->assertNotInstanceOf(RequestState::class, $this->requestStateStore->get($this->stateId));
     }
 
     public function testGetIsHitRequestState(): void
@@ -102,7 +102,7 @@ final class RequestStateStoreTest extends TestCase
         );
         ($setUp)($this->cacheItem, $state);
 
-        self::assertSame($state, $this->requestStateStore->get($this->stateId));
+        $this->assertSame($state, $this->requestStateStore->get($this->stateId));
     }
 
     public function testRemove(): void
@@ -113,7 +113,7 @@ final class RequestStateStoreTest extends TestCase
             ->with($this->cachePrefix.$id)
             ->willReturn(true);
 
-        self::assertTrue($this->requestStateStore->remove($id));
+        $this->assertTrue($this->requestStateStore->remove($id));
     }
 
     public function testClear(): void

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -249,7 +249,7 @@ final class WebhookModelTest extends TestCase
             ->with('test-webhook.com', $responsePayload)
             ->willReturn(new Response(200, [], 'Success'));
 
-        self::assertTrue($this->model->processWebhook($webhook, $queue));
+        $this->assertTrue($this->model->processWebhook($webhook, $queue));
     }
 
     public function testMinAndMaxQueueIdWhenNoneIsSet(): void

--- a/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
@@ -331,8 +331,8 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
                 $modifiedBy
             );
 
-        $modifiedBy->expects(self::atLeastOnce())->method('getEmail')->willReturn($modifiedByEmail);
-        $owner->expects(self::atLeastOnce())->method('getEmail')->willReturn($ownerEmail);
+        $modifiedBy->expects($this->atLeastOnce())->method('getEmail')->willReturn($modifiedByEmail);
+        $owner->expects($this->atLeastOnce())->method('getEmail')->willReturn($ownerEmail);
 
         $this->mailHelperMock
             ->expects($this->once())
@@ -351,7 +351,7 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
             ->method('setBody')
             ->with($details);
 
-        $this->coreParamHelperMock->expects(self::atLeastOnce())
+        $this->coreParamHelperMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnMap([
                 ['webhook_send_notification_to_author', 1, true],
@@ -440,7 +440,7 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
             ->method('setBody')
             ->with($details);
 
-        $this->coreParamHelperMock->expects(self::atLeastOnce())
+        $this->coreParamHelperMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnMap([
                 ['webhook_send_notification_to_author', 1, false],

--- a/plugins/GrapesJsBuilderBundle/Tests/InstallFixtures/ORM/GrapeJsDataTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/InstallFixtures/ORM/GrapeJsDataTest.php
@@ -29,12 +29,12 @@ final class GrapeJsDataTest extends MauticMysqlTestCase
             'bundle'      => 'GrapesJsBuilderBundle',
         ];
         $plugin = $this->em->getRepository(Plugin::class)->findOneBy($findOneByCriteria);
-        self::assertNull($plugin);
+        $this->assertNotInstanceOf(Plugin::class, $plugin);
 
         $this->loadFixtures([GrapesJsData::class]);
 
         $plugin = $this->em->getRepository(Plugin::class)->findOneBy($findOneByCriteria);
-        self::assertInstanceOf(Plugin::class, $plugin);
+        $this->assertInstanceOf(Plugin::class, $plugin);
 
         $integration = $this->em->getRepository(Integration::class)->findOneBy(
             [
@@ -43,6 +43,6 @@ final class GrapeJsDataTest extends MauticMysqlTestCase
                 'plugin'      => $plugin,
             ]
         );
-        self::assertInstanceOf(Integration::class, $integration);
+        $this->assertInstanceOf(Integration::class, $integration);
     }
 }

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
@@ -31,8 +31,8 @@ final class GrapesJsControllerTest extends TestCase
         $controller = $this->getControllerForEditorState($this->createStub(CorePermissions::class), null);
         $response   = $controller->editorStateAction('email', 'new123');
 
-        self::assertInstanceOf(JsonResponse::class, $response);
-        self::assertSame('{"editorState":null}', $response->getContent());
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame('{"editorState":null}', $response->getContent());
     }
 
     public function testEditorStateActionReturnsEditorStateFromJsonContent(): void
@@ -51,7 +51,7 @@ final class GrapesJsControllerTest extends TestCase
         $controller = $this->getControllerForEditorState($security, $entity);
         $response   = $controller->editorStateAction('email', '15');
 
-        self::assertSame('{"editorState":{"components":[{"type":"text"}]}}', $response->getContent());
+        $this->assertSame('{"editorState":{"components":[{"type":"text"}]}}', $response->getContent());
     }
 
     public function testEditorStateActionReturnsEditorStateFromSerializedContent(): void
@@ -66,7 +66,7 @@ final class GrapesJsControllerTest extends TestCase
         $controller = $this->getControllerForEditorState($security, $entity);
         $response   = $controller->editorStateAction('email', '33');
 
-        self::assertSame('{"editorState":{"pages":[]}}', $response->getContent());
+        $this->assertSame('{"editorState":{"pages":[]}}', $response->getContent());
     }
 
     public function testEditorStateActionReturnsNullWhenEditorStateCannotBeDecoded(): void
@@ -85,7 +85,7 @@ final class GrapesJsControllerTest extends TestCase
         $controller = $this->getControllerForEditorState($security, $entity);
         $response   = $controller->editorStateAction('email', '20');
 
-        self::assertSame('{"editorState":null}', $response->getContent());
+        $this->assertSame('{"editorState":null}', $response->getContent());
     }
 
     private function getControllerForEditorState(CorePermissions $security, ?Email $entity): GrapesJsController

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
@@ -57,11 +57,11 @@ final class InjectCustomContentSubscriberTest extends TestCase
         $subscriber = new InjectCustomContentSubscriber($this->config, $this->model, $this->twig, $requestStack, $this->router);
         $event      = new CustomContentEvent('view', 'email.settings.advanced', ['email' => new Email()]);
 
-        $this->twig->expects(self::never())->method('render');
+        $this->twig->expects($this->never())->method('render');
 
         $subscriber->injectViewCustomContent($event);
 
-        self::assertSame([], $event->getContent());
+        $this->assertSame([], $event->getContent());
     }
 
     public function testInjectViewCustomContentUsesRequestCustomMjmlOnPost(): void
@@ -90,7 +90,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
         $subscriber->injectViewCustomContent($event);
 
-        self::assertSame(['<div>ok</div>'], $event->getContent());
+        $this->assertSame(['<div>ok</div>'], $event->getContent());
     }
 
     public function testInjectViewCustomContentUsesStoredMjmlOnGet(): void
@@ -117,7 +117,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
         $subscriber->injectViewCustomContent($event);
 
-        self::assertSame(['<div>stored</div>'], $event->getContent());
+        $this->assertSame(['<div>stored</div>'], $event->getContent());
     }
 
     public function testInjectViewCustomContentInjectsPageHeaderVars(): void
@@ -127,7 +127,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
         $this->config->method('isPublished')->willReturn(true);
 
-        $this->router->expects(self::exactly(3))
+        $this->router->expects($this->exactly(3))
             ->method('generate')
             ->willReturnMap([
                 ['grapesjsbuilder_assets', [], 0, 'https://example.test/assets'],
@@ -152,6 +152,6 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
         $subscriber->injectViewCustomContent($event);
 
-        self::assertSame(['<script>vars</script>'], $event->getContent());
+        $this->assertSame(['<script>vars</script>'], $event->getContent());
     }
 }

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/PageSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/PageSubscriberTest.php
@@ -36,7 +36,7 @@ final class PageSubscriberTest extends TestCase
     public function testOnPagePostSaveSkipsWhenPluginNotPublished(): void
     {
         $this->config->method('isPublished')->willReturn(false);
-        $this->model->expects(self::never())->method('addOrEditPageEntity');
+        $this->model->expects($this->never())->method('addOrEditPageEntity');
 
         $this->subscriber->onPagePostSave(new PageEvent(new Page()));
     }

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
@@ -88,7 +88,7 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
         /** @var MockObject&EmailRepository $emailRepository */
         $emailRepository = $this->createMock(EmailRepository::class);
-        $emailRepository->expects(self::never())->method('saveEntity');
+        $emailRepository->expects($this->never())->method('saveEntity');
 
         /** @var MockObject&EmailModel $emailModel */
         $emailModel = $this->createMock(EmailModel::class);
@@ -97,7 +97,7 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
         /** @var MockObject&EntityManager $entityManager */
         $entityManager = $this->createMock(EntityManager::class);
-        $entityManager->expects(self::never())->method('getRepository');
+        $entityManager->expects($this->never())->method('getRepository');
 
         $model = $this->getModel($requestStack, $emailModel, $entityManager);
 
@@ -143,8 +143,8 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
         /** @var MockObject&EntityManager $entityManagerNoEditor */
         $entityManagerNoEditor = $this->createMock(EntityManager::class);
-        $entityManagerNoEditor->expects(self::never())->method('persist');
-        $entityManagerNoEditor->expects(self::never())->method('flush');
+        $entityManagerNoEditor->expects($this->never())->method('persist');
+        $entityManagerNoEditor->expects($this->never())->method('flush');
 
         $modelNoEditor = $this->getModel($requestStackNoEditor, $emailModel, $entityManagerNoEditor);
         $modelNoEditor->addOrEditPageEntity(new Page());

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -442,7 +442,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
         $api = new SalesforceApi($integration);
 
-        self::assertEquals('2019-05-22 19:36:30', $api->getOrganizationCreatedDate());
+        $this->assertEquals('2019-05-22 19:36:30', $api->getOrganizationCreatedDate());
 
         $api->getLeads($params, 'Lead');
     }
@@ -515,7 +515,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 
         $api = new SalesforceApi($integration);
 
-        self::assertEquals('2019-05-22 19:36:30', $api->getOrganizationCreatedDate());
+        $this->assertEquals('2019-05-22 19:36:30', $api->getOrganizationCreatedDate());
 
         $api->getLeads($params, 'Lead');
     }

--- a/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
@@ -44,7 +44,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
 
     public function testGetRequiredKeyFields(): void
     {
-        self::assertSame([], $this->integration->getRequiredKeyFields());
+        $this->assertSame([], $this->integration->getRequiredKeyFields());
     }
 
     public function testGetBearerTokenEmpty(): void
@@ -62,7 +62,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertNull($this->integration->getBearerToken());
+        $this->assertNull($this->integration->getBearerToken());
     }
 
     public function testGetBearerTokenSet(): void
@@ -82,18 +82,15 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertSame($token, $this->integration->getBearerToken());
+        $this->assertSame($token, $this->integration->getBearerToken());
     }
 
     public function testGetFormSettings(): void
     {
-        self::assertSame(
-            [
-                'requires_callback'      => false,
-                'requires_authorization' => false,
-            ],
-            $this->integration->getFormSettings()
-        );
+        $this->assertSame([
+            'requires_callback'      => false,
+            'requires_authorization' => false,
+        ], $this->integration->getFormSettings());
     }
 
     public function testGetAuthenticationTypeNoOauthToken(): void
@@ -111,7 +108,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertSame('key', $this->integration->getAuthenticationType());
+        $this->assertSame('key', $this->integration->getAuthenticationType());
     }
 
     public function testGetAuthenticationTypeWithOauthToken(): void
@@ -129,7 +126,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertSame('oauth2', $this->integration->getAuthenticationType());
+        $this->assertSame('oauth2', $this->integration->getAuthenticationType());
     }
 
     public function testIsAuthorizedNoOauthToken(): void
@@ -147,7 +144,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertFalse($this->integration->isAuthorized());
+        $this->assertFalse($this->integration->isAuthorized());
     }
 
     public function testIsAuthorizedWithOauthToken(): void
@@ -165,13 +162,13 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        self::assertTrue($this->integration->isAuthorized());
+        $this->assertTrue($this->integration->isAuthorized());
     }
 
     public function testAppendToFormKeys(): void
     {
         $builder = $this->createMock(FormBuilderInterface::class);
-        $matcher = self::exactly(2);
+        $matcher = $this->exactly(2);
         $builder->expects($matcher)
             ->method('add')->willReturnCallback(function (...$parameters) use ($matcher): void {
                 if (1 === $matcher->numberOfInvocations()) {

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -696,11 +696,11 @@ final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
         $sf = $this->getSalesforceIntegration();
         $sf->amendLeadDataBeforePush($input);
 
-        self::assertSame($input, $output);
-        self::assertSame('string', gettype($output[0]));
-        self::assertSame('boolean', gettype($output[1]));
-        self::assertSame('string', gettype($output[2]));
-        self::assertSame('integer', gettype($output[3]));
+        $this->assertSame($input, $output);
+        $this->assertSame('string', gettype($output[0]));
+        $this->assertSame('boolean', gettype($output[1]));
+        $this->assertSame('string', gettype($output[2]));
+        $this->assertSame('integer', gettype($output[3]));
     }
 
     protected function setMaxInvocations(string $name, int $max): self

--- a/plugins/MauticFocusBundle/Tests/Form/Type/ContentTypeTest.php
+++ b/plugins/MauticFocusBundle/Tests/Form/Type/ContentTypeTest.php
@@ -22,7 +22,7 @@ final class ContentTypeTest extends TestCase
 
     public function testBuilderForm(): void
     {
-        $this->formBuilder->expects(self::exactly(7))->method('add')->willReturnSelf();
+        $this->formBuilder->expects($this->exactly(7))->method('add')->willReturnSelf();
         $options     = [];
         $contentType = new ContentType();
         $contentType->buildForm($this->formBuilder, $options);

--- a/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
+++ b/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
@@ -40,14 +40,14 @@ final class TokenHelperTest extends TestCase
     {
         $content = 'content';
 
-        self::assertSame([], $this->helper->findFocusTokens($content));
+        $this->assertSame([], $this->helper->findFocusTokens($content));
     }
 
     public function testFindFocusTokensFound(): void
     {
         $content = 'content {focus=1}';
 
-        self::assertSame(['{focus=1}' => ''], $this->helper->findFocusTokens($content));
+        $this->assertSame(['{focus=1}' => ''], $this->helper->findFocusTokens($content));
     }
 
     public function testFindFocusTokensFoundAddScriptByFocusPublishedStatus(): void
@@ -63,10 +63,7 @@ final class TokenHelperTest extends TestCase
             ->with($focusItemId)
             ->willReturn($focusItem);
 
-        self::assertSame(
-            ['{focus=1}' => '<script src="" type="text/javascript" charset="utf-8" async="async"></script>'],
-            $this->helper->findFocusTokens($content)
-        );
+        $this->assertSame(['{focus=1}' => '<script src="" type="text/javascript" charset="utf-8" async="async"></script>'], $this->helper->findFocusTokens($content));
     }
 
     public function testFindFocusTokensFoundAddScriptByAccessCheck(): void
@@ -93,9 +90,6 @@ final class TokenHelperTest extends TestCase
             )
             ->willReturn(true);
 
-        self::assertSame(
-            ['{focus=1}' => '<script src="" type="text/javascript" charset="utf-8" async="async"></script>'],
-            $this->helper->findFocusTokens($content)
-        );
+        $this->assertSame(['{focus=1}' => '<script src="" type="text/javascript" charset="utf-8" async="async"></script>'], $this->helper->findFocusTokens($content));
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -64,9 +64,6 @@ return RectorConfig::configure()
             __DIR__.'/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php',
         ],
 
-        // waits for descission
-        Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
-
         // fix in rector-dev
         Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Entity/CommonRepository.php',
@@ -135,9 +132,6 @@ return RectorConfig::configure()
 
         Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector::class,
 
-        // phpunit
-        Rector\PHPUnit\CodeQuality\Rector\Class_\AssertClassToThisAssertRector::class,
-        Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
         // will be fixed
         Rector\PHPUnit\CodeQuality\Rector\Expression\DecorateWillReturnMapWithExpectsMockRector::class,
         Rector\PHPUnit\CodeQuality\Rector\MethodCall\CallbackSingleAssertToSimplerRector::class,


### PR DESCRIPTION
Quick grep shows prevalence:

Total 9156 in *Test.php under app/.                                                                                                        
                                                                                                                                             
  - $this->assert → 8104                                                                                                                     
  - self::assert → 1052

Goal of this rule (will be enabled soon as phpunit code quality set) is to unite these calls under sole syntax :+1: 