### PR TITLE
[ci] verify Mautic against the api-library integration suite

### DIFF
--- a/.github/workflows/api-library-tests.yml
+++ b/.github/workflows/api-library-tests.yml
@@ -1,0 +1,125 @@
+name: API library compatibility
+
+# Runs the mautic/api-library integration test suite against THIS checkout of
+# Mautic, so a change in Mautic that breaks the public API is caught before merge.
+# It is the mirror of mautic/api-library's own workflow, which tests the library
+# against Mautic's main branch.
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      api-library-ref:
+        description: 'Branch, tag or commit of mautic/api-library to test against'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  api-library:
+    runs-on: ubuntu-24.04
+    name: PHPUnit (api-library)
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: mautictest
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      mailhog:
+        image: mailhog/mailhog:latest
+        ports:
+          - 1025:1025
+
+      redis:
+        image: redis:6
+        ports:
+          - 6379:6379
+
+    steps:
+    - name: Checkout Mautic (this PR)
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      with:
+        php-version: '8.2'
+        ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
+        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        coverage: none
+
+    - name: Set SYMFONY_ENV to test
+      run: echo "SYMFONY_ENV=test" >> $GITHUB_ENV
+
+    - name: Install Apache
+      # Apache serves Mautic over HTTP so the api-library tests can hit a live instance.
+      # The mod-php version below must exist in the ubuntu-24.04 image; keep it in sync
+      # with the range in app/release_metadata.json.
+      run: |
+        sudo apt-get update -o Acquire::Retries=3
+        sudo apt-get install -y --no-install-recommends apache2 libapache2-mod-php8.3
+
+        sudo a2enmod rewrite
+        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.3/apache2/php.ini
+        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.3/apache2/php.ini
+        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.3/apache2/php.ini
+        sudo service apache2 restart
+
+    - name: Clone mautic/api-library
+      # Cloned outside the workspace so the "move to web root" step below does not sweep it up.
+      run: |
+        gh repo clone mautic/api-library "$HOME/api-library" -- \
+          --branch "${{ github.event.inputs.api-library-ref || 'main' }}" --single-branch --depth 1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Move Mautic to the web root
+      run: |
+        shopt -s dotglob
+        sudo chmod -R 777 /var/www/html
+        sudo chown -R www-data:www-data /var/www/html
+        rm -rf /var/www/html/*
+        mv "$GITHUB_WORKSPACE"/* /var/www/html/
+        cp "$HOME/api-library/.github/ci-files/.env" /var/www/html/
+        sed -i 's/DB_PORT=3306/DB_PORT=${{ job.services.mysql.ports[3306] }}/g' /var/www/html/.env
+        rm -f /var/www/html/.env.test
+
+    - name: Install Mautic
+      working-directory: /var/www/html
+      env:
+        DB_PORT: ${{ job.services.mysql.ports[3306] }}
+      run: |
+        APP_ENV=prod SYMFONY_ENV=prod composer install --prefer-dist --no-progress
+        cp "$HOME/api-library/.github/ci-files/local_5.php" ./config/local.php
+        php bin/console mautic:install http://localhost/ --force --env=test
+        php bin/console cache:warmup --no-interaction --env=test
+
+    - name: Enable Twilio plugin
+      # Needed for MessagesTest; the credentials are dummy and never contact Twilio.
+      working-directory: /var/www/html
+      run: |
+        mysql -uroot -P${{ job.services.mysql.ports[3306] }} -h127.0.0.1 -e "USE mautictest; INSERT INTO plugin_integration_settings (plugin_id, name, is_published, supported_features, api_keys, feature_settings) VALUES (NULL, 'Twilio', 1, 'a:0:{}', 'a:2:{s:8:\"username\";s:169:\"bzFmNlIydWRSZXlIN2lQVkdpanJ4aTQ2NUh6RVdDbHlLRVhsWGZ4b0kyZVNxLzYrQ1J6V1RvMnlhVEp0c245TEp6eStQekx5ZVhLWjB1YVdoR3RnR2dHQ3k1emVVdGt5NzZKUmtjUnJ3c1E9|L8tbZRIYhwatT7Mq+HAdYA==\";s:8:\"password\";s:169:\"T2d2cFpXQWE5YVZnNFFianJSYURRYUtGRHBNZGZjM1VETXg2Wm5Va3NheW43MjVWUlJhTVlCL2pYMDBpbElONStiVVBNbEM3M3BaeGJMNkFKNUFEN1pTNldSRjc4bUM4SDh1SE9OY1k5MTg9|TeuSvfx4XSUOvp0O7T49Cg==\";}', 'a:4:{s:20:\"sending_phone_number\";N;s:22:\"disable_trackable_urls\";i:0;s:16:\"frequency_number\";N;s:14:\"frequency_time\";N;}');"
+        php bin/console mautic:plugins:reload --env=test
+
+    - name: Set correct ownership so Apache can access the files
+      run: sudo chown -R www-data:www-data /var/www/html
+
+    - name: Run api-library tests
+      working-directory: /home/runner/api-library
+      run: |
+        cp .github/ci-files/local.config.php tests/local.config.php
+        composer install --prefer-dist --no-progress
+        vendor/bin/phpunit
+
+    - name: Upload Mautic logs as artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: always()
+      with:
+        name: mautic-logs
+        path: /var/www/html/var/logs/

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1620,12 +1620,12 @@ class CommonRepository extends ServiceEntityRepository
                         case 'isEmpty':
                         case 'isNotEmpty':
                             if ('isEmpty' === $clause['expr']) {
-                                $whereClause = $query->expr()->or(
+                                $whereClause = $query->expr()->orX(
                                     $query->expr()->eq($column, $query->expr()->literal('')),
                                     $query->expr()->isNull($column)
                                 );
                             } else {
-                                $whereClause = $query->expr()->and(
+                                $whereClause = $query->expr()->andX(
                                     $query->expr()->neq($column, $query->expr()->literal('')),
                                     $query->expr()->isNotNull($column)
                                 );


### PR DESCRIPTION
This adds a workflow that runs the [mautic/api-library](https://github.com/mautic/api-library) integration test suite against **this** checkout of Mautic.

Reverts https://github.com/mautic/mautic/pull/16505

## Notes

- Reuses the api-library's own `.github/ci-files/` (`.env`, `local_5.php`, `local.config.php`) straight from the clone — no config duplicated into Mautic.
- Installs via the v5+ path only (this repo is 7.2.0-rc); the api-library's Mautic-4 fork is dropped.
