### PR TITLE
[phpstan 0] Use Types::JSON instead of deprecated Types::ARRAY

### DIFF
--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -95,7 +95,7 @@ class Widget extends FormEntity
         $builder->addField('height', Types::INTEGER);
         $builder->addNullableField('cacheTimeout', Types::INTEGER, 'cache_timeout');
         $builder->addNullableField('ordering', Types::INTEGER);
-        $builder->addNullableField('params', Types::ARRAY);
+        $builder->addNullableField('params', Types::JSON);
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -383,8 +383,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
             ->build();
 
         $builder->addNullableField('template', Types::STRING);
-        $builder->addNullableField('content', Types::ARRAY);
-        $builder->addNullableField('utmTags', Types::ARRAY, 'utm_tags');
+        $builder->addNullableField('content', Types::JSON);
+        $builder->addNullableField('utmTags', Types::JSON, 'utm_tags');
         $builder->addNullableField('plainText', Types::TEXT, 'plain_text');
         $builder->addNullableField('customHtml', Types::TEXT, 'custom_html');
         $builder->addNullableField('emailType', Types::TEXT, 'email_type');

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -251,13 +251,13 @@ class Field implements UuidInterface
         $builder->addField('alias', Types::STRING);
         $builder->addField('type', Types::STRING);
         $builder->addNamedField('isCustom', Types::BOOLEAN, 'is_custom');
-        $builder->addNullableField('customParameters', Types::ARRAY, 'custom_parameters');
+        $builder->addNullableField('customParameters', Types::JSON, 'custom_parameters');
         $builder->addNullableField('defaultValue', Types::TEXT, 'default_value');
         $builder->addNamedField('isRequired', Types::BOOLEAN, 'is_required');
         $builder->addNullableField('validationMessage', Types::TEXT, 'validation_message');
         $builder->addNullableField('helpMessage', Types::TEXT, 'help_message');
         $builder->addNullableField('order', Types::INTEGER, 'field_order');
-        $builder->addNullableField('properties', Types::ARRAY);
+        $builder->addNullableField('properties', Types::JSON);
         $builder->addNullableField('validation', Types::JSON);
 
         $builder->addNullableField('parent', 'string', 'parent_id');

--- a/app/bundles/LeadBundle/Entity/ContactExportScheduler.php
+++ b/app/bundles/LeadBundle/Entity/ContactExportScheduler.php
@@ -46,7 +46,7 @@ class ContactExportScheduler
         $builder->createField('scheduledDateTime', Types::DATETIME_IMMUTABLE)
             ->columnName('scheduled_datetime')
             ->build();
-        $builder->addNullableField('data', Types::ARRAY);
+        $builder->addNullableField('data', Types::JSON);
     }
 
     public static function loadValidatorMetadata(ValidatorClassMetadata $metadata): void

--- a/app/bundles/LeadBundle/Entity/UtmTag.php
+++ b/app/bundles/LeadBundle/Entity/UtmTag.php
@@ -80,7 +80,7 @@ class UtmTag
         $builder->addId();
         $builder->addDateAdded();
         $builder->addLead(false, 'CASCADE', false, 'utmtags');
-        $builder->addNullableField('query', Types::ARRAY);
+        $builder->addNullableField('query', Types::JSON);
         $builder->addNullableField('referer', Types::TEXT);
         $builder->addNullableField('remoteHost', Types::STRING, 'remote_host');
         $builder->addNullableField('url', Types::TEXT);

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -173,29 +173,29 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
 
         $builder->addField('source', Types::STRING);
 
-        $builder->createField('columns', Types::ARRAY)
+        $builder->createField('columns', Types::JSON)
             ->nullable()
             ->build();
 
-        $builder->createField('filters', Types::ARRAY)
+        $builder->createField('filters', Types::JSON)
             ->nullable()
             ->build();
 
-        $builder->createField('tableOrder', Types::ARRAY)
+        $builder->createField('tableOrder', Types::JSON)
             ->columnName('table_order')
             ->nullable()
             ->build();
 
-        $builder->createField('graphs', Types::ARRAY)
+        $builder->createField('graphs', Types::JSON)
             ->nullable()
             ->build();
 
-        $builder->createField('groupBy', Types::ARRAY)
+        $builder->createField('groupBy', Types::JSON)
             ->columnName('group_by')
             ->nullable()
             ->build();
 
-        $builder->createField('aggregators', Types::ARRAY)
+        $builder->createField('aggregators', Types::JSON)
             ->columnName('aggregators')
             ->nullable()
             ->build();

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/AssetsSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/AssetsSubscriberTest.php
@@ -200,7 +200,9 @@ final class AssetsSubscriberTest extends TestCase
         );
     }
 
-    /** @param array<string, mixed>|string $content */
+    /**
+     * @param array<string, mixed>|string $content
+     */
     private function writeManifest(array|string $content): void
     {
         $data = is_array($content) ? json_encode($content) : $content;


### PR DESCRIPTION
Doctrine DBAL deprecated the `array` type. This switches the affected entity mappings from `Types::ARRAY` to `Types::JSON` and rebases the custom `ArrayType` on `JsonType`.

```diff
-        $builder->addNullableField('params', Types::ARRAY);
+        $builder->addNullableField('params', Types::JSON);
```
