### PR TITLE
Add return type to `configure()` in `Command` to avoid deprecation

### DIFF
--- a/app/bundles/CampaignBundle/Command/ExecuteEventCommand.php
+++ b/app/bundles/CampaignBundle/Command/ExecuteEventCommand.php
@@ -27,7 +27,7 @@ class ExecuteEventCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -70,7 +70,7 @@ class TriggerCampaignCommand extends ModeratedCommand
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
+++ b/app/bundles/CampaignBundle/Command/UpdateLeadCampaignsCommand.php
@@ -43,7 +43,7 @@ class UpdateLeadCampaignsCommand extends ModeratedCommand
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('--batch-limit', '-l', InputOption::VALUE_OPTIONAL, 'Set batch size of contacts to process per round. Defaults to 300.', 300)

--- a/app/bundles/CampaignBundle/Command/ValidateEventCommand.php
+++ b/app/bundles/CampaignBundle/Command/ValidateEventCommand.php
@@ -28,7 +28,7 @@ class ValidateEventCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
+++ b/app/bundles/ChannelBundle/Command/ProcessMarketingMessagesQueueCommand.php
@@ -31,7 +31,7 @@ class ProcessMarketingMessagesQueueCommand extends ModeratedCommand
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -33,7 +33,7 @@ class SendChannelBroadcastCommand extends ModeratedCommand
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setHelp(

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -33,7 +33,7 @@ class ApplyUpdatesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition(

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -24,7 +24,7 @@ class ConvertConfigCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([

--- a/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
@@ -25,7 +25,7 @@ class FindUpdatesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setHelp(<<<'EOT'

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -26,7 +26,7 @@ class InstallDataCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -31,7 +31,7 @@ class MaxMindDoNotSellPurgeCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -53,7 +53,7 @@ abstract class ModeratedCommand extends Command
     /**
      * Set moderation options.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('--bypass-locking', null, InputOption::VALUE_NONE, 'Bypass locking.')

--- a/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
@@ -22,7 +22,7 @@ class UpdateDoNotSellListCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setHelp(

--- a/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
@@ -26,7 +26,7 @@ class UpdateIpDataStoreCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setHelp(

--- a/app/bundles/CoreBundle/Tests/Unit/Command/src/FakeModeratedCommand.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/src/FakeModeratedCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Lock\LockInterface;
 
 class FakeModeratedCommand extends ModeratedCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('mautic:fake:command');
 

--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -29,7 +29,7 @@ class ProcessFetchEmailCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.')

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -38,7 +38,7 @@ class InstallCommand extends Command
     /**
      * Note: in every option (addOption()), please leave the default value empty to prevent problems with values from local.php being overwritten.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND)

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -32,7 +32,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -27,7 +27,7 @@ class FetchLeadsCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
+++ b/app/bundles/PluginBundle/Command/PushLeadActivityCommand.php
@@ -26,7 +26,7 @@ class PushLeadActivityCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/app/bundles/ReportBundle/Scheduler/Command/ExportSchedulerCommand.php
+++ b/app/bundles/ReportBundle/Scheduler/Command/ExportSchedulerCommand.php
@@ -27,7 +27,7 @@ class ExportSchedulerCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption('--report', 'report', InputOption::VALUE_OPTIONAL, 'ID of report. Process all reports if not set.');
         $this->addOption('--cleanup-only', 'co', InputOption::VALUE_NONE, 'Only cleanup old files without processing new export.');

--- a/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
+++ b/app/bundles/WebhookBundle/Command/ProcessWebhookQueuesCommand.php
@@ -31,7 +31,7 @@ class ProcessWebhookQueuesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption(
             '--webhook-id',

--- a/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
+++ b/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
@@ -22,7 +22,7 @@ class MauticSocialMonitoringCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('mid', 'i', InputOption::VALUE_OPTIONAL, 'The id of a specific monitor record to process')

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -63,7 +63,7 @@ abstract class MonitorTwitterBaseCommand extends Command
     /**
      * Command configuration. Set the name, description, and options here.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Sometimes this function is declared with typed return value, sometimes not, this trigger a deprecation

Add return type to all usages to avoid those deprecations