### PR TITLE
Add return type to `getTests()` from Twig

### DIFF
--- a/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigTest;
 
 class NumericExtension extends AbstractExtension
 {
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest('numeric', fn ($value): bool => !is_array($value) && is_numeric($value)),

--- a/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
@@ -17,7 +17,7 @@ class ObjectExtension extends AbstractExtension
         ];
     }
 
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest('object', fn ($value): bool => is_object($value)),


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Sometimes this function is declared with typed return value, sometimes not, this trigger a deprecation

Add return type to all usages to avoid those deprecations