### PR TITLE
Bumping the Guzzle library to latest

### DIFF
--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/ApiKey/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/ApiKey/HttpFactoryTest.php
@@ -126,7 +126,7 @@ final class HttpFactoryTest extends TestCase
 
         try {
             // Triggering an exception so we can extract the request
-            $client->request('get', 'foobar');
+            $client->request('get', 'http://foobar.invalid/test');
         } catch (ConnectException $exception) {
             $query = $exception->getRequest()->getUri()->getQuery();
             $this->assertEquals('abc=123', $query);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/BasicAuth/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/BasicAuth/HttpFactoryTest.php
@@ -111,7 +111,7 @@ final class HttpFactoryTest extends TestCase
 
         try {
             // Triggering an exception so we can extract the request
-            $client->request('get', 'foobar');
+            $client->request('get', 'http://foobar.invalid/test');
         } catch (ConnectException $exception) {
             $headers = $exception->getRequest()->getHeaders();
             $this->assertArrayHasKey('Authorization', $headers);

--- a/app/composer.json
+++ b/app/composer.json
@@ -43,7 +43,7 @@
     "gaufrette/extras": "^0.1.0",
     "geoip2/geoip2": "~2.0",
     "giggsey/libphonenumber-for-php": "^8.12",
-    "guzzlehttp/guzzle": "~7.10.0",
+    "guzzlehttp/guzzle": "~7.14.0",
     "guzzlehttp/oauth-subscriber": "^0.8.1",
     "helios-ag/fm-elfinder-bundle": "^13.0",
     "illuminate/collections": "^10.48",

--- a/composer.lock
+++ b/composer.lock
@@ -3561,25 +3561,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -3587,9 +3588,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -3667,7 +3669,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.1"
             },
             "funding": [
                 {
@@ -3683,7 +3685,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-13T01:32:54+00:00"
         },
         {
             "name": "guzzlehttp/oauth-subscriber",
@@ -3776,24 +3778,25 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -3839,7 +3842,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -3855,20 +3858,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.1",
+            "version": "2.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
                 "shasum": ""
             },
             "require": {
@@ -3877,7 +3880,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -3958,7 +3961,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
             },
             "funding": [
                 {
@@ -3974,7 +3977,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T09:49:37+00:00"
+            "time": "2026-07-13T01:27:20+00:00"
         },
         {
             "name": "helios-ag/fm-elfinder-bundle",
@@ -6188,7 +6191,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "3b5b8367a891299d526dc785848ff5a20fc01865"
+                "reference": "8ead463e990895fb726930fb648ac19b3394566c"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6216,7 +6219,7 @@
                 "gaufrette/extras": "^0.1.0",
                 "geoip2/geoip2": "~2.0",
                 "giggsey/libphonenumber-for-php": "^8.12",
-                "guzzlehttp/guzzle": "~7.10.0",
+                "guzzlehttp/guzzle": "~7.14.0",
                 "guzzlehttp/oauth-subscriber": "^0.8.1",
                 "helios-ag/fm-elfinder-bundle": "^13.0",
                 "illuminate/collections": "^10.48",


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

Bumping the `guzzlehttp/guzzle` library to the latest as the current version has vulnerabilities reported.

```
composer update guzzlehttp/guzzle --with-all-dependenc
ies
Gathering patches for root package.
Loading composer repositories with package information
Updating dependencies                                 
Lock file operations: 0 installs, 4 updates, 0 removals
  - Upgrading guzzlehttp/guzzle (7.10.0 => 7.14.1)
  - Upgrading guzzlehttp/promises (2.3.0 => 2.5.1)
  - Upgrading guzzlehttp/psr7 (2.12.1 => 2.12.5)
  - Upgrading mautic/core-lib (7.0.0-dev 3b5b836 => 7.0.0-dev 8ead463)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 4 updates, 0 removals
  - Downloading guzzlehttp/psr7 (2.12.5)
  - Downloading guzzlehttp/promises (2.5.1)
  - Downloading guzzlehttp/guzzle (7.14.1)
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Upgrading guzzlehttp/psr7 (2.12.1 => 2.12.5): Extracting archive
  - Upgrading guzzlehttp/promises (2.3.0 => 2.5.1): Extracting archive
  - Upgrading guzzlehttp/guzzle (7.10.0 => 7.14.1): Extracting archive
  - Upgrading mautic/core-lib (7.0.0-dev 3b5b836 => 7.0.0-dev 8ead463): Source already present
```

### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. CI checks should be enough.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->