### PR TITLE
Fix deprecation about `Extension` class namespace

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -4,8 +4,8 @@ namespace Mautic\CoreBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class MauticCoreExtension extends Extension
 {

--- a/app/bundles/LeadBundle/DependencyInjection/MauticLeadExtension.php
+++ b/app/bundles/LeadBundle/DependencyInjection/MauticLeadExtension.php
@@ -6,8 +6,8 @@ namespace Mautic\LeadBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class MauticLeadExtension extends Extension
 {

--- a/plugins/MauticCloudStorageBundle/DependencyInjection/MauticCloudStorageExtension.php
+++ b/plugins/MauticCloudStorageBundle/DependencyInjection/MauticCloudStorageExtension.php
@@ -6,8 +6,8 @@ namespace MauticPlugin\MauticCloudStorageBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class MauticCloudStorageExtension extends Extension
 {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL | I'm not sure this is required here
| Issue(s) addressed                     | 

## Description

This is properly deprecated from Symfony 8.1 but this class is marked as internal from 7.1

Use `Symfony\Component\DependencyInjection\Extension\Extension` in place of `Symfony\Component\HttpKernel\DependencyInjection\Extension` to follow Symfony changes