### PR TITLE
Add return type to `getOrder()` from Doctrine

### DIFF
--- a/app/bundles/CampaignBundle/DataFixtures/ORM/CampaignData.php
+++ b/app/bundles/CampaignBundle/DataFixtures/ORM/CampaignData.php
@@ -44,10 +44,7 @@ class CampaignData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 0;
     }

--- a/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
+++ b/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
@@ -41,10 +41,7 @@ class LoadEmailData extends AbstractFixture implements OrderedFixtureInterface
         }
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 9;
     }

--- a/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
+++ b/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
@@ -61,7 +61,7 @@ class LoadFormResultData extends AbstractFixture implements OrderedFixtureInterf
         $importResults($results2);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 9;
     }

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -64,7 +64,7 @@ class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, 
         }
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LoadReportData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LoadReportData.php
@@ -40,7 +40,7 @@ class LoadReportData extends AbstractFixture implements OrderedFixtureInterface,
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/RoleData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/RoleData.php
@@ -37,7 +37,7 @@ class RoleData extends AbstractFixture implements OrderedFixtureInterface, Fixtu
         $this->addReference('admin-role', $role);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
@@ -32,10 +32,7 @@ class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface
         }
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 4;
     }

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
@@ -62,10 +62,7 @@ class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface
         }
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadListData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadListData.php
@@ -43,10 +43,7 @@ class LoadLeadListData extends AbstractFixture implements OrderedFixtureInterfac
         $this->segmentModel->rebuildListLeads($list);
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadClickData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadClickData.php
@@ -126,10 +126,7 @@ class LoadClickData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 6;
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadDncData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadDncData.php
@@ -23,10 +23,7 @@ class LoadDncData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 8;
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadPageHitData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadPageHitData.php
@@ -104,10 +104,7 @@ class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 6;
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadSegmentsData.php
@@ -1101,10 +1101,7 @@ class LoadSegmentsData extends AbstractFixture implements OrderedFixtureInterfac
         }
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 7;
     }

--- a/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadTagData.php
+++ b/app/bundles/LeadBundle/Tests/DataFixtures/ORM/LoadTagData.php
@@ -31,10 +31,7 @@ class LoadTagData extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    /**
-     * @return int
-     */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 8;
     }

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
@@ -30,7 +30,7 @@ class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInte
         $this->setReference('page-cat-1', $cat);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 6;
     }

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
@@ -45,7 +45,7 @@ class LoadPageData extends AbstractFixture implements OrderedFixtureInterface
         }
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 7;
     }

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
@@ -42,7 +42,7 @@ class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
         }
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 8;
     }

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadRoleData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadRoleData.php
@@ -51,7 +51,7 @@ class LoadRoleData extends AbstractFixture implements OrderedFixtureInterface, F
         $this->addReference('sales-role', $role);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -48,7 +48,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
         $this->addReference('sales-user', $user);
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 2;
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

In most case the return type was in a phpdoc, sometimes not, this trigger a deprecation

Add native return type to all usages to avoid those deprecations & being stricter than phpdoc