### PR TITLE
[tests] use data provider with 1 line = 1 use case yield syntax, that allows expr use between items

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -901,9 +901,9 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
     }
 
     /**
-     * @return array<string, array{republishBehavior: string, triggerMode: string, intervalDays: int, auditLogs: array<array{dateAdded: string, details: array<string, array<int, mixed>>}>, expectedTriggerDate: string, expectedIsScheduled: bool}>
+     * @return \Iterator<string, array{republishBehavior: string, triggerMode: string, intervalDays: int, auditLogs: array<array{dateAdded: string, details: array<string, array<int, mixed>>}>, expectedTriggerDate: string, expectedIsScheduled: bool}>
      */
-    public static function republishBehaviorProvider(): array
+    public static function republishBehaviorProvider(): \Iterator
     {
         $unpublishedAfter5days = 'published, unpublished and published';
         $auditLogs             = [
@@ -928,98 +928,95 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
                 ],
             ],
         ];
-
-        return [
-            'Same the original trigger date as it should not change' => [
-                'republishBehavior'      => RepublishBehavior::COUNT_ALL_TIME->value,
-                'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'           => 10,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
+        yield 'Same the original trigger date as it should not change' => [
+            'republishBehavior'      => RepublishBehavior::COUNT_ALL_TIME->value,
+            'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'           => 10,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
                 ],
             ],
-            '10 days after last publish which is 2024-10-10 00:00:00' => [
-                'republishBehavior'      => RepublishBehavior::RESTART_ON_PUBLISH->value,
-                'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'           => 10,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-20 00:00:00', // 10 days after last publish
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
-                    [
-                        'changedTo' => '2024-10-20 00:00:00',
-                        'note'      => 'Campaign republish behavior: restart_on_publish',
-                    ],
+        ];
+        yield '10 days after last publish which is 2024-10-10 00:00:00' => [
+            'republishBehavior'      => RepublishBehavior::RESTART_ON_PUBLISH->value,
+            'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'           => 10,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-20 00:00:00', // 10 days after last publish
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
+                ],
+                [
+                    'changedTo' => '2024-10-20 00:00:00',
+                    'note'      => 'Campaign republish behavior: restart_on_publish',
                 ],
             ],
-            'Scheduled at 2024-10-02 00:00:00 for 10 days (2024-10-12 00:00:00), unpublished at 2024-10-05 00:00:00 after 3 days, published 2024-10-10 00:00:00 (5 days)' => [
-                'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'           => 10,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-17 00:00:00', // 3 days were already published, 7 remaining to go after publish of 2024-10-10 00:00:00.
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
-                    [
-                        'changedTo' => '2024-10-17 00:00:00',
-                        'note'      => 'Campaign republish behavior: count_only_while_published',
-                    ],
+        ];
+        yield 'Scheduled at 2024-10-02 00:00:00 for 10 days (2024-10-12 00:00:00), unpublished at 2024-10-05 00:00:00 after 3 days, published 2024-10-10 00:00:00 (5 days)' => [
+            'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'           => 10,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-17 00:00:00', // 3 days were already published, 7 remaining to go after publish of 2024-10-10 00:00:00.
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
+                ],
+                [
+                    'changedTo' => '2024-10-17 00:00:00',
+                    'note'      => 'Campaign republish behavior: count_only_while_published',
                 ],
             ],
-            'Absolute date trigger mode should not do anything' => [
-                'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'            => Event::TRIGGER_MODE_DATE,
-                'intervalDays'           => 10,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
+        ];
+        yield 'Absolute date trigger mode should not do anything' => [
+            'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'            => Event::TRIGGER_MODE_DATE,
+            'intervalDays'           => 10,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
                 ],
             ],
-            'Immediate trigger mode should not extend anything' => [
-                'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'            => Event::TRIGGER_MODE_IMMEDIATE,
-                'intervalDays'           => 10,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
+        ];
+        yield 'Immediate trigger mode should not extend anything' => [
+            'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'            => Event::TRIGGER_MODE_IMMEDIATE,
+            'intervalDays'           => 10,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
                 ],
             ],
-            'If the interval is empty then there will be no extension' => [
-                'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'           => 0,
-                'auditLogs'              => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
-                'expectedTriggerDateLog' => [
-                    [
-                        'changedTo' => '2024-10-12 00:00:00',
-                        'note'      => 'Test setup',
-                    ],
+        ];
+        yield 'If the interval is empty then there will be no extension' => [
+            'republishBehavior'      => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'            => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'           => 0,
+            'auditLogs'              => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate'    => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled'    => false, // Executed anyway as the trigger date is still in the past
+            'expectedTriggerDateLog' => [
+                [
+                    'changedTo' => '2024-10-12 00:00:00',
+                    'note'      => 'Test setup',
                 ],
             ],
         ];

--- a/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
@@ -69,7 +69,7 @@ final class EventControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<(int | string), array<string>>
+     * @return \Iterator<(int|string), array<string>>
      */
     public static function fieldAndValueProvider(): \Iterator
     {

--- a/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
@@ -69,16 +69,14 @@ final class EventControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return string[][]
+     * @return \Iterator<(int | string), array<string>>
      */
-    public static function fieldAndValueProvider(): array
+    public static function fieldAndValueProvider(): \Iterator
     {
-        return [
-            'country'  => ['country', 'India'],
-            'region'   => ['state', 'Arizona'],
-            'timezone' => ['timezone', 'Marigot'],
-            'locale'   => ['preferred_locale', 'af'],
-        ];
+        yield 'country' => ['country', 'India'];
+        yield 'region' => ['state', 'Arizona'];
+        yield 'timezone' => ['timezone', 'Marigot'];
+        yield 'locale' => ['preferred_locale', 'af'];
     }
 
     public function testActionAtSpecificTimeWorkflow(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
@@ -59,25 +59,23 @@ final class VisitedPageConditionControllerFunctionalTest extends MauticMysqlTest
     }
 
     /**
-     * @return array<mixed,mixed>
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function fieldAndValueProvider(): array
+    public static function fieldAndValueProvider(): \Iterator
     {
-        return [
-            [
-                'pageUrl'          => ['page_url', 'https://example.com'],
-                'startDate'        => ['startDate', (new \DateTime())->format('Y-m-d H:i:s')],
-                'endDate'          => ['endDate', (new \DateTime())->modify('+ 5 days')->format('Y-m-d H:i:s')],
-                'accumulativeTime' => ['accumulative_time', 5],
-                'page'             => ['page', null],
-            ],
-            [
-                'pageUrl'          => ['page_url', 'https://example.com'],
-                'startDate'        => ['startDate', (new \DateTime())->format('Y-m-d H:i:s')],
-                'endDate'          => ['endDate', (new \DateTime())->modify('+ 10 days')->format('Y-m-d H:i:s')],
-                'accumulativeTime' => ['accumulative_time', null],
-                'page'             => ['page', ''],
-            ],
+        yield [
+            'pageUrl'          => ['page_url', 'https://example.com'],
+            'startDate'        => ['startDate', (new \DateTime())->format('Y-m-d H:i:s')],
+            'endDate'          => ['endDate', (new \DateTime())->modify('+ 5 days')->format('Y-m-d H:i:s')],
+            'accumulativeTime' => ['accumulative_time', 5],
+            'page'             => ['page', null],
+        ];
+        yield [
+            'pageUrl'          => ['page_url', 'https://example.com'],
+            'startDate'        => ['startDate', (new \DateTime())->format('Y-m-d H:i:s')],
+            'endDate'          => ['endDate', (new \DateTime())->modify('+ 10 days')->format('Y-m-d H:i:s')],
+            'accumulativeTime' => ['accumulative_time', null],
+            'page'             => ['page', ''],
         ];
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
@@ -59,7 +59,7 @@ final class VisitedPageConditionControllerFunctionalTest extends MauticMysqlTest
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function fieldAndValueProvider(): \Iterator
     {

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
@@ -94,9 +94,9 @@ final class ScheduledExecutionerExtendTriggerDateTest extends AbstractCampaignCo
     }
 
     /**
-     * @return array<string, array{republishBehavior: string, triggerMode: string, intervalDays: int, auditLogs: array<array{dateAdded: string, details: array<string, array<int, mixed>>}>, expectedTriggerDate: string, expectedIsScheduled: bool}>
+     * @return \Iterator<string, array{republishBehavior: string, triggerMode: string, intervalDays: int, auditLogs: array<array{dateAdded: string, details: array<string, array<int, mixed>>}>, expectedTriggerDate: string, expectedIsScheduled: bool}>
      */
-    public static function republishBehaviorProvider(): array
+    public static function republishBehaviorProvider(): \Iterator
     {
         $unpublishedAfter5days = 'published, unpublished and published';
         $auditLogs             = [
@@ -125,64 +125,61 @@ final class ScheduledExecutionerExtendTriggerDateTest extends AbstractCampaignCo
         $startDate      = new \DateTime('2024-10-02 00:00:00');
         $endDate        = new \DateTime('2034-10-02 00:00:00');
         $tenYearsInDays = $endDate->diff($startDate)->days;
-
-        return [
-            'Same the original trigger date as it should not change' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ALL_TIME->value,
-                'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'        => 10,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
-            '10 days after last publish which is 2024-10-10 00:00:00' => [
-                'republishBehavior'   => RepublishBehavior::RESTART_ON_PUBLISH->value,
-                'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'        => 10,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-20 00:00:00', // 10 days after last publish
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
-            'Scheduled at 2024-10-02 00:00:00 for 10 days (2024-10-12 00:00:00), unpublished at 2024-10-05 00:00:00 after 3 days, published 2024-10-10 00:00:00 (5 days). From this it would be another 10 days but 3 were already served.' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'        => 10,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-17 00:00:00', // 3 days were already published, 7 remaining to go.
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
-            'Scheduled 10 years into the future so it should reschedule, not execute. Republished 2024-10-10 00:00:00 with 3 days already published before.' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'        => $tenYearsInDays, // 3652 days (Warning, this test will fail in 10 years. Sending regards to future maintainers!)
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2034-10-07 00:00:00', // 10 years after 2024-10-10 minus 3 days before the last publish date.
-                'expectedIsScheduled' => true, // Not executed but rescheduled for 10 years in the future
-            ],
-            'Absolute date trigger mode should not do anything' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'         => Event::TRIGGER_MODE_DATE,
-                'intervalDays'        => 10,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
-            'Immediate trigger mode should not extend anything' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'         => Event::TRIGGER_MODE_IMMEDIATE,
-                'intervalDays'        => 10,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
-            'If the interval is empty then there will be no extension' => [
-                'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
-                'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
-                'intervalDays'        => 0,
-                'auditLogs'           => $auditLogs[$unpublishedAfter5days],
-                'expectedTriggerDate' => '2024-10-02 00:00:00', // Since there is no interval, the trigger date remains the same as the date triggered (created)
-                'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
-            ],
+        yield 'Same the original trigger date as it should not change' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ALL_TIME->value,
+            'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'        => 10,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
+        ];
+        yield '10 days after last publish which is 2024-10-10 00:00:00' => [
+            'republishBehavior'   => RepublishBehavior::RESTART_ON_PUBLISH->value,
+            'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'        => 10,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-20 00:00:00', // 10 days after last publish
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
+        ];
+        yield 'Scheduled at 2024-10-02 00:00:00 for 10 days (2024-10-12 00:00:00), unpublished at 2024-10-05 00:00:00 after 3 days, published 2024-10-10 00:00:00 (5 days). From this it would be another 10 days but 3 were already served.' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'        => 10,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-17 00:00:00', // 3 days were already published, 7 remaining to go.
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
+        ];
+        yield 'Scheduled 10 years into the future so it should reschedule, not execute. Republished 2024-10-10 00:00:00 with 3 days already published before.' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'        => $tenYearsInDays, // 3652 days (Warning, this test will fail in 10 years. Sending regards to future maintainers!)
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2034-10-07 00:00:00', // 10 years after 2024-10-10 minus 3 days before the last publish date.
+            'expectedIsScheduled' => true, // Not executed but rescheduled for 10 years in the future
+        ];
+        yield 'Absolute date trigger mode should not do anything' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'         => Event::TRIGGER_MODE_DATE,
+            'intervalDays'        => 10,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
+        ];
+        yield 'Immediate trigger mode should not extend anything' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'         => Event::TRIGGER_MODE_IMMEDIATE,
+            'intervalDays'        => 10,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-12 00:00:00', // Original trigger date
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
+        ];
+        yield 'If the interval is empty then there will be no extension' => [
+            'republishBehavior'   => RepublishBehavior::COUNT_ONLY_WHILE_PUBLISHED->value,
+            'triggerMode'         => Event::TRIGGER_MODE_INTERVAL,
+            'intervalDays'        => 0,
+            'auditLogs'           => $auditLogs[$unpublishedAfter5days],
+            'expectedTriggerDate' => '2024-10-02 00:00:00', // Since there is no interval, the trigger date remains the same as the date triggered (created)
+            'expectedIsScheduled' => false, // Executed anyway as the trigger date is still in the past
         ];
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -66,43 +66,41 @@ final class IntervalTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string, array<mixed>>
+     * @return \Iterator<string, array<mixed>>
      */
-    public static function provideBatchReschedulingData(): array
+    public static function provideBatchReschedulingData(): \Iterator
     {
-        return [
-            'test on specified hour'                     => [new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')],
-            'test on previous day specified hour'        => [new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-17 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')],
-            'test on next day specified hour'            => [new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-19 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')],
-            'test on start time'                         => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time'                  => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time previous day'     => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time next day'         => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time'                   => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time previous day'      => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time next day'          => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')],
-            'test on end time'                           => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time'                    => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time previous day'       => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time next day'           => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time'                     => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time previous day'        => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time next day'            => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')],
-            'test in time range'                         => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')],
-            'test on before time range'                  => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on before time range previous day'     => [new \DateTime('2018-10-18 10:00'), new \DateTime('2018-10-18 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on before time range next day'         => [new \DateTime('2018-10-20 10:00'), new \DateTime('2018-10-20 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on after end time range'               => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on after end time range previous day'  => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on after end time range next day'      => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on allowed day'                        => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 8:00'), 'UTC', null, null, null, [0]],
-            'test on restricted days'                    => [new \DateTime('2018-10-24 08:00'), new \DateTime('2018-10-21 08:00'), 'UTC', null, null, null, [3, 5]],
-            'test on all restricted days'                => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), 'UTC', null, null, null, []],
-            'test in between wrong start/end time order' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 8:00')],
-            'test combination of rules'                  => [new \DateTime('2018-10-26 08:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00'), [5, 6]],
-            'test valid timezone'                        => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 09:00'), 'America/New_York', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')],
-            'test invalid timezone'                      => [new \DateTime('2018-10-19 09:00'), new \DateTime('2018-10-19 13:00'), 'UTC2', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')],
-        ];
+        yield 'test on specified hour' => [new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')];
+        yield 'test on previous day specified hour' => [new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-17 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')];
+        yield 'test on next day specified hour' => [new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-19 16:00'), 'UTC', new \DateTime('2018-10-18 16:00')];
+        yield 'test on start time' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time previous day' => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time next day' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time' => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time previous day' => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time next day' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on end time' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time previous day' => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time next day' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time' => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time previous day' => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time next day' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test in time range' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on before time range' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on before time range previous day' => [new \DateTime('2018-10-18 10:00'), new \DateTime('2018-10-18 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on before time range next day' => [new \DateTime('2018-10-20 10:00'), new \DateTime('2018-10-20 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on after end time range' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time range previous day' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-18 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time range next day' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on allowed day' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 8:00'), 'UTC', null, null, null, [0]];
+        yield 'test on restricted days' => [new \DateTime('2018-10-24 08:00'), new \DateTime('2018-10-21 08:00'), 'UTC', null, null, null, [3, 5]];
+        yield 'test on all restricted days' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), 'UTC', null, null, null, []];
+        yield 'test in between wrong start/end time order' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-19 10:00'), 'UTC', null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 8:00')];
+        yield 'test combination of rules' => [new \DateTime('2018-10-26 08:00'), new \DateTime('2018-10-20 12:00'), 'UTC', null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00'), [5, 6]];
+        yield 'test valid timezone' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 09:00'), 'America/New_York', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test invalid timezone' => [new \DateTime('2018-10-19 09:00'), new \DateTime('2018-10-19 13:00'), 'UTC2', null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')];
     }
 
     /**
@@ -142,41 +140,39 @@ final class IntervalTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string, array<mixed>>
+     * @return \Iterator<string, array<mixed>>
      */
-    public static function ProvidereschedulingData(): array
+    public static function ProvidereschedulingData(): \Iterator
     {
-        return [
-            'test on specified hour'                     => [new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00')],
-            'test on previous day specified hour'        => [new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-18 16:00')],
-            'test on next day specified hour'            => [new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-18 16:00')],
-            'test on start time'                         => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time'                  => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time previous day'     => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on before start time next day'         => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time'                   => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time previous day'      => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on after start time next day'          => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 10:00')],
-            'test on end time'                           => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time'                    => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time previous day'       => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on before end time next day'           => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time'                     => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time previous day'        => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test on after end time next day'            => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, null, new \DateTime('2018-10-19 10:00')],
-            'test in time range'                         => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')],
-            'test on before time range'                  => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on before time range previous day'     => [new \DateTime('2018-10-18 10:00'), new \DateTime('2018-10-18 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on before time range next day'         => [new \DateTime('2018-10-20 10:00'), new \DateTime('2018-10-20 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')],
-            'test on after end time range'               => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on after end time range previous day'  => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on after end time range next day'      => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')],
-            'test on allowed day'                        => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 8:00'), null, null, null, [0]],
-            'test on restricted days'                    => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), null, null, null, [3, 5]],
-            'test on all restricted days'                => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), null, null, null, []],
-            'test in between wrong start/end time order' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 8:00')],
-            'test combination of rules'                  => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00'), [5, 6]],
-        ];
+        yield 'test on specified hour' => [new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00'), new \DateTime('2018-10-18 16:00')];
+        yield 'test on previous day specified hour' => [new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-17 16:00'), new \DateTime('2018-10-18 16:00')];
+        yield 'test on next day specified hour' => [new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-19 16:00'), new \DateTime('2018-10-18 16:00')];
+        yield 'test on start time' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time previous day' => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before start time next day' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time' => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time previous day' => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after start time next day' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on end time' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time' => [new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 8:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time previous day' => [new \DateTime('2018-10-18 08:00'), new \DateTime('2018-10-18 8:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on before end time next day' => [new \DateTime('2018-10-20 08:00'), new \DateTime('2018-10-20 8:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time' => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time previous day' => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time next day' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, null, new \DateTime('2018-10-19 10:00')];
+        yield 'test in time range' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 8:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on before time range' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on before time range previous day' => [new \DateTime('2018-10-18 10:00'), new \DateTime('2018-10-18 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on before time range next day' => [new \DateTime('2018-10-20 10:00'), new \DateTime('2018-10-20 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 11:00')];
+        yield 'test on after end time range' => [new \DateTime('2018-10-19 12:00'), new \DateTime('2018-10-19 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time range previous day' => [new \DateTime('2018-10-18 12:00'), new \DateTime('2018-10-18 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on after end time range next day' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00')];
+        yield 'test on allowed day' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 8:00'), null, null, null, [0]];
+        yield 'test on restricted days' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), null, null, null, [3, 5]];
+        yield 'test on all restricted days' => [new \DateTime('2018-10-21 08:00'), new \DateTime('2018-10-21 08:00'), null, null, null, []];
+        yield 'test in between wrong start/end time order' => [new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 10:00'), null, new \DateTime('2018-10-19 10:00'), new \DateTime('2018-10-19 8:00')];
+        yield 'test combination of rules' => [new \DateTime('2018-10-20 12:00'), new \DateTime('2018-10-20 12:00'), null, new \DateTime('2018-10-19 08:00'), new \DateTime('2018-10-19 10:00'), [5, 6]];
     }
 
     public function testGetExecutionDateTimeThrowsNotSchedulableException(): void

--- a/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
@@ -94,7 +94,7 @@ final class SortableListTransformerTest extends TestCase
     }
 
     /**
-     * @return \Iterator<string, array{input: array<string, array<(int | string), string>>, expected: array<string, array<array<string, string>>>}>
+     * @return \Iterator<string, array{input: array<string, array<(int|string), string>>, expected: array<string, array<array<string, string>>>}>
      */
     public static function standardListProvider(): \Iterator
     {
@@ -131,7 +131,7 @@ final class SortableListTransformerTest extends TestCase
     }
 
     /**
-     * @return \Iterator<string, array{input: array<string, array<(int | string), string>>, expected: array<string, array<string>>}>
+     * @return \Iterator<string, array{input: array<string, array<(int|string), string>>, expected: array<string, array<string>>}>
      */
     public static function standardListWithoutLabelsProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/DataTransformer/SortableListTransformerTest.php
@@ -94,124 +94,116 @@ final class SortableListTransformerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{input: array<string, array<int|string, string>>, expected: array<string, array<array<string, string>>>}>
+     * @return \Iterator<string, array{input: array<string, array<(int | string), string>>, expected: array<string, array<array<string, string>>>}>
      */
-    public static function standardListProvider(): array
+    public static function standardListProvider(): \Iterator
     {
-        return [
-            'simple list' => [
-                'input' => [
-                    'list' => [
-                        3 => 'a@example.com',
-                        2 => 'b@example.com',
-                    ],
-                ],
-                'expected' => [
-                    'list' => [
-                        ['label' => 'a@example.com', 'value' => 'a@example.com'],
-                        ['label' => 'b@example.com', 'value' => 'b@example.com'],
-                    ],
+        yield 'simple list' => [
+            'input' => [
+                'list' => [
+                    3 => 'a@example.com',
+                    2 => 'b@example.com',
                 ],
             ],
-            'non sequential indexes' => [
-                'input' => [
-                    'list' => ['item1', 'item2', 'item3'],
-                ],
-                'expected' => [
-                    'list' => [
-                        ['label' => 'item1', 'value' => 'item1'],
-                        ['label' => 'item2', 'value' => 'item2'],
-                        ['label' => 'item3', 'value' => 'item3'],
-                    ],
+            'expected' => [
+                'list' => [
+                    ['label' => 'a@example.com', 'value' => 'a@example.com'],
+                    ['label' => 'b@example.com', 'value' => 'b@example.com'],
                 ],
             ],
-            'empty list' => [
-                'input'    => ['list' => []],
-                'expected' => ['list' => []],
+        ];
+        yield 'non sequential indexes' => [
+            'input' => [
+                'list' => ['item1', 'item2', 'item3'],
             ],
+            'expected' => [
+                'list' => [
+                    ['label' => 'item1', 'value' => 'item1'],
+                    ['label' => 'item2', 'value' => 'item2'],
+                    ['label' => 'item3', 'value' => 'item3'],
+                ],
+            ],
+        ];
+        yield 'empty list' => [
+            'input'    => ['list' => []],
+            'expected' => ['list' => []],
         ];
     }
 
     /**
-     * @return array<string, array{input: array<string, array<int|string, string>>, expected: array<string, array<string>>}>
+     * @return \Iterator<string, array{input: array<string, array<(int | string), string>>, expected: array<string, array<string>>}>
      */
-    public static function standardListWithoutLabelsProvider(): array
+    public static function standardListWithoutLabelsProvider(): \Iterator
     {
-        return [
-            'simple list without labels' => [
-                'input' => [
-                    'list' => ['item1', 'item2', 'item3'],
-                ],
-                'expected' => [
-                    'list' => ['item1', 'item2', 'item3'],
+        yield 'simple list without labels' => [
+            'input' => [
+                'list' => ['item1', 'item2', 'item3'],
+            ],
+            'expected' => [
+                'list' => ['item1', 'item2', 'item3'],
+            ],
+        ];
+        yield 'non sequential indexes' => [
+            'input' => [
+                'list' => [
+                    6 => 'item1',
+                    3 => 'item2',
+                    4 => 'item3',
                 ],
             ],
-            'non sequential indexes' => [
-                'input' => [
-                    'list' => [
-                        6 => 'item1',
-                        3 => 'item2',
-                        4 => 'item3',
-                    ],
-                ],
-                'expected' => [
-                    'list' => ['item1', 'item2', 'item3'],
-                ],
+            'expected' => [
+                'list' => ['item1', 'item2', 'item3'],
             ],
-            'empty list' => [
-                'input'    => ['list' => []],
-                'expected' => ['list' => []],
-            ],
+        ];
+        yield 'empty list' => [
+            'input'    => ['list' => []],
+            'expected' => ['list' => []],
         ];
     }
 
     /**
-     * @return array<string, array{input: array<string, string>, expected: array<string, array<array<string, string>>>}>
+     * @return \Iterator<string, array{input: array<string, string>, expected: array<string, array<array<string, string>>>}>
      */
-    public static function keyValuePairProvider(): array
+    public static function keyValuePairProvider(): \Iterator
     {
-        return [
-            'key value pairs' => [
-                'input' => [
-                    'key1' => 'value1',
-                    'key2' => 'value2',
-                ],
-                'expected' => [
-                    'list' => [
-                        ['label' => 'key1', 'value' => 'value1'],
-                        ['label' => 'key2', 'value' => 'value2'],
-                    ],
+        yield 'key value pairs' => [
+            'input' => [
+                'key1' => 'value1',
+                'key2' => 'value2',
+            ],
+            'expected' => [
+                'list' => [
+                    ['label' => 'key1', 'value' => 'value1'],
+                    ['label' => 'key2', 'value' => 'value2'],
                 ],
             ],
-            'empty array' => [
-                'input'    => [],
-                'expected' => ['list' => []],
-            ],
+        ];
+        yield 'empty array' => [
+            'input'    => [],
+            'expected' => ['list' => []],
         ];
     }
 
     /**
-     * @return array<string, array{input: array<string, array<array<string, string>>>, expected: array<string, string>}>
+     * @return \Iterator<string, array{input: array<string, array<array<string, string>>>, expected: array<string, string>}>
      */
-    public static function reverseKeyValuePairProvider(): array
+    public static function reverseKeyValuePairProvider(): \Iterator
     {
-        return [
-            'standard key-value pairs' => [
-                'input' => [
-                    'list' => [
-                        ['label' => 'key1', 'value' => 'value1'],
-                        ['label' => 'key2', 'value' => 'value2'],
-                    ],
-                ],
-                'expected' => [
-                    'key1' => 'value1',
-                    'key2' => 'value2',
+        yield 'standard key-value pairs' => [
+            'input' => [
+                'list' => [
+                    ['label' => 'key1', 'value' => 'value1'],
+                    ['label' => 'key2', 'value' => 'value2'],
                 ],
             ],
-            'empty list' => [
-                'input'    => ['list' => []],
-                'expected' => [],
+            'expected' => [
+                'key1' => 'value1',
+                'key2' => 'value2',
             ],
+        ];
+        yield 'empty list' => [
+            'input'    => ['list' => []],
+            'expected' => [],
         ];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/PrivateAddressCheckerTest.php
@@ -55,74 +55,64 @@ final class PrivateAddressCheckerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function privateIpProvider(): array
+    public static function privateIpProvider(): \Iterator
     {
-        return [
-            'IPv4 Local'           => ['127.0.0.1'],
-            'IPv4 Private Class A' => ['10.0.0.1'],
-            'IPv4 Private Class B' => ['172.16.0.1'],
-            'IPv4 Private Class C' => ['192.168.0.1'],
-            'IPv4 Link Local'      => ['169.254.0.1'],
-            'IPv6 Localhost'       => ['::1'],
-            'IPv6 Unique Local'    => ['fc00::1'],
-            'IPv6 Link Local'      => ['fe80::1'],
-        ];
+        yield 'IPv4 Local' => ['127.0.0.1'];
+        yield 'IPv4 Private Class A' => ['10.0.0.1'];
+        yield 'IPv4 Private Class B' => ['172.16.0.1'];
+        yield 'IPv4 Private Class C' => ['192.168.0.1'];
+        yield 'IPv4 Link Local' => ['169.254.0.1'];
+        yield 'IPv6 Localhost' => ['::1'];
+        yield 'IPv6 Unique Local' => ['fc00::1'];
+        yield 'IPv6 Link Local' => ['fe80::1'];
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function publicIpProvider(): array
+    public static function publicIpProvider(): \Iterator
     {
-        return [
-            'IPv4 Public'             => ['8.8.8.8'],
-            'IPv4 Public Alternative' => ['203.0.113.1'],
-            'IPv6 Public'             => ['2001:4860:4860::8888'],
-        ];
+        yield 'IPv4 Public' => ['8.8.8.8'];
+        yield 'IPv4 Public Alternative' => ['203.0.113.1'];
+        yield 'IPv6 Public' => ['2001:4860:4860::8888'];
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function privateUrlProvider(): array
+    public static function privateUrlProvider(): \Iterator
     {
-        return [
-            'Localhost'                      => ['http://localhost'],
-            'Localhost with port'            => ['http://localhost:8080'],
-            'IPv4 Private'                   => ['http://192.168.1.1'],
-            'IPv4 Private with path'         => ['https://10.0.0.1/path'],
-            'IPv6 Localhost'                 => ['http://[::1]'],
-            'IPv6 Private'                   => ['http://[fc00::1]'],
-            'Domain resolving to private IP' => ['http://private.example.com'],
-        ];
+        yield 'Localhost' => ['http://localhost'];
+        yield 'Localhost with port' => ['http://localhost:8080'];
+        yield 'IPv4 Private' => ['http://192.168.1.1'];
+        yield 'IPv4 Private with path' => ['https://10.0.0.1/path'];
+        yield 'IPv6 Localhost' => ['http://[::1]'];
+        yield 'IPv6 Private' => ['http://[fc00::1]'];
+        yield 'Domain resolving to private IP' => ['http://private.example.com'];
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function publicUrlProvider(): array
+    public static function publicUrlProvider(): \Iterator
     {
-        return [
-            'Public Domain' => ['http://public.example.com'],
-            'IPv4 Public'   => ['http://8.8.8.8'],
-            'IPv6 Public'   => ['http://[2001:4860:4860::8888]'],
-            'HTTPS URL'     => ['https://api.example.com/v1'],
-        ];
+        yield 'Public Domain' => ['http://public.example.com'];
+        yield 'IPv4 Public' => ['http://8.8.8.8'];
+        yield 'IPv6 Public' => ['http://[2001:4860:4860::8888]'];
+        yield 'HTTPS URL' => ['https://api.example.com/v1'];
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function invalidUrlProvider(): array
+    public static function invalidUrlProvider(): \Iterator
     {
-        return [
-            'Empty URL'          => [''],
-            'Invalid Format'     => ['not-a-url'],
-            'Missing Protocol'   => ['example.com'],
-            'Invalid Characters' => ['http://example.com\\invalid'],
-        ];
+        yield 'Empty URL' => [''];
+        yield 'Invalid Format' => ['not-a-url'];
+        yield 'Missing Protocol' => ['example.com'];
+        yield 'Invalid Characters' => ['http://example.com\\invalid'];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('invalidUrlProvider')]
@@ -151,15 +141,13 @@ final class PrivateAddressCheckerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{string, bool}>
+     * @return \Iterator<string, array{string, bool}>
      */
-    public static function edgeCaseUrlProvider(): array
+    public static function edgeCaseUrlProvider(): \Iterator
     {
-        return [
-            'URL with Port'        => ['http://[::1]:8080', true],
-            'IPv6 with Zone Index' => ['http://[fe80::1%eth0]', true],
-            'IPv6 Full Format'     => ['http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', false],
-        ];
+        yield 'URL with Port' => ['http://[::1]:8080', true];
+        yield 'IPv6 with Zone Index' => ['http://[fe80::1%eth0]', true];
+        yield 'IPv6 Full Format' => ['http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', false];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('allowedUrlProvider')]
@@ -184,30 +172,26 @@ final class PrivateAddressCheckerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function allowedUrlProvider(): array
+    public static function allowedUrlProvider(): \Iterator
     {
-        return [
-            'Public Domain'                => ['http://public.example.com'],
-            'Allowed Private IP'           => ['http://192.168.1.1'],
-            'Allowed Localhost'            => ['http://localhost'],
-            'Allowed IPv6 Localhost'       => ['http://[::1]'],
-            'Domain to Allowed Private IP' => ['http://private.example.com'], // Resolves to 192.168.1.1
-        ];
+        yield 'Public Domain' => ['http://public.example.com'];
+        yield 'Allowed Private IP' => ['http://192.168.1.1'];
+        yield 'Allowed Localhost' => ['http://localhost'];
+        yield 'Allowed IPv6 Localhost' => ['http://[::1]'];
+        yield 'Domain to Allowed Private IP' => ['http://private.example.com'];
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return \Iterator<string, array{string}>
      */
-    public static function disallowedUrlProvider(): array
+    public static function disallowedUrlProvider(): \Iterator
     {
-        return [
-            'Disallowed Private IP'           => ['http://192.168.1.1'],
-            'Different Private IP'            => ['http://192.168.1.3'],
-            'Domain to Disallowed Private IP' => ['http://private.example.com'],
-            'Localhost when not allowed'      => ['http://localhost'],
-        ];
+        yield 'Disallowed Private IP' => ['http://192.168.1.1'];
+        yield 'Different Private IP' => ['http://192.168.1.3'];
+        yield 'Domain to Disallowed Private IP' => ['http://private.example.com'];
+        yield 'Localhost when not allowed' => ['http://localhost'];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('invalidUrlProvider')]

--- a/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
@@ -24,43 +24,41 @@ final class PurifyExtensionTest extends TestCase
     }
 
     /**
-     * @return array<string, array{input: ?string, expected: string}>
+     * @return \Iterator<string, array{input: (string | null), expected: string}>
      */
-    public static function purifyHtmlDataProvider(): array
+    public static function purifyHtmlDataProvider(): \Iterator
     {
-        return [
-            'null input' => [
-                'input'    => null,
-                'expected' => '',
-            ],
-            'empty string' => [
-                'input'    => '',
-                'expected' => '',
-            ],
-            'plain text' => [
-                'input'    => 'Hello World',
-                'expected' => 'Hello World',
-            ],
-            'basic html' => [
-                'input'    => '<p>Hello World</p>',
-                'expected' => '<p>Hello World</p>',
-            ],
-            'link with target blank' => [
-                'input'    => '<a href="https://example.com" target="_blank">Link</a>',
-                'expected' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
-            ],
-            'malicious html' => [
-                'input'    => '<script>alert("xss")</script><p>Hello</p>',
-                'expected' => '<p>Hello</p>',
-            ],
-            'mixed content' => [
-                'input'    => '<p>Hello</p><script>alert("xss")</script><a href="https://example.com" target="_blank">Link</a>',
-                'expected' => '<p>Hello</p><a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
-            ],
-            'invalid html' => [
-                'input'    => '<p>Unclosed paragraph<a>Unclosed link',
-                'expected' => '<p>Unclosed paragraph<a>Unclosed link</a></p>',
-            ],
+        yield 'null input' => [
+            'input'    => null,
+            'expected' => '',
+        ];
+        yield 'empty string' => [
+            'input'    => '',
+            'expected' => '',
+        ];
+        yield 'plain text' => [
+            'input'    => 'Hello World',
+            'expected' => 'Hello World',
+        ];
+        yield 'basic html' => [
+            'input'    => '<p>Hello World</p>',
+            'expected' => '<p>Hello World</p>',
+        ];
+        yield 'link with target blank' => [
+            'input'    => '<a href="https://example.com" target="_blank">Link</a>',
+            'expected' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
+        ];
+        yield 'malicious html' => [
+            'input'    => '<script>alert("xss")</script><p>Hello</p>',
+            'expected' => '<p>Hello</p>',
+        ];
+        yield 'mixed content' => [
+            'input'    => '<p>Hello</p><script>alert("xss")</script><a href="https://example.com" target="_blank">Link</a>',
+            'expected' => '<p>Hello</p><a href="https://example.com" target="_blank" rel="noreferrer noopener">Link</a>',
+        ];
+        yield 'invalid html' => [
+            'input'    => '<p>Unclosed paragraph<a>Unclosed link',
+            'expected' => '<p>Unclosed paragraph<a>Unclosed link</a></p>',
         ];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/Extension/PurifyExtensionTest.php
@@ -24,7 +24,7 @@ final class PurifyExtensionTest extends TestCase
     }
 
     /**
-     * @return \Iterator<string, array{input: (string | null), expected: string}>
+     * @return \Iterator<string, array{input: (string|null), expected: string}>
      */
     public static function purifyHtmlDataProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/SortableValueLabelListTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/SortableValueLabelListTypeTest.php
@@ -150,7 +150,7 @@ final class SortableValueLabelListTypeTest extends TestCase
     }
 
     /**
-     * @return \Iterator<string, array{mixed, bool, (string | null)}>
+     * @return \Iterator<string, array{mixed, bool, (string|null)}>
      */
     public static function eventListenerDataProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/SortableValueLabelListTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/SortableValueLabelListTypeTest.php
@@ -150,31 +150,29 @@ final class SortableValueLabelListTypeTest extends TestCase
     }
 
     /**
-     * @return array<string, array{mixed, bool, string|null}>
+     * @return \Iterator<string, array{mixed, bool, (string | null)}>
      */
-    public static function eventListenerDataProvider(): array
+    public static function eventListenerDataProvider(): \Iterator
     {
-        return [
-            'auto generates value' => [
-                ['label' => 'Test Label', 'value' => ''],
-                true,
-                'test_label',
-            ],
-            'does not modify when value exists' => [
-                ['label' => 'Test Label', 'value' => 'existing_value'],
-                false,
-                null,
-            ],
-            'does not modify when label empty' => [
-                ['label' => '', 'value' => ''],
-                false,
-                null,
-            ],
-            'handles non-array data' => [
-                'not_an_array',
-                false,
-                null,
-            ],
+        yield 'auto generates value' => [
+            ['label' => 'Test Label', 'value' => ''],
+            true,
+            'test_label',
+        ];
+        yield 'does not modify when value exists' => [
+            ['label' => 'Test Label', 'value' => 'existing_value'],
+            false,
+            null,
+        ];
+        yield 'does not modify when label empty' => [
+            ['label' => '', 'value' => ''],
+            false,
+            null,
+        ];
+        yield 'handles non-array data' => [
+            'not_an_array',
+            false,
+            null,
         ];
     }
 
@@ -207,51 +205,49 @@ final class SortableValueLabelListTypeTest extends TestCase
     }
 
     /**
-     * @return array<int, array{string, string}>
+     * @return \Iterator<int, array{string, string}>
      */
-    public static function slugifyDataProvider(): array
+    public static function slugifyDataProvider(): \Iterator
     {
-        return [
-            ['My Option', 'my_option'],
-            ['First Choice!', 'first_choice'],
-            ['Test-Value_123', 'testvalue_123'],
-            ['Special@#$%Characters', 'specialcharacters'],
-            ['  Trimmed  Spaces  ', 'trimmed_spaces'],
-            ['Multiple___Underscores', 'multiple_underscores'],
-            ['Àccénted Chàracters', 'accented_characters'],
-            ['Привет мир', 'privet_mir'],
-            ['', ''],
-            ['123Numbers', '123numbers'],
-            ['Numéro', 'numero'],
-            ['Âge', 'age'],
-            ['Straße', 'strasse'],
-            ['Über', 'uber'],
-            ['Teléfono', 'telefono'],
-            ['Dirección', 'direccion'],
-            ['Coração', 'coracao'],
-            ['Ação', 'acao'],
-            ['Födelsedag', 'fodelsedag'],
-            ['Äktenskap', 'aktenskap'],
-            ['Номер', 'nomer'],
-            ['Адрес', 'adres'],
-            ['电话', 'dian_hua'],
-            ['地址', 'de_zhi'],
-            ['電話番号', 'dian_hua_fan_hao'],
-            ['住所', 'zhu_suo'],
-            ['رقم', 'rqm'],
-            ['عنوان', 'nwan'],
-            ['Adres', 'adres'],
-            ['Yaş', 'yas'],
-            ['Adresa', 'adresa'],
-            ['Číslo', 'cislo'],
-            ['Ulica', 'ulica'],
-            ['Wiek', 'wiek'],
-            ['Cím', 'cim'],
-            ['Születésnap', 'szuletesnap'],
-            ['Διεύθυνση', 'dieuthynse'],
-            ['Ηλικία', 'elikia'],
-            ['주소', 'juso'],
-            ['전화번호', 'jeonhwabeonho'],
-        ];
+        yield ['My Option', 'my_option'];
+        yield ['First Choice!', 'first_choice'];
+        yield ['Test-Value_123', 'testvalue_123'];
+        yield ['Special@#$%Characters', 'specialcharacters'];
+        yield ['  Trimmed  Spaces  ', 'trimmed_spaces'];
+        yield ['Multiple___Underscores', 'multiple_underscores'];
+        yield ['Àccénted Chàracters', 'accented_characters'];
+        yield ['Привет мир', 'privet_mir'];
+        yield ['', ''];
+        yield ['123Numbers', '123numbers'];
+        yield ['Numéro', 'numero'];
+        yield ['Âge', 'age'];
+        yield ['Straße', 'strasse'];
+        yield ['Über', 'uber'];
+        yield ['Teléfono', 'telefono'];
+        yield ['Dirección', 'direccion'];
+        yield ['Coração', 'coracao'];
+        yield ['Ação', 'acao'];
+        yield ['Födelsedag', 'fodelsedag'];
+        yield ['Äktenskap', 'aktenskap'];
+        yield ['Номер', 'nomer'];
+        yield ['Адрес', 'adres'];
+        yield ['电话', 'dian_hua'];
+        yield ['地址', 'de_zhi'];
+        yield ['電話番号', 'dian_hua_fan_hao'];
+        yield ['住所', 'zhu_suo'];
+        yield ['رقم', 'rqm'];
+        yield ['عنوان', 'nwan'];
+        yield ['Adres', 'adres'];
+        yield ['Yaş', 'yas'];
+        yield ['Adresa', 'adresa'];
+        yield ['Číslo', 'cislo'];
+        yield ['Ulica', 'ulica'];
+        yield ['Wiek', 'wiek'];
+        yield ['Cím', 'cim'];
+        yield ['Születésnap', 'szuletesnap'];
+        yield ['Διεύθυνση', 'dieuthynse'];
+        yield ['Ηλικία', 'elikia'];
+        yield ['주소', 'juso'];
+        yield ['전화번호', 'jeonhwabeonho'];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -158,104 +158,100 @@ final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: ?string, 1: int, 2: array<int, array<string, mixed>>}>
+     * @return \Iterator<int, array{(string | null), int, array<int, array<string, mixed>>}>
      */
-    public static function validateDataProvider(): array
+    public static function validateDataProvider(): \Iterator
     {
         $constraint = new CircularDependency(['message' => 'mautic.core.segment.circular_dependency_exists']);
-
-        return [
-            // Segment 1 is dependent on Segment 2 which is dependent on segment 1 - circular
+        // Segment 1 is dependent on Segment 2 which is dependent on segment 1 - circular
+        yield [
+            $constraint->message,
+            2, // current segment id
             [
-                $constraint->message,
-                2, // current segment id
                 [
-                    [
-                        'glue'     => 'and',
-                        'field'    => 'leadlist',
-                        'object'   => 'lead',
-                        'type'     => 'leadlist',
-                        'filter'   => [1], // Keeping filter in the root to test also for BC segments.
-                        'display'  => null,
-                        'operator' => 'in',
-                    ],
+                    'glue'     => 'and',
+                    'field'    => 'leadlist',
+                    'object'   => 'lead',
+                    'type'     => 'leadlist',
+                    'filter'   => [1], // Keeping filter in the root to test also for BC segments.
+                    'display'  => null,
+                    'operator' => 'in',
                 ],
             ],
-            // Segment 2 is dependent on Segment 1 which is dependent on segment 2 - circular
+        ];
+        // Segment 2 is dependent on Segment 1 which is dependent on segment 2 - circular
+        yield [
+            $constraint->message,
+            1, // current segment id
             [
-                $constraint->message,
-                1, // current segment id
                 [
-                    [
-                        'glue'       => 'and',
-                        'field'      => 'leadlist',
-                        'object'     => 'lead',
-                        'type'       => 'leadlist',
-                        'properties' => ['filter' => [2]],
-                        'display'    => null,
-                        'operator'   => 'in',
-                    ],
+                    'glue'       => 'and',
+                    'field'      => 'leadlist',
+                    'object'     => 'lead',
+                    'type'       => 'leadlist',
+                    'properties' => ['filter' => [2]],
+                    'display'    => null,
+                    'operator'   => 'in',
                 ],
             ],
-            // Test when there are no validation errors
-            // The segment in the filter (3) is NOT dependent on any
+        ];
+        // Test when there are no validation errors
+        // The segment in the filter (3) is NOT dependent on any
+        yield [
+            null,
+            1, // current segment id
             [
-                null,
-                1, // current segment id
                 [
-                    [
-                        'glue'       => 'and',
-                        'field'      => 'leadlist',
-                        'object'     => 'lead',
-                        'type'       => 'leadlist',
-                        'properties' => ['filter' => [3]],
-                        'display'    => null,
-                        'operator'   => 'in',
-                    ],
+                    'glue'       => 'and',
+                    'field'      => 'leadlist',
+                    'object'     => 'lead',
+                    'type'       => 'leadlist',
+                    'properties' => ['filter' => [3]],
+                    'display'    => null,
+                    'operator'   => 'in',
                 ],
             ],
-            // Test when no lead list filters
+        ];
+        // Test when no lead list filters
+        yield [
+            null,
+            1, // current segment id
             [
-                null,
-                1, // current segment id
                 [
-                    [
-                        'glue'     => 'and',
-                        'field'    => 'first_name',
-                        'object'   => 'lead',
-                        'type'     => 'text',
-                        'filter'   => 'Doe', // Keeping filter in the root to test also for BC segments.
-                        'display'  => null,
-                        'operator' => '=',
-                    ],
+                    'glue'     => 'and',
+                    'field'    => 'first_name',
+                    'object'   => 'lead',
+                    'type'     => 'text',
+                    'filter'   => 'Doe', // Keeping filter in the root to test also for BC segments.
+                    'display'  => null,
+                    'operator' => '=',
                 ],
             ],
-            // Test multiple lead list filters. Fails because 2 is dependent on 1
+        ];
+        // Test multiple lead list filters. Fails because 2 is dependent on 1
+        yield [
+            $constraint->message,
+            2, // current segment id
             [
-                $constraint->message,
-                2, // current segment id
                 [
-                    [
-                        'glue'       => 'and',
-                        'field'      => 'leadlist',
-                        'object'     => 'lead',
-                        'type'       => 'leadlist',
-                        'properties' => ['filter' => [1]],
-                        'display'    => null,
-                        'operator'   => 'in',
-                    ],
-                    [
-                        'glue'       => 'and',
-                        'field'      => 'leadlist',
-                        'object'     => 'lead',
-                        'type'       => 'leadlist',
-                        'properties' => ['filter' => [3]],
-                        'display'    => null,
-                        'operator'   => 'in',
-                    ],
+                    'glue'       => 'and',
+                    'field'      => 'leadlist',
+                    'object'     => 'lead',
+                    'type'       => 'leadlist',
+                    'properties' => ['filter' => [1]],
+                    'display'    => null,
+                    'operator'   => 'in',
+                ],
+                [
+                    'glue'       => 'and',
+                    'field'      => 'leadlist',
+                    'object'     => 'lead',
+                    'type'       => 'leadlist',
+                    'properties' => ['filter' => [3]],
+                    'display'    => null,
+                    'operator'   => 'in',
                 ],
             ],
-            // @TODO: MUST ADD TEST CASES ONCE WE FIX DEEP CIRCULAR (1 depends on 2 which depends on 3 which depends on 1) TO AN ARBITRARY DEPTH
         ];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -158,7 +158,7 @@ final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Iterator<int, array{(string | null), int, array<int, array<string, mixed>>}>
+     * @return \Iterator<int, array{(string|null), int, array<int, array<string, mixed>>}>
      */
     public static function validateDataProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
@@ -25,16 +25,14 @@ final class EmailAddressHelperTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return \Iterator<int, array<int, string>>
      */
-    public static function emailProvider(): array
+    public static function emailProvider(): \Iterator
     {
-        return [
-            ['test@example.com', 'test@example.com'],
-            ['TEST@example.com', 'test@example.com'],
-            ['test+suffix@example.com', 'test+suffix@example.com'],
-            ['!#$%^&*()@example.com', '@example.com'],
-        ];
+        yield ['test@example.com', 'test@example.com'];
+        yield ['TEST@example.com', 'test@example.com'];
+        yield ['test+suffix@example.com', 'test+suffix@example.com'];
+        yield ['!#$%^&*()@example.com', '@example.com'];
     }
 
     /**
@@ -50,15 +48,13 @@ final class EmailAddressHelperTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<int, string>|string>>
+     * @return \Iterator<int, array<int, (array<int, string> | string)>>
      */
-    public static function variationsProvider(): array
+    public static function variationsProvider(): \Iterator
     {
-        return [
-            ['test@example.com', ['test@example.com']],
-            ['TEST@example.com', ['TEST@example.com', 'test@example.com']],
-            ['test+suffix@example.com', ['test+suffix@example.com', 'test@example.com']],
-            ['!#$%^&*()@example.com', ['!#$%^&*()@example.com', '@example.com']],
-        ];
+        yield ['test@example.com', ['test@example.com']];
+        yield ['TEST@example.com', ['TEST@example.com', 'test@example.com']];
+        yield ['test+suffix@example.com', ['test+suffix@example.com', 'test@example.com']];
+        yield ['!#$%^&*()@example.com', ['!#$%^&*()@example.com', '@example.com']];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EmailAddressHelperTest.php
@@ -48,7 +48,7 @@ final class EmailAddressHelperTest extends TestCase
     }
 
     /**
-     * @return \Iterator<int, array<int, (array<int, string> | string)>>
+     * @return \Iterator<int, array<int, (array<int, string>|string)>>
      */
     public static function variationsProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileHelperTest.php
@@ -19,16 +19,14 @@ final class FileHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: int, 1: float}>
+     * @return \Iterator<int, array{int, float}>
      */
-    public static function bytesToMegabytesProvider(): array
+    public static function bytesToMegabytesProvider(): \Iterator
     {
-        return [
-            [0, 0.0],
-            [1_048_576, 1.0],
-            [10_485_760, 10.0],
-            [-10_485_760, -10.0],
-        ];
+        yield [0, 0.0];
+        yield [1_048_576, 1.0];
+        yield [10_485_760, 10.0];
+        yield [-10_485_760, -10.0];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('megabytesToBytesProvider')]
@@ -41,15 +39,13 @@ final class FileHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: int, 1: int}>
+     * @return \Iterator<int, array{int, int}>
      */
-    public static function megabytesToBytesProvider(): array
+    public static function megabytesToBytesProvider(): \Iterator
     {
-        return [
-            [0, 0],
-            [1, 1_048_576],
-            [5, 5_242_880],
-        ];
+        yield [0, 0];
+        yield [1, 1_048_576];
+        yield [5, 5_242_880];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('phpSizeToBytesProvider')]
@@ -62,19 +58,17 @@ final class FileHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: string, 1: int}>
+     * @return \Iterator<int, array{string, int}>
      */
-    public static function phpSizeToBytesProvider(): array
+    public static function phpSizeToBytesProvider(): \Iterator
     {
-        return [
-            ['3048M', 3_196_059_648],
-            ['127M', 133_169_152],
-            ['1k', 1024],
-            ['1K ', 1024],
-            ['1M', 1_048_576],
-            ['1G', 1_073_741_824],
-            ['1P', 1_125_899_906_842_624],
-            ['1024', 1024],
-        ];
+        yield ['3048M', 3_196_059_648];
+        yield ['127M', 133_169_152];
+        yield ['1k', 1024];
+        yield ['1K ', 1024];
+        yield ['1M', 1_048_576];
+        yield ['1G', 1_073_741_824];
+        yield ['1P', 1_125_899_906_842_624];
+        yield ['1024', 1024];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -305,7 +305,7 @@ final class InputHelperTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), array<string>>
+     * @return \Iterator<(int|string), array<string>>
      */
     public static function minifyHTMLProvider(): \Iterator
     {
@@ -335,7 +335,7 @@ final class InputHelperTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function underscoreProvider(): \Iterator
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/InputHelperTest.php
@@ -305,29 +305,27 @@ final class InputHelperTest extends TestCase
     }
 
     /**
-     * @return array<array<string>>
+     * @return \Iterator<(int | string), array<string>>
      */
-    public static function minifyHTMLProvider(): array
+    public static function minifyHTMLProvider(): \Iterator
     {
-        return [
-            // Test with a simple HTML string with no whitespace
-            ['<p>Hello World</p>', '<p>Hello World</p>'],
-            // Test with an HTML string with multiple spaces between tags
-            ['<p>    Hello World    </p>', '<p>Hello World</p>'],
-            // Test with an HTML string with multiple newlines between tags
-            ["<p>\n\nHello World\n\n</p>", '<p>Hello World</p>'],
-            // Test with an HTML string with inline CSS
-            ['<p style="color: red;">Hello World</p>', '<p style="color:red;">Hello World</p>'],
-            // Test with an empty HTML string
-            ['', ''],
-            // Test with an HTML string with multiple attributes
-            ['<p class="big" id="title">Hello World</p>', '<p class="big" id="title">Hello World</p>'],
-            // Test with an HTML string with multiple same tag
-            ['<p>Hello World</p><p>Hello World</p>', '<p>Hello World</p><p>Hello World</p>'],
-            // Test with an HTML string with multiple same tag but with different attributes
-            ['<p class="big">Hello World</p><p class="small">Hello World</p>', '<p class="big">Hello World</p><p class="small">Hello World</p>'],
-            [file_get_contents(__DIR__.'/resource/email/email-no-minify.html'), file_get_contents(__DIR__.'/resource/email/email-minify.html')],
-        ];
+        // Test with a simple HTML string with no whitespace
+        yield ['<p>Hello World</p>', '<p>Hello World</p>'];
+        // Test with an HTML string with multiple spaces between tags
+        yield ['<p>    Hello World    </p>', '<p>Hello World</p>'];
+        // Test with an HTML string with multiple newlines between tags
+        yield ["<p>\n\nHello World\n\n</p>", '<p>Hello World</p>'];
+        // Test with an HTML string with inline CSS
+        yield ['<p style="color: red;">Hello World</p>', '<p style="color:red;">Hello World</p>'];
+        // Test with an empty HTML string
+        yield ['', ''];
+        // Test with an HTML string with multiple attributes
+        yield ['<p class="big" id="title">Hello World</p>', '<p class="big" id="title">Hello World</p>'];
+        // Test with an HTML string with multiple same tag
+        yield ['<p>Hello World</p><p>Hello World</p>', '<p>Hello World</p><p>Hello World</p>'];
+        // Test with an HTML string with multiple same tag but with different attributes
+        yield ['<p class="big">Hello World</p><p class="small">Hello World</p>', '<p class="big">Hello World</p><p class="small">Hello World</p>'];
+        yield [file_get_contents(__DIR__.'/resource/email/email-no-minify.html'), file_get_contents(__DIR__.'/resource/email/email-minify.html')];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('underscoreProvider')]
@@ -337,25 +335,23 @@ final class InputHelperTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function underscoreProvider(): array
+    public static function underscoreProvider(): \Iterator
     {
-        return [
-            ['hello', 'hello'],
-            [null, null],
-            [false, ''],
-            [true, '1'],
-            [0, '0'],
-            [10, '10'],
-            [[null], [null]],
-            [[0], ['0']],
-            [[false], ['']],
-            [[true], ['1']],
-            [[null, 'hello'], [null, 'hello']],
-            [[null, 3], [null, '3']],
-            [[[null]], [[null]]],
-        ];
+        yield ['hello', 'hello'];
+        yield [null, null];
+        yield [false, ''];
+        yield [true, '1'];
+        yield [0, '0'];
+        yield [10, '10'];
+        yield [[null], [null]];
+        yield [[0], ['0']];
+        yield [[false], ['']];
+        yield [[true], ['1']];
+        yield [[null, 'hello'], [null, 'hello']];
+        yield [[null, 3], [null, '3']];
+        yield [[[null]], [[null]]];
     }
 
     #[\PHPUnit\Framework\Attributes\TestDox('Test that clean filter converts special characters to HTML entities')]

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
@@ -38,21 +38,19 @@ final class PageHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: int, 1: int, 2: int}>
+     * @return \Iterator<int, array{int, int, int}>
      */
-    public static function pageProvider(): array
+    public static function pageProvider(): \Iterator
     {
-        return [
-            [0, 10, 1],
-            [1, 10, 1],
-            [5, 10, 1],
-            [10, 10, 1],
-            [11, 10, 2],
-            [20, 10, 2],
-            [21, 10, 3],
-            [15, 15, 1],
-            [16, 15, 2],
-        ];
+        yield [0, 10, 1];
+        yield [1, 10, 1];
+        yield [5, 10, 1];
+        yield [10, 10, 1];
+        yield [11, 10, 2];
+        yield [20, 10, 2];
+        yield [21, 10, 3];
+        yield [15, 15, 1];
+        yield [16, 15, 2];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('startProvider')]
@@ -67,15 +65,13 @@ final class PageHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: int, 1: int, 2: int}>
+     * @return \Iterator<int, array{int, int, int}>
      */
-    public static function startProvider(): array
+    public static function startProvider(): \Iterator
     {
-        return [
-            [0, 10, 1],
-            [1, 10, 1],
-            [10, 10, 1],
-            [11, 10, 2],
-        ];
+        yield [0, 10, 1];
+        yield [1, 10, 1];
+        yield [10, 10, 1];
+        yield [11, 10, 2];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
@@ -139,55 +139,53 @@ final class FormatterHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string, array<string>>
+     * @return \Iterator<string, array<string>>
      */
-    public static function urlFormatProvider(): array
+    public static function urlFormatProvider(): \Iterator
     {
-        return [
-            'normal url' => [
-                'http://example.com',
-                '<a href="http://example.com" target="_blank">http://example.com</a>',
-            ],
-            'malicious url' => [
-                'http://example.com"><script>alert("XSS")</script>',
-                '<a href="http://example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;" target="_blank">http://example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;</a>',
-            ],
-            'malicious url2' => [
-                'http://example.com?a="<b>test</b>',
-                '<a href="http://example.com?a=%22%3Cb%3Etest%3C%2Fb%3E" target="_blank">http://example.com?a=%22%3Cb%3Etest%3C%2Fb%3E</a>',
-            ],
-            'url with single GET parameter' => [
-                'http://example.com/page?param=value',
-                '<a href="http://example.com/page?param=value" target="_blank">http://example.com/page?param=value</a>',
-            ],
-            'url with multiple GET parameters' => [
-                'http://example.com/search?q=test&page=1&sort=desc',
-                '<a href="http://example.com/search?q=test&page=1&sort=desc" target="_blank">http://example.com/search?q=test&page=1&sort=desc</a>',
-            ],
-            'url with encoded GET parameters' => [
-                'http://example.com/search?q=hello+world&lang=en',
-                '<a href="http://example.com/search?q=hello%20world&lang=en" target="_blank">http://example.com/search?q=hello%20world&lang=en</a>',
-            ],
-            'url with special characters in GET parameters' => [
-                'http://example.com/path?param=value&special=!@#$%^&*()',
-                '<a href="http://example.com/path?param=value&special=%21%40#$%^&*()" target="_blank">http://example.com/path?param=value&special=%21%40#$%^&*()</a>',
-            ],
-            'https url' => [
-                'https://secure.example.com',
-                '<a href="https://secure.example.com" target="_blank">https://secure.example.com</a>',
-            ],
-            'url with port number' => [
-                'http://example.com:8080/path',
-                '<a href="http://example.com:8080/path" target="_blank">http://example.com:8080/path</a>',
-            ],
-            'url with username and password' => [
-                'http://user:pass@example.com',
-                '<a href="http://user:pass@example.com" target="_blank">http://user:pass@example.com</a>',
-            ],
-            'url with fragment identifier' => [
-                'http://example.com/page#section',
-                '<a href="http://example.com/page#section" target="_blank">http://example.com/page#section</a>',
-            ],
+        yield 'normal url' => [
+            'http://example.com',
+            '<a href="http://example.com" target="_blank">http://example.com</a>',
+        ];
+        yield 'malicious url' => [
+            'http://example.com"><script>alert("XSS")</script>',
+            '<a href="http://example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;" target="_blank">http://example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;</a>',
+        ];
+        yield 'malicious url2' => [
+            'http://example.com?a="<b>test</b>',
+            '<a href="http://example.com?a=%22%3Cb%3Etest%3C%2Fb%3E" target="_blank">http://example.com?a=%22%3Cb%3Etest%3C%2Fb%3E</a>',
+        ];
+        yield 'url with single GET parameter' => [
+            'http://example.com/page?param=value',
+            '<a href="http://example.com/page?param=value" target="_blank">http://example.com/page?param=value</a>',
+        ];
+        yield 'url with multiple GET parameters' => [
+            'http://example.com/search?q=test&page=1&sort=desc',
+            '<a href="http://example.com/search?q=test&page=1&sort=desc" target="_blank">http://example.com/search?q=test&page=1&sort=desc</a>',
+        ];
+        yield 'url with encoded GET parameters' => [
+            'http://example.com/search?q=hello+world&lang=en',
+            '<a href="http://example.com/search?q=hello%20world&lang=en" target="_blank">http://example.com/search?q=hello%20world&lang=en</a>',
+        ];
+        yield 'url with special characters in GET parameters' => [
+            'http://example.com/path?param=value&special=!@#$%^&*()',
+            '<a href="http://example.com/path?param=value&special=%21%40#$%^&*()" target="_blank">http://example.com/path?param=value&special=%21%40#$%^&*()</a>',
+        ];
+        yield 'https url' => [
+            'https://secure.example.com',
+            '<a href="https://secure.example.com" target="_blank">https://secure.example.com</a>',
+        ];
+        yield 'url with port number' => [
+            'http://example.com:8080/path',
+            '<a href="http://example.com:8080/path" target="_blank">http://example.com:8080/path</a>',
+        ];
+        yield 'url with username and password' => [
+            'http://user:pass@example.com',
+            '<a href="http://user:pass@example.com" target="_blank">http://user:pass@example.com</a>',
+        ];
+        yield 'url with fragment identifier' => [
+            'http://example.com/page#section',
+            '<a href="http://example.com/page#section" target="_blank">http://example.com/page#section</a>',
         ];
     }
 
@@ -199,23 +197,21 @@ final class FormatterHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string, array<string>>
+     * @return \Iterator<string, array<string>>
      */
-    public static function emailFormatProvider(): array
+    public static function emailFormatProvider(): \Iterator
     {
-        return [
-            'normal email' => [
-                'user@example.com',
-                '<a href="mailto:user@example.com">user@example.com</a>',
-            ],
-            'email with alias' => [
-                'user.one+test@example.com',
-                '<a href="mailto:user.one+test@example.com">user.one+test@example.com</a>',
-            ],
-            'malicious email' => [
-                'user@example.com"><script>alert("XSS")</script>',
-                '<a href="mailto:user@example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;">user@example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;</a>',
-            ],
+        yield 'normal email' => [
+            'user@example.com',
+            '<a href="mailto:user@example.com">user@example.com</a>',
+        ];
+        yield 'email with alias' => [
+            'user.one+test@example.com',
+            '<a href="mailto:user.one+test@example.com">user.one+test@example.com</a>',
+        ];
+        yield 'malicious email' => [
+            'user@example.com"><script>alert("XSS")</script>',
+            '<a href="mailto:user@example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;">user@example.com&#34;&#62;&#60;script&#62;alert(&#34;XSS&#34;)&#60;/script&#62;</a>',
         ];
     }
 

--- a/app/bundles/EmailBundle/Tests/Entity/StatTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatTest.php
@@ -40,20 +40,18 @@ final class StatTest extends TestCase
      * Data provider for addOpenDetails.
      */
     /**
-     * @return array<string, array{0: int}>
+     * @return \Iterator<string, array{int}>
      */
-    public static function addOpenDetailsTestProvider(): array
+    public static function addOpenDetailsTestProvider(): \Iterator
     {
-        return [
-            'no openDetails'            => [0],
-            'one openDetail'            => [1],
-            'low number of openDetails' => [10],
-            'one away from threshold'   => [Stat::MAX_OPEN_DETAILS - 1],
-            'exactly at threshold'      => [Stat::MAX_OPEN_DETAILS],
-            'one past threshold'        => [Stat::MAX_OPEN_DETAILS + 1],
-            'slightly above threshold'  => [Stat::MAX_OPEN_DETAILS + 10],
-            'well beyond threshold'     => [Stat::MAX_OPEN_DETAILS * 10],
-        ];
+        yield 'no openDetails' => [0];
+        yield 'one openDetail' => [1];
+        yield 'low number of openDetails' => [10];
+        yield 'one away from threshold' => [Stat::MAX_OPEN_DETAILS - 1];
+        yield 'exactly at threshold' => [Stat::MAX_OPEN_DETAILS];
+        yield 'one past threshold' => [Stat::MAX_OPEN_DETAILS + 1];
+        yield 'slightly above threshold' => [Stat::MAX_OPEN_DETAILS + 10];
+        yield 'well beyond threshold' => [Stat::MAX_OPEN_DETAILS * 10];
     }
 
     public function testChanges(): void

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -943,25 +943,23 @@ final class MailHelperTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function provideEmails(): array
+    public static function provideEmails(): \Iterator
     {
-        return [
-            ['john@doe.com', true],
-            ['john@doe.email', true],
-            ['john@doe.whatevertldtheycomewithinthefuture', true],
-            ['john.doe@email.com', true],
-            ['john+doe@email.com', true],
-            ['john@doe', false],
-            ['jo hn@doe.email', false],
-            ['jo^hn@doe.email', false],
-            ['jo\'hn@doe.email', false],
-            ['jo;hn@doe.email', false],
-            ['jo&hn@doe.email', false],
-            ['jo*hn@doe.email', false],
-            ['jo%hn@doe.email', false],
-        ];
+        yield ['john@doe.com', true];
+        yield ['john@doe.email', true];
+        yield ['john@doe.whatevertldtheycomewithinthefuture', true];
+        yield ['john.doe@email.com', true];
+        yield ['john+doe@email.com', true];
+        yield ['john@doe', false];
+        yield ['jo hn@doe.email', false];
+        yield ['jo^hn@doe.email', false];
+        yield ['jo\'hn@doe.email', false];
+        yield ['jo;hn@doe.email', false];
+        yield ['jo&hn@doe.email', false];
+        yield ['jo*hn@doe.email', false];
+        yield ['jo%hn@doe.email', false];
     }
 
     public function testValidateEmailWithoutTld(): void
@@ -1475,14 +1473,12 @@ final class MailHelperTest extends TestCase
     }
 
     /**
-     * @return array<array<bool|int|string>>
+     * @return \Iterator<(int | string), array<(bool | int | string)>>
      */
-    public static function minifyHtmlDataProvider(): array
+    public static function minifyHtmlDataProvider(): \Iterator
     {
-        return [
-            [false, self::MINIFY_HTML, self::MINIFY_HTML],
-            [true, self::MINIFY_HTML, InputHelper::minifyHTML(self::MINIFY_HTML)],
-        ];
+        yield [false, self::MINIFY_HTML, self::MINIFY_HTML];
+        yield [true, self::MINIFY_HTML, InputHelper::minifyHTML(self::MINIFY_HTML)];
     }
 
     public function testHeadersAreTokenized(): void

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -943,7 +943,7 @@ final class MailHelperTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function provideEmails(): \Iterator
     {
@@ -1473,7 +1473,7 @@ final class MailHelperTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), array<(bool | int | string)>>
+     * @return \Iterator<(int|string), array<(bool|int|string)>>
      */
     public static function minifyHtmlDataProvider(): \Iterator
     {

--- a/app/bundles/EmailBundle/Tests/Helper/PlainTextHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PlainTextHelperTest.php
@@ -114,7 +114,7 @@ HTML,
     }
 
     /**
-     * @return \Iterator<int, array<int, (int | string | null)>>
+     * @return \Iterator<int, array<int, (int|string|null)>>
      */
     public static function getPreviewProvider(): \Iterator
     {

--- a/app/bundles/EmailBundle/Tests/Helper/PlainTextHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PlainTextHelperTest.php
@@ -20,34 +20,33 @@ final class PlainTextHelperTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return \Iterator<int, array<int, string>>
      */
-    public static function emailContentProvider(): array
+    public static function emailContentProvider(): \Iterator
     {
-        return [
-            // Test case 1: Simple paragraph
-            [
-                '<p>This is a simple paragraph.</p>',
-                'This is a simple paragraph.',
-            ],
-            // Test case 2: Line breaks
-            [
-                '<p>This is line one.<br>This is line two.</p>',
-                "This is line one.\nThis is line two.",
-            ],
-            // Test case 3: Links
-            [
-                '<p>Check this <a href="http://example.com">link</a>.</p>',
-                'Check this link [http://example.com].',
-            ],
-            // Test case 4: Bold text
-            [
-                '<p>This is <strong>bold</strong> text.</p>',
-                'This is bold text.',
-            ],
-            // Test case 5: Full html body
-            [
-                '<!DOCTYPE html>
+        // Test case 1: Simple paragraph
+        yield [
+            '<p>This is a simple paragraph.</p>',
+            'This is a simple paragraph.',
+        ];
+        // Test case 2: Line breaks
+        yield [
+            '<p>This is line one.<br>This is line two.</p>',
+            "This is line one.\nThis is line two.",
+        ];
+        // Test case 3: Links
+        yield [
+            '<p>Check this <a href="http://example.com">link</a>.</p>',
+            'Check this link [http://example.com].',
+        ];
+        // Test case 4: Bold text
+        yield [
+            '<p>This is <strong>bold</strong> text.</p>',
+            'This is bold text.',
+        ];
+        // Test case 5: Full html body
+        yield [
+            '<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -59,45 +58,44 @@ final class PlainTextHelperTest extends TestCase
     <!-- More HTML content here -->
 </body>
 </html>',
-                "WELCOME TO OUR NEWSLETTER\n\nThis is an example paragraph in our email content.",
-            ],
-            [
-                <<<HTML
+            "WELCOME TO OUR NEWSLETTER\n\nThis is an example paragraph in our email content.",
+        ];
+        yield [
+            <<<HTML
 <a href="https://example.com">text</a>
 HTML,
-                <<<HTML
+            <<<HTML
 text [https://example.com]
 HTML,
-            ],
-            [
-                <<<HTML
+        ];
+        yield [
+            <<<HTML
 <a href="https://example.com">link 1</a>
 <a href="https://examples.com">link 2</a>
 HTML,
-                <<<HTML
+            <<<HTML
 link 1 [https://example.com] link 2 [https://examples.com]
 HTML,
-            ],
-            [
-                <<<HTML
+        ];
+        yield [
+            <<<HTML
 <a href="https://example.com">text<br></a>
 HTML,
-                <<<HTML
+            <<<HTML
 text
 [https://example.com]
 HTML,
-            ],
-            [
-                <<<HTML
+        ];
+        yield [
+            <<<HTML
 <h1>something</h1>
 <h2>another something</h2>
 HTML,
-                <<<HTML
+            <<<HTML
 SOMETHING
 
 ANOTHER SOMETHING
 HTML,
-            ],
         ];
     }
 
@@ -116,30 +114,28 @@ HTML,
     }
 
     /**
-     * @return array<int, array<int, string|int|null>>
+     * @return \Iterator<int, array<int, (int | string | null)>>
      */
-    public static function getPreviewProvider(): array
+    public static function getPreviewProvider(): \Iterator
     {
-        return [
-            // Test case 1: Simple paragraph, with default options
-            [
-                null,
-                '<p>This is a simple paragraph.</p>',
-                'This is a simple paragraph.',
-            ],
-            // Test case 2: Simple paragraph, with length set to 10 (whitespace truncated)
-            [
-                10,
-                '<p>This is a simple paragraph.</p>',
-                'This is a...',
-            ],
-            // Test case 3: Full html body
-            [
-                25,
-                '<h1>Welcome to Our Newsletter</h1>
+        // Test case 1: Simple paragraph, with default options
+        yield [
+            null,
+            '<p>This is a simple paragraph.</p>',
+            'This is a simple paragraph.',
+        ];
+        // Test case 2: Simple paragraph, with length set to 10 (whitespace truncated)
+        yield [
+            10,
+            '<p>This is a simple paragraph.</p>',
+            'This is a...',
+        ];
+        // Test case 3: Full html body
+        yield [
+            25,
+            '<h1>Welcome to Our Newsletter</h1>
     <p>This is an example paragraph in our email content.</p>',
-                'WELCOME TO OUR NEWSLETTER...',
-            ],
+            'WELCOME TO OUR NEWSLETTER...',
         ];
     }
 }

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
@@ -38,34 +38,26 @@ final class DsnParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string, array{
-     *     dsnReport: string,
-     *     expectedEmail: string,
-     *     expectedCategory: string,
-     *     expectedType: string,
-     *     expectedFinal: bool,
-     *     expectedRuleNumber?: string|null
-     * }>
+     * @return \Iterator<string, array{dsnReport: string, expectedEmail: string, expectedCategory: string, expectedType: string, expectedFinal: bool, expectedRuleNumber?: (string | null)}>
      */
-    public static function bouncedEmailProvider(): array
+    public static function bouncedEmailProvider(): \Iterator
     {
-        return [
-            'basic DNS unknown - host not found' => [
-                'dsnReport'   => <<<'DSN'
+        yield 'basic DNS unknown - host not found' => [
+            'dsnReport'   => <<<'DSN'
 Original-Recipient: sdfgsdfg@seznan.cz
 Final-Recipient: rfc822;sdfgsdfg@seznan.cz
 Action: failed
 Status: 5.4.4
 Diagnostic-Code: DNS; Host not found
 DSN,
-                'expectedEmail'      => 'sdfgsdfg@seznan.cz',
-                'expectedCategory'   => Category::DNS_UNKNOWN,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => null,
-            ],
-            'postfix unknown user - user does not exist' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'sdfgsdfg@seznan.cz',
+            'expectedCategory'   => Category::DNS_UNKNOWN,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => null,
+        ];
+        yield 'postfix unknown user - user does not exist' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; aaaaaaaaaaaaa@yoursite.com
 Original-Recipient: rfc822;aaaaaaaaaaaaa@yoursite.com
 Action: failed
@@ -74,116 +66,115 @@ Remote-MTA: dns; mail-server.yoursite.com
 Diagnostic-Code: smtp; 550 5.1.1 <aaaaaaaaaaaaa@yoursite.com> User doesn't
     exist: aaaaaaaaaaaaa@yoursite.com
 DSN,
-                'expectedEmail'      => 'aaaaaaaaaaaaa@yoursite.com',
-                'expectedCategory'   => Category::UNKNOWN,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => null,
-            ],
-            'unified group agent - sender not permitted to send to group' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'aaaaaaaaaaaaa@yoursite.com',
+            'expectedCategory'   => Category::UNKNOWN,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => null,
+        ];
+        yield 'unified group agent - sender not permitted to send to group' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; sender@example.com
 Action: failed
 Status: 5.7.193
 Diagnostic-Code: smtp;550 5.7.193 UnifiedGroupAgent; Delivery failed because the sender isn't a group member or external senders aren't permitted to send to this group.
 DSN,
-                'expectedEmail'      => 'sender@example.com',
-                'expectedCategory'   => Category::USER_REJECT,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => '0230',
-            ],
-            'message expired - cannot connect to remote server' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'sender@example.com',
+            'expectedCategory'   => Category::USER_REJECT,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => '0230',
+        ];
+        yield 'message expired - cannot connect to remote server' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; recipient@example.com
 Action: failed
 Status: 5.4.317
 Diagnostic-Code: smtp;550 5.4.317 Message expired, cannot connect to remote server
 DSN,
-                'expectedEmail'      => 'recipient@example.com',
-                'expectedCategory'   => Category::DNS_UNKNOWN,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => '0232',
-            ],
-            'outlook 550 5.4.1 access denied' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'recipient@example.com',
+            'expectedCategory'   => Category::DNS_UNKNOWN,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => '0232',
+        ];
+        yield 'outlook 550 5.4.1 access denied' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; user@outlook.com
 Action: failed
 Status: 5.4.1
 Diagnostic-Code: smtp;550 5.4.1 Recipient address rejected: Access denied
 DSN,
-                'expectedEmail'      => 'user@outlook.com',
-                'expectedCategory'   => Category::USER_REJECT,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => '0233',
-            ],
-            'outlook 550 5.1.10 recipient not found' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'user@outlook.com',
+            'expectedCategory'   => Category::USER_REJECT,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => '0233',
+        ];
+        yield 'outlook 550 5.1.10 recipient not found' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; user@outlook.com
 Action: failed
 Status: 5.1.10
 Diagnostic-Code: smtp;550 5.1.10 RESOLVER.ADR.RecipientNotFound; Recipient not found by Exchange address book
 DSN,
-                'expectedEmail'      => 'user@outlook.com',
-                'expectedCategory'   => Category::UNKNOWN,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => '0136',
-            ],
-            'outlook 550 5.7.133 sender not authenticated for group' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'user@outlook.com',
+            'expectedCategory'   => Category::UNKNOWN,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => '0136',
+        ];
+        yield 'outlook 550 5.7.133 sender not authenticated for group' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; group@outlook.com
 Action: failed
 Status: 5.7.133
 Diagnostic-Code: smtp;550 5.7.133 RESOLVER.RST.SenderNotAuthenticatedForGroup; Sender not authenticated for group
 DSN,
-                'expectedEmail'      => 'group@outlook.com',
-                'expectedCategory'   => Category::USER_REJECT,
-                'expectedType'       => Type::HARD,
-                'expectedFinal'      => true,
-                'expectedRuleNumber' => '0206',
-            ],
-            'outlook 550 5.7.1 client host blocked' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'group@outlook.com',
+            'expectedCategory'   => Category::USER_REJECT,
+            'expectedType'       => Type::HARD,
+            'expectedFinal'      => true,
+            'expectedRuleNumber' => '0206',
+        ];
+        yield 'outlook 550 5.7.1 client host blocked' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; user@outlook.com
 Action: failed
 Status: 5.7.1
 Diagnostic-Code: smtp;550 5.7.1 Service unavailable, Client host [1.2.3.4] blocked using Spamhaus
 DSN,
-                'expectedEmail'      => 'user@outlook.com',
-                'expectedCategory'   => Category::ANTISPAM,
-                'expectedType'       => Type::BLOCKED,
-                'expectedFinal'      => false,
-                'expectedRuleNumber' => '0201',
-            ],
-            'outlook 550 5.7.606 banned sending IP' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'user@outlook.com',
+            'expectedCategory'   => Category::ANTISPAM,
+            'expectedType'       => Type::BLOCKED,
+            'expectedFinal'      => false,
+            'expectedRuleNumber' => '0201',
+        ];
+        yield 'outlook 550 5.7.606 banned sending IP' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; user@outlook.com
 Action: failed
 Status: 5.7.606
 Diagnostic-Code: smtp;550 5.7.606 Access denied, banned sending IP [1.2.3.4]
 DSN,
-                'expectedEmail'      => 'user@outlook.com',
-                'expectedCategory'   => Category::ANTISPAM,
-                'expectedType'       => Type::BLOCKED,
-                'expectedFinal'      => false,
-                'expectedRuleNumber' => '0235',
-            ],
-            'outlook 550 5.7.511 banned sender' => [
-                'dsnReport'   => <<<'DSN'
+            'expectedEmail'      => 'user@outlook.com',
+            'expectedCategory'   => Category::ANTISPAM,
+            'expectedType'       => Type::BLOCKED,
+            'expectedFinal'      => false,
+            'expectedRuleNumber' => '0235',
+        ];
+        yield 'outlook 550 5.7.511 banned sender' => [
+            'dsnReport'   => <<<'DSN'
 Final-Recipient: rfc822; user@outlook.com
 Action: failed
 Status: 5.7.511
 Diagnostic-Code: smtp;550 5.7.511 Access denied, banned sender [user@outlook.com]
 DSN,
-                'expectedEmail'      => 'user@outlook.com',
-                'expectedCategory'   => Category::ANTISPAM,
-                'expectedType'       => Type::BLOCKED,
-                'expectedFinal'      => false,
-                'expectedRuleNumber' => '0234',
-            ],
+            'expectedEmail'      => 'user@outlook.com',
+            'expectedCategory'   => Category::ANTISPAM,
+            'expectedType'       => Type::BLOCKED,
+            'expectedFinal'      => false,
+            'expectedRuleNumber' => '0234',
         ];
     }
 

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/Bounce/DsnParserTest.php
@@ -38,7 +38,7 @@ final class DsnParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Iterator<string, array{dsnReport: string, expectedEmail: string, expectedCategory: string, expectedType: string, expectedFinal: bool, expectedRuleNumber?: (string | null)}>
+     * @return \Iterator<string, array{dsnReport: string, expectedEmail: string, expectedCategory: string, expectedType: string, expectedFinal: bool, expectedRuleNumber?: (string|null)}>
      */
     public static function bouncedEmailProvider(): \Iterator
     {

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -143,120 +143,118 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, mixed>>>
+     * @return \Iterator<int, array<int, array<string, mixed>>>
      */
-    public static function formDataProvider(): array
+    public static function formDataProvider(): \Iterator
     {
-        return [
+        yield [
             [
-                [
-                    'name'        => 'Form API test',
-                    'formType'    => 'standalone',
-                    'isPublished' => true,
-                    'description' => 'Functional API test',
-                    'fields'      => [
-                        [
-                            'label'     => 'Email',
-                            'alias'     => 'email',
-                            'type'      => 'text',
-                            'leadField' => 'email',
-                        ],
-                        [
-                            'label'        => 'Company Address',
-                            'type'         => 'text',
-                            'alias'        => 'companyaddress1',
-                            'leadField'    => 'companyaddress1',
-                        ],
-                        [
-                            'label'        => 'Company Phone',
-                            'type'         => 'tel',
-                            'alias'        => 'phone',
-                            'leadField'    => 'companyphone',
-                        ],
-                        [
-                            'label'        => 'Country',
-                            'type'         => 'country',
-                            'alias'        => 'country',
-                            'mappedObject' => 'contact',
-                            'mappedField'  => 'country',
-                        ],
+                'name'        => 'Form API test',
+                'formType'    => 'standalone',
+                'isPublished' => true,
+                'description' => 'Functional API test',
+                'fields'      => [
+                    [
+                        'label'     => 'Email',
+                        'alias'     => 'email',
+                        'type'      => 'text',
+                        'leadField' => 'email',
                     ],
-                    'postAction'  => 'return',
+                    [
+                        'label'        => 'Company Address',
+                        'type'         => 'text',
+                        'alias'        => 'companyaddress1',
+                        'leadField'    => 'companyaddress1',
+                    ],
+                    [
+                        'label'        => 'Company Phone',
+                        'type'         => 'tel',
+                        'alias'        => 'phone',
+                        'leadField'    => 'companyphone',
+                    ],
+                    [
+                        'label'        => 'Country',
+                        'type'         => 'country',
+                        'alias'        => 'country',
+                        'mappedObject' => 'contact',
+                        'mappedField'  => 'country',
+                    ],
                 ],
-                [
-                    'newName'      => 'Form API test',
-                    'fields'       => [
-                        [
-                            'mappedObject' => 'contact',
-                            'leadField'    => 'email',
-                            'mappedField'  => 'email',
-                        ],
-                        [
-                            'mappedObject' => 'company',
-                            'leadField'    => 'companyaddress1',
-                            'mappedField'  => 'companyaddress1',
-                        ],
-                        [
-                            'mappedObject' => 'company',
-                            'leadField'    => 'companyphone',
-                            'mappedField'  => 'companyphone',
-                        ], [
-                            'mappedObject' => 'contact',
-                            'leadField'    => 'country',
-                            'mappedField'  => 'country',
-                        ],
+                'postAction'  => 'return',
+            ],
+            [
+                'newName'      => 'Form API test',
+                'fields'       => [
+                    [
+                        'mappedObject' => 'contact',
+                        'leadField'    => 'email',
+                        'mappedField'  => 'email',
+                    ],
+                    [
+                        'mappedObject' => 'company',
+                        'leadField'    => 'companyaddress1',
+                        'mappedField'  => 'companyaddress1',
+                    ],
+                    [
+                        'mappedObject' => 'company',
+                        'leadField'    => 'companyphone',
+                        'mappedField'  => 'companyphone',
+                    ], [
+                        'mappedObject' => 'contact',
+                        'leadField'    => 'country',
+                        'mappedField'  => 'country',
                     ],
                 ],
             ],
+        ];
+        yield [
             [
-                [
-                    'name'        => 'Form',
-                    'formType'    => 'standalone',
-                    'isPublished' => true,
-                    'description' => 'Functional API test2',
-                    'fields'      => [
-                        [
-                            'label'        => 'Lastname',
-                            'alias'        => 'lastname',
-                            'type'         => 'text',
-                            'mappedField'  => 'lastname',
-                            'mappedObject' => 'contact',
-                        ],
-                        [
-                            'label'        => 'Company Email',
-                            'type'         => 'text',
-                            'alias'        => 'companyemail1',
-                            'mappedField'  => 'companyemail',
-                            'mappedObject' => 'company',
-                            'leadField'    => 'companyemail',
-                        ],
-                        [
-                            'label'        => 'Phone',
-                            'type'         => 'tel',
-                            'alias'        => 'phone',
-                            'leadField'    => 'position',
-                        ],
+                'name'        => 'Form',
+                'formType'    => 'standalone',
+                'isPublished' => true,
+                'description' => 'Functional API test2',
+                'fields'      => [
+                    [
+                        'label'        => 'Lastname',
+                        'alias'        => 'lastname',
+                        'type'         => 'text',
+                        'mappedField'  => 'lastname',
+                        'mappedObject' => 'contact',
                     ],
-                    'postAction'  => 'return',
+                    [
+                        'label'        => 'Company Email',
+                        'type'         => 'text',
+                        'alias'        => 'companyemail1',
+                        'mappedField'  => 'companyemail',
+                        'mappedObject' => 'company',
+                        'leadField'    => 'companyemail',
+                    ],
+                    [
+                        'label'        => 'Phone',
+                        'type'         => 'tel',
+                        'alias'        => 'phone',
+                        'leadField'    => 'position',
+                    ],
                 ],
-                [
-                    'newName'      => 'Form API test',
-                    'fields'       => [
-                        [
-                            'mappedObject' => 'contact',
-                            'leadField'    => 'lastname',
-                            'mappedField'  => 'lastname',
-                        ],
-                        [
-                            'mappedObject' => 'company',
-                            'leadField'    => 'companyemail',
-                            'mappedField'  => 'companyemail',
-                        ],
-                        [
-                            'mappedObject' => 'contact',
-                            'leadField'    => 'position',
-                            'mappedField'  => 'position',
-                        ],
+                'postAction'  => 'return',
+            ],
+            [
+                'newName'      => 'Form API test',
+                'fields'       => [
+                    [
+                        'mappedObject' => 'contact',
+                        'leadField'    => 'lastname',
+                        'mappedField'  => 'lastname',
+                    ],
+                    [
+                        'mappedObject' => 'company',
+                        'leadField'    => 'companyemail',
+                        'mappedField'  => 'companyemail',
+                    ],
+                    [
+                        'mappedObject' => 'contact',
+                        'leadField'    => 'position',
+                        'mappedField'  => 'position',
                     ],
                 ],
             ],

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
@@ -201,58 +201,54 @@ final class FormApiControllerTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array<mixed>>
+     * @return \Iterator<string, array<mixed>>
      */
-    public static function formDataProvider(): array
+    public static function formDataProvider(): \Iterator
     {
-        return [
-            'simple form' => [
-                [
-                    'name'        => 'Simple Test Form',
-                    'description' => 'A simple test form',
-                ],
-                Response::HTTP_CREATED,
+        yield 'simple form' => [
+            [
+                'name'        => 'Simple Test Form',
+                'description' => 'A simple test form',
             ],
-            'form with fields' => [
-                [
-                    'name'   => 'Form with Fields',
-                    'fields' => [
-                        [
-                            'label' => 'First Name',
-                            'type'  => 'text',
-                            'alias' => 'first_name',
-                        ],
-                        [
-                            'label' => 'Email Address',
-                            'type'  => 'email',
-                            'alias' => 'email',
-                        ],
+            Response::HTTP_CREATED,
+        ];
+        yield 'form with fields' => [
+            [
+                'name'   => 'Form with Fields',
+                'fields' => [
+                    [
+                        'label' => 'First Name',
+                        'type'  => 'text',
+                        'alias' => 'first_name',
+                    ],
+                    [
+                        'label' => 'Email Address',
+                        'type'  => 'email',
+                        'alias' => 'email',
                     ],
                 ],
-                Response::HTTP_CREATED,
             ],
+            Response::HTTP_CREATED,
         ];
     }
 
     /**
-     * @return array<string, array<mixed>>
+     * @return \Iterator<string, array<mixed>>
      */
-    public static function updateFormDataProvider(): array
+    public static function updateFormDataProvider(): \Iterator
     {
-        return [
-            'update name only' => [
-                ['name' => 'Original Form'],
-                ['name' => 'Updated Form Name'],
-            ],
-            'add fields to existing form' => [
-                ['name' => 'Form without fields'],
-                [
-                    'name'   => 'Form with fields',
-                    'fields' => [
-                        [
-                            'label' => 'New Field',
-                            'type'  => 'text',
-                        ],
+        yield 'update name only' => [
+            ['name' => 'Original Form'],
+            ['name' => 'Updated Form Name'],
+        ];
+        yield 'add fields to existing form' => [
+            ['name' => 'Form without fields'],
+            [
+                'name'   => 'Form with fields',
+                'fields' => [
+                    [
+                        'label' => 'New Field',
+                        'type'  => 'text',
                     ],
                 ],
             ],

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -149,7 +149,7 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<string, array{fieldType: string, label: string, expectedHtmlFragment: string, additionalValues: (array<string, mixed> | null)}>
+     * @return \Iterator<string, array{fieldType: string, label: string, expectedHtmlFragment: string, additionalValues: (array<string, mixed>|null)}>
      */
     public static function provideFieldTypesData(): \Iterator
     {

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -149,124 +149,117 @@ final class FieldControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{
-     *     fieldType: string,
-     *     label: string,
-     *     expectedHtmlFragment: string,
-     *     additionalValues: array<string, mixed>|null
-     * }>
+     * @return \Iterator<string, array{fieldType: string, label: string, expectedHtmlFragment: string, additionalValues: (array<string, mixed> | null)}>
      */
-    public static function provideFieldTypesData(): array
+    public static function provideFieldTypesData(): \Iterator
     {
-        return [
-            'email field with link in label' => [
-                'fieldType'            => 'email',
-                'label'                => 'Email <a href="https://example.com" target="_blank">link</a>',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => '',
-                'additionalValues'     => null,
-            ],
-            'email field with link in helpMessage' => [
-                'fieldType'            => 'email',
-                'label'                => 'Email',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => 'Find more info at <a href="https://example.com" target="_blank">link</a>',
-                'additionalValues'     => null,
-            ],
-            'checkbox group field with link in label' => [
-                'fieldType'            => 'checkboxgrp',
-                'label'                => 'Checkbox Group <a href="https://example.com" target="_blank">link</a>',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => '',
-                'additionalValues'     => [
-                    'formfield' => [
-                        'properties' => [
-                            'optionlist' => [
-                                'list' => [
-                                    [
-                                        'label' => 'option1',
-                                        'value' => 'option1',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'checkbox group field with link in helpMessage' => [
-                'fieldType'            => 'checkboxgrp',
-                'label'                => 'Checkbox Group',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => 'Find <a href="https://example.com" target="_blank">link</a>',
-                'additionalValues'     => [
-                    'formfield' => [
-                        'properties' => [
-                            'optionlist' => [
-                                'list' => [
-                                    [
-                                        'label' => 'option1',
-                                        'value' => 'option1',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'checkbox group field with link in option label' => [
-                'fieldType'            => 'checkboxgrp',
-                'label'                => 'Checkbox Group',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">terms and conditions</a>',
-                'helpMessage'          => '',
-                'additionalValues'     => [
-                    'formfield' => [
-                        'properties' => [
-                            'optionlist' => [
-                                'list' => [
-                                    [
-                                        'label' => 'I agree with the <a href="https://example.com" target="_blank">terms and conditions</a>.',
-                                        'value' => '1',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'select field with link in label' => [
-                'fieldType'            => 'select',
-                'label'                => 'Select',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => 'Get <a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'additionalValues'     => [
-                    'formfield' => [
-                        'properties' => [
+        yield 'email field with link in label' => [
+            'fieldType'            => 'email',
+            'label'                => 'Email <a href="https://example.com" target="_blank">link</a>',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => '',
+            'additionalValues'     => null,
+        ];
+        yield 'email field with link in helpMessage' => [
+            'fieldType'            => 'email',
+            'label'                => 'Email',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => 'Find more info at <a href="https://example.com" target="_blank">link</a>',
+            'additionalValues'     => null,
+        ];
+        yield 'checkbox group field with link in label' => [
+            'fieldType'            => 'checkboxgrp',
+            'label'                => 'Checkbox Group <a href="https://example.com" target="_blank">link</a>',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => '',
+            'additionalValues'     => [
+                'formfield' => [
+                    'properties' => [
+                        'optionlist' => [
                             'list' => [
-                                'list' => [
-                                    [
-                                        'label' => 'abc',
-                                        'value' => 'abc',
-                                    ],
+                                [
+                                    'label' => 'option1',
+                                    'value' => 'option1',
                                 ],
                             ],
                         ],
                     ],
                 ],
             ],
-            'select field with link in helpMessage' => [
-                'fieldType'            => 'select',
-                'label'                => 'Select <a href="https://example.com" target="_blank">link</a>',
-                'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
-                'helpMessage'          => '',
-                'additionalValues'     => [
-                    'formfield' => [
-                        'properties' => [
+        ];
+        yield 'checkbox group field with link in helpMessage' => [
+            'fieldType'            => 'checkboxgrp',
+            'label'                => 'Checkbox Group',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => 'Find <a href="https://example.com" target="_blank">link</a>',
+            'additionalValues'     => [
+                'formfield' => [
+                    'properties' => [
+                        'optionlist' => [
                             'list' => [
-                                'list' => [
-                                    [
-                                        'label' => 'abc',
-                                        'value' => 'abc',
-                                    ],
+                                [
+                                    'label' => 'option1',
+                                    'value' => 'option1',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'checkbox group field with link in option label' => [
+            'fieldType'            => 'checkboxgrp',
+            'label'                => 'Checkbox Group',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">terms and conditions</a>',
+            'helpMessage'          => '',
+            'additionalValues'     => [
+                'formfield' => [
+                    'properties' => [
+                        'optionlist' => [
+                            'list' => [
+                                [
+                                    'label' => 'I agree with the <a href="https://example.com" target="_blank">terms and conditions</a>.',
+                                    'value' => '1',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'select field with link in label' => [
+            'fieldType'            => 'select',
+            'label'                => 'Select',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => 'Get <a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'additionalValues'     => [
+                'formfield' => [
+                    'properties' => [
+                        'list' => [
+                            'list' => [
+                                [
+                                    'label' => 'abc',
+                                    'value' => 'abc',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'select field with link in helpMessage' => [
+            'fieldType'            => 'select',
+            'label'                => 'Select <a href="https://example.com" target="_blank">link</a>',
+            'expectedHtmlFragment' => '<a href="https://example.com" target="_blank" rel="noreferrer noopener">link</a>',
+            'helpMessage'          => '',
+            'additionalValues'     => [
+                'formfield' => [
+                    'properties' => [
+                        'list' => [
+                            'list' => [
+                                [
+                                    'label' => 'abc',
+                                    'value' => 'abc',
                                 ],
                             ],
                         ],

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -493,15 +493,13 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{formType: string|null}>
+     * @return \Iterator<string, array{formType: (string | null)}>
      */
-    public static function formTypeDataProvider(): array
+    public static function formTypeDataProvider(): \Iterator
     {
-        return [
-            'campaign form type'   => ['formType' => 'campaign'],
-            'standalone form type' => ['formType' => 'standalone'],
-            'no form type'         => ['formType' => null],
-        ];
+        yield 'campaign form type' => ['formType' => 'campaign'];
+        yield 'standalone form type' => ['formType' => 'standalone'];
+        yield 'no form type' => ['formType' => null];
     }
 
     public function testFetchFormSubmissionsApiIfPermissionNotGrantedForUser(): void
@@ -909,120 +907,118 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{submissionData: array<string, string>, expectedData: array<string, string>}>
+     * @return \Iterator<string, array{submissionData: array<string, string>, expectedData: array<string, string>}>
      */
-    public static function formFieldValuesMappingDataProvider(): array
+    public static function formFieldValuesMappingDataProvider(): \Iterator
     {
-        return [
-            'normal_submission' => [
-                'submissionData' => [
-                    'email'           => 'john@example.com',
-                    'firstname'       => 'John',
-                    'lastname'        => 'Doe',
-                    'country'         => 'United States',
-                    'company_name'    => 'Acme Inc',
-                    'company_country' => 'United States',
-                    'company_city'    => 'New York',
-                    'message'         => 'Hello, this is a normal submission.',
-                ],
-                'expectedData' => [
-                    'email'           => 'john@example.com',
-                    'firstname'       => 'John',
-                    'lastname'        => 'Doe',
-                    'country'         => 'United States',
-                    'company_name'    => 'Acme Inc',
-                    'company_country' => 'United States',
-                    'company_city'    => 'New York',
-                    'message'         => 'Hello, this is a normal submission.',
-                ],
+        yield 'normal_submission' => [
+            'submissionData' => [
+                'email'           => 'john@example.com',
+                'firstname'       => 'John',
+                'lastname'        => 'Doe',
+                'country'         => 'United States',
+                'company_name'    => 'Acme Inc',
+                'company_country' => 'United States',
+                'company_city'    => 'New York',
+                'message'         => 'Hello, this is a normal submission.',
             ],
-            'special_characters' => [
-                'submissionData' => [
-                    'email'           => 'jane@example.com',
-                    'firstname'       => 'Jane',
-                    'lastname'        => 'O\'Brien-Smith',
-                    'country'         => 'Ireland',
-                    'company_name'    => '"Super" R&D Company, Ltd.',
-                    'company_country' => 'Ireland',
-                    'company_city'    => 'Dublin',
-                    'message'         => 'Super & Special',
-                ],
-                'expectedData' => [
-                    'email'           => 'jane@example.com',
-                    'firstname'       => 'Jane',
-                    'lastname'        => 'O\'Brien-Smith',
-                    'country'         => 'Ireland',
-                    'company_name'    => '"Super" R&D Company, Ltd.',
-                    'company_country' => 'Ireland',
-                    'company_city'    => 'Dublin',
-                    'message'         => 'Super & Special',
-                ],
+            'expectedData' => [
+                'email'           => 'john@example.com',
+                'firstname'       => 'John',
+                'lastname'        => 'Doe',
+                'country'         => 'United States',
+                'company_name'    => 'Acme Inc',
+                'company_country' => 'United States',
+                'company_city'    => 'New York',
+                'message'         => 'Hello, this is a normal submission.',
             ],
-            'xss_attempt' => [
-                'submissionData' => [
-                    'email'           => 'hacker@evil.com',
-                    'firstname'       => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                    'lastname'        => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                    'country'         => 'Poland',
-                    'company_name'    => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                    'company_country' => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                    'company_city'    => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                    'message'         => '<script>alert("XSS")</script>',
-                ],
-                'expectedData' => [
-                    'email'           => 'hacker@evil.com',
-                    'firstname'       => 'alert("XSS")',
-                    'lastname'        => 'alert("XSS")',
-                    'country'         => 'Poland',
-                    'company_name'    => 'alert("XSS")',
-                    'company_country' => 'alert("XSS")',
-                    'company_city'    => 'alert("XSS")',
-                    'message'         => 'alert("XSS")',
-                ],
+        ];
+        yield 'special_characters' => [
+            'submissionData' => [
+                'email'           => 'jane@example.com',
+                'firstname'       => 'Jane',
+                'lastname'        => 'O\'Brien-Smith',
+                'country'         => 'Ireland',
+                'company_name'    => '"Super" R&D Company, Ltd.',
+                'company_country' => 'Ireland',
+                'company_city'    => 'Dublin',
+                'message'         => 'Super & Special',
             ],
-            'sql_injection_attempt' => [
-                'submissionData' => [
-                    'email'           => 'sqlhacker@evil.com',
-                    'firstname'       => "Robert'; DROP TABLE users; --",
-                    'lastname'        => 'Tables',
-                    'country'         => 'United States',
-                    'company_name'    => "Malicious' Corp; DELETE FROM companies WHERE 1=1; --",
-                    'company_country' => 'United States',
-                    'company_city'    => 'SQL City',
-                    'message'         => "Robert'; DROP TABLE messages; --",
-                ],
-                'expectedData' => [
-                    'email'           => 'sqlhacker@evil.com',
-                    'firstname'       => "Robert'; DROP TABLE users; --",
-                    'lastname'        => 'Tables',
-                    'country'         => 'United States',
-                    'company_name'    => "Malicious' Corp; DELETE FROM companies WHERE 1=1; --",
-                    'company_country' => 'United States',
-                    'company_city'    => 'SQL City',
-                    'message'         => "Robert'; DROP TABLE messages; --",
-                ],
+            'expectedData' => [
+                'email'           => 'jane@example.com',
+                'firstname'       => 'Jane',
+                'lastname'        => 'O\'Brien-Smith',
+                'country'         => 'Ireland',
+                'company_name'    => '"Super" R&D Company, Ltd.',
+                'company_country' => 'Ireland',
+                'company_city'    => 'Dublin',
+                'message'         => 'Super & Special',
             ],
-            'unicode_characters' => [
-                'submissionData' => [
-                    'email'           => 'unicode@example.com',
-                    'firstname'       => 'José',
-                    'lastname'        => 'Martínez',
-                    'country'         => 'Spain',
-                    'company_name'    => '株式会社スマイル',
-                    'company_country' => 'Japan',
-                    'company_city'    => '東京',
-                    'message'         => 'こんにちは、世界！',
-                ],
-                'expectedData' => [
-                    'email'           => 'unicode@example.com',
-                    'firstname'       => 'José',
-                    'lastname'        => 'Martínez',
-                    'country'         => 'Spain',
-                    'company_name'    => '株式会社スマイル',
-                    'company_country' => 'Japan',
-                    'company_city'    => '東京',
-                    'message'         => 'こんにちは、世界！',
-                ],
+        ];
+        yield 'xss_attempt' => [
+            'submissionData' => [
+                'email'           => 'hacker@evil.com',
+                'firstname'       => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
+                'lastname'        => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
+                'country'         => 'Poland',
+                'company_name'    => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
+                'company_country' => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
+                'company_city'    => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
+                'message'         => '<script>alert("XSS")</script>',
+            ],
+            'expectedData' => [
+                'email'           => 'hacker@evil.com',
+                'firstname'       => 'alert("XSS")',
+                'lastname'        => 'alert("XSS")',
+                'country'         => 'Poland',
+                'company_name'    => 'alert("XSS")',
+                'company_country' => 'alert("XSS")',
+                'company_city'    => 'alert("XSS")',
+                'message'         => 'alert("XSS")',
+            ],
+        ];
+        yield 'sql_injection_attempt' => [
+            'submissionData' => [
+                'email'           => 'sqlhacker@evil.com',
+                'firstname'       => "Robert'; DROP TABLE users; --",
+                'lastname'        => 'Tables',
+                'country'         => 'United States',
+                'company_name'    => "Malicious' Corp; DELETE FROM companies WHERE 1=1; --",
+                'company_country' => 'United States',
+                'company_city'    => 'SQL City',
+                'message'         => "Robert'; DROP TABLE messages; --",
+            ],
+            'expectedData' => [
+                'email'           => 'sqlhacker@evil.com',
+                'firstname'       => "Robert'; DROP TABLE users; --",
+                'lastname'        => 'Tables',
+                'country'         => 'United States',
+                'company_name'    => "Malicious' Corp; DELETE FROM companies WHERE 1=1; --",
+                'company_country' => 'United States',
+                'company_city'    => 'SQL City',
+                'message'         => "Robert'; DROP TABLE messages; --",
+            ],
+        ];
+        yield 'unicode_characters' => [
+            'submissionData' => [
+                'email'           => 'unicode@example.com',
+                'firstname'       => 'José',
+                'lastname'        => 'Martínez',
+                'country'         => 'Spain',
+                'company_name'    => '株式会社スマイル',
+                'company_country' => 'Japan',
+                'company_city'    => '東京',
+                'message'         => 'こんにちは、世界！',
+            ],
+            'expectedData' => [
+                'email'           => 'unicode@example.com',
+                'firstname'       => 'José',
+                'lastname'        => 'Martínez',
+                'country'         => 'Spain',
+                'company_name'    => '株式会社スマイル',
+                'company_country' => 'Japan',
+                'company_city'    => '東京',
+                'message'         => 'こんにちは、世界！',
             ],
         ];
     }
@@ -1133,90 +1129,88 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{submissionData: array<string, string>, expectedData: array<string, string>}>
+     * @return \Iterator<string, array{submissionData: array<string, string>, expectedData: array<string, string>}>
      */
-    public static function formCustomFieldsMappingDataProvider(): array
+    public static function formCustomFieldsMappingDataProvider(): \Iterator
     {
-        return [
-            'simple_value' => [
-                'submissionData' => [
-                    'animal' => 'Dog',
-                ],
-                'expectedData' => [
-                    'animal' => 'Dog',
-                ],
+        yield 'simple_value' => [
+            'submissionData' => [
+                'animal' => 'Dog',
             ],
-            'special_characters' => [
-                'submissionData' => [
-                    'animal' => 'Guinea-Pig & Hamster\'s "friend"',
-                ],
-                'expectedData' => [
-                    'animal' => 'Guinea-Pig & Hamster\'s "friend"',
-                ],
+            'expectedData' => [
+                'animal' => 'Dog',
             ],
-            'xss_attempt' => [
-                'submissionData' => [
-                    'animal' => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
-                ],
-                'expectedData' => [
-                    'animal' => 'alert("XSS")',
-                ],
+        ];
+        yield 'special_characters' => [
+            'submissionData' => [
+                'animal' => 'Guinea-Pig & Hamster\'s "friend"',
             ],
-            'sql_injection' => [
-                'submissionData' => [
-                    'animal' => "Cat'; DROP TABLE animals; --",
-                ],
-                'expectedData' => [
-                    'animal' => "Cat'; DROP TABLE animals; --",
-                ],
+            'expectedData' => [
+                'animal' => 'Guinea-Pig & Hamster\'s "friend"',
             ],
-            'unicode_and_emoji' => [
-                'submissionData' => [
-                    'animal' => '🐕 犬 🐈 猫',  // Dog and Cat in Japanese with emojis
-                ],
-                'expectedData' => [
-                    'animal' => '🐕 犬 🐈 猫',
-                ],
+        ];
+        yield 'xss_attempt' => [
+            'submissionData' => [
+                'animal' => '<script>alert("XSS")</script><img src=x onerror=alert("XSS")>',
             ],
-            'nested_tags' => [
-                'submissionData' => [
-                    'animal' => '<div><span>Text</span></div>',
-                ],
-                'expectedData' => [
-                    'animal' => 'Text',
-                ],
+            'expectedData' => [
+                'animal' => 'alert("XSS")',
             ],
-            'incomplete_tags' => [
-                'submissionData' => [
-                    'animal' => '<div><span>Text',
-                ],
-                'expectedData' => [
-                    'animal' => 'Text',
-                ],
+        ];
+        yield 'sql_injection' => [
+            'submissionData' => [
+                'animal' => "Cat'; DROP TABLE animals; --",
             ],
-            'null_byte' => [
-                'submissionData' => [
-                    'animal' => "Dog\x00Cat",
-                ],
-                'expectedData' => [
-                    'animal' => 'DogCat',
-                ],
+            'expectedData' => [
+                'animal' => "Cat'; DROP TABLE animals; --",
             ],
-            'javascript_protocol' => [
-                'submissionData' => [
-                    'animal' => '<a href="javascript:alert(\'XSS\')">Click me</a>',
-                ],
-                'expectedData' => [
-                    'animal' => 'Click me',
-                ],
+        ];
+        yield 'unicode_and_emoji' => [
+            'submissionData' => [
+                'animal' => '🐕 犬 🐈 猫',  // Dog and Cat in Japanese with emojis
             ],
-            'css_expression' => [
-                'submissionData' => [
-                    'animal' => '<div style="width: expression(alert(\'XSS\'));">Test</div>',
-                ],
-                'expectedData' => [
-                    'animal' => 'Test',
-                ],
+            'expectedData' => [
+                'animal' => '🐕 犬 🐈 猫',
+            ],
+        ];
+        yield 'nested_tags' => [
+            'submissionData' => [
+                'animal' => '<div><span>Text</span></div>',
+            ],
+            'expectedData' => [
+                'animal' => 'Text',
+            ],
+        ];
+        yield 'incomplete_tags' => [
+            'submissionData' => [
+                'animal' => '<div><span>Text',
+            ],
+            'expectedData' => [
+                'animal' => 'Text',
+            ],
+        ];
+        yield 'null_byte' => [
+            'submissionData' => [
+                'animal' => "Dog\x00Cat",
+            ],
+            'expectedData' => [
+                'animal' => 'DogCat',
+            ],
+        ];
+        yield 'javascript_protocol' => [
+            'submissionData' => [
+                'animal' => '<a href="javascript:alert(\'XSS\')">Click me</a>',
+            ],
+            'expectedData' => [
+                'animal' => 'Click me',
+            ],
+        ];
+        yield 'css_expression' => [
+            'submissionData' => [
+                'animal' => '<div style="width: expression(alert(\'XSS\'));">Test</div>',
+            ],
+            'expectedData' => [
+                'animal' => 'Test',
             ],
         ];
     }
@@ -1403,19 +1397,17 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{0: string, 1: string}>
+     * @return \Iterator<string, array{string, string}>
      */
-    public static function htmlFieldSubmissionDataProvider(): array
+    public static function htmlFieldSubmissionDataProvider(): \Iterator
     {
-        return [
-            'any_text' => [
-                '<div></div>',
-                'test1@test.com',
-            ],
-            'with_content' => [
-                '<div>Some content</div>',
-                'test2@test.com',
-            ],
+        yield 'any_text' => [
+            '<div></div>',
+            'test1@test.com',
+        ];
+        yield 'with_content' => [
+            '<div>Some content</div>',
+            'test2@test.com',
         ];
     }
 

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -493,7 +493,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<string, array{formType: (string | null)}>
+     * @return \Iterator<string, array{formType: (string|null)}>
      */
     public static function formTypeDataProvider(): \Iterator
     {

--- a/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/FormFieldHelperTest.php
@@ -30,81 +30,79 @@ final class FormFieldHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: Field, 1: mixed, 2: string, 3: mixed, 4: string}>
+     * @return \Iterator<int, array{Field, mixed, string, mixed, string}>
      */
-    public static function fieldProvider(): array
+    public static function fieldProvider(): \Iterator
     {
-        return [
-            [
-                self::getField('First Name', 'text'),
-                '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
-                '<input value="" id="mauticform_input_mautic_firstname" />',
-                '<input id="mauticform_input_mautic_firstname" value="&quot;/&gt;alert(0)" />',
-                'Tags should be stripped from textet field values submitted via GET to prevent XSS.',
-            ],
-            [
-                self::getField('First Name', 'text'),
-                '%22%20onfocus=%22alert(123)',
-                '<input value="" id="mauticform_input_mautic_firstname" />',
-                '<input id="mauticform_input_mautic_firstname" value="&quot; onfocus=&quot;alert(123)" />',
-                'Inline JS values should not be allowed via GET to prevent XSS.',
-            ],
-            [
-                self::getField('Phone', 'tel'),
-                '+41 123 456 7890',
-                '<input value="" id="mauticform_input_mautic_phone" />',
-                '<input id="mauticform_input_mautic_phone" value="+41 123 456 7890" />',
-                'Phone number are populated properly',
-            ],
-            [
-                self::getField('Description', 'textarea'),
-                '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
-                '<textarea id="mauticform_input_mautic_description"></textarea>',
-                '<textarea id="mauticform_input_mautic_description">&quot;/&gt;alert(0)</textarea>',
-                'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
-            ],
-            [
-                self::getField('Description', 'textarea'),
-                '%22%20onfocus=%22alert(123)',
-                '<textarea id="mauticform_input_mautic_description"></textarea>',
-                '<textarea id="mauticform_input_mautic_description">&quot; onfocus=&quot;alert(123)</textarea>',
-                'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
-            ],
-            [
-                self::getField('Checkbox Single', 'checkboxgrp'),
-                'myvalue',
-                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
-                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
-                'Single value checkbox groups should have their values set appropriately via GET.',
-            ],
-            [
-                self::getField('Checkbox Multi', 'checkboxgrp'),
-                'myvalue%7Calsomyvalue',
-                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
-                '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
-                'Multi-value checkbox groups should have their values set appropriately via GET.',
-            ],
-            [
-                self::getField('Radio Single', 'radiogrp'),
-                'myvalue',
-                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
-                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue" checked /><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
-                'Single value radio groups should have their values set appropriately via GET.',
-            ],
-            [
-                self::getField('Select', 'select'),
-                'myvalue',
-                '<select id="mauticform_input_mautic_select"><option value="myvalue">My Value</option></select>',
-                '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
-                'Select lists should have their values set appropriately via GET.',
-            ],
-            [
-                self::getField('Rating', 'rating'),
-                '3',
-                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'1" value="1"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'2" value="2"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'3" value="3"/>',
-                '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'1" value="1"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'2" value="2"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'3" value="3" checked />',
-                'Rating fields should have their values set appropriately via GET.',
-            ],
+        yield [
+            self::getField('First Name', 'text'),
+            '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
+            '<input value="" id="mauticform_input_mautic_firstname" />',
+            '<input id="mauticform_input_mautic_firstname" value="&quot;/&gt;alert(0)" />',
+            'Tags should be stripped from textet field values submitted via GET to prevent XSS.',
+        ];
+        yield [
+            self::getField('First Name', 'text'),
+            '%22%20onfocus=%22alert(123)',
+            '<input value="" id="mauticform_input_mautic_firstname" />',
+            '<input id="mauticform_input_mautic_firstname" value="&quot; onfocus=&quot;alert(123)" />',
+            'Inline JS values should not be allowed via GET to prevent XSS.',
+        ];
+        yield [
+            self::getField('Phone', 'tel'),
+            '+41 123 456 7890',
+            '<input value="" id="mauticform_input_mautic_phone" />',
+            '<input id="mauticform_input_mautic_phone" value="+41 123 456 7890" />',
+            'Phone number are populated properly',
+        ];
+        yield [
+            self::getField('Description', 'textarea'),
+            '%22%2F%3E%3Cscript%3Ealert%280%29%3C%2Fscript%3E',
+            '<textarea id="mauticform_input_mautic_description"></textarea>',
+            '<textarea id="mauticform_input_mautic_description">&quot;/&gt;alert(0)</textarea>',
+            'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
+        ];
+        yield [
+            self::getField('Description', 'textarea'),
+            '%22%20onfocus=%22alert(123)',
+            '<textarea id="mauticform_input_mautic_description"></textarea>',
+            '<textarea id="mauticform_input_mautic_description">&quot; onfocus=&quot;alert(123)</textarea>',
+            'Tags should be stripped from textarea field values submitted via GET to prevent XSS.',
+        ];
+        yield [
+            self::getField('Checkbox Single', 'checkboxgrp'),
+            'myvalue',
+            '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
+            '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Single').'2" value="notmyvalue"/>',
+            'Single value checkbox groups should have their values set appropriately via GET.',
+        ];
+        yield [
+            self::getField('Checkbox Multi', 'checkboxgrp'),
+            'myvalue%7Calsomyvalue',
+            '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue"/><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
+            '<input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'1" value="myvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'2" value="alsomyvalue" checked /><input id="mauticform_checkboxgrp_checkbox_'.self::getAliasFromName('Checkbox Multi').'3" value="notmyvalue"/>',
+            'Multi-value checkbox groups should have their values set appropriately via GET.',
+        ];
+        yield [
+            self::getField('Radio Single', 'radiogrp'),
+            'myvalue',
+            '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
+            '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="myvalue" checked /><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Radio Single').'1" value="notmyvalue"/>',
+            'Single value radio groups should have their values set appropriately via GET.',
+        ];
+        yield [
+            self::getField('Select', 'select'),
+            'myvalue',
+            '<select id="mauticform_input_mautic_select"><option value="myvalue">My Value</option></select>',
+            '<select id="mauticform_input_mautic_select"><option value="myvalue" selected="selected">My Value</option></select>',
+            'Select lists should have their values set appropriately via GET.',
+        ];
+        yield [
+            self::getField('Rating', 'rating'),
+            '3',
+            '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'1" value="1"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'2" value="2"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'3" value="3"/>',
+            '<input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'1" value="1"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'2" value="2"/><input id="mauticform_radiogrp_radio_'.self::getAliasFromName('Rating').'3" value="3" checked />',
+            'Rating fields should have their values set appropriately via GET.',
         ];
     }
 

--- a/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
@@ -45,13 +45,12 @@ final class CreateCustomFieldCommandTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, bool|int>>
+     * @return \Iterator<int, array<int, (bool | int)>>
      */
-    public static function completeRunMethodProvider(): array
+    public static function completeRunMethodProvider(): \Iterator
     {
-        return [
-            [true, 1],  // `completeRun` should be called once
-            [false, 0], // `completeRun` should never be called
-        ];
+        yield [true, 1];
+        // `completeRun` should be called once
+        yield [false, 0];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CreateCustomFieldCommandTest.php
@@ -45,7 +45,7 @@ final class CreateCustomFieldCommandTest extends TestCase
     }
 
     /**
-     * @return \Iterator<int, array<int, (bool | int)>>
+     * @return \Iterator<int, array<int, (bool|int)>>
      */
     public static function completeRunMethodProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -182,23 +182,21 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{companyData: array<string, mixed>, expectedStatusCode: int}>
+     * @return \Iterator<string, array{companyData: array<string, mixed>, expectedStatusCode: int}>
      */
-    public static function companyCreateDataProvider(): array
+    public static function companyCreateDataProvider(): \Iterator
     {
-        return [
-            'valid company with all fields' => [
-                'companyData' => [
-                    'score'       => 0,
-                    'socialCache' => [],
-                    'city'        => 'Boston',
-                    'state'       => 'Massachusetts',
-                    'country'     => 'United States',
-                    'name'        => 'Mautic',
-                    'industry'    => 'Software',
-                ],
-                'expectedStatusCode' => Response::HTTP_CREATED,
+        yield 'valid company with all fields' => [
+            'companyData' => [
+                'score'       => 0,
+                'socialCache' => [],
+                'city'        => 'Boston',
+                'state'       => 'Massachusetts',
+                'country'     => 'United States',
+                'name'        => 'Mautic',
+                'industry'    => 'Software',
             ],
+            'expectedStatusCode' => Response::HTTP_CREATED,
         ];
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -844,7 +844,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<int, array<int, (bool | string | null)>>
+     * @return \Iterator<int, array<int, (bool|string|null)>>
      */
     public static function dateFieldProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -844,21 +844,19 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<int, array<int, bool|string|null>>
+     * @return \Iterator<int, array<int, (bool | string | null)>>
      */
-    public static function dateFieldProvider(): array
+    public static function dateFieldProvider(): \Iterator
     {
-        return [
-            ['Today', false],
-            ['Not-a-date', true],
-            ['birthday', false],
-            ['2023-01-01 11:00', false],
-            ['2023-01-01 11:00:00', false],
-            ['2023-01-01', false],
-            ['next week', false],
-            [null, false],
-            ['\b\d{4}-(10|11|12)-\d{2}\b', false, 'regexp'],
-        ];
+        yield ['Today', false];
+        yield ['Not-a-date', true];
+        yield ['birthday', false];
+        yield ['2023-01-01 11:00', false];
+        yield ['2023-01-01 11:00:00', false];
+        yield ['2023-01-01', false];
+        yield ['next week', false];
+        yield [null, false];
+        yield ['\b\d{4}-(10|11|12)-\d{2}\b', false, 'regexp'];
     }
 
     public function testRecentActivityFeedOnSegmentDetailsPage(): void

--- a/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
@@ -41,18 +41,16 @@ final class UtmTagTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<string|array<bool|string|''>>
+     * @return \Iterator<(int | string), (array<(bool | string)> | string)>
      */
-    public static function utmTagsDataProvider(): array
+    public static function utmTagsDataProvider(): \Iterator
     {
-        return [
-            'All tags are empty'       => ['', '', '', '', '', false],
-            'Only utmCampaign is set'  => ['campaign', '', '', '', '', true],
-            'Only utmSource is set'    => ['', 'source', '', '', '', true],
-            'Only utmMedium is set'    => ['', '', 'medium', '', '', true],
-            'Only utmContent is set'   => ['', '', '', 'content', '', true],
-            'Only utmTerm is set'      => ['', '', '', '', 'term', true],
-            'All tags are set'         => ['campaign', 'source', 'medium', 'content', 'term', true],
-        ];
+        yield 'All tags are empty' => ['', '', '', '', '', false];
+        yield 'Only utmCampaign is set' => ['campaign', '', '', '', '', true];
+        yield 'Only utmSource is set' => ['', 'source', '', '', '', true];
+        yield 'Only utmMedium is set' => ['', '', 'medium', '', '', true];
+        yield 'Only utmContent is set' => ['', '', '', 'content', '', true];
+        yield 'Only utmTerm is set' => ['', '', '', '', 'term', true];
+        yield 'All tags are set' => ['campaign', 'source', 'medium', 'content', 'term', true];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/UtmTagTest.php
@@ -41,7 +41,7 @@ final class UtmTagTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), (array<(bool | string)> | string)>
+     * @return \Iterator<(int|string), (array<(bool|string)>|string)>
      */
     public static function utmTagsDataProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -1138,20 +1138,18 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<int, array{string, string, string, bool}>
+     * @return \Iterator<int, array{string, string, string, bool}>
      */
-    public static function regexOperatorProvider(): array
+    public static function regexOperatorProvider(): \Iterator
     {
-        return [
-            // [operator, regex, fieldValue, expectedResult]
-            [OperatorOptions::REGEXP, "^\d{4}-03-24$", '2026-03-24', true],
-            [OperatorOptions::REGEXP, "^\d{4}-12-31$", '2026-03-24', false],
-            [OperatorOptions::REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', true],
-            [OperatorOptions::REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', false],
-            [OperatorOptions::NOT_REGEXP, "^\d{4}-12-31$", '2026-03-24', true],
-            [OperatorOptions::NOT_REGEXP, "^\d{4}-03-24$", '2026-03-24', false],
-            [OperatorOptions::NOT_REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', true],
-            [OperatorOptions::NOT_REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', false],
-        ];
+        // [operator, regex, fieldValue, expectedResult]
+        yield [OperatorOptions::REGEXP, "^\d{4}-03-24$", '2026-03-24', true];
+        yield [OperatorOptions::REGEXP, "^\d{4}-12-31$", '2026-03-24', false];
+        yield [OperatorOptions::REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', true];
+        yield [OperatorOptions::REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', false];
+        yield [OperatorOptions::NOT_REGEXP, "^\d{4}-12-31$", '2026-03-24', true];
+        yield [OperatorOptions::NOT_REGEXP, "^\d{4}-03-24$", '2026-03-24', false];
+        yield [OperatorOptions::NOT_REGEXP, "^\d{4}-12-\d{2}$", '2026-03-24', true];
+        yield [OperatorOptions::NOT_REGEXP, "^\d{4}-03-\d{2}$", '2026-03-24', false];
     }
 }

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -49,7 +49,7 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     ];
 
     /**
-     * @return \Iterator<int, array<string, (array<int, string> | bool | int | null)>>
+     * @return \Iterator<int, array<string, (array<int, string>|bool|int|null)>>
      */
     public static function provideFormDNC(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -49,47 +49,45 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     ];
 
     /**
-     * @return array<int, array<string, array<int, string>|bool|int|null>>
+     * @return \Iterator<int, array<string, (array<int, string> | bool | int | null)>>
      */
-    public static function provideFormDNC(): array
+    public static function provideFormDNC(): \Iterator
     {
-        return [
-            [
-                'reason'   => 1,
-                'channels' => ['email'],
-                'expected' => true,
-                'dncLead'  => 1,
-            ],
-            [
-                'reason'   => 2,
-                'channels' => ['email'],
-                'expected' => false,
-                'dncLead'  => 1,
-            ],
-            [
-                'reason'   => 3,
-                'channels' => ['email'],
-                'expected' => false,
-                'dncLead'  => 1,
-            ],
-            [
-                'reason'   => 2,
-                'channels' => ['email'],
-                'expected' => true,
-                'dncLead'  => 2,
-            ],
-            [
-                'reason'   => null,
-                'channels' => ['email'],
-                'expected' => true,
-                'dncLead'  => 2,
-            ],
-            [
-                'reason'   => null,
-                'channels' => ['email'],
-                'expected' => false,
-                'dncLead'  => 0,
-            ],
+        yield [
+            'reason'   => 1,
+            'channels' => ['email'],
+            'expected' => true,
+            'dncLead'  => 1,
+        ];
+        yield [
+            'reason'   => 2,
+            'channels' => ['email'],
+            'expected' => false,
+            'dncLead'  => 1,
+        ];
+        yield [
+            'reason'   => 3,
+            'channels' => ['email'],
+            'expected' => false,
+            'dncLead'  => 1,
+        ];
+        yield [
+            'reason'   => 2,
+            'channels' => ['email'],
+            'expected' => true,
+            'dncLead'  => 2,
+        ];
+        yield [
+            'reason'   => null,
+            'channels' => ['email'],
+            'expected' => true,
+            'dncLead'  => 2,
+        ];
+        yield [
+            'reason'   => null,
+            'channels' => ['email'],
+            'expected' => false,
+            'dncLead'  => 0,
         ];
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -78,7 +78,7 @@ final class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<int, array<string, (array<string, (array<string, array<int, string>> | string)> | string)>> $properties
+     * @return \Iterator<int, array<string, (array<string, (array<string, array<int, string>>|string)>|string)>> $properties
      */
     public static function normalizeData(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -78,61 +78,57 @@ final class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<int, array<string, array<string, array<string, array<int,string>>|string>|string>> $properties
+     * @return \Iterator<int, array<string, (array<string, (array<string, array<int, string>> | string)> | string)>> $properties
      */
-    public static function normalizeData(): array
+    public static function normalizeData(): \Iterator
     {
-        return [
-            // Test for boolean custom field
-            [
-                'value'      => '1',
-                'type'       => 'boolean',
-                'properties' => [
-                    'yes' => 'True',
-                    'no'  => 'False',
-                ],
-                'expected'   => 'True',
+        // Test for boolean custom field
+        yield [
+            'value'      => '1',
+            'type'       => 'boolean',
+            'properties' => [
+                'yes' => 'True',
+                'no'  => 'False',
             ],
-            [
-                'value'      => '0',
-                'type'       => 'boolean',
-                'properties' => [
-                    'yes' => 'True',
-                    'no'  => 'False',
-                ],
-                'expected'   => 'False',
+            'expected'   => 'True',
+        ];
+        yield [
+            'value'      => '0',
+            'type'       => 'boolean',
+            'properties' => [
+                'yes' => 'True',
+                'no'  => 'False',
             ],
-
-            // Test for select custom field
-            [
-                'value'      => '2',
-                'type'       => 'select',
-                'properties' => [
+            'expected'   => 'False',
+        ];
+        // Test for select custom field
+        yield [
+            'value'      => '2',
+            'type'       => 'select',
+            'properties' => [
+                'list' => [
                     'list' => [
-                        'list' => [
-                            1 => 'Option 1',
-                            2 => 'Option 2',
-                        ],
+                        1 => 'Option 1',
+                        2 => 'Option 2',
                     ],
                 ],
-                'expected'   => 'Option 2',
             ],
-
-            // Test for multiselect custom field
-            [
-                'value'      => '1|3',
-                'type'       => 'multiselect',
-                'properties' => [
+            'expected'   => 'Option 2',
+        ];
+        // Test for multiselect custom field
+        yield [
+            'value'      => '1|3',
+            'type'       => 'multiselect',
+            'properties' => [
+                'list' => [
                     'list' => [
-                        'list' => [
-                            1 => 'Option 1',
-                            2 => 'Option 2',
-                            3 => 'Option 3',
-                        ],
+                        1 => 'Option 1',
+                        2 => 'Option 2',
+                        3 => 'Option 3',
                     ],
                 ],
-                'expected'   => 'Option 1|Option 3',
             ],
+            'expected'   => 'Option 1|Option 3',
         ];
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -286,32 +286,28 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return \Iterator<int, array<int, string>>
      */
-    public static function eventDataProvider(): array
+    public static function eventDataProvider(): \Iterator
     {
-        return [
-            ['leads'],
-            ['contact.frequencyrules'],
-            ['lead.pointlog'],
-            ['contact.attribution.first'],
-            ['contact.attribution.multi'],
-            ['contact.attribution.last'],
-            ['companies'],
-        ];
+        yield ['leads'];
+        yield ['contact.frequencyrules'];
+        yield ['lead.pointlog'];
+        yield ['contact.attribution.first'];
+        yield ['contact.attribution.multi'];
+        yield ['contact.attribution.last'];
+        yield ['companies'];
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return \Iterator<int, array<int, string>>
      */
-    public static function reportGraphEventDataProvider(): array
+    public static function reportGraphEventDataProvider(): \Iterator
     {
-        return [
-            ['leads'],
-            ['lead.pointlog'],
-            ['contact.attribution.multi'],
-            ['companies'],
-        ];
+        yield ['leads'];
+        yield ['lead.pointlog'];
+        yield ['contact.attribution.multi'];
+        yield ['companies'];
     }
 
     public function testNotRelevantContextBuilder(): void

--- a/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
@@ -44,30 +44,28 @@ final class FieldAliasToFqcnMapTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function aliasFqcnProvider(): array
+    public static function aliasFqcnProvider(): \Iterator
     {
-        return [
-            ['boolean', BooleanType::class],
-            ['country', CountryType::class],
-            ['date', DateType::class],
-            ['datetime', DateTimeType::class],
-            ['email', EmailType::class],
-            ['hidden', HiddenType::class],
-            ['locale', LocaleType::class],
-            ['lookup', LookupType::class],
-            ['multiselect', MultiselectType::class],
-            ['number', NumberType::class],
-            ['region', RegionType::class],
-            ['select', SelectType::class],
-            ['tel', TelType::class],
-            ['text', TextType::class],
-            ['textarea', TextareaType::class],
-            ['time', TimeType::class],
-            ['timezone', TimezoneType::class],
-            ['url', UrlType::class],
-            ['html', HtmlType::class],
-        ];
+        yield ['boolean', BooleanType::class];
+        yield ['country', CountryType::class];
+        yield ['date', DateType::class];
+        yield ['datetime', DateTimeType::class];
+        yield ['email', EmailType::class];
+        yield ['hidden', HiddenType::class];
+        yield ['locale', LocaleType::class];
+        yield ['lookup', LookupType::class];
+        yield ['multiselect', MultiselectType::class];
+        yield ['number', NumberType::class];
+        yield ['region', RegionType::class];
+        yield ['select', SelectType::class];
+        yield ['tel', TelType::class];
+        yield ['text', TextType::class];
+        yield ['textarea', TextareaType::class];
+        yield ['time', TimeType::class];
+        yield ['timezone', TimezoneType::class];
+        yield ['url', UrlType::class];
+        yield ['html', HtmlType::class];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/FieldAliasToFqcnMapTest.php
@@ -44,7 +44,7 @@ final class FieldAliasToFqcnMapTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function aliasFqcnProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/SafeUrlValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/SafeUrlValidatorTest.php
@@ -31,14 +31,12 @@ final class SafeUrlValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @return list<array{string, bool}>
+     * @return \Iterator<int<0, max>, array{string, bool}>
      */
-    public static function urlProvider(): array
+    public static function urlProvider(): \Iterator
     {
-        return [
-            ['http://example.com', true],
-            ['https://example.com/path', true],
-            ['data:text/html;base64,abc', false],
-        ];
+        yield ['http://example.com', true];
+        yield ['https://example.com/path', true];
+        yield ['data:text/html;base64,abc', false];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
@@ -20,15 +20,13 @@ final class LeadRepositoryTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<int, list<array<string, bool>>>
+     * @return \Iterator<int, list<array<string, bool>>>
      */
-    public static function joinIpAddressesProvider(): array
+    public static function joinIpAddressesProvider(): \Iterator
     {
-        return [
-            [[]],
-            [['joinIpAddresses' => true]],
-            [['joinIpAddresses' => false]],
-        ];
+        yield [[]];
+        yield [['joinIpAddresses' => true]];
+        yield [['joinIpAddresses' => false]];
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -273,7 +273,7 @@ final class TokenHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Iterator<int, array<int, (int | string)>>
+     * @return \Iterator<int, array<int, (int|string)>>
      */
     public static function dataLabelProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -273,16 +273,13 @@ final class TokenHelperTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array<int, int|string>>
+     * @return \Iterator<int, array<int, (int | string)>>
      */
-    public static function dataLabelProvider(): array
+    public static function dataLabelProvider(): \Iterator
     {
-        return
-            [
-                ['{contactfield=select}', 'first'],
-                ['{contactfield=select|label}', 'First option'],
-                ['{contactfield=bool}', 1],
-                ['{contactfield=bool|label}', 'Yes'],
-            ];
+        yield ['{contactfield=select}', 'first'];
+        yield ['{contactfield=select|label}', 'First option'];
+        yield ['{contactfield=bool}', 1];
+        yield ['{contactfield=bool|label}', 'Yes'];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
@@ -101,31 +101,29 @@ final class LeadListModelTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: array<int, mixed>, 1: array<int, mixed>, 2: string}>
+     * @return \Iterator<int, array{array<int, mixed>, array<int, mixed>, string}>
      */
-    public static function segmentTestDataProvider(): array
+    public static function segmentTestDataProvider(): \Iterator
     {
-        return [
-            [
-                [1],
-                [1 => '1'],
-                '2 is dependent on 1, so 1 cannot be deleted.',
-            ],
-            [
-                [1, 3],
-                [1 => '1', 3 => '3'],
-                '2 is dependent on 1 & 3, so 1 & 3 cannot be deleted.',
-            ],
-            [
-                [1, 2, 3, 4],
-                [],
-                'Since we are deleting all segments, it should not prevent any from being deleted.',
-            ],
-            [
-                [2],
-                [],
-                'Segments without any other segment dependent on them should always be able to be deleted.',
-            ],
+        yield [
+            [1],
+            [1 => '1'],
+            '2 is dependent on 1, so 1 cannot be deleted.',
+        ];
+        yield [
+            [1, 3],
+            [1 => '1', 3 => '3'],
+            '2 is dependent on 1 & 3, so 1 & 3 cannot be deleted.',
+        ];
+        yield [
+            [1, 2, 3, 4],
+            [],
+            'Since we are deleting all segments, it should not prevent any from being deleted.',
+        ];
+        yield [
+            [2],
+            [],
+            'Segments without any other segment dependent on them should always be able to be deleted.',
         ];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -255,14 +255,12 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<mixed>
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function fieldValueProvider(): array
+    public static function fieldValueProvider(): \Iterator
     {
-        return [
-            'allowed_value'    => ['female', 'female'],
-            'disallowed_value' => ['gibberish', null],
-            'with_quotes'      => ['other\'s', 'other\'s'],
-        ];
+        yield 'allowed_value' => ['female', 'female'];
+        yield 'disallowed_value' => ['gibberish', null];
+        yield 'with_quotes' => ['other\'s', 'other\'s'];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -255,7 +255,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function fieldValueProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -127,66 +127,64 @@ final class ListModelTest extends TestCase
     }
 
     /**
-     * @return array<int, array{0: array<int, mixed>, 1: string|null, 2: array<string|int, mixed>}>
+     * @return \Iterator<int, array{array<int, mixed>, (string | null), array<(int | string), mixed>}>
      */
-    public static function sourceTypeTestDataProvider(): array
+    public static function sourceTypeTestDataProvider(): \Iterator
     {
-        return [
+        yield [
+            [],
+            'categories',
+            [],
+        ];
+        yield [
             [
-                [],
-                'categories',
-                [],
-            ],
-            [
-                [
-                    0 => [
-                        'id'     => 1,
-                        'title'  => 'Segment Test Category 1',
-                        'alias'  => 'Alias Test Category 1',
-                        'bundle' => 'segment',
-                    ],
-                    1 => [
-                        'id'     => 2,
-                        'title'  => 'Segment Test Category 2',
-                        'alias'  => 'Alias Test Category 2',
-                        'bundle' => 'segment',
-                    ],
+                0 => [
+                    'id'     => 1,
+                    'title'  => 'Segment Test Category 1',
+                    'alias'  => 'Alias Test Category 1',
+                    'bundle' => 'segment',
                 ],
-                null,
-                [
-                    'categories' => [
-                        'Alias Test Category 1' => 'Segment Test Category 1',
-                        'Alias Test Category 2' => 'Segment Test Category 2',
-                    ],
+                1 => [
+                    'id'     => 2,
+                    'title'  => 'Segment Test Category 2',
+                    'alias'  => 'Alias Test Category 2',
+                    'bundle' => 'segment',
                 ],
             ],
+            null,
             [
-                [
-                    0 => [
-                        'id'     => 1,
-                        'title'  => 'Segment Test Category 1',
-                        'alias'  => 'Alias Test Category 1',
-                        'bundle' => 'segment',
-                    ],
-                    1 => [
-                        'id'     => 2,
-                        'title'  => 'Segment Test Category 2',
-                        'alias'  => 'Alias Test Category 2',
-                        'bundle' => 'segment',
-                    ],
-                ],
-                'categories',
-                [
+                'categories' => [
                     'Alias Test Category 1' => 'Segment Test Category 1',
                     'Alias Test Category 2' => 'Segment Test Category 2',
                 ],
             ],
+        ];
+        yield [
             [
-                [],
-                null,
-                [
-                    'categories' => [],
+                0 => [
+                    'id'     => 1,
+                    'title'  => 'Segment Test Category 1',
+                    'alias'  => 'Alias Test Category 1',
+                    'bundle' => 'segment',
                 ],
+                1 => [
+                    'id'     => 2,
+                    'title'  => 'Segment Test Category 2',
+                    'alias'  => 'Alias Test Category 2',
+                    'bundle' => 'segment',
+                ],
+            ],
+            'categories',
+            [
+                'Alias Test Category 1' => 'Segment Test Category 1',
+                'Alias Test Category 2' => 'Segment Test Category 2',
+            ],
+        ];
+        yield [
+            [],
+            null,
+            [
+                'categories' => [],
             ],
         ];
     }

--- a/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -127,7 +127,7 @@ final class ListModelTest extends TestCase
     }
 
     /**
-     * @return \Iterator<int, array{array<int, mixed>, (string | null), array<(int | string), mixed>}>
+     * @return \Iterator<int, array{array<int, mixed>, (string|null), array<(int|string), mixed>}>
      */
     public static function sourceTypeTestDataProvider(): \Iterator
     {

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterCrateTest.php
@@ -248,16 +248,14 @@ final class ContactSegmentFilterCrateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array<int, array{0: string}>
+     * @return \Iterator<int, array{string}>
      */
-    public static function specialFieldsToConvertToEmptyProvider(): array
+    public static function specialFieldsToConvertToEmptyProvider(): \Iterator
     {
-        return [
-            ['page_id'],
-            ['email_id'],
-            ['redirect_id'],
-            ['notification'],
-        ];
+        yield ['page_id'];
+        yield ['email_id'];
+        yield ['redirect_id'];
+        yield ['notification'];
     }
 
     public function testBehaviorsTypeFilter(): void

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -198,16 +198,14 @@ final class DateOptionFactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return string[][]
+     * @return \Iterator<(int | string), array<string>>
      */
-    public static function getRelativeDateNotations(): array
+    public static function getRelativeDateNotations(): \Iterator
     {
-        return [
-            [DateRelativeInterval::class, 'first day of January 2021'],
-            [DateRelativeInterval::class, 'last day of January 2021'],
-            [DateRelativeInterval::class, '5 days ago'],
-            [DateDefault::class, 'day of January 2021'],
-        ];
+        yield [DateRelativeInterval::class, 'first day of January 2021'];
+        yield [DateRelativeInterval::class, 'last day of January 2021'];
+        yield [DateRelativeInterval::class, '5 days ago'];
+        yield [DateDefault::class, 'day of January 2021'];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('getRelativeDateNotations')]

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -198,7 +198,7 @@ final class DateOptionFactoryTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), array<string>>
+     * @return \Iterator<(int|string), array<string>>
      */
     public static function getRelativeDateNotations(): \Iterator
     {

--- a/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
@@ -12,14 +12,12 @@ use Symfony\Component\HttpFoundation\Request;
 final class DeviceTrackingServiceClearCookiesTest extends MauticMysqlTestCase
 {
     /**
-     * @return array<string, array{bool}>
+     * @return \Iterator<string, array{bool}>
      */
-    public static function blockedTrackingCookieDataProvider(): array
+    public static function blockedTrackingCookieDataProvider(): \Iterator
     {
-        return [
-            'with blocked tracking cookie'    => [true],
-            'without blocked tracking cookie' => [false],
-        ];
+        yield 'with blocked tracking cookie' => [true];
+        yield 'without blocked tracking cookie' => [false];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('blockedTrackingCookieDataProvider')]

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -64,51 +64,49 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array<int, string|null>>
+     * @return \Iterator<string, array<int, (string | null)>>
      */
-    public static function xssPayloadsProvider(): array
+    public static function xssPayloadsProvider(): \Iterator
     {
-        return [
-            'Basic script tag' => [
-                '<script>alert(1)</script>',
-                'alert(1)',
-            ],
-            'Script tag with attributes' => [
-                '<script src="http://example.com/evil.js"></script>',
-                null,
-            ],
-            'Encoded script tag' => [
-                '&#60;script&#62;alert(1)&#60;/script&#62;',
-                'alert(1)',
-            ],
-            'On-event handler' => [
-                '<img src="x" onerror="alert(1)">',
-                null,
-            ],
-            'JavaScript protocol in URL' => [
-                '<a href="javascript:alert(1)">Click me</a>',
-                'Click me',
-            ],
-            'SVG with embedded script' => [
-                '<svg><script>alert(1)</script></svg>',
-                'alert(1)',
-            ],
-            'CSS expression' => [
-                '<div style="background:url(javascript:alert(1))">',
-                null,
-            ],
-            'Malformed tag' => [
-                '<img """><script>alert("XSS")</script>"<',
-                'alert("XSS")"',
-            ],
-            'Malformed tag2' => [
-                '<IMG SRC="jav&#x09;ascript:alert(\'XSS\');">',
-                null,
-            ],
-            'Unicode escape' => [
-                '<script>\u0061lert(1)</script>',
-                '\u0061lert(1)',
-            ],
+        yield 'Basic script tag' => [
+            '<script>alert(1)</script>',
+            'alert(1)',
+        ];
+        yield 'Script tag with attributes' => [
+            '<script src="http://example.com/evil.js"></script>',
+            null,
+        ];
+        yield 'Encoded script tag' => [
+            '&#60;script&#62;alert(1)&#60;/script&#62;',
+            'alert(1)',
+        ];
+        yield 'On-event handler' => [
+            '<img src="x" onerror="alert(1)">',
+            null,
+        ];
+        yield 'JavaScript protocol in URL' => [
+            '<a href="javascript:alert(1)">Click me</a>',
+            'Click me',
+        ];
+        yield 'SVG with embedded script' => [
+            '<svg><script>alert(1)</script></svg>',
+            'alert(1)',
+        ];
+        yield 'CSS expression' => [
+            '<div style="background:url(javascript:alert(1))">',
+            null,
+        ];
+        yield 'Malformed tag' => [
+            '<img """><script>alert("XSS")</script>"<',
+            'alert("XSS")"',
+        ];
+        yield 'Malformed tag2' => [
+            '<IMG SRC="jav&#x09;ascript:alert(\'XSS\');">',
+            null,
+        ];
+        yield 'Unicode escape' => [
+            '<script>\u0061lert(1)</script>',
+            '\u0061lert(1)',
         ];
     }
 

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -64,7 +64,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<string, array<int, (string | null)>>
+     * @return \Iterator<string, array<int, (string|null)>>
      */
     public static function xssPayloadsProvider(): \Iterator
     {

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -62,49 +62,47 @@ final class PointActionHelperTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, mixed>>
+     * @return \Iterator<string, array<int, mixed>>
      */
-    public static function urlHitsActionDataProvider(): array
+    public static function urlHitsActionDataProvider(): \Iterator
     {
-        return [
-            'url_matches_first_hit' => [
-                [
-                    'id'         => 2,
-                    'type'       => 'url.hit',
-                    'name'       => 'Hit page',
-                    'properties' => [
-                        'page_url'               => 'https://example.com/ppk',
-                        'page_hits'              => 1,
-                        'accumulative_time_unit' => 'H',
-                        'accumulative_time'      => 0,
-                        'returns_within_unit'    => 'H',
-                        'returns_within'         => 0,
-                        'returns_after_unit'     => 'H',
-                        'returns_after'          => 0,
-                    ],
-                    'points' => 5,
+        yield 'url_matches_first_hit' => [
+            [
+                'id'         => 2,
+                'type'       => 'url.hit',
+                'name'       => 'Hit page',
+                'properties' => [
+                    'page_url'               => 'https://example.com/ppk',
+                    'page_hits'              => 1,
+                    'accumulative_time_unit' => 'H',
+                    'accumulative_time'      => 0,
+                    'returns_within_unit'    => 'H',
+                    'returns_within'         => 0,
+                    'returns_after_unit'     => 'H',
+                    'returns_after'          => 0,
                 ],
-                true,
+                'points' => 5,
             ],
-            'url_does_not_match' => [
-                [
-                    'id'         => 3,
-                    'type'       => 'url.hit',
-                    'name'       => 'Invalid URL',
-                    'properties' => [
-                        'page_url'               => 'https://example.com/invalid',
-                        'page_hits'              => 1,
-                        'accumulative_time_unit' => 'H',
-                        'accumulative_time'      => 0,
-                        'returns_within_unit'    => 'H',
-                        'returns_within'         => 0,
-                        'returns_after_unit'     => 'H',
-                        'returns_after'          => 0,
-                    ],
-                    'points' => 5,
+            true,
+        ];
+        yield 'url_does_not_match' => [
+            [
+                'id'         => 3,
+                'type'       => 'url.hit',
+                'name'       => 'Invalid URL',
+                'properties' => [
+                    'page_url'               => 'https://example.com/invalid',
+                    'page_hits'              => 1,
+                    'accumulative_time_unit' => 'H',
+                    'accumulative_time'      => 0,
+                    'returns_within_unit'    => 'H',
+                    'returns_within'         => 0,
+                    'returns_after_unit'     => 'H',
+                    'returns_after'          => 0,
                 ],
-                false,
+                'points' => 5,
             ],
+            false,
         ];
     }
 
@@ -136,49 +134,47 @@ final class PointActionHelperTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, mixed>>
+     * @return \Iterator<string, array<int, mixed>>
      */
-    public static function returnWithinActionDataProvider(): array
+    public static function returnWithinActionDataProvider(): \Iterator
     {
-        return [
-            'valid_return_within' => [
-                [
-                    'id'         => 1,
-                    'type'       => 'url.hit',
-                    'name'       => 'Test return within',
-                    'properties' => [
-                        'page_url'               => 'https://example.com/test/',
-                        'page_hits'              => null,
-                        'accumulative_time_unit' => 'H',
-                        'accumulative_time'      => 0,
-                        'returns_within_unit'    => 'H',
-                        'returns_within'         => 14400, // 4 hours in seconds
-                        'returns_after_unit'     => 'H',
-                        'returns_after'          => 0,
-                    ],
-                    'points' => 3,
+        yield 'valid_return_within' => [
+            [
+                'id'         => 1,
+                'type'       => 'url.hit',
+                'name'       => 'Test return within',
+                'properties' => [
+                    'page_url'               => 'https://example.com/test/',
+                    'page_hits'              => null,
+                    'accumulative_time_unit' => 'H',
+                    'accumulative_time'      => 0,
+                    'returns_within_unit'    => 'H',
+                    'returns_within'         => 14400, // 4 hours in seconds
+                    'returns_after_unit'     => 'H',
+                    'returns_after'          => 0,
                 ],
-                true,
+                'points' => 3,
             ],
-            'invalid_return_within' => [
-                [
-                    'id'         => 4,
-                    'type'       => 'url.hit',
-                    'name'       => 'Invalid Return Within',
-                    'properties' => [
-                        'page_url'               => 'https://example.com/test/',
-                        'page_hits'              => null,
-                        'accumulative_time_unit' => 'H',
-                        'accumulative_time'      => 0,
-                        'returns_within_unit'    => 'H',
-                        'returns_within'         => 3600, // 1 hour in seconds
-                        'returns_after_unit'     => 'H',
-                        'returns_after'          => 0,
-                    ],
-                    'points' => 3,
+            true,
+        ];
+        yield 'invalid_return_within' => [
+            [
+                'id'         => 4,
+                'type'       => 'url.hit',
+                'name'       => 'Invalid Return Within',
+                'properties' => [
+                    'page_url'               => 'https://example.com/test/',
+                    'page_hits'              => null,
+                    'accumulative_time_unit' => 'H',
+                    'accumulative_time'      => 0,
+                    'returns_within_unit'    => 'H',
+                    'returns_within'         => 3600, // 1 hour in seconds
+                    'returns_after_unit'     => 'H',
+                    'returns_after'          => 0,
                 ],
-                false,
+                'points' => 3,
             ],
+            false,
         ];
     }
 }

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -691,7 +691,7 @@ CONTENT;
     }
 
     /**
-     * @return \Iterator<(int | string), array<(bool | null)>> Use null to include both <a> and <map> tags
+     * @return \Iterator<(int|string), array<(bool|null)>> Use null to include both <a> and <map> tags
      */
     public static function trackMapProvider(): \Iterator
     {

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -691,14 +691,12 @@ CONTENT;
     }
 
     /**
-     * @return array<array<bool|null>> Use null to include both <a> and <map> tags
+     * @return \Iterator<(int | string), array<(bool | null)>> Use null to include both <a> and <map> tags
      */
-    public static function trackMapProvider(): array
+    public static function trackMapProvider(): \Iterator
     {
-        return [
-            [true],
-            [false],
-            [null],
-        ];
+        yield [true];
+        yield [false];
+        yield [null];
     }
 }

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -198,23 +198,21 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array<string>>
+     * @return \Iterator<string, array<string>>
      */
-    public static function xssPayloadsProvider(): array
+    public static function xssPayloadsProvider(): \Iterator
     {
-        return [
-            'option break with img onerror' => [
-                '</option><img src=x onerror="alert(1)">',
-                '<img src=x onerror="alert(1)">',
-            ],
-            'script tag'                    => [
-                '<script>alert(1)</script>',
-                '<script>alert(1)</script>',
-            ],
-            'quote escape with img onerror' => [
-                '"><img src=x onerror=alert(1)>',
-                '<img src=x onerror=alert(1)>',
-            ],
+        yield 'option break with img onerror' => [
+            '</option><img src=x onerror="alert(1)">',
+            '<img src=x onerror="alert(1)">',
+        ];
+        yield 'script tag' => [
+            '<script>alert(1)</script>',
+            '<script>alert(1)</script>',
+        ];
+        yield 'quote escape with img onerror' => [
+            '"><img src=x onerror=alert(1)>',
+            '<img src=x onerror=alert(1)>',
         ];
     }
 
@@ -306,14 +304,12 @@ final class AjaxControllerTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array<string>>
+     * @return \Iterator<string, array<string>>
      */
-    public static function specialCharacterProjectNamesProvider(): array
+    public static function specialCharacterProjectNamesProvider(): \Iterator
     {
-        return [
-            'ampersand'      => ['Project & Company'],
-            'double quotes'  => ['Client "ABC" Ltd'],
-            'single quotes'  => ["Q1 '26 Results"],
-        ];
+        yield 'ampersand' => ['Project & Company'];
+        yield 'double quotes' => ['Client "ABC" Ltd'];
+        yield 'single quotes' => ["Q1 '26 Results"];
     }
 }

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -423,27 +423,22 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<mixed>[]
+     * @return \Iterator<(int | string), array<mixed>>
      */
-    public static function scheduleProvider(): array
+    public static function scheduleProvider(): \Iterator
     {
-        return [
-            'null_to_now'      => [null, null, null, SchedulerEnum::UNIT_NOW, null, null],
-            'null_to_daily'    => [null, null, null, SchedulerEnum::UNIT_DAILY, null, null],
-            'null_to_weekly'   => [null, null, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null],
-            'null_to_monthly'  => [null, null, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_MO, SchedulerEnum::MONTH_FREQUENCY_FIRST],
-
-            'daily_to_weekly'  => [SchedulerEnum::UNIT_DAILY, null, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null],
-            'daily_to_monthly' => [SchedulerEnum::UNIT_DAILY, null, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_MO, '1'],
-
-            'weekly_to_daily'   => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null, SchedulerEnum::UNIT_DAILY, null, null],
-            'weekly_to_weekly'  => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_TU, null],
-            'weekly_to_monthly' => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_WE, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_TH, '-1'],
-
-            'monthly_to_daily'   => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '-1', SchedulerEnum::UNIT_DAILY, null, null],
-            'monthly_to_weekly'  => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '1', SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_SA, null],
-            'monthly_to_monthly' => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '1', SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_SU, '-1'],
-        ];
+        yield 'null_to_now' => [null, null, null, SchedulerEnum::UNIT_NOW, null, null];
+        yield 'null_to_daily' => [null, null, null, SchedulerEnum::UNIT_DAILY, null, null];
+        yield 'null_to_weekly' => [null, null, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null];
+        yield 'null_to_monthly' => [null, null, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_MO, SchedulerEnum::MONTH_FREQUENCY_FIRST];
+        yield 'daily_to_weekly' => [SchedulerEnum::UNIT_DAILY, null, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null];
+        yield 'daily_to_monthly' => [SchedulerEnum::UNIT_DAILY, null, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_MO, '1'];
+        yield 'weekly_to_daily' => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null, SchedulerEnum::UNIT_DAILY, null, null];
+        yield 'weekly_to_weekly' => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_MO, null, SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_TU, null];
+        yield 'weekly_to_monthly' => [SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_WE, null, SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_TH, '-1'];
+        yield 'monthly_to_daily' => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '-1', SchedulerEnum::UNIT_DAILY, null, null];
+        yield 'monthly_to_weekly' => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '1', SchedulerEnum::UNIT_WEEKLY, SchedulerEnum::DAY_SA, null];
+        yield 'monthly_to_monthly' => [SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_FR, '1', SchedulerEnum::UNIT_MONTHLY, SchedulerEnum::DAY_SU, '-1'];
     }
 
     public function testDescriptionIsNotEscaped(): void

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -423,7 +423,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return \Iterator<(int | string), array<mixed>>
+     * @return \Iterator<(int|string), array<mixed>>
      */
     public static function scheduleProvider(): \Iterator
     {

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -328,14 +328,12 @@ final class ReportGeneratorEventTest extends TestCase
     }
 
     /**
-     * @return array<mixed>
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function applyFilterProvider(): array
+    public static function applyFilterProvider(): \Iterator
     {
-        return [
-            [false, 't.a_date IS NULL OR (t.a_date BETWEEN :dateFrom AND :dateTo)', 'Y-m-d H:i:s'],
-            [true, 't.a_date IS NULL OR (DATE(t.a_date) BETWEEN :dateFrom AND :dateTo)', 'Y-m-d'],
-        ];
+        yield [false, 't.a_date IS NULL OR (t.a_date BETWEEN :dateFrom AND :dateTo)', 'Y-m-d H:i:s'];
+        yield [true, 't.a_date IS NULL OR (DATE(t.a_date) BETWEEN :dateFrom AND :dateTo)', 'Y-m-d'];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('applyFilterWithoutNullValuesProvider')]
@@ -380,13 +378,11 @@ final class ReportGeneratorEventTest extends TestCase
     }
 
     /**
-     * @return array<mixed>
+     * @return \Iterator<(int | string), mixed>
      */
-    public static function applyFilterWithoutNullValuesProvider(): array
+    public static function applyFilterWithoutNullValuesProvider(): \Iterator
     {
-        return [
-            [false, 't.a_date BETWEEN :dateFrom AND :dateTo', 'Y-m-d H:i:s'],
-            [true, 'DATE(t.a_date) BETWEEN :dateFrom AND :dateTo', 'Y-m-d'],
-        ];
+        yield [false, 't.a_date BETWEEN :dateFrom AND :dateTo', 'Y-m-d H:i:s'];
+        yield [true, 'DATE(t.a_date) BETWEEN :dateFrom AND :dateTo', 'Y-m-d'];
     }
 }

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -328,7 +328,7 @@ final class ReportGeneratorEventTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function applyFilterProvider(): \Iterator
     {
@@ -378,7 +378,7 @@ final class ReportGeneratorEventTest extends TestCase
     }
 
     /**
-     * @return \Iterator<(int | string), mixed>
+     * @return \Iterator<(int|string), mixed>
      */
     public static function applyFilterWithoutNullValuesProvider(): \Iterator
     {

--- a/app/bundles/SmsBundle/Tests/Functional/SmsTranslationFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsTranslationFunctionalTest.php
@@ -61,13 +61,11 @@ final class SmsTranslationFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{string, bool, string}>
+     * @return \Iterator<string, array{string, bool, string}>
      */
-    public static function smsTimelineStatusProvider(): array
+    public static function smsTimelineStatusProvider(): \Iterator
     {
-        return [
-            'sent'      => ['sent', false, 'Text Message Sent'],
-            'failed'    => ['failed', true, 'Text Message Failed'],
-        ];
+        yield 'sent' => ['sent', false, 'Text Message Sent'];
+        yield 'failed' => ['failed', true, 'Text Message Failed'];
     }
 }

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -260,21 +260,19 @@ final class UserApiControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @return array<string, array{userData: array<string, mixed>, expectedStatusCode: int}>
+     * @return \Iterator<string, array{userData: array<string, mixed>, expectedStatusCode: int}>
      */
-    public static function userCreateDataProvider(): array
+    public static function userCreateDataProvider(): \Iterator
     {
-        return [
-            'valid user with password' => [
-                'userData' => [
-                    'username'      => 'john',
-                    'plainPassword' => 'jjohn@123',
-                    'firstName'     => 'John',
-                    'lastName'      => 'Doe',
-                    'email'         => 'john.doe@email.com',
-                ],
-                'expectedStatusCode' => Response::HTTP_CREATED,
+        yield 'valid user with password' => [
+            'userData' => [
+                'username'      => 'john',
+                'plainPassword' => 'jjohn@123',
+                'firstName'     => 'John',
+                'lastName'      => 'Doe',
+                'email'         => 'john.doe@email.com',
             ],
+            'expectedStatusCode' => Response::HTTP_CREATED,
         ];
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -66,7 +66,6 @@ return RectorConfig::configure()
 
         // waits for descission
         Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
-        Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector::class,
 
         // fix in rector-dev
         Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector::class => [


### PR DESCRIPTION
This greatly improve readability and moficiation of data providers. It's no longer nested matrix array, but 1 line = 1 item. We can modify 6th line and add a variable above, instead of placing it in the very top and using later.

Let me know if it's a good fit to your style or not :+1: 

There is a Rector rule that automates this, so you can keep writing in the old way and let Rector handle it. No overhead work, no changes in `--filter test#name` run