### PR TITLE
Add return type to `getFunctions()` to fix deprecation

### DIFF
--- a/app/bundles/CoreBundle/Twig/Extension/AnalyticsExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AnalyticsExtension.php
@@ -15,7 +15,7 @@ class AnalyticsExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('analyticsGetCode', $this->getCode(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/AppExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AppExtension.php
@@ -13,7 +13,7 @@ class AppExtension extends AbstractExtension
     /**
      * @return TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('ini_get', fn ($value): string|false => ini_get($value)),

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -18,7 +18,7 @@ class AssetExtension extends AbstractExtension
     /**
      * @see Twig_Extension::getFunctions()
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('outputScripts', $this->outputScripts(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/BarChartExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/BarChartExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 final class BarChartExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('barChartInitialize', $this->createNewChart(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/ButtonExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ButtonExtension.php
@@ -21,7 +21,7 @@ class ButtonExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('buttonReset', $this->reset(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/ConfigExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ConfigExtension.php
@@ -15,7 +15,7 @@ class ConfigExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('configGetParameter', $this->get(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/ContentExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ContentExtension.php
@@ -15,7 +15,7 @@ class ContentExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('customContent', $this->getCustomContent(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/CoreHelpersExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/CoreHelpersExtension.php
@@ -20,7 +20,7 @@ class CoreHelpersExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             // Used by CoreBundle:Helper:list_filters.html.twig

--- a/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
@@ -15,7 +15,7 @@ class DateExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('dateToText', $this->toText(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
@@ -13,7 +13,7 @@ class DateTimeExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('dateTimeGetUtcDateTime', $this->getUtcDateTime(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/DeviceExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DeviceExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class DeviceExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('deviceGetFullName', AbstractDeviceParser::getFullName(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/EnumExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/EnumExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class EnumExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('enumConditionalFieldTypes', ConditionalFieldEnum::getConditionalFieldTypes(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
@@ -11,7 +11,7 @@ use Twig\TwigFunction;
 
 class FormExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('formFieldFormatList', $this->formatList(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
@@ -23,7 +23,7 @@ class FormatterExtension extends AbstractExtension
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('format', $this->_(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/GravatarExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/GravatarExtension.php
@@ -15,7 +15,7 @@ class GravatarExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('gravatarGetImage', $this->getImage(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -9,7 +9,7 @@ use Twig\TwigFunction;
 
 final class HtmlExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('htmlAttributesStringToArray', $this->convertHtmlAttributesToArray(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/InputExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/InputExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class InputExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('inputUrl', InputHelper::url(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/MautibotExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/MautibotExtension.php
@@ -15,7 +15,7 @@ class MautibotExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('mautibotGetImage', $this->getImage(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/MenuExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/MenuExtension.php
@@ -17,7 +17,7 @@ class MenuExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('menuRender', $this->menuRender(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigTest;
 
 class ObjectExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('method_exists', fn ($obj, $method): bool => method_exists($obj, $method)),

--- a/app/bundles/CoreBundle/Twig/Extension/SearchCommandListExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SearchCommandListExtension.php
@@ -15,7 +15,7 @@ class SearchCommandListExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('searchCommandList', $this->getSearchCommandList(...), ['is_safe' => ['all']]),

--- a/app/bundles/CoreBundle/Twig/Extension/SecurityExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SecurityExtension.php
@@ -16,7 +16,7 @@ class SecurityExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('securityGetAuthenticationContext', $this->getContext(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/SerializerExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SerializerExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class SerializerExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('serializerDecode', Serializer::decode(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/StorageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/StorageExtension.php
@@ -20,7 +20,7 @@ class StorageExtension extends AbstractExtension
      */
     protected array $storage = [];
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('save', $this->save(...), ['needs_context' => true]),

--- a/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
@@ -15,7 +15,7 @@ final class ThemesExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('getTextOnBrandColor', $this->getTextOnBrandColor(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/TranslatorExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/TranslatorExtension.php
@@ -15,7 +15,7 @@ class TranslatorExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('translatorGetJsLang', $this->getJsLang(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/VersionExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/VersionExtension.php
@@ -15,7 +15,7 @@ class VersionExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('mauticAppVersion', $this->getVersion(...)),

--- a/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
+++ b/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
@@ -18,7 +18,7 @@ final class FormFieldExtension extends AbstractExtension
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('formFieldParseBooleanList', [FormFieldHelper::class, 'parseBooleanList']),

--- a/app/bundles/LeadBundle/Twig/Extension/DncReasonExtension.php
+++ b/app/bundles/LeadBundle/Twig/Extension/DncReasonExtension.php
@@ -19,7 +19,7 @@ class DncReasonExtension extends AbstractExtension
     /**
      * @see Twig_Extension::getFunctions()
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('dncReasonToText', $this->toText(...)),

--- a/app/bundles/LeadBundle/Twig/Extension/FormFieldExtension.php
+++ b/app/bundles/LeadBundle/Twig/Extension/FormFieldExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 final class FormFieldExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('leadFieldCountryChoices', FormFieldHelper::getCountryChoices(...)),

--- a/app/bundles/LeadBundle/Twig/Extension/LeadExtension.php
+++ b/app/bundles/LeadBundle/Twig/Extension/LeadExtension.php
@@ -19,7 +19,7 @@ class LeadExtension extends AbstractExtension
     /**
      * @see Twig_Extension::getFunctions()
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('leadGetAvatar', $this->getAvatar(...)),


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Sometimes this function is declared with typed return value, sometimes not, this trigger a deprecation

Add return type to all usages to avoid those deprecations