### PR TITLE
fix: preserve fractional contact API values

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -191,7 +191,7 @@ trait CustomFieldsApiControllerTrait
                 $parameters,
                 function ($value): bool {
                     if (is_numeric($value)) {
-                        return 0 !== (int) $value;
+                        return 0.0 !== (float) $value;
                     }
 
                     return true;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\LeadBundle\Controller\Api\CustomFieldsApiControllerTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\FieldModel;
+use Symfony\Component\Form\Form;
 
 final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCase
 {
@@ -67,7 +68,7 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
     #[\PHPUnit\Framework\Attributes\DataProvider('numericValueProvider')]
     public function testSetCustomFieldValuesFiltersOnlyNumericZero(mixed $value, array $expectedParameters): void
     {
-        $model = new class {
+        $model = new class() {
             /**
              * @var array<string, mixed>
              */
@@ -85,20 +86,27 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
         $controller = new class($model) {
             use CustomFieldsApiControllerTrait;
 
+            private string $entityNameOne = 'lead';
+
             public function __construct(private object $model)
             {
+            }
+
+            public function getModel(?string $name): object
+            {
+                return $this->model;
             }
 
             /**
              * @param array<string, mixed> $parameters
              */
-            public function setCustomFieldValuesPublic(Lead $lead, array $parameters): void
+            public function setCustomFieldValuesPublic(Lead $lead, Form $form, array $parameters): void
             {
-                $this->setCustomFieldValues($lead, new \ArrayIterator(), $parameters, true);
+                $this->setCustomFieldValues($lead, $form, $parameters, true);
             }
         };
 
-        $controller->setCustomFieldValuesPublic(new Lead(), ['number_field' => $value]);
+        $controller->setCustomFieldValuesPublic(new Lead(), $this->createMock(Form::class), ['number_field' => $value]);
 
         self::assertSame($expectedParameters, $model->parameters);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\LeadBundle\Controller\Api\CustomFieldsApiControllerTrait;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\FieldModel;
 
 final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCase
@@ -58,5 +59,63 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
 
         $this->assertSame($result, (array) $controller->getEntityFormOptionsPublic()['fields']); // Calling once, should be live
         $this->assertSame($result, (array) $controller->getEntityFormOptionsPublic()['fields']); // Calling twice, should be cached
+    }
+
+    /**
+     * @param array<string, mixed> $expectedParameters
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('numericValueProvider')]
+    public function testSetCustomFieldValuesFiltersOnlyNumericZero(mixed $value, array $expectedParameters): void
+    {
+        $model = new class {
+            /**
+             * @var array<string, mixed>
+             */
+            public array $parameters = [];
+
+            /**
+             * @param array<string, mixed> $parameters
+             */
+            public function setFieldValues(Lead $lead, array $parameters, bool $overwriteWithBlank): void
+            {
+                $this->parameters = $parameters;
+            }
+        };
+
+        $controller = new class($model) {
+            use CustomFieldsApiControllerTrait;
+
+            public function __construct(private object $model)
+            {
+            }
+
+            /**
+             * @param array<string, mixed> $parameters
+             */
+            public function setCustomFieldValuesPublic(Lead $lead, array $parameters): void
+            {
+                $this->setCustomFieldValues($lead, new \ArrayIterator(), $parameters, true);
+            }
+        };
+
+        $controller->setCustomFieldValuesPublic(new Lead(), ['number_field' => $value]);
+
+        self::assertSame($expectedParameters, $model->parameters);
+    }
+
+    /**
+     * @return \Generator<string, array{mixed, array<string, mixed>}>
+     */
+    public static function numericValueProvider(): \Generator
+    {
+        yield 'positive fraction' => [0.5, ['number_field' => 0.5]];
+        yield 'positive fraction string' => ['0.5', ['number_field' => '0.5']];
+        yield 'negative fraction' => [-0.5, ['number_field' => -0.5]];
+        yield 'integer' => [5, ['number_field' => 5]];
+        yield 'integer string' => ['5', ['number_field' => '5']];
+        yield 'integer zero' => [0, []];
+        yield 'float zero' => [0.0, []];
+        yield 'zero string' => ['0', []];
+        yield 'decimal zero string' => ['0.00', []];
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -106,9 +106,9 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
             }
         };
 
-        $controller->setCustomFieldValuesPublic(new Lead(), $this->createMock(Form::class), ['number_field' => $value]);
+        $controller->setCustomFieldValuesPublic(new Lead(), $this->createStub(Form::class), ['number_field' => $value]);
 
-        self::assertSame($expectedParameters, $model->parameters);
+        $this->assertSame($expectedParameters, $model->parameters);
     }
 
     /**


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ (`7.1` is closed, so this targets `7.x`)
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16590

## Description

Contact API `POST` and `PATCH` requests filter numeric zero values before updating custom fields. The filter cast every numeric value to an integer, causing valid fractional values between `-1` and `1`, such as `0.5` and `-0.5`, to be truncated to zero and silently discarded.

This change compares numeric values as floats instead. Actual zero representations continue to be filtered, preserving the existing contact merge behavior, while non-zero fractions reach `LeadModel::setFieldValues()`.

The regression test covers:

- positive and negative fractional values
- numeric strings
- integer values
- integer, float, and string zero representations

---

### 📋 Steps to test this PR:

1. Create a decimal number contact field, for example `last_order_value`.
2. Create or select a contact.
3. Send a `PATCH` request to `/api/contacts/{id}/edit` with `"last_order_value": 0.5`.
4. Fetch the contact and verify that `last_order_value` is now `0.5`.
5. Repeat with `-0.5` and verify that the negative fraction is also saved.
6. Run:

```shell
ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
```

Expected result: all tests pass.
