### PR TITLE
[cs] make new_with_parentheses explicit for anonymous classes

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -46,7 +46,7 @@ return (new PhpCsFixer\Config())
         'Mautic/no_table_prefix_definition_in_tests'       => true,
         'multiline_whitespace_before_semicolons'           => true,
         'nullable_type_declaration_for_default_null_value' => true,
-        'new_with_parentheses'                             => ['anonymous_class' => false],
+        'new_with_parentheses'                             => ['anonymous_class' => true],
         'no_superfluous_phpdoc_tags'                       => [
             'allow_mixed' => true,
         ],

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -46,6 +46,7 @@ return (new PhpCsFixer\Config())
         'Mautic/no_table_prefix_definition_in_tests'       => true,
         'multiline_whitespace_before_semicolons'           => true,
         'nullable_type_declaration_for_default_null_value' => true,
+        'new_with_parentheses'                             => ['anonymous_class' => false],
         'no_superfluous_phpdoc_tags'                       => [
             'allow_mixed' => true,
         ],

--- a/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
@@ -35,7 +35,7 @@ final class DashboardSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->router      = $this->createMock(RouterInterface::class);
         $this->permissions = $this->createMock(CorePermissions::class);
         $this->cacheProvider = $this->createMock(CacheProviderTagAwareInterface::class);
-        $this->translator  = new class implements TranslatorInterface {
+        $this->translator  = new class() implements TranslatorInterface {
             public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
             {
                 return (string) $id;

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -39,19 +39,19 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnReportBuilderWithUnknownContext(): void
     {
-        $companyReportData = new class extends CompanyReportData {
+        $companyReportData = new class() extends CompanyReportData {
             public function __construct()
             {
             }
         };
 
-        $downloadRepository = new class extends DownloadRepository {
+        $downloadRepository = new class() extends DownloadRepository {
             public function __construct()
             {
             }
         };
 
-        $event = new class extends ReportBuilderEvent {
+        $event = new class() extends ReportBuilderEvent {
             public function __construct()
             {
                 $this->context = 'unicorn';
@@ -67,7 +67,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnReportBuilderWithAssetDownloadContext(): void
     {
-        $companyReportData = new class extends CompanyReportData {
+        $companyReportData = new class() extends CompanyReportData {
             public function __construct()
             {
             }
@@ -81,7 +81,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
             }
         };
 
-        $downloadRepository = new class extends DownloadRepository {
+        $downloadRepository = new class() extends DownloadRepository {
             public function __construct()
             {
             }
@@ -134,7 +134,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function createTranslatorMock(): TranslatorInterface
     {
-        return new class implements TranslatorInterface {
+        return new class() implements TranslatorInterface {
             /**
              * @param array<int|string> $parameters
              */

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -27,13 +27,13 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
     {
         $event    = new Event();
         $campaign = new Campaign();
-        $leadLog  = new class extends LeadEventLog {
+        $leadLog  = new class() extends LeadEventLog {
             public function getId(): int
             {
                 return 456;
             }
         };
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 789;
@@ -77,12 +77,12 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             }
         };
 
-        $eventExecutioner = new class extends EventExecutioner {
+        $eventExecutioner = new class() extends EventExecutioner {
             public function __construct()
             {
             }
         };
-        $translator = new class extends Translator {
+        $translator = new class() extends Translator {
             public function __construct()
             {
             }
@@ -97,13 +97,13 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
                 return $id;
             }
         };
-        $leadRepository = new class extends LeadRepository {
+        $leadRepository = new class() extends LeadRepository {
             public function __construct()
             {
             }
         };
 
-        $eventScheduler = new class extends EventScheduler {
+        $eventScheduler = new class() extends EventScheduler {
             public function __construct()
             {
             }
@@ -139,19 +139,19 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
     public function testOnJumpToEventWhenEventExists(): void
     {
         $event    = new Event();
-        $campaign = new class extends Campaign {
+        $campaign = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;
             }
         };
-        $leadLog = new class extends LeadEventLog {
+        $leadLog = new class() extends LeadEventLog {
             public function getId(): int
             {
                 return 456;
             }
         };
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 789;
@@ -192,7 +192,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
                 );
 
                 return [
-                    new class extends Event {
+                    new class() extends Event {
                         public function getId(): int
                         {
                             return 222;
@@ -202,7 +202,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             }
         };
 
-        $eventExecutioner = new class extends EventExecutioner {
+        $eventExecutioner = new class() extends EventExecutioner {
             public function __construct()
             {
             }
@@ -214,12 +214,12 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
                 Assert::assertSame(789, $contacts->first()->getId());
             }
         };
-        $translator = new class extends Translator {
+        $translator = new class() extends Translator {
             public function __construct()
             {
             }
         };
-        $leadRepository = new class extends LeadRepository {
+        $leadRepository = new class() extends LeadRepository {
             public function __construct()
             {
             }
@@ -231,7 +231,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             }
         };
 
-        $eventScheduler = new class extends EventScheduler {
+        $eventScheduler = new class() extends EventScheduler {
             public function __construct()
             {
             }

--- a/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
@@ -86,7 +86,7 @@ final class KickoffExecutionerTest extends \PHPUnit\Framework\TestCase
 
         $event    = new Event();
         $event2   = new Event();
-        $campaign = new class extends Campaign {
+        $campaign = new class() extends Campaign {
             /**
              * @var ArrayCollection<int,Event>
              */

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
@@ -90,7 +90,7 @@ final class MembershipBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testWhileLoopBreaksWithNoMoreContacts(): void
     {
-        $campaign = new class extends Campaign {
+        $campaign = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;
@@ -151,7 +151,7 @@ final class MembershipBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testWhileLoopBreaksWithNoMoreContactsForRepeatableCampaign(): void
     {
-        $campaign = new class extends Campaign {
+        $campaign = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
@@ -110,7 +110,7 @@ final class MembershipManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testContactsAreAddedOrUpdated(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function __construct(
                 private readonly int $id = 1,
             ) {
@@ -121,7 +121,7 @@ final class MembershipManagerTest extends \PHPUnit\Framework\TestCase
                 return $this->id;
             }
         };
-        $contact2 = new class extends Lead {
+        $contact2 = new class() extends Lead {
             public function __construct(
                 private readonly int $id = 2,
             ) {
@@ -163,7 +163,7 @@ final class MembershipManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testContactsAreRemoved(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function __construct(
                 private readonly int $id = 1,
             ) {
@@ -174,7 +174,7 @@ final class MembershipManagerTest extends \PHPUnit\Framework\TestCase
                 return $this->id;
             }
         };
-        $contact2 = new class extends Lead {
+        $contact2 = new class() extends Lead {
             public function __construct(
                 private readonly int $id = 2,
             ) {

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/PreUpAssertionMigrationTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/PreUpAssertionMigrationTest.php
@@ -14,7 +14,7 @@ final class PreUpAssertionMigrationTest extends TestCase
 {
     public function testPreUpWithoutSkipAssertions(): void
     {
-        $migration = new class extends PreUpAssertionMigration {
+        $migration = new class() extends PreUpAssertionMigration {
             /**
              * @var array<string>
              */
@@ -44,7 +44,7 @@ final class PreUpAssertionMigrationTest extends TestCase
 
     public function testPreUpSkipped(): void
     {
-        $migration = new class extends PreUpAssertionMigration {
+        $migration = new class() extends PreUpAssertionMigration {
             /**
              * @var array<string>
              */
@@ -88,7 +88,7 @@ final class PreUpAssertionMigrationTest extends TestCase
 
     public function testPreUpNotSkipped(): void
     {
-        $migration = new class extends PreUpAssertionMigration {
+        $migration = new class() extends PreUpAssertionMigration {
             /**
              * @var array<string>
              */

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -430,7 +430,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
 
     private function createEmail(): Email
     {
-        return new class extends Email {
+        return new class() extends Email {
             private int $id = 0;
 
             public function getId(): int

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -235,7 +235,7 @@ final class ThemeHelperTest extends TestCase
     public function testCopyWithNoNewDirName(): void
     {
         $themeHelper = new ThemeHelper(
-            new class extends PathsHelper {
+            new class() extends PathsHelper {
                 public function __construct()
                 {
                 }
@@ -248,17 +248,17 @@ final class ThemeHelperTest extends TestCase
                 }
             },
             new Environment(new FilesystemLoader()),
-            new class extends Translator {
+            new class() extends Translator {
                 public function __construct()
                 {
                 }
             },
-            new class extends CoreParametersHelper {
+            new class() extends CoreParametersHelper {
                 public function __construct()
                 {
                 }
             },
-            new class extends Filesystem {
+            new class() extends Filesystem {
                 /**
                  * @param string $files
                  */
@@ -290,7 +290,7 @@ final class ThemeHelperTest extends TestCase
                     Assert::assertSame('{"name":"New Theme Name"}', $content);
                 }
             },
-            new class extends Finder {
+            new class() extends Finder {
                 /**
                  * @var SplFileInfo[]
                  */
@@ -323,7 +323,7 @@ final class ThemeHelperTest extends TestCase
     public function testCopyWithNewDirName(): void
     {
         $themeHelper = new ThemeHelper(
-            new class extends PathsHelper {
+            new class() extends PathsHelper {
                 public function __construct()
                 {
                 }
@@ -336,17 +336,17 @@ final class ThemeHelperTest extends TestCase
                 }
             },
             new Environment(new FilesystemLoader()),
-            new class extends Translator {
+            new class() extends Translator {
                 public function __construct()
                 {
                 }
             },
-            new class extends CoreParametersHelper {
+            new class() extends CoreParametersHelper {
                 public function __construct()
                 {
                 }
             },
-            new class extends Filesystem {
+            new class() extends Filesystem {
                 /**
                  * @param string $files
                  */
@@ -378,7 +378,7 @@ final class ThemeHelperTest extends TestCase
                     Assert::assertSame('{"name":"New Theme Name"}', $content);
                 }
             },
-            new class extends Finder {
+            new class() extends Finder {
                 /**
                  * @var SplFileInfo[]
                  */

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -874,7 +874,7 @@ final class UpdateHelperTest extends TestCase
 
     private function getFailingPreUpdateTest(): AbstractPreUpdateCheck
     {
-        return new class extends AbstractPreUpdateCheck {
+        return new class() extends AbstractPreUpdateCheck {
             public function runCheck(): PreUpdateCheckResult
             {
                 return new PreUpdateCheckResult(false, null, [new PreUpdateCheckError('Dummy')]);
@@ -884,7 +884,7 @@ final class UpdateHelperTest extends TestCase
 
     private function getPassingPreUpdateTest(): AbstractPreUpdateCheck
     {
-        return new class extends AbstractPreUpdateCheck {
+        return new class() extends AbstractPreUpdateCheck {
             public function runCheck(): PreUpdateCheckResult
             {
                 return new PreUpdateCheckResult(true, null);

--- a/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
@@ -65,7 +65,7 @@ final class BulkNotificationTest extends TestCase
 
     private function createNotificationModelFake(): NotificationModel
     {
-        return new class extends NotificationModel {
+        return new class() extends NotificationModel {
             /**
              * @var mixed[]
              */

--- a/app/bundles/CoreBundle/Tests/Unit/Shortener/ShortenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Shortener/ShortenerTest.php
@@ -83,7 +83,7 @@ final class ShortenerTest extends TestCase
 
     public function testGetEnabledServices(): void
     {
-        $enabledService = new class implements ShortenerServiceInterface {
+        $enabledService = new class() implements ShortenerServiceInterface {
             public function shortenUrl(string $url): string
             {
                 return 'shortUrl';
@@ -100,7 +100,7 @@ final class ShortenerTest extends TestCase
             }
         };
 
-        $disabledService = new class implements ShortenerServiceInterface {
+        $disabledService = new class() implements ShortenerServiceInterface {
             public function shortenUrl(string $url): string
             {
                 return 'shortUrl';

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ConfigHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/ConfigHelperTest.php
@@ -12,7 +12,7 @@ final class ConfigHelperTest extends \PHPUnit\Framework\TestCase
 {
     public function testGet(): void
     {
-        $coreParametersHelper = new class extends CoreParametersHelper {
+        $coreParametersHelper = new class() extends CoreParametersHelper {
             public function __construct()
             {
             }
@@ -32,7 +32,7 @@ final class ConfigHelperTest extends \PHPUnit\Framework\TestCase
 
     public function testGetName(): void
     {
-        $coreParametersHelper = new class extends CoreParametersHelper {
+        $coreParametersHelper = new class() extends CoreParametersHelper {
             public function __construct()
             {
             }

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -75,7 +75,7 @@ final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnEmailResendWithNoStat(): void
     {
-        $message = new class extends MauticMessage {
+        $message = new class() extends MauticMessage {
             public ?string $leadIdHash = 'some-hash';
         };
 
@@ -97,7 +97,7 @@ final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnEmailResendWithNoRetry(): void
     {
-        $message = new class extends MauticMessage {
+        $message = new class() extends MauticMessage {
             public ?string $leadIdHash = 'some-hash';
         };
 
@@ -164,7 +164,7 @@ final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testOnEmailResendWith4Retry(): void
     {
-        $message = new class extends MauticMessage {
+        $message = new class() extends MauticMessage {
             public ?string $leadIdHash = 'some-hash';
         };
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -676,7 +676,7 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
                 ]
             );
 
-        $email = new class extends Email {
+        $email = new class() extends Email {
             public function getId(): int
             {
                 return 1;

--- a/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
@@ -38,7 +38,7 @@ final class EmailStatModelTest extends TestCase
                 }
             );
 
-        $dispatcher = new class extends EventDispatcher {
+        $dispatcher = new class() extends EventDispatcher {
             public int $dispatchMethodCounter = 0;
 
             public function dispatch(object $event, ?string $eventName = null): object

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
@@ -99,7 +99,7 @@ final class SendEmailToUserTest extends \PHPUnit\Framework\TestCase
     public function testSendEmailWithNoError(): void
     {
         $lead  = new Lead();
-        $owner = new class extends User {
+        $owner = new class() extends User {
             public function getId(): int
             {
                 return 10;
@@ -116,7 +116,7 @@ final class SendEmailToUserTest extends \PHPUnit\Framework\TestCase
             ->with(33)
             ->willReturn($email);
 
-        $emailSendEvent                           = new class extends EmailSendEvent {
+        $emailSendEvent                           = new class() extends EmailSendEvent {
             public int $getTokenMethodCallCounter = 0;
 
             public function __construct()

--- a/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
@@ -19,7 +19,7 @@ final class TransportCallbackTest extends TestCase
 {
     public function testStatSave(): void
     {
-        $dncModel = new class extends DoNotContact {
+        $dncModel = new class() extends DoNotContact {
             public function __construct()
             {
             }
@@ -33,7 +33,7 @@ final class TransportCallbackTest extends TestCase
             }
         };
 
-        $contactFinder = new class extends ContactFinder {
+        $contactFinder = new class() extends ContactFinder {
             public function __construct()
             {
             }
@@ -52,7 +52,7 @@ final class TransportCallbackTest extends TestCase
             }
         };
 
-        $emailStatModel = new class extends EmailStatModel {
+        $emailStatModel = new class() extends EmailStatModel {
             public function __construct()
             {
             }

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -20,7 +20,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
 {
     public function testSingleValueModeRejectsCommaSeparatedValues(): void
     {
-        $context = new class extends ExecutionContext {
+        $context = new class() extends ExecutionContext {
             public int $violationCount = 0;
 
             public function __construct()
@@ -36,7 +36,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
             }
         };
 
-        $translator = new class extends Translator {
+        $translator = new class() extends Translator {
             public function __construct()
             {
             }
@@ -52,7 +52,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
 
         $dispatcher = new EventDispatcher();
 
-        $fieldModel = new class extends FieldModel {
+        $fieldModel = new class() extends FieldModel {
             public function __construct()
             {
             }
@@ -77,7 +77,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('provider')]
     public function testNoEmailsProvided(?string $value, int $expectedViolationCount, callable $getFieldMocker, callable $violationResult): void
     {
-        $context = new class extends ExecutionContext {
+        $context = new class() extends ExecutionContext {
             /**
              * @var callable
              */
@@ -101,7 +101,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
 
         $context->violationResult = $violationResult;
 
-        $translator = new class extends Translator {
+        $translator = new class() extends Translator {
             public function __construct()
             {
             }
@@ -117,7 +117,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
 
         $dispatcher = new EventDispatcher();
 
-        $fieldModel = new class extends FieldModel {
+        $fieldModel = new class() extends FieldModel {
             /**
              * @var callable
              */

--- a/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/FieldCollectorTest.php
@@ -14,7 +14,7 @@ final class FieldCollectorTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuildCollectionForNoObject(): void
     {
-        $dispatcher                               = new class extends EventDispatcher {
+        $dispatcher                               = new class() extends EventDispatcher {
             public int $dispatchMethodCallCounter = 0;
 
             public function dispatch(object $event, ?string $eventName = null): FieldCollection

--- a/app/bundles/FormBundle/Tests/Collector/MappedObjectCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/MappedObjectCollectorTest.php
@@ -13,7 +13,7 @@ final class MappedObjectCollectorTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuildCollectionForNoObject(): void
     {
-        $fieldCollector                            = new class implements FieldCollectorInterface {
+        $fieldCollector                            = new class() implements FieldCollectorInterface {
             public int $getFieldsMethodCallCounter = 0;
 
             public function getFields(string $object): FieldCollection
@@ -32,7 +32,7 @@ final class MappedObjectCollectorTest extends \PHPUnit\Framework\TestCase
 
     public function testBuildCollectionForOneObject(): void
     {
-        $fieldCollector                            = new class implements FieldCollectorInterface {
+        $fieldCollector                            = new class() implements FieldCollectorInterface {
             public int $getFieldsMethodCallCounter = 0;
 
             public function getFields(string $object): FieldCollection
@@ -52,7 +52,7 @@ final class MappedObjectCollectorTest extends \PHPUnit\Framework\TestCase
 
     public function testBuildCollectionForMultipleObjects(): void
     {
-        $fieldCollector                            = new class implements FieldCollectorInterface {
+        $fieldCollector                            = new class() implements FieldCollectorInterface {
             public int $getFieldsMethodCallCounter = 0;
 
             public function getFields(string $object): FieldCollection

--- a/app/bundles/FormBundle/Tests/Collector/ObjectCollectorTest.php
+++ b/app/bundles/FormBundle/Tests/Collector/ObjectCollectorTest.php
@@ -14,7 +14,7 @@ final class ObjectCollectorTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuildCollectionForNoObject(): void
     {
-        $dispatcher                               = new class extends EventDispatcher {
+        $dispatcher                               = new class() extends EventDispatcher {
             public int $dispatchMethodCallCounter = 0;
 
             public function dispatch(object $event, ?string $eventName = null): ObjectCollection

--- a/app/bundles/FormBundle/Tests/Entity/FieldTest.php
+++ b/app/bundles/FormBundle/Tests/Entity/FieldTest.php
@@ -246,7 +246,7 @@ final class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $field   = new Field();
         $form    = new Form();
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getFieldValue($field, $group = null): string
             {
                 Assert::assertSame('field_a', $field);
@@ -266,7 +266,7 @@ final class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $field   = new Field();
         $form    = new Form();
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getFieldValue($field, $group = null): null
             {
                 Assert::assertSame('field_a', $field);
@@ -286,7 +286,7 @@ final class FieldTest extends \PHPUnit\Framework\TestCase
     {
         $field   = new Field();
         $form    = new Form();
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getFieldValue($field, $group = null): string
             {
                 Assert::assertSame('field_a', $field);

--- a/app/bundles/FormBundle/Tests/Event/Service/FieldValueTransformerTest.php
+++ b/app/bundles/FormBundle/Tests/Event/Service/FieldValueTransformerTest.php
@@ -17,7 +17,7 @@ final class FieldValueTransformerTest extends \PHPUnit\Framework\TestCase
 {
     public function testTransformValuesAfterSubmitWithNoFieldsNoMatchesAndNoTokens(): void
     {
-        $router = new class extends Router {
+        $router = new class() extends Router {
             public function __construct()
             {
             }
@@ -36,7 +36,7 @@ final class FieldValueTransformerTest extends \PHPUnit\Framework\TestCase
 
     public function testTransformValuesAfterSubmitWithFileFieldMatchesAndTokens(): void
     {
-        $router                                   = new class extends Router {
+        $router                                   = new class() extends Router {
             public int $generateMethodCallCounter = 0;
 
             public function __construct()
@@ -57,7 +57,7 @@ final class FieldValueTransformerTest extends \PHPUnit\Framework\TestCase
             }
         };
         $transformer = new FieldValueTransformer($router);
-        $submission  = new class extends Submission {
+        $submission  = new class() extends Submission {
             public function getId(): int
             {
                 return 456;

--- a/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
@@ -24,10 +24,10 @@ final class FieldModelTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
 
-        $platform = new class {
+        $platform = new class() {
             public function getReservedKeywordsList(): object
             {
-                return new class {
+                return new class() {
                     public function isKeyword(): bool
                     {
                         return false;

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
@@ -311,7 +311,7 @@ final class SubmissionModelTest extends \PHPUnit\Framework\TestCase
         $server    = $request->server->all();
         $form      = new Form();
         $fields    = $this->getTestFormFields();
-        $formModel = new class extends FormModel {
+        $formModel = new class() extends FormModel {
             public function __construct()
             {
             }

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -29,7 +29,7 @@ final class LeadSubscriberTest extends MauticMysqlTestCase
 
         static::getContainer()->set(
             'mautic.integrations.helper.sync_integrations',
-            new class extends SyncIntegrationsHelper {
+            new class() extends SyncIntegrationsHelper {
                 public function __construct()
                 {
                 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/ApiKey/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/ApiKey/HttpFactoryTest.php
@@ -24,7 +24,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(InvalidCredentialsException::class);
 
-        $credentials = new class implements AuthCredentialsInterface {
+        $credentials = new class() implements AuthCredentialsInterface {
         };
 
         (new HttpFactory())->getClient($credentials);
@@ -34,7 +34,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements HeaderCredentialsInterface {
+        $credentials = new class() implements HeaderCredentialsInterface {
             public function getApiKey(): string
             {
                 return '';
@@ -51,7 +51,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testInstantiatedClientIsReturned(): void
     {
-        $credentials = new class implements HeaderCredentialsInterface {
+        $credentials = new class() implements HeaderCredentialsInterface {
             public function getApiKey(): string
             {
                 return 'abc';
@@ -69,7 +69,7 @@ final class HttpFactoryTest extends TestCase
         $client2 = $factory->getClient($credentials);
         $this->assertTrue($client1 === $client2);
 
-        $credential2 = new class implements HeaderCredentialsInterface {
+        $credential2 = new class() implements HeaderCredentialsInterface {
             public function getApiKey(): string
             {
                 return '123';
@@ -87,7 +87,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testHeaderCredentialsSetsHeader(): void
     {
-        $credentials = new class implements HeaderCredentialsInterface {
+        $credentials = new class() implements HeaderCredentialsInterface {
             public function getApiKey(): string
             {
                 return '123';
@@ -109,7 +109,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testParameterCredentialsAppendsToken(): void
     {
-        $credentials = new class implements ParameterCredentialsInterface {
+        $credentials = new class() implements ParameterCredentialsInterface {
             public function getApiKey(): string
             {
                 return '123';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/BasicAuth/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/BasicAuth/HttpFactoryTest.php
@@ -21,7 +21,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getUsername(): string
             {
                 return '';
@@ -40,7 +40,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getUsername(): string
             {
                 return '123';
@@ -57,7 +57,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testInstantiatedClientIsReturned(): void
     {
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getUsername(): string
             {
                 return 'foo';
@@ -75,7 +75,7 @@ final class HttpFactoryTest extends TestCase
         $client2 = $factory->getClient($credentials);
         $this->assertTrue($client1 === $client2);
 
-        $credentials2 = new class implements CredentialsInterface {
+        $credentials2 = new class() implements CredentialsInterface {
             public function getUsername(): string
             {
                 return 'bar';
@@ -93,7 +93,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testHeaderIsSet(): void
     {
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getUsername(): string
             {
                 return 'foo';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth2ThreeLegged/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth2ThreeLegged/HttpFactoryTest.php
@@ -31,7 +31,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return '';
@@ -60,7 +60,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -87,7 +87,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testBaseURISetOnBaseUriAwareCredentials(): void
     {
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -142,7 +142,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -171,7 +171,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -198,7 +198,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testInstantiatedClientIsReturned(): void
     {
-        $credentials = new class implements CredentialsInterface {
+        $credentials = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -226,7 +226,7 @@ final class HttpFactoryTest extends TestCase
         $client2 = $factory->getClient($credentials);
         $this->assertTrue($client1 === $client2);
 
-        $credentials2 = new class implements CredentialsInterface {
+        $credentials2 = new class() implements CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';
@@ -343,7 +343,7 @@ final class HttpFactoryTest extends TestCase
 
     private function getCredentials(): CredentialsInterface&CodeInterface&RedirectUriInterface&ScopeInterface
     {
-        return new class implements CredentialsInterface, CodeInterface, RedirectUriInterface, ScopeInterface {
+        return new class() implements CredentialsInterface, CodeInterface, RedirectUriInterface, ScopeInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://auth.url';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth2TwoLegged/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth2TwoLegged/HttpFactoryTest.php
@@ -36,7 +36,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(InvalidCredentialsException::class);
 
-        $credentials = new class implements AuthCredentialsInterface {
+        $credentials = new class() implements AuthCredentialsInterface {
         };
 
         (new HttpFactory())->getClient($credentials);
@@ -46,7 +46,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements ClientCredentialsGrantInterface {
+        $credentials = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return '';
@@ -70,7 +70,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements ClientCredentialsGrantInterface {
+        $credentials = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -94,7 +94,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements ClientCredentialsGrantInterface {
+        $credentials = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -118,7 +118,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements PasswordCredentialsGrantInterface {
+        $credentials = new class() implements PasswordCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -152,7 +152,7 @@ final class HttpFactoryTest extends TestCase
     {
         $this->expectException(PluginNotConfiguredException::class);
 
-        $credentials = new class implements PasswordCredentialsGrantInterface {
+        $credentials = new class() implements PasswordCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -184,7 +184,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testInstantiatedClientIsReturned(): void
     {
-        $credentials = new class implements ClientCredentialsGrantInterface {
+        $credentials = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -207,7 +207,7 @@ final class HttpFactoryTest extends TestCase
         $client2 = $factory->getClient($credentials);
         $this->assertTrue($client1 === $client2);
 
-        $credentials2 = new class implements ClientCredentialsGrantInterface {
+        $credentials2 = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -256,7 +256,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testPasswordGrantTypeIsUsed(): void
     {
-        $credentials = new class implements PasswordCredentialsGrantInterface {
+        $credentials = new class() implements PasswordCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -293,7 +293,7 @@ final class HttpFactoryTest extends TestCase
 
     public function testClientCredentialsGrantTypeIsUsed(): void
     {
-        $credentials = new class implements ClientCredentialsGrantInterface {
+        $credentials = new class() implements ClientCredentialsGrantInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';
@@ -382,7 +382,7 @@ final class HttpFactoryTest extends TestCase
 
     private function getCredentials(): PasswordCredentialsGrantInterface&StateInterface&ScopeInterface&CredentialsInterface
     {
-        return new class implements PasswordCredentialsGrantInterface, StateInterface, ScopeInterface, CredentialsInterface {
+        return new class() implements PasswordCredentialsGrantInterface, StateInterface, ScopeInterface, CredentialsInterface {
             public function getAuthorizationUrl(): string
             {
                 return 'http://test.com';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Integration/ConfigFormNotesTraitTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Integration/ConfigFormNotesTraitTest.php
@@ -13,7 +13,7 @@ final class ConfigFormNotesTraitTest extends TestCase
 {
     public function testConfigFormNotesTraitFormDefaultValues(): void
     {
-        $configFormNotes = new class implements ConfigFormNotesInterface {
+        $configFormNotes = new class() implements ConfigFormNotesInterface {
             use ConfigFormNotesTrait;
         };
 
@@ -24,7 +24,7 @@ final class ConfigFormNotesTraitTest extends TestCase
 
     public function testConfigFormNotesTraitFormForCustomValues(): void
     {
-        $configFormNotes = new class implements ConfigFormNotesInterface {
+        $configFormNotes = new class() implements ConfigFormNotesInterface {
             use ConfigFormNotesTrait;
 
             public function getAuthorizationNote(): Note

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
@@ -210,7 +210,7 @@ final class FullObjectReportBuilderTest extends TestCase
                 return true;
             });
 
-        $contactEntity = new class extends Lead {
+        $contactEntity = new class() extends Lead {
             public function getId(): int
             {
                 return 1;
@@ -313,7 +313,7 @@ final class FullObjectReportBuilderTest extends TestCase
                 return true;
             });
 
-        $companyEntity = new class extends CompanyEntity {
+        $companyEntity = new class() extends CompanyEntity {
             public function getId(): int
             {
                 return 1;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -126,7 +126,7 @@ final class ObjectChangeGeneratorTest extends TestCase
     public function testFieldsWithDirectionToIntegrationAreSkipped(): void
     {
         $objectChangeGenerator = new ObjectChangeGenerator(
-            new class extends ValueHelper {
+            new class() extends ValueHelper {
             }
         );
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -354,7 +354,7 @@ final class ObjectChangeGeneratorTest extends TestCase
     public function testFieldsWithDirectionToIntegrationAreSkipped(): void
     {
         $objectChangeGenerator = new ObjectChangeGenerator(
-            new class implements SyncJudgeInterface {
+            new class() implements SyncJudgeInterface {
                 public function adjudicate(
                     $mode,
                     InformationChangeRequestDAO $leftChangeRequest,
@@ -363,9 +363,9 @@ final class ObjectChangeGeneratorTest extends TestCase
                     return $leftChangeRequest;
                 }
             },
-            new class extends ValueHelper {
+            new class() extends ValueHelper {
             },
-            new class extends FieldHelper {
+            new class() extends FieldHelper {
                 public function __construct()
                 {
                 }
@@ -377,7 +377,7 @@ final class ObjectChangeGeneratorTest extends TestCase
                     return ['email' => []];
                 }
             },
-            new class extends BulkNotification {
+            new class() extends BulkNotification {
                 public function __construct()
                 {
                 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -36,7 +36,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         static::getContainer()->set(
             'session',
             new Session(
-                new class extends FixedMockFileSessionStorage {
+                new class() extends FixedMockFileSessionStorage {
                     public function start(): bool
                     {
                         throw new \RuntimeException('Session cannot be started during API call. It must be stateless.');

--- a/app/bundles/LeadBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -22,7 +22,7 @@ final class EmailSubscriberTest extends TestCase
 
         $event           = new TokenReplacementEvent($value, $contact);
         $emailSubscriber = new EmailSubscriber(
-            new class extends BuilderTokenHelperFactory {
+            new class() extends BuilderTokenHelperFactory {
                 public function __construct()
                 {
                 }

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
@@ -40,7 +40,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $subscriber = new ImportCompanySubscriber(
             $this->getFieldListFake(),
-            new class extends CorePermissions {
+            new class() extends CorePermissions {
                 public function __construct()
                 {
                 }
@@ -67,7 +67,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $subscriber = new ImportCompanySubscriber(
             $this->getFieldListFake(),
-            new class extends CorePermissions {
+            new class() extends CorePermissions {
                 public function __construct()
                 {
                 }
@@ -110,7 +110,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
     public function testOnFieldMapping(): void
     {
         $subscriber = new ImportCompanySubscriber(
-            new class extends FieldList {
+            new class() extends FieldList {
                 public function __construct()
                 {
                 }
@@ -169,7 +169,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber = new ImportCompanySubscriber(
             $this->getFieldListFake(),
             $this->getCorePermissionsFake(),
-            new class extends CompanyModel {
+            new class() extends CompanyModel {
                 public function __construct()
                 {
                 }
@@ -243,7 +243,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getFieldListFake(): FieldList
     {
-        return new class extends FieldList {
+        return new class() extends FieldList {
             public function __construct()
             {
             }
@@ -252,7 +252,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getCorePermissionsFake(): CorePermissions
     {
-        return new class extends CorePermissions {
+        return new class() extends CorePermissions {
             public function __construct()
             {
             }
@@ -261,7 +261,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getCompanyModelFake(): CompanyModel
     {
-        return new class extends CompanyModel {
+        return new class() extends CompanyModel {
             public function __construct()
             {
             }
@@ -270,7 +270,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getTranslatorFake(): TranslatorInterface
     {
-        return new class extends Translator {
+        return new class() extends Translator {
             public function __construct()
             {
             }

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
@@ -40,7 +40,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $event      = new ImportValidateEvent('contacts', $formMock);
         $subscriber = new ImportContactSubscriber(
-            new class extends FieldList {
+            new class() extends FieldList {
                 public function __construct()
                 {
                 }
@@ -77,7 +77,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $event      = new ImportValidateEvent('contacts', $formMock);
         $subscriber = new ImportContactSubscriber(
-            new class extends FieldList {
+            new class() extends FieldList {
                 public function __construct()
                 {
                 }
@@ -114,7 +114,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $subscriber = new ImportContactSubscriber(
             $this->getFieldListFake(),
-            new class extends CorePermissions {
+            new class() extends CorePermissions {
                 public function __construct()
                 {
                 }
@@ -141,7 +141,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $subscriber = new ImportContactSubscriber(
             $this->getFieldListFake(),
-            new class extends CorePermissions {
+            new class() extends CorePermissions {
                 public function __construct()
                 {
                 }
@@ -184,7 +184,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
     public function testOnFieldMapping(): void
     {
         $subscriber = new ImportContactSubscriber(
-            new class extends FieldList {
+            new class() extends FieldList {
                 public function __construct()
                 {
                 }
@@ -254,7 +254,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
         $subscriber = new ImportContactSubscriber(
             $this->getFieldListFake(),
             $this->getCorePermissionsFake(),
-            new class extends LeadModel {
+            new class() extends LeadModel {
                 public function __construct()
                 {
                 }
@@ -275,7 +275,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getFieldListFake(): FieldList
     {
-        return new class extends FieldList {
+        return new class() extends FieldList {
             public function __construct()
             {
             }
@@ -284,7 +284,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getCorePermissionsFake(): CorePermissions
     {
-        return new class extends CorePermissions {
+        return new class() extends CorePermissions {
             public function __construct()
             {
             }
@@ -293,7 +293,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getLeadModelFake(): LeadModel
     {
-        return new class extends LeadModel {
+        return new class() extends LeadModel {
             public function __construct()
             {
             }
@@ -302,7 +302,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 
     private function getTranslatorFake(): TranslatorInterface
     {
-        return new class extends Translator {
+        return new class() extends Translator {
             public function __construct()
             {
             }

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -337,7 +337,7 @@ final class OwnerSubscriberTest extends TestCase
 
     protected function getUser(): User
     {
-        $user = new class extends User {
+        $user = new class() extends User {
             public function setId(int $id): void
             {
                 $this->id = $id;

--- a/app/bundles/LeadBundle/Tests/Form/Type/FilterTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/FilterTypeTest.php
@@ -146,7 +146,7 @@ final class FilterTypeTest extends \PHPUnit\Framework\TestCase
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame(FormEvents::PRE_SET_DATA, $parameters[0]);
                     $callback = function (callable $formModifier): void {
-                        $form = new class extends Form {
+                        $form = new class() extends Form {
                             public int $addMethodCallCounter = 0;
 
                             public function __construct()
@@ -160,7 +160,7 @@ final class FilterTypeTest extends \PHPUnit\Framework\TestCase
                             {
                                 Assert::assertSame('properties', $name);
 
-                                return new class extends Form {
+                                return new class() extends Form {
                                     public function __construct()
                                     {
                                     }

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -260,7 +260,7 @@ final class FieldModelTest extends MauticMysqlTestCase
     {
         // Log queries so we can detect if alter queries were executed
         /**  $stack */
-        $stack                    = new class implements SQLLogger { /** @phpstan-ignore-line SQLLogger is deprecated */
+        $stack                    = new class() implements SQLLogger { /** @phpstan-ignore-line SQLLogger is deprecated */
             /**
              * @var array<mixed>
              */

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -617,7 +617,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
      */
     private function getFieldPaginatorFake(): Paginator
     {
-        return new class extends Paginator {
+        return new class() extends Paginator {
             public function __construct()
             {
             }

--- a/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
@@ -97,6 +97,6 @@ final class CanPublishValidatorTest extends TestCase
 
         $this->expectException(UnexpectedTypeException::class);
 
-        $this->canPublishValidator->validate(1, new class extends Constraint {});
+        $this->canPublishValidator->validate(1, new class() extends Constraint {});
     }
 }

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -133,7 +133,7 @@ final class AbstractIntegrationTest extends AbstractIntegrationTestCase
                 'ignore_event_dispatch' => true,
                 'encode_parameters'     => 'json',
             ],
-            new class {
+            new class() {
                 /**
                  * @param mixed[] $options
                  */
@@ -159,7 +159,7 @@ final class AbstractIntegrationTest extends AbstractIntegrationTestCase
             ['this will be' => 'encoded to form array'],
             'POST',
             ['ignore_event_dispatch' => true],
-            new class {
+            new class() {
                 /**
                  * @param mixed[] $options
                  */

--- a/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
@@ -42,14 +42,14 @@ final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->translator->method('trans')->willReturn('mautic.sms.campaign.failed.missing_entity');
 
         $event    = new Event();
-        $campaign = new class extends Campaign {
+        $campaign = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;
             }
         };
         $contact = new Lead();
-        $leadLog = new class extends LeadEventLog {
+        $leadLog = new class() extends LeadEventLog {
             public function getId(): int
             {
                 return 456;
@@ -76,14 +76,14 @@ final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
         $sms      = new Sms();
         $event    = new Event();
         $contact  = new Lead();
-        $leadLog  = new class extends LeadEventLog {
+        $leadLog  = new class() extends LeadEventLog {
             public function getId(): int
             {
                 return 456;
             }
         };
 
-        $campaign  = new class extends Campaign {
+        $campaign  = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;
@@ -129,14 +129,14 @@ final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
         $smsModel->method('getEntity')->willReturn($sms);
 
         $event     = new Event();
-        $campaign  = new class extends Campaign {
+        $campaign  = new class() extends Campaign {
             public function getId(): int
             {
                 return 111;
             }
         };
         $contact  = new Lead();
-        $leadLog  = new class extends LeadEventLog {
+        $leadLog  = new class() extends LeadEventLog {
             public function getId(): int
             {
                 return 456;

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -85,7 +85,7 @@ final class TransportChainTest extends MauticMysqlTestCase
 
     public function testSendBatchSms(): void
     {
-        $bulkSmsTransport = new class implements BulkTransportInterface {
+        $bulkSmsTransport = new class() implements BulkTransportInterface {
             public function sendBatchSms(RecipientCollection $collection, string $content): RecipientCollection
             {
                 foreach ($collection as &$recipient) {
@@ -105,7 +105,7 @@ final class TransportChainTest extends MauticMysqlTestCase
 
     public function testSendMessage(): void
     {
-        $mmsTransport = new class implements TransportInterface, MMSTransportInterface {
+        $mmsTransport = new class() implements TransportInterface, MMSTransportInterface {
             public function sendMms(Lead $lead, string $content, array $media): bool
             {
                 return true;

--- a/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
@@ -23,7 +23,7 @@ final class CampaignSubscriberTest extends TestCase
 {
     public function testOnCampaignTriggerStageChangeWhenStageNotFound(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -38,13 +38,13 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -75,7 +75,7 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testOnCampaignTriggerStageChangeWhenStageUnpublished(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -90,13 +90,13 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -105,7 +105,7 @@ final class CampaignSubscriberTest extends TestCase
             {
                 Assert::assertSame(123, $id);
 
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -136,7 +136,7 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testOnCampaignTriggerStageChangeWhenContactHasNoStage(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -155,7 +155,7 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
@@ -165,7 +165,7 @@ final class CampaignSubscriberTest extends TestCase
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -174,7 +174,7 @@ final class CampaignSubscriberTest extends TestCase
             {
                 Assert::assertSame(123, $id);
 
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -201,7 +201,7 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testOnCampaignTriggerStageChangeWhenContactHasTheSameStage(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -209,7 +209,7 @@ final class CampaignSubscriberTest extends TestCase
 
             public function getStage(): Stage
             {
-                return new class extends Stage {
+                return new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -230,13 +230,13 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -245,7 +245,7 @@ final class CampaignSubscriberTest extends TestCase
             {
                 Assert::assertSame(123, $id);
 
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -278,7 +278,7 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testOnCampaignTriggerStageChangeWhenContactHasStageWithGreaterWeight(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -286,7 +286,7 @@ final class CampaignSubscriberTest extends TestCase
 
             public function getStage(): Stage
             {
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 444;
@@ -311,13 +311,13 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -326,7 +326,7 @@ final class CampaignSubscriberTest extends TestCase
             {
                 Assert::assertSame(123, $id);
 
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -360,7 +360,7 @@ final class CampaignSubscriberTest extends TestCase
 
     public function testOnCampaignTriggerStageChangeWhenContactHasStageWithLowerWeight(): void
     {
-        $contact = new class extends Lead {
+        $contact = new class() extends Lead {
             public function getId(): int
             {
                 return 333;
@@ -368,7 +368,7 @@ final class CampaignSubscriberTest extends TestCase
 
             public function getStage(): Stage
             {
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 444;
@@ -393,7 +393,7 @@ final class CampaignSubscriberTest extends TestCase
 
         $event->setProperties(['stage' => 123]);
 
-        $contactModel = new class extends LeadModel {
+        $contactModel = new class() extends LeadModel {
             public function __construct()
             {
             }
@@ -403,7 +403,7 @@ final class CampaignSubscriberTest extends TestCase
             }
         };
 
-        $stageModel = new class extends StageModel {
+        $stageModel = new class() extends StageModel {
             public function __construct()
             {
             }
@@ -412,7 +412,7 @@ final class CampaignSubscriberTest extends TestCase
             {
                 Assert::assertSame(123, $id);
 
-                $stage = new class extends Stage {
+                $stage = new class() extends Stage {
                     public function getId(): int
                     {
                         return 123;
@@ -440,7 +440,7 @@ final class CampaignSubscriberTest extends TestCase
 
     private function createTranslatorMock(): TranslatorInterface
     {
-        return new class implements TranslatorInterface {
+        return new class() implements TranslatorInterface {
             /**
              * @param array<string, mixed> $parameters
              */

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -202,7 +202,7 @@ final class WebhookModelTest extends TestCase
 
     public function testProcessWebhook(): void
     {
-        $webhook = new class extends Webhook {
+        $webhook = new class() extends Webhook {
             public function getId(): int
             {
                 return 1;
@@ -213,7 +213,7 @@ final class WebhookModelTest extends TestCase
         $event = new Event();
         $event->setEventType('mautic.email_on_send');
 
-        $queue = new class extends WebhookQueue {
+        $queue = new class() extends WebhookQueue {
             public function getId(): string
             {
                 return '1';
@@ -256,7 +256,7 @@ final class WebhookModelTest extends TestCase
 
     public function testMinAndMaxQueueIdWhenNoneIsSet(): void
     {
-        $webhook = new class extends Webhook {
+        $webhook = new class() extends Webhook {
             public function getId(): int
             {
                 return 1;
@@ -331,7 +331,7 @@ final class WebhookModelTest extends TestCase
 
     public function testMinAndMaxQueueIdWhenBothSet(): void
     {
-        $webhook = new class extends Webhook {
+        $webhook = new class() extends Webhook {
             public function getId(): int
             {
                 return 1;

--- a/app/middlewares/Tests/Dev/IpRestrictMiddlewareTest.php
+++ b/app/middlewares/Tests/Dev/IpRestrictMiddlewareTest.php
@@ -31,7 +31,7 @@ class IpRestrictMiddlewareTest extends \PHPUnit\Framework\TestCase
     {
         $inputRequest = new Request();
         $inputRequest->server->set('REMOTE_ADDR', '127.0.0.1'); // 127.0.0.1 is always allowed.
-        $httpKernel = new class implements HttpKernelInterface {
+        $httpKernel = new class() implements HttpKernelInterface {
             public function __construct()
             {
             }
@@ -52,7 +52,7 @@ class IpRestrictMiddlewareTest extends \PHPUnit\Framework\TestCase
     {
         $inputRequest = new Request();
         $inputRequest->server->set('REMOTE_ADDR', 'unallowed.ip.address');
-        $httpKernel                 = new class implements HttpKernelInterface {
+        $httpKernel                 = new class() implements HttpKernelInterface {
             public $handleWasCalled = false;
 
             public function __construct()

--- a/ecs.php
+++ b/ecs.php
@@ -35,6 +35,7 @@ return ECSConfig::configure()
         PhpCsFixer\Fixer\ControlStructure\NoSuperfluousElseifFixer::class,
         PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer::class,
         PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer::class,
+        PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer::class,
     ])
     ->withPreparedSets(
         comments: true,

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
@@ -26,7 +26,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
 {
     public function testAddOrEditEntityWithoutMatchingEntityAndNoRequestQuery(): void
     {
-        $requestStack = new class extends RequestStack {
+        $requestStack = new class() extends RequestStack {
             public function __construct()
             {
             }
@@ -37,7 +37,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             }
         };
 
-        $emailRepository = new class extends EmailRepository {
+        $emailRepository = new class() extends EmailRepository {
             public int $saveEntityCallCount = 0;
 
             public function __construct()
@@ -56,7 +56,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
 
         $emailModel = $this->getEmailModel($emailRepository);
 
-        $grapesJsBuilderRepository = new class extends GrapesJsBuilderRepository {
+        $grapesJsBuilderRepository = new class() extends GrapesJsBuilderRepository {
             public int $saveEntityCallCount = 0;
 
             public function __construct()
@@ -117,7 +117,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
 
     public function testAddOrEditEntityWithoutMatchingEntityAndGrapeRequestQuery(): void
     {
-        $requestStack = new class extends RequestStack {
+        $requestStack = new class() extends RequestStack {
             public function __construct()
             {
             }
@@ -138,7 +138,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             }
         };
 
-        $emailRepository           = new class extends EmailRepository {
+        $emailRepository           = new class() extends EmailRepository {
             public int $saveEntityCallCount = 0;
 
             public function __construct()
@@ -158,7 +158,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
 
         $emailModel = $this->getEmailModel($emailRepository);
 
-        $grapesJsBuilderRepository = new class extends GrapesJsBuilderRepository {
+        $grapesJsBuilderRepository = new class() extends GrapesJsBuilderRepository {
             public int $saveEntityCallCount = 0;
 
             public function __construct()
@@ -235,7 +235,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
 
     private function getTranslator(): Translator
     {
-        return new class extends Translator {
+        return new class() extends Translator {
             public function __construct()
             {
             }

--- a/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
@@ -16,7 +16,7 @@ final class TagManagerIntegrationTest extends TestCase
     {
         parent::setUp();
 
-        $this->tagManagerIntegration = new class extends TagManagerIntegration {
+        $this->tagManagerIntegration = new class() extends TagManagerIntegration {
             public function __construct()
             {
             }


### PR DESCRIPTION
Just a detail, that shows the `class()` is actually calling a constructor and allows passing args.
It's more consistent with other `class($...)` calls that already use args:

<img width="834" height="1310" alt="image" src="https://github.com/user-attachments/assets/83b4101a-93be-4f74-b4ca-689d266a5bd4" />


Let me know if you like it or not :+1: 