### PR TITLE
[rector] Apply getModel('...') migration to last place :checkered_flag: 

### DIFF
--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -52,7 +52,6 @@ class EventController extends CommonFormController
         private readonly CampaignModel $campaignModel,
         private readonly \Mautic\CampaignBundle\Model\EventModel $eventModel,
     ) {
-        // @phpstan-ignore-next-line Ignore as AbstractStandardFormController is deprecated
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
@@ -446,7 +446,6 @@ final class LegacyEventDispatcherTest extends TestCase
      */
     private function getLegacyEventDispatcher(): LegacyEventDispatcher
     {
-        /** @phpstan-ignore new.deprecated */
         return new LegacyEventDispatcher(
             $this->dispatcher,
             $this->scheduler,

--- a/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
@@ -67,7 +67,6 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
             'eventSettings'   => [],
         ];
 
-        /** @phpstan-ignore new.deprecated */
         $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false);
 
         $this->campaignSubscriber->onCampaignTriggerCondition($campaignExecutionEvent);

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -87,7 +87,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $scheduler = $this->createMock(EventScheduler::class);
 
-        /** @phpstan-ignore new.deprecated */
         $legacyDispatcher = new LegacyEventDispatcher(
             $this->dispatcher,
             $scheduler,

--- a/app/bundles/ConfigBundle/Controller/SysinfoController.php
+++ b/app/bundles/ConfigBundle/Controller/SysinfoController.php
@@ -32,7 +32,6 @@ class SysinfoController extends FormController
         RequestStack $requestStack,
         CorePermissions $security,
     ) {
-        // @phpstan-ignore-next-line Ignore as AbstractStandardFormController is deprecated
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
+use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
@@ -26,10 +27,20 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractStandardFormController extends AbstractFormController
 {
     use FormErrorMessagesTrait;
+
+    private AuditLogModel $auditLogModel;
+
+    #[Required]
+    public function autowireAbstractFormController(
+        AuditLogModel $auditLogModel,
+    ) {
+        $this->auditLogModel = $auditLogModel;
+    }
 
     public function __construct(
         protected FormFactoryInterface $formFactory,
@@ -1080,7 +1091,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $this->setListFilters();
 
         // Audit log entries
-        $logs = ($logObject) ? $this->getModel('core.auditlog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
+        $logs = ($logObject) ? $this->auditLogModel->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
 
         // Generate route
         $routeVars = [

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -38,7 +38,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     #[Required]
     public function autowireAbstractFormController(
         AuditLogModel $auditLogModel,
-    ) {
+    ): void {
         $this->auditLogModel = $auditLogModel;
     }
 

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -48,7 +48,6 @@ class FieldController extends CommonFormController
         $this->fieldHelper                 = $fieldHelper;
         $this->formFactory                 = $formFactory;
 
-        // @phpstan-ignore-next-line FormController extends deprecated AbstractStandardFormController; fix requires class hierarchy refactoring
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -50,7 +50,6 @@ class FormController extends CommonFormController
         private readonly \Mautic\CoreBundle\Model\AuditLogModel $auditLogModel,
         private readonly SubmissionModel $submissionModel,
     ) {
-        // @phpstan-ignore-next-line FormController extends deprecated AbstractStandardFormController; fix requires class hierarchy refactoring
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -58,7 +58,6 @@ class ResultController extends CommonFormController
             'formresult' // mauticContent
         );
 
-        // @phpstan-ignore-next-line FormController extends deprecated AbstractStandardFormController; fix requires class hierarchy refactoring
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -103,7 +103,6 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->detach($campaign);
 
         $contact = $this->em->getRepository(Lead::class)->findOneBy(['email' => 'testing@ampersand.select']);
-        // @phpstan-ignore new.deprecated
         $event   = new CampaignExecutionEvent(
             [
                 'lead'            => $contact,

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -67,7 +67,6 @@ class ImportController extends FormController
         CorePermissions $security,
         private readonly ImportModel $importModel,
     ) {
-        // @phpstan-ignore-next-line FormController extends deprecated AbstractStandardFormController; fix requires class hierarchy refactoring
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -259,7 +259,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         foreach ($contacts as $contact) {
             $args['lead'] = $this->contactRepository->getEntity($contact->getId());
 
-            $event      = new CampaignExecutionEvent($args, true); // @phpstan-ignore new.deprecated
+            $event      = new CampaignExecutionEvent($args, true);
             $dispatcher = static::getContainer()->get('event_dispatcher');
             $result     = $dispatcher->dispatch(
                 $event,
@@ -1056,7 +1056,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
             'eventSettings'   => [],
         ];
 
-        $event           = new CampaignExecutionEvent($args, false, $log); // @phpstan-ignore new.deprecated
+        $event           = new CampaignExecutionEvent($args, false, $log);
         $eventDispatcher = static::getContainer()->get('event_dispatcher');
         $eventDispatcher->dispatch($event, 'mautic.lead.on_campaign_trigger_action');
 

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -230,7 +230,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        // @phpstan-ignore new.deprecated
         $event = new CampaignExecutionEvent($args, true);
         $this->subscriber->onCampaignTriggerActionUpdateCompany($event);
         $this->assertTrue($event->getResult());
@@ -268,7 +267,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        // @phpstan-ignore new.deprecated
         $event = new CampaignExecutionEvent($args, true);
         $this->subscriber->onCampaignTriggerCondition($event);
         $this->assertSame($expected, $event->getResult());
@@ -312,7 +310,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        // @phpstan-ignore new.deprecated
         $event = new CampaignExecutionEvent($args, true);
         $this->subscriber->onCampaignTriggerCondition($event);
         $this->assertTrue($event->getResult());
@@ -357,7 +354,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        // @phpstan-ignore new.deprecated
         $event = new CampaignExecutionEvent($args, true);
         $this->subscriber->onCampaignTriggerCondition($event);
         $this->assertTrue($event->getResult());
@@ -402,7 +398,6 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             'eventSettings'   => [],
         ];
 
-        // @phpstan-ignore new.deprecated
         $event = new CampaignExecutionEvent($args, true);
         $this->subscriber->onCampaignTriggerCondition($event);
         $this->assertTrue($event->getResult());

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -82,7 +82,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
             'eventSettings'   => [],
         ];
 
-        $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false); // @phpstan-ignore new.deprecated
+        $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false);
 
         $this->campaignSubscriber->onCampaignTriggerCondition($campaignExecutionEvent);
         $this->assertTrue($campaignExecutionEvent->getResult());
@@ -145,7 +145,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
             'eventSettings'   => [],
         ];
 
-        $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false); // @phpstan-ignore new.deprecated
+        $campaignExecutionEvent = new CampaignExecutionEvent($eventProperties, false);
 
         $this->campaignSubscriber->onCampaignTriggerCondition($campaignExecutionEvent);
         $this->assertInstanceOf(CampaignExecutionEvent::class, $campaignExecutionEvent); // @phpstan-ignore classConstant.deprecatedClass

--- a/app/bundles/WebhookBundle/Controller/WebhookController.php
+++ b/app/bundles/WebhookBundle/Controller/WebhookController.php
@@ -31,7 +31,6 @@ class WebhookController extends FormController
             'mauticWebhook' // mauticContent
         );
 
-        // @phpstan-ignore-next-line FormController extends deprecated AbstractStandardFormController; fix requires class hierarchy refactoring
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
 

--- a/app/migrations/Version20211209022550.php
+++ b/app/migrations/Version20211209022550.php
@@ -7,7 +7,6 @@ namespace Mautic\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Model\RoleModel;
@@ -16,11 +15,10 @@ final class Version20211209022550 extends AbstractMauticMigration
 {
     public function postUp(Schema $schema): void
     {
-        /** @var RoleModel $model */
-        $model = $this->container->get(ModelFactory::class)->getModel('user.role');
+        $roleModel = $this->container->get(RoleModel::class);
 
         // Get all non admin roles.
-        $roles = $model->getEntities([
+        $roles = $roleModel->getEntities([
             'orderBy'       => 'r.id',
             'orderByDir'    => 'ASC',
             'filter'        => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4822,18 +4822,6 @@ parameters:
 			path: app/bundles/FormBundle/Controller/Api/FormApiController.php
 
 		-
-			message: '#^Access to an undefined property Mautic\\FormBundle\\Controller\\Api\\SubmissionApiController\:\:\$formModel\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
-
-		-
-			message: '#^Constructor of class Mautic\\FormBundle\\Controller\\Api\\SubmissionApiController has an unused parameter \$formModel\.$#'
-			identifier: constructor.unusedParameter
-			count: 1
-			path: app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
-
-		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 parameters:
 	tmpDir: ./var/phpstan-cache
 	level: 6
-	#reportUnmatchedIgnoredErrors: false
+	reportUnmatchedIgnoredErrors: false
 	treatPhpDocTypesAsCertain: false
 	parallel:
 		processTimeout: 1000.0
@@ -36,11 +36,6 @@ parameters:
 	bootstrapFiles:
 		- phpstan-bootstrap.php
 	ignoreErrors:
-        # optional child method access
-		-
-			identifier: '#Call to an undefined method Mautic\\CoreBundle\\Controller\\AbstractFormController::getPermissionBase\(\)#'
-			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
-
 		- identifier: missingType.generics
 		# controllers - group missing parameter types to fix later
 		-
@@ -147,9 +142,6 @@ parameters:
 			message: '#class\s+Mautic#'
 		-
 			identifier: class.extendsDeprecatedClass
-			message: '#class\s+Mautic#'
-		-
-			identifier: staticMethod.deprecatedClass
 			message: '#class\s+Mautic#'
 		-
 			identifier: method.deprecatedClass

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 parameters:
 	tmpDir: ./var/phpstan-cache
 	level: 6
-	reportUnmatchedIgnoredErrors: false
+	#reportUnmatchedIgnoredErrors: false
 	treatPhpDocTypesAsCertain: false
 	parallel:
 		processTimeout: 1000.0

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1600,7 +1600,6 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                         ++$updated;
                     }
                 } else {
-                    // @phpstan-ignore-next-line $item is mixed from untyped $response array; structure is guaranteed by SugarCRM API
                     $error = 'Unknown status code '.$item['httpStatusCode'];
                     // @phpstan-ignore-next-line $item is mixed from untyped $response array; structure is guaranteed by SugarCRM API
                     $this->logIntegrationError(new \Exception($error.' ('.$item['reference_id'].')'));

--- a/utils/phpstan/src/Rule/NoGetModelWithStringInControllerRule.php
+++ b/utils/phpstan/src/Rule/NoGetModelWithStringInControllerRule.php
@@ -81,6 +81,7 @@ final class NoGetModelWithStringInControllerRule implements Rule
             $firstArg->value->value
         ))
             ->identifier('mautic.noGetModelWithStringInController')
+            ->nonIgnorable()
             ->build();
 
         return [$ruleError];

--- a/utils/phpstan/src/Rule/NoRequiredMethodWithConstructorInControllerRule.php
+++ b/utils/phpstan/src/Rule/NoRequiredMethodWithConstructorInControllerRule.php
@@ -83,6 +83,7 @@ final class NoRequiredMethodWithConstructorInControllerRule implements Rule
             ))
                 ->identifier('mautic.noRequiredMethodWithConstructorInController')
                 ->line($classMethod->getStartLine())
+                ->nonIgnorable()
                 ->build();
         }
 


### PR DESCRIPTION
Ref: https://github.com/mautic/mautic/pull/16582

Adds a configurable rule turning a `ModelFactory` lookup by string alias into a typed dependency.
