### PR TITLE
Add `vote` parameter to `voteOnAttribute`

### DIFF
--- a/app/bundles/ApiBundle/Security/Voter/ApiPermissionVoter.php
+++ b/app/bundles/ApiBundle/Security/Voter/ApiPermissionVoter.php
@@ -4,6 +4,7 @@ namespace Mautic\ApiBundle\Security\Voter;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -20,7 +21,7 @@ class ApiPermissionVoter extends Voter
         return str_contains($attribute, ':');
     }
 
-    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         $user = $token->getUser();
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Starting from Symfony 7.2, the function `voteOnAttribute` got a new `$vote` parameter.
This parameter is nullable, it should be safe to add it as `null` to remove deprecation