### PR TITLE
[phpstan] allow fast phpstan run + make use of local dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 !/var/cache/.gitkeep
 
 /var/phpstan-cache/*
+phpstan.dist.neon
+phpstan.neon.dist
 
 /app/logs/*
 !/app/logs/.gitkeep

--- a/app/assets/scaffold/files/example.gitignore
+++ b/app/assets/scaffold/files/example.gitignore
@@ -32,6 +32,8 @@
 !/var/cache/.gitkeep
 
 /var/phpstan-cache/*
+phpstan.dist.neon
+phpstan.neon.dist
 
 /app/logs/*
 !/app/logs/.gitkeep

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,6 @@ parameters:
 	reportUnmatchedIgnoredErrors: false
 	treatPhpDocTypesAsCertain: false
 	parallel:
-		maximumNumberOfProcesses: 2
 		processTimeout: 1000.0
     # see https://github.com/tomasVotruba/type-coverage
 	type_coverage:


### PR DESCRIPTION
Follow up to: https://github.com/mautic/mautic/pull/16500 to allow faster PHPStan run (e.g. 8x faster on my machine).

@escopecz Create `phpstan.neon.dist` with to override main config. It's only versioned for you:

```yaml
includes:
    - phpstan.neon
 
parameters:
    paths:
        maximumNumberOfProcesses: 2
```