### PR TITLE
Do not take the return value from the request, only from the database

### DIFF
--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -122,7 +122,14 @@ final class PublicController extends CommonFormController
             return null;
         }
 
-        $return = InputHelper::url((string) $return, false, null, null, ['mauticError', 'mauticMessage'], true);
+        $rawReturn = (string) $return;
+        $return = InputHelper::url($rawReturn, false, null, null, ['mauticError', 'mauticMessage'], true);
+
+        // Reject URLs containing backslashes or @ signs that could be misinterpreted
+        // by browsers differently than PHP's parse_url.
+        if (str_contains($return, '\\') || (str_contains($return, '@') && !str_starts_with($return, '/'))) {
+            return null;
+        }
 
         // Allow relative URLs (starting with /)
         if (str_starts_with($return, '/') && !str_starts_with($return, '//')) {
@@ -134,11 +141,23 @@ final class PublicController extends CommonFormController
             return null;
         }
 
-        // Allow same-origin URLs
+        // Allow same-origin URLs (comparing scheme, host, and port)
         $siteUrl = (string) $this->coreParametersHelper->get('site_url');
         if ('' !== $siteUrl) {
-            $siteHost = parse_url($siteUrl, PHP_URL_HOST);
-            if ($siteHost && strtolower($siteHost) === strtolower($returnHost)) {
+            $siteScheme = parse_url($siteUrl, PHP_URL_SCHEME);
+            $siteHost   = parse_url($siteUrl, PHP_URL_HOST);
+            $sitePort   = parse_url($siteUrl, PHP_URL_PORT);
+
+            $returnScheme = parse_url($return, PHP_URL_SCHEME);
+            $returnPort   = parse_url($return, PHP_URL_PORT);
+
+            // Normalize ports: null means default port for the scheme
+            $sitePort   = $sitePort ?? ('https' === $siteScheme ? 443 : 80);
+            $returnPort = $returnPort ?? ('https' === $returnScheme ? 443 : 80);
+
+            if ($siteHost && strtolower($siteScheme) === strtolower($returnScheme)
+                && strtolower($siteHost) === strtolower($returnHost)
+                && $sitePort === $returnPort) {
                 return $return;
             }
         }
@@ -254,9 +273,17 @@ final class PublicController extends CommonFormController
         $post   = $this->getSubmittedPost($request);
         $server = $request->server->all();
 
-        // Remove the user-controlled 'return' field so it is not stored as the submission referrer.
-        // The SubmissionModel will fall back to HTTP_REFERER which is a trusted browser header.
-        unset($post['return']);
+        // Validate and replace the user-controlled 'return' field with a trusted URL.
+        // This preserves the submission referrer metadata and repost actions, but prevents
+        // untrusted URLs from being stored or used for redirects.
+        $trustedReturn = $this->getTrustedReturnUrl($request);
+        if (null !== $trustedReturn) {
+            $post['return'] = $trustedReturn;
+        } else {
+            // If the provided return URL is untrusted, remove it so SubmissionModel falls back
+            // to HTTP_REFERER which is a trusted browser header.
+            unset($post['return']);
+        }
 
         $result = $this->submissionModel->saveSubmission($post, $server, $form, $request, true);
 

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -152,8 +152,8 @@ final class PublicController extends CommonFormController
             $returnPort   = parse_url($return, PHP_URL_PORT);
 
             // Normalize ports: null means default port for the scheme
-            $sitePort   = $sitePort ?? ('https' === $siteScheme ? 443 : 80);
-            $returnPort = $returnPort ?? ('https' === $returnScheme ? 443 : 80);
+            $sitePort ??= 'https' === $siteScheme ? 443 : 80;
+            $returnPort ??= 'https' === $returnScheme ? 443 : 80;
 
             if ($siteHost && strtolower($siteScheme) === strtolower($returnScheme)
                 && strtolower($siteHost) === strtolower($returnHost)

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -63,8 +63,7 @@ final class PublicController extends CommonFormController
             $this->throwAccessDenied();
         }
 
-        $context          = $this->createSubmitContext($request);
-        $submissionResult = $this->processSubmittedForm($request, $context, $dateTemplateHelper, $notificationModel, $userRepository);
+        $submissionResult = $this->processSubmittedForm($request, $dateTemplateHelper, $notificationModel, $userRepository);
 
         if ($submissionResult['response'] instanceof Response) {
             return $submissionResult['response'];
@@ -75,55 +74,46 @@ final class PublicController extends CommonFormController
             $submissionResult['postActionProperty'] = $this->replacePostSubmitTokens($submissionResult['postActionProperty'], $submissionResult['submissionEvent'], $pageTokenHelper);
         }
 
-        return ($context['messengerMode'] || $context['isAjax'])
-            ? $this->buildMessengerResponse($context, $submissionResult)
-            : $this->buildStandardResponse($request, $context, $submissionResult);
+        return ($this->isMessengerMode($request) || $this->isAjax($request))
+            ? $this->buildMessengerResponse($request, $submissionResult)
+            : $this->buildStandardResponse($request, $submissionResult);
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function createSubmitContext(Request $request): array
+    private function getSubmittedPost(Request $request): array
     {
-        $server = $request->server->all();
-        $post   = $request->request->all()['mauticform'] ?? [];
-        $post   = is_array($post) ? $post : [];
-        $return = $post['return'] ?? false;
-        $query  = '?';
+        $post = $request->request->all()['mauticform'] ?? [];
 
-        if (empty($return)) {
-            // try to get it from the HTTP_REFERER
-            $return = $server['HTTP_REFERER'] ?? false;
-        }
+        return is_array($post) ? $post : [];
+    }
 
-        if (!empty($return)) {
-            // remove mauticError and mauticMessage from the referer so it doesn't get sent back
-            $return = InputHelper::url((string) $return, false, null, null, ['mauticError', 'mauticMessage'], true);
-            $query  = (!str_contains($return, '?')) ? '?' : '&';
-        }
+    private function isAjax(Request $request): bool
+    {
+        return (bool) $request->query->get('ajax');
+    }
 
-        return [
-            'isAjax'        => (bool) $request->query->get('ajax'),
-            'messengerMode' => !empty($post['messenger']),
-            'post'          => $post,
-            'query'         => $query,
-            'return'        => $return,
-            'server'        => $server,
-        ];
+    private function isMessengerMode(Request $request): bool
+    {
+        $post = $this->getSubmittedPost($request);
+        $messenger = $post['messenger'] ?? null;
+
+        // This is a transport hint set by mautic-form JS to request messenger-style responses.
+        // It must not be used for business/security decisions.
+        return in_array($messenger, [1, '1', true, 'true'], true);
     }
 
     /**
-     * @param array<string, mixed> $context
-     *
      * @return array<string, mixed>
      */
     private function processSubmittedForm(
         Request $request,
-        array $context,
         DateHelper $dateTemplateHelper,
         NotificationModel $notificationModel,
         UserRepository $userRepository,
     ): array {
+        $post = $this->getSubmittedPost($request);
         $result = [
             'callbackResponses'  => [],
             'error'              => null,
@@ -133,8 +123,6 @@ final class PublicController extends CommonFormController
             'response'           => null,
             'submissionEvent'    => null,
         ];
-        $post = $context['post'];
-        \assert(is_array($post));
 
         if (!isset($post['formId'])) {
             $result['error'] = $this->translator->trans('mautic.form.submit.error.unavailable', [], 'flashes');
@@ -154,7 +142,7 @@ final class PublicController extends CommonFormController
                 if (null === $result['error']) {
                     $result = array_merge(
                         $result,
-                        $this->handlePublishedForm($request, $context, $form, $notificationModel, $userRepository)
+                        $this->handlePublishedForm($request, $form, $notificationModel, $userRepository)
                     );
                 }
             }
@@ -193,13 +181,10 @@ final class PublicController extends CommonFormController
     }
 
     /**
-     * @param array<string, mixed> $context
-     *
      * @return array<string, mixed>
      */
     private function handlePublishedForm(
         Request $request,
-        array $context,
         Form $form,
         NotificationModel $notificationModel,
         UserRepository $userRepository,
@@ -214,14 +199,12 @@ final class PublicController extends CommonFormController
             ];
         }
 
-        $post   = $context['post'];
-        $server = $context['server'];
-        \assert(is_array($post));
-        \assert(is_array($server));
+        $post   = $this->getSubmittedPost($request);
+        $server = $request->server->all();
 
         $result = $this->submissionModel->saveSubmission($post, $server, $form, $request, true);
 
-        return $this->handleSubmissionResult($result, $context);
+        return $this->handleSubmissionResult($request, $result);
     }
 
     private function notifySubmissionLimitReached(Form $form, NotificationModel $notificationModel, UserRepository $userRepository): void
@@ -249,18 +232,20 @@ final class PublicController extends CommonFormController
 
     /**
      * @param array<string, mixed> $result
-     * @param array<string, mixed> $context
      *
      * @return array<string, mixed>
      */
-    private function handleSubmissionResult(array $result, array $context): array
+    private function handleSubmissionResult(Request $request, array $result): array
     {
+        $messengerMode = $this->isMessengerMode($request);
+        $isAjax        = $this->isAjax($request);
+
         if (!empty($result['errors'])) {
             return [
                 'error' => $this->formatSubmissionErrors(
                     $result['errors'],
-                    (bool) $context['messengerMode'],
-                    (bool) $context['isAjax']
+                    $messengerMode,
+                    $isAjax
                 ),
             ];
         }
@@ -270,8 +255,8 @@ final class PublicController extends CommonFormController
             $submissionEvent = $result['callback'];
             $callbackResult  = $this->dispatchPostSubmitCallbacks(
                 $submissionEvent,
-                (bool) $context['messengerMode'],
-                (bool) $context['isAjax']
+                $messengerMode,
+                $isAjax
             );
 
             return array_merge(['submissionEvent' => $submissionEvent], $callbackResult);
@@ -331,11 +316,11 @@ final class PublicController extends CommonFormController
     }
 
     /**
-     * @param array<string, mixed> $context
      * @param array<string, mixed> $submissionResult
      */
-    private function buildMessengerResponse(array $context, array $submissionResult): Response
+    private function buildMessengerResponse(Request $request, array $submissionResult): Response
     {
+        $post = $this->getSubmittedPost($request);
         $data  = ['success' => 1];
         $error = $submissionResult['error'];
 
@@ -350,14 +335,11 @@ final class PublicController extends CommonFormController
             $data = $this->addMessengerSuccessData($data, $submissionResult);
         }
 
-        $post = $context['post'];
-        \assert(is_array($post));
-
         if (isset($post['formName'])) {
             $data['formName'] = $post['formName'];
         }
 
-        if ((bool) $context['isAjax']) {
+        if ($this->isAjax($request)) {
             // Post via ajax so return a json response
             return new JsonResponse($data);
         }
@@ -429,12 +411,11 @@ final class PublicController extends CommonFormController
     }
 
     /**
-     * @param array<string, mixed> $context
      * @param array<string, mixed> $submissionResult
      */
-    private function buildStandardResponse(Request $request, array $context, array $submissionResult): Response
+    private function buildStandardResponse(Request $request, array $submissionResult): Response
     {
-        $response = $this->getStandardRedirectResponse($context, $submissionResult);
+        $response = $this->getStandardRedirectResponse($submissionResult);
 
         if (null === $response) {
             $msg     = $submissionResult['postActionProperty'];
@@ -463,31 +444,15 @@ final class PublicController extends CommonFormController
     }
 
     /**
-     * @param array<string, mixed> $context
      * @param array<string, mixed> $submissionResult
      */
-    private function getStandardRedirectResponse(array $context, array $submissionResult): ?Response
+    private function getStandardRedirectResponse(array $submissionResult): ?Response
     {
-        $error    = $submissionResult['error'];
-        $response = null;
-
-        if (!empty($error) && $context['return']) {
-            $form = $submissionResult['form'];
-            $hash = ($form instanceof Form) ? '#'.strtolower($form->getAlias()) : '';
-
-            $response = $this->redirect($context['return'].$context['query'].'mauticError='.rawurlencode((string) $error).$hash); // NOSONAR return URL is sanitized in createSubmitContext().
-        } elseif ('redirect' === $submissionResult['postAction']) {
-            $response = $this->redirect((string) $submissionResult['postActionProperty']);
-        } elseif ('return' === $submissionResult['postAction'] && !empty($context['return'])) {
-            $return = (string) $context['return'];
-            if (!empty($submissionResult['postActionProperty'])) {
-                $return .= $context['query'].'mauticMessage='.rawurlencode((string) $submissionResult['postActionProperty']);
-            }
-
-            $response = $this->redirect($return); // NOSONAR return URL is sanitized in createSubmitContext().
+        if ('redirect' === $submissionResult['postAction']) {
+            return $this->redirect((string) $submissionResult['postActionProperty']);
         }
 
-        return $response;
+        return null;
     }
 
     /**
@@ -588,14 +553,14 @@ final class PublicController extends CommonFormController
     /**
      * Generates JS file for automatic form generation.
      */
-    public function generateAction(Request $request): Response
+    public function generateAction(Request $request, FormModel $model): Response
     {
         // Don't store a visitor with this request
         defined('MAUTIC_NON_TRACKABLE_REQUEST') || define('MAUTIC_NON_TRACKABLE_REQUEST', 1);
 
         $formId = (int) $request->get('id');
-        $form  = $this->formModel->getEntity($formId);
-        $js    = '';
+        $form   = $this->formModel->getEntity($formId);
+        $js     = '';
 
         if (null !== $form) {
             $status = $form->getPublishStatus();

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -105,6 +105,44 @@ final class PublicController extends CommonFormController
     }
 
     /**
+     * Returns a sanitized return URL only if it is relative or same-origin as site_url.
+     * External/untrusted URLs are rejected and null is returned.
+     */
+    private function getTrustedReturnUrl(Request $request): ?string
+    {
+        $post   = $this->getSubmittedPost($request);
+        $return = $post['return'] ?? '';
+
+        if (empty($return)) {
+            $return = $request->server->get('HTTP_REFERER', '');
+        }
+
+        if (empty($return)) {
+            return null;
+        }
+
+        $return = InputHelper::url((string) $return, false, null, null, ['mauticError', 'mauticMessage'], true);
+
+        // Allow relative URLs (starting with /)
+        if (str_starts_with($return, '/') && !str_starts_with($return, '//')) {
+            return $return;
+        }
+
+        // Allow same-origin URLs
+        $siteUrl = (string) $this->coreParametersHelper->get('site_url');
+        if (!empty($siteUrl)) {
+            $siteHost   = parse_url($siteUrl, PHP_URL_HOST);
+            $returnHost = parse_url($return, PHP_URL_HOST);
+
+            if ($siteHost && $returnHost && strtolower($siteHost) === strtolower($returnHost)) {
+                return $return;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function processSubmittedForm(
@@ -201,6 +239,10 @@ final class PublicController extends CommonFormController
 
         $post   = $this->getSubmittedPost($request);
         $server = $request->server->all();
+
+        // Remove the user-controlled 'return' field so it is not stored as the submission referrer.
+        // The SubmissionModel will fall back to HTTP_REFERER which is a trusted browser header.
+        unset($post['return']);
 
         $result = $this->submissionModel->saveSubmission($post, $server, $form, $request, true);
 
@@ -415,7 +457,7 @@ final class PublicController extends CommonFormController
      */
     private function buildStandardResponse(Request $request, array $submissionResult): Response
     {
-        $response = $this->getStandardRedirectResponse($submissionResult);
+        $response = $this->getStandardRedirectResponse($request, $submissionResult);
 
         if (null === $response) {
             $msg     = $submissionResult['postActionProperty'];
@@ -446,10 +488,31 @@ final class PublicController extends CommonFormController
     /**
      * @param array<string, mixed> $submissionResult
      */
-    private function getStandardRedirectResponse(array $submissionResult): ?Response
+    private function getStandardRedirectResponse(Request $request, array $submissionResult): ?Response
     {
-        if ('redirect' === $submissionResult['postAction']) {
+        $error = $submissionResult['error'];
+
+        if (!empty($error)) {
+            $return = $this->getTrustedReturnUrl($request);
+            if ($return) {
+                $form  = $submissionResult['form'];
+                $hash  = ($form instanceof Form) ? '#'.strtolower($form->getAlias()) : '';
+                $query = !str_contains($return, '?') ? '?' : '&';
+
+                return $this->redirect($return.$query.'mauticError='.rawurlencode((string) $error).$hash);
+            }
+        } elseif ('redirect' === $submissionResult['postAction']) {
             return $this->redirect((string) $submissionResult['postActionProperty']);
+        } elseif ('return' === $submissionResult['postAction']) {
+            $return = $this->getTrustedReturnUrl($request);
+            if ($return) {
+                if (!empty($submissionResult['postActionProperty'])) {
+                    $query  = !str_contains($return, '?') ? '?' : '&';
+                    $return .= $query.'mauticMessage='.rawurlencode((string) $submissionResult['postActionProperty']);
+                }
+
+                return $this->redirect($return);
+            }
         }
 
         return null;

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -131,7 +131,7 @@ final class PublicController extends CommonFormController
             return null;
         }
 
-        // Allow relative URLs (starting with /)
+        // Allow relative URLs (starting with / but not //)
         if (str_starts_with($return, '/') && !str_starts_with($return, '//')) {
             return $return;
         }
@@ -151,14 +151,17 @@ final class PublicController extends CommonFormController
             $returnScheme = parse_url($return, PHP_URL_SCHEME);
             $returnPort   = parse_url($return, PHP_URL_PORT);
 
-            // Normalize ports: null means default port for the scheme
-            $sitePort ??= 'https' === $siteScheme ? 443 : 80;
-            $returnPort ??= 'https' === $returnScheme ? 443 : 80;
+            // Only proceed with same-origin check if both URLs have schemes
+            if ($siteScheme && $returnScheme) {
+                // Normalize ports: null means default port for the scheme
+                $sitePort ??= 'https' === $siteScheme ? 443 : 80;
+                $returnPort ??= 'https' === $returnScheme ? 443 : 80;
 
-            if ($siteHost && strtolower($siteScheme) === strtolower($returnScheme)
-                && strtolower($siteHost) === strtolower($returnHost)
-                && $sitePort === $returnPort) {
-                return $return;
+                if ($siteHost && strtolower($siteScheme) === strtolower($returnScheme)
+                    && strtolower($siteHost) === strtolower($returnHost)
+                    && $sitePort === $returnPort) {
+                    return $return;
+                }
             }
         }
 
@@ -280,8 +283,8 @@ final class PublicController extends CommonFormController
         if (null !== $trustedReturn) {
             $post['return'] = $trustedReturn;
         } else {
-            // If the provided return URL is untrusted, remove it so SubmissionModel falls back
-            // to HTTP_REFERER which is a trusted browser header.
+            // If the provided return URL is untrusted, remove it to prevent
+            // submission redirection to user-controlled URLs.
             unset($post['return']);
         }
 

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -105,7 +105,8 @@ final class PublicController extends CommonFormController
     }
 
     /**
-     * Returns a sanitized return URL only if it is relative or same-origin as site_url.
+     * Returns a sanitized return URL only if it is relative, same-origin as site_url,
+     * or matches a domain listed in the CORS valid_domains configuration.
      * External/untrusted URLs are rejected and null is returned.
      */
     private function getTrustedReturnUrl(Request $request): ?string
@@ -113,11 +114,11 @@ final class PublicController extends CommonFormController
         $post   = $this->getSubmittedPost($request);
         $return = $post['return'] ?? '';
 
-        if (empty($return)) {
+        if ('' === $return) {
             $return = $request->server->get('HTTP_REFERER', '');
         }
 
-        if (empty($return)) {
+        if ('' === $return) {
             return null;
         }
 
@@ -128,13 +129,26 @@ final class PublicController extends CommonFormController
             return $return;
         }
 
+        $returnHost = parse_url($return, PHP_URL_HOST);
+        if (!$returnHost) {
+            return null;
+        }
+
         // Allow same-origin URLs
         $siteUrl = (string) $this->coreParametersHelper->get('site_url');
-        if (!empty($siteUrl)) {
-            $siteHost   = parse_url($siteUrl, PHP_URL_HOST);
-            $returnHost = parse_url($return, PHP_URL_HOST);
+        if ('' !== $siteUrl) {
+            $siteHost = parse_url($siteUrl, PHP_URL_HOST);
+            if ($siteHost && strtolower($siteHost) === strtolower($returnHost)) {
+                return $return;
+            }
+        }
 
-            if ($siteHost && $returnHost && strtolower($siteHost) === strtolower($returnHost)) {
+        // Allow URLs matching CORS valid domains configuration
+        $validDomains = (array) $this->coreParametersHelper->get('cors_valid_domains');
+        $returnOrigin = parse_url($return, PHP_URL_SCHEME).'://'.$returnHost;
+
+        foreach ($validDomains as $validDomain) {
+            if (fnmatch($validDomain, $returnOrigin, FNM_CASEFOLD)) {
                 return $return;
             }
         }
@@ -492,7 +506,7 @@ final class PublicController extends CommonFormController
     {
         $error = $submissionResult['error'];
 
-        if (!empty($error)) {
+        if ($error) {
             $return = $this->getTrustedReturnUrl($request);
             if ($return) {
                 $form  = $submissionResult['form'];

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -160,6 +160,115 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->client->followRedirects(true);
     }
 
+    public function testSameOriginReturnUrlIsAllowedOnValidationError(): void
+    {
+        $payload = [
+            'name'        => 'Same origin return test form',
+            'description' => 'Form created via submission test',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'postAction'  => 'return',
+            'fields'      => [
+                [
+                    'label'      => 'Email',
+                    'type'       => 'email',
+                    'alias'      => 'email',
+                    'isRequired' => true,
+                    'leadField'  => 'email',
+                ],
+                [
+                    'label' => 'Submit',
+                    'type'  => 'button',
+                ],
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $formId   = $response['form']['id'];
+
+        // Use a relative return URL (same-origin by definition)
+        $this->client->followRedirects(false);
+        $this->client->request(
+            Request::METHOD_POST,
+            "/form/submit?formId={$formId}",
+            [
+                'mauticform' => [
+                    'formId' => $formId,
+                    'return' => '/my-landing-page',
+                ],
+            ]
+        );
+
+        $submitResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_FOUND, $submitResponse->getStatusCode());
+
+        $redirectUrl = $submitResponse->headers->get('Location');
+        $this->assertNotNull($redirectUrl);
+
+        // Should redirect back to the same-origin return URL with the error
+        $urlParts = parse_url($redirectUrl);
+        $this->assertSame('/my-landing-page', $urlParts['path'] ?? null);
+        $this->assertStringContainsString('mauticError', $redirectUrl);
+
+        $this->client->followRedirects(true);
+    }
+
+    public function testMaliciousReturnUrlIsNotStoredAsReferrer(): void
+    {
+        $payload = [
+            'name'        => 'Referrer security test form',
+            'description' => 'Form created via submission test',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'postAction'  => 'return',
+            'fields'      => [
+                [
+                    'label'     => 'Email',
+                    'type'      => 'email',
+                    'alias'     => 'email',
+                    'leadField' => 'email',
+                ],
+                [
+                    'label' => 'Submit',
+                    'type'  => 'button',
+                ],
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $formId   = $response['form']['id'];
+
+        $this->client->request(
+            Request::METHOD_POST,
+            "/form/submit?formId={$formId}",
+            [
+                'mauticform' => [
+                    'formId' => $formId,
+                    'email'  => 'test@example.com',
+                    'return' => 'https://attacker.com/phishing',
+                ],
+            ]
+        );
+
+        /** @var SubmissionRepository $submissionRepository */
+        $submissionRepository = $this->em->getRepository(Submission::class);
+        $submissions          = $submissionRepository->findBy(['form' => $formId]);
+
+        $this->assertCount(1, $submissions);
+        $this->assertStringNotContainsString('attacker.com', $submissions[0]->getReferer());
+    }
+
     public function testRequiredConditionalFieldIfNotEmpty(): void
     {
         // Create the test form via API.

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -149,6 +149,20 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             'expectedRedirectContains'    => '/form/message',
             'expectedRedirectNotContains' => 'any-domain.com',
         ];
+
+        yield 'relative URL with backslash is rejected' => [
+            'returnUrl'                   => '/\attacker.example/evil',
+            'corsValidDomains'            => [],
+            'expectedRedirectContains'    => '/form/message',
+            'expectedRedirectNotContains' => 'attacker.example',
+        ];
+
+        yield 'absolute URL with backslash is rejected' => [
+            'returnUrl'                   => 'https://attacker.example\@mautic7.ddev.site/evil',
+            'corsValidDomains'            => ['https://mautic7.ddev.site'],
+            'expectedRedirectContains'    => '/form/message',
+            'expectedRedirectNotContains' => 'attacker.example',
+        ];
     }
 
     /**

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -103,6 +103,63 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('bar', $queryParams['foo']);
     }
 
+    public function testMaliciousReturnUrlIsIgnoredOnValidationError(): void
+    {
+        $payload = [
+            'name'        => 'Return URL security test form',
+            'description' => 'Form created via submission test',
+            'formType'    => 'standalone',
+            'isPublished' => true,
+            'postAction'  => 'return',
+            'fields'      => [
+                [
+                    'label'      => 'Email',
+                    'type'       => 'email',
+                    'alias'      => 'email',
+                    'isRequired' => true,
+                    'leadField'  => 'email',
+                ],
+                [
+                    'label' => 'Submit',
+                    'type'  => 'button',
+                ],
+            ],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
+        $clientResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $response = json_decode($clientResponse->getContent(), true);
+        $formId   = $response['form']['id'];
+
+        $this->client->followRedirects(false);
+        $this->client->request(
+            Request::METHOD_POST,
+            "/form/submit?formId={$formId}",
+            [
+                'mauticform' => [
+                    'formId' => $formId,
+                    'return' => 'https://attacker.com/phishing',
+                ],
+            ]
+        );
+
+        $submitResponse = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_FOUND, $submitResponse->getStatusCode());
+
+        $redirectUrl = $submitResponse->headers->get('Location');
+        $this->assertNotNull($redirectUrl);
+        $this->assertStringNotContainsString('attacker.com', $redirectUrl);
+
+        $urlParts = parse_url($redirectUrl);
+        $this->assertSame('/form/message', $urlParts['path'] ?? null);
+
+        $this->client->followRedirects(true);
+    }
+
     public function testRequiredConditionalFieldIfNotEmpty(): void
     {
         // Create the test form via API.
@@ -1367,12 +1424,11 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $redirectUrl = $secondResponse->headers->get('Location');
         $this->assertNotNull($redirectUrl);
         $urlParts = parse_url($redirectUrl);
-        $query    = [];
-        if (isset($urlParts['query'])) {
-            parse_str($urlParts['query'], $query);
-        }
+        $this->assertSame('/form/message', $urlParts['path'] ?? null);
 
-        $this->assertSame('Stop here', urldecode($query['mauticError'] ?? ''));
+        $this->client->followRedirect();
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Stop here', $this->client->getResponse()->getContent());
         $this->client->followRedirects(true);
 
         // Ensure no additional submissions were created after hitting the limit.

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -168,7 +168,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     /**
      * @param list<string> $corsValidDomains
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('returnUrlTrustProvider')]
+    #[DataProvider('returnUrlTrustProvider')]
     public function testReturnUrlTrustValidation(string $returnUrl, array $corsValidDomains, string $expectedRedirectContains, ?string $expectedRedirectNotContains): void
     {
         $this->configParams['cors_valid_domains'] = $corsValidDomains;

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -271,12 +271,12 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         );
 
         $submissionRepository = $this->em->getRepository(Submission::class);
-        \assert($submissionRepository instanceof SubmissionRepository);
+        $this->assertInstanceOf(SubmissionRepository::class, $submissionRepository);
 
         $submissions = $submissionRepository->findBy(['form' => $formId]);
 
         $this->assertCount(1, $submissions);
-        $this->assertStringNotContainsString('attacker.com', $submissions[0]->getReferer());
+        $this->assertStringNotContainsString('attacker.com', (string) $submissions[0]->getReferer());
     }
 
     public function testRequiredConditionalFieldIfNotEmpty(): void

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -1515,7 +1515,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $countSql = "SELECT submission_count FROM {$prefix}forms WHERE id = ?";
         $this->assertSame(1, (int) $this->connection->fetchOne($countSql, [$formId]));
 
-        // Second submission should be blocked by the submission limit and redirect with the custom message.
+        // Second submission should be blocked by the submission limit and redirect back with the error.
         $this->client->followRedirects(false);
         $this->client->request(
             Request::METHOD_POST,
@@ -1529,11 +1529,9 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $redirectUrl = $secondResponse->headers->get('Location');
         $this->assertNotNull($redirectUrl);
         $urlParts = parse_url($redirectUrl);
-        $this->assertSame('/form/message', $urlParts['path'] ?? null);
-
-        $this->client->followRedirect();
-        $this->assertResponseIsSuccessful();
-        $this->assertStringContainsString('Stop here', $this->client->getResponse()->getContent());
+        $this->assertSame('/submission-limit-return', $urlParts['path'] ?? null);
+        parse_str($urlParts['query'] ?? '', $queryParams);
+        $this->assertSame('Stop here', $queryParams['mauticError'] ?? null);
         $this->client->followRedirects(true);
 
         // Ensure no additional submissions were created after hitting the limit.

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -103,67 +103,65 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('bar', $queryParams['foo']);
     }
 
-    public function testMaliciousReturnUrlIsIgnoredOnValidationError(): void
+    /**
+     * @return iterable<string, array{returnUrl: string, corsValidDomains: list<string>, expectedRedirectContains: string, expectedRedirectNotContains: string|null}>
+     */
+    public static function returnUrlTrustProvider(): iterable
     {
-        $payload = [
-            'name'        => 'Return URL security test form',
-            'description' => 'Form created via submission test',
-            'formType'    => 'standalone',
-            'isPublished' => true,
-            'postAction'  => 'return',
-            'fields'      => [
-                [
-                    'label'      => 'Email',
-                    'type'       => 'email',
-                    'alias'      => 'email',
-                    'isRequired' => true,
-                    'leadField'  => 'email',
-                ],
-                [
-                    'label' => 'Submit',
-                    'type'  => 'button',
-                ],
-            ],
+        yield 'malicious external URL is rejected' => [
+            'returnUrl'                   => 'https://attacker.com/phishing',
+            'corsValidDomains'            => [],
+            'expectedRedirectContains'    => '/form/message',
+            'expectedRedirectNotContains' => 'attacker.com',
         ];
 
-        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
-        $clientResponse = $this->client->getResponse();
+        yield 'relative URL is allowed' => [
+            'returnUrl'                   => '/my-landing-page',
+            'corsValidDomains'            => [],
+            'expectedRedirectContains'    => '/my-landing-page',
+            'expectedRedirectNotContains' => null,
+        ];
 
-        $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        yield 'exact CORS domain is allowed' => [
+            'returnUrl'                   => 'https://trusted.example.com/landing',
+            'corsValidDomains'            => ['https://trusted.example.com'],
+            'expectedRedirectContains'    => 'trusted.example.com/landing',
+            'expectedRedirectNotContains' => null,
+        ];
 
-        $response = json_decode($clientResponse->getContent(), true);
-        $formId   = $response['form']['id'];
+        yield 'wildcard CORS domain is allowed' => [
+            'returnUrl'                   => 'https://sub.wildcard.org/page',
+            'corsValidDomains'            => ['https://*.wildcard.org'],
+            'expectedRedirectContains'    => 'sub.wildcard.org/page',
+            'expectedRedirectNotContains' => null,
+        ];
 
-        $this->client->followRedirects(false);
-        $this->client->request(
-            Request::METHOD_POST,
-            "/form/submit?formId={$formId}",
-            [
-                'mauticform' => [
-                    'formId' => $formId,
-                    'return' => 'https://attacker.com/phishing',
-                ],
-            ]
-        );
+        yield 'URL not in CORS config is rejected' => [
+            'returnUrl'                   => 'https://evil.com/phish',
+            'corsValidDomains'            => ['https://trusted.example.com'],
+            'expectedRedirectContains'    => '/form/message',
+            'expectedRedirectNotContains' => 'evil.com',
+        ];
 
-        $submitResponse = $this->client->getResponse();
-
-        $this->assertSame(Response::HTTP_FOUND, $submitResponse->getStatusCode());
-
-        $redirectUrl = $submitResponse->headers->get('Location');
-        $this->assertNotNull($redirectUrl);
-        $this->assertStringNotContainsString('attacker.com', $redirectUrl);
-
-        $urlParts = parse_url($redirectUrl);
-        $this->assertSame('/form/message', $urlParts['path'] ?? null);
-
-        $this->client->followRedirects(true);
+        yield 'unrestricted CORS mode still requires valid domains' => [
+            'returnUrl'                   => 'https://any-domain.com/page',
+            'corsValidDomains'            => [],
+            'expectedRedirectContains'    => '/form/message',
+            'expectedRedirectNotContains' => 'any-domain.com',
+        ];
     }
 
-    public function testSameOriginReturnUrlIsAllowedOnValidationError(): void
+    /**
+     * @param list<string> $corsValidDomains
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('returnUrlTrustProvider')]
+    public function testReturnUrlTrustValidation(string $returnUrl, array $corsValidDomains, string $expectedRedirectContains, ?string $expectedRedirectNotContains): void
     {
+        $this->configParams['cors_valid_domains'] = $corsValidDomains;
+        $this->setUpSymfony($this->configParams);
+
         $payload = [
-            'name'        => 'Same origin return test form',
+            'name'        => 'Return URL trust test form',
             'description' => 'Form created via submission test',
             'formType'    => 'standalone',
             'isPublished' => true,
@@ -185,13 +183,11 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
-
         $this->assertSame(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
         $response = json_decode($clientResponse->getContent(), true);
         $formId   = $response['form']['id'];
 
-        // Use a relative return URL (same-origin by definition)
         $this->client->followRedirects(false);
         $this->client->request(
             Request::METHOD_POST,
@@ -199,22 +195,21 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             [
                 'mauticform' => [
                     'formId' => $formId,
-                    'return' => '/my-landing-page',
+                    'return' => $returnUrl,
                 ],
             ]
         );
 
         $submitResponse = $this->client->getResponse();
-
         $this->assertSame(Response::HTTP_FOUND, $submitResponse->getStatusCode());
 
         $redirectUrl = $submitResponse->headers->get('Location');
         $this->assertNotNull($redirectUrl);
+        $this->assertStringContainsString($expectedRedirectContains, $redirectUrl);
 
-        // Should redirect back to the same-origin return URL with the error
-        $urlParts = parse_url($redirectUrl);
-        $this->assertSame('/my-landing-page', $urlParts['path'] ?? null);
-        $this->assertStringContainsString('mauticError', $redirectUrl);
+        if (null !== $expectedRedirectNotContains) {
+            $this->assertStringNotContainsString($expectedRedirectNotContains, $redirectUrl);
+        }
 
         $this->client->followRedirects(true);
     }
@@ -261,9 +256,10 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
             ]
         );
 
-        /** @var SubmissionRepository $submissionRepository */
         $submissionRepository = $this->em->getRepository(Submission::class);
-        $submissions          = $submissionRepository->findBy(['form' => $formId]);
+        \assert($submissionRepository instanceof SubmissionRepository);
+
+        $submissions = $submissionRepository->findBy(['form' => $formId]);
 
         $this->assertCount(1, $submissions);
         $this->assertStringNotContainsString('attacker.com', $submissions[0]->getReferer());


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://github.com/mautic/mautic/issues/16419

## Description

Mautic shouldn't trust the "return" value coming from the form submission request as it can be changed. Instead it should always take the return value from the database when processing the form submission.

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a new form. One form field is all we need.
3. Test various return options that they still work as you'd expect.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->