### PR TITLE
Add return type to `getSubscribedEvents`

### DIFF
--- a/app/bundles/ApiBundle/ApiPlatform/EventListener/MauticWriteSubscriber.php
+++ b/app/bundles/ApiBundle/ApiPlatform/EventListener/MauticWriteSubscriber.php
@@ -20,7 +20,7 @@ final readonly class MauticWriteSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::VIEW => ['addData', EventPriorities::PRE_WRITE],

--- a/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticWriteSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticWriteSubscriberTest.php
@@ -46,7 +46,7 @@ final class MauticWriteSubscriberTest extends TestCase
         $expected = [
             'kernel.view'=> ['addData', EventPriorities::PRE_WRITE],
         ];
-        $this->assertEquals($expected, MauticWriteSubscriber::getSubscribedEvents());
+        $this->assertSame($expected, MauticWriteSubscriber::getSubscribedEvents());
     }
 
     public function testAddDataWithWrongMethod(): void


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ 
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ 
| Related user documentation PR URL      | 
| Related developer documentation PR URL |
| Issue(s) addressed                     | 

## Description

Add native return type to avoid deprecation 