### PR TITLE
Fix captcha honeypot fields visibility in forms

### DIFF
--- a/app/bundles/FormBundle/Resources/views/Builder/_style.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/_style.html.twig
@@ -39,6 +39,8 @@
     .mauticform-slider { margin: 0; padding: 0; }
     .mauticform-slider-value { float: right; font-size: 0.875em; min-block-size: 1.145em; margin-top: .25em; }
 
+    .mauticform-row.mauticform-honeypot { display: none; }
+
     .mauticform-page-wrapper {
         display: flex;
         flex-wrap: wrap;

--- a/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Builder/form.html.twig
@@ -30,6 +30,7 @@
 {{ style|raw }}
 <style type="text/css" scoped>
     .mauticform-field-hidden { display:none }
+    .mauticform-row.mauticform-honeypot { display: none; }
 </style>
 <div id="mauticform_wrapper{{ formName }}" class="mauticform_wrapper">
     <form autocomplete="false" role="form" method="post" action="{{ action }}" id="mauticform{{ formName }}" {% if isAjax %}data-mautic-form="{{ formName|trim('_', 'left') }}"{% endif %} enctype="multipart/form-data" {{ form.formAttributes|raw }}>

--- a/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
@@ -3,13 +3,11 @@
 
 {% if field.properties.captcha is not defined or field.properties.captcha is empty %}
     {% set required = false %}
-    {% if inForm is not defined or inForm is empty or false == inForm %}
-        {# Use as a honeypot #}
-        {% set field = field|merge({
-                'containerAttributes': field.containerAttributes ~ ' style="display:none;"',
-        }) %}
-    {% else %}
-        {# Hide the input #}
+    {% set field = field|merge({
+            'containerAttributes': (field.containerAttributes|default('') ~ ' class="mauticform-honeypot"')|trim,
+    }) %}
+    {% if inForm is defined and (true == inForm or inForm is not empty) %}
+        {# Hide the input in the builder preview #}
         {% set type = 'hidden' %}
     {% endif %}
 {% endif %}

--- a/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
+++ b/app/bundles/FormBundle/Resources/views/Field/captcha.html.twig
@@ -3,8 +3,16 @@
 
 {% if field.properties.captcha is not defined or field.properties.captcha is empty %}
     {% set required = false %}
+    {% set containerAttributes = htmlAttributesStringToArray(field.containerAttributes|default('')) %}
+    {% set containerAttributes = containerAttributes|merge({
+        'class': containerAttributes.class|default([])|merge(['mauticform-honeypot']),
+    }) %}
+    {% set containerAttributesString = '' %}
+    {% for attrName, attrValue in containerAttributes %}
+        {% set containerAttributesString = containerAttributesString ~ ' ' ~ attrName ~ '="' ~ (attrValue is iterable ? attrValue|join(' ') : attrValue) ~ '"' %}
+    {% endfor %}
     {% set field = field|merge({
-            'containerAttributes': (field.containerAttributes|default('') ~ ' class="mauticform-honeypot"')|trim,
+        'containerAttributes': containerAttributesString|trim,
     }) %}
     {% if inForm is defined and (true == inForm or inForm is not empty) %}
         {# Hide the input in the builder preview #}

--- a/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
@@ -50,7 +50,25 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         );
     }
 
-    private function createFormWithHoneypotCaptcha(): int
+    public function testHoneypotCaptchaFieldMergesHoneypotClassWithExistingContainerClasses(): void
+    {
+        $formId = $this->createFormWithHoneypotCaptcha('class="custom-class"');
+
+        /** @var FormModel $formModel */
+        $formModel = static::getContainer()->get('mautic.form.model.form');
+        $form      = $formModel->getEntity($formId);
+        self::assertInstanceOf(Form::class, $form);
+
+        $html = $formModel->generateHtml($form, false);
+
+        preg_match('/<div[^>]*\bid="mauticform_[^"]*honeypot"[^>]*>/', $html, $honeypotRow);
+        self::assertNotEmpty($honeypotRow, $html);
+        self::assertStringContainsString('custom-class', $honeypotRow[0], $html);
+        self::assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
+        self::assertSame(1, substr_count($honeypotRow[0], 'class="'), $html);
+    }
+
+    private function createFormWithHoneypotCaptcha(string $containerAttributes = ''): int
     {
         $payload = [
             'name'        => 'Honeypot captcha test form',
@@ -71,6 +89,7 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
                     'properties' => [
                         'captcha' => '',
                     ],
+                    'containerAttributes' => $containerAttributes,
                 ],
                 [
                     'label' => 'Submit',

--- a/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\FormBundle\Tests\Model;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Model\FormModel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
+{
+    protected $useCleanupRollback = false;
+
+    public function testHoneypotCaptchaFieldIsHiddenInGeneratedFormHtml(): void
+    {
+        $formId = $this->createFormWithHoneypotCaptcha();
+
+        /** @var FormModel $formModel */
+        $formModel = static::getContainer()->get('mautic.form.model.form');
+        $form      = $formModel->getEntity($formId);
+        self::assertInstanceOf(Form::class, $form);
+
+        $html = $formModel->generateHtml($form, false);
+        self::assertStringContainsString('mauticform-honeypot', $html);
+
+        $honeypotRow = [];
+        if (preg_match('/<div[^>]*id="mauticform_[^"]*honeypot"[^>]*>/', $html, $honeypotRow)) {
+            self::assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
+        } else {
+            self::fail('Honeypot captcha row not found in generated HTML.');
+        }
+    }
+
+    public function testHoneypotCaptchaFieldIsHiddenOnFormPreview(): void
+    {
+        $formId = $this->createFormWithHoneypotCaptcha();
+
+        $crawler = $this->client->request(Request::METHOD_GET, "/s/forms/preview/{$formId}");
+        self::assertResponseIsSuccessful();
+
+        $honeypotRow = $crawler->filter('[id$="_honeypot"]');
+        self::assertGreaterThan(0, $honeypotRow->count());
+        self::assertStringContainsString(
+            'mauticform-honeypot',
+            (string) $honeypotRow->attr('class'),
+            $crawler->html()
+        );
+    }
+
+    private function createFormWithHoneypotCaptcha(): int
+    {
+        $payload = [
+            'name'        => 'Honeypot captcha test form',
+            'formType'    => 'standalone',
+            'description' => 'Form with honeypot captcha',
+            'isPublished' => true,
+            'fields'      => [
+                [
+                    'label'      => 'Email',
+                    'alias'      => 'email',
+                    'type'       => 'email',
+                    'leadField'  => 'email',
+                ],
+                [
+                    'label'      => 'Leave blank',
+                    'alias'      => 'honeypot',
+                    'type'       => 'captcha',
+                    'properties' => [
+                        'captcha' => '',
+                    ],
+                ],
+                [
+                    'label' => 'Submit',
+                    'alias' => 'submit',
+                    'type'  => 'button',
+                ],
+            ],
+            'postAction' => 'return',
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+
+        return (int) $response['form']['id'];
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #16485

## Description

Captcha fields used as honeypots are showing as normal visible form fields when their answer is left blank. This means visitors can see a field that should stay hidden, and the form no longer behaves as expected for spam protection.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create or open a form with a Captcha field.
3. Leave the answer blank so it should work as a hidden honeypot.
4. View the form.