### PR TITLE
Add return type to `getFilters()` from Twig

### DIFF
--- a/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
@@ -16,7 +16,7 @@ class FormatterExtension extends AbstractExtension
     ) {
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('formatter_simple_array_to_html', $this->simpleArrayToHtml(...), ['is_safe' => ['html']]),

--- a/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
@@ -15,7 +15,7 @@ class LanguageExtension extends AbstractExtension
     ) {
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('language_name', $this->getLanguageName(...)),

--- a/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
@@ -17,7 +17,7 @@ class NumericExtension extends AbstractExtension
         ];
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('int', fn ($value): int => (int) $value),

--- a/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
@@ -9,7 +9,7 @@ use Twig\TwigFilter;
 
 final class PurifyExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('purify_allow_target_blank', $this->purifyAllowTargetBlank(...), ['is_safe' => ['html']]),

--- a/app/bundles/InstallBundle/Twig/TwigExtension.php
+++ b/app/bundles/InstallBundle/Twig/TwigExtension.php
@@ -15,7 +15,7 @@ class TwigExtension extends AbstractExtension
      *
      * @return mixed[]
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('phpversion', $this->phpversion(...)),


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Sometimes this function is declared with typed return value, sometimes not, this trigger a deprecation

Add return type to all usages to avoid those deprecations