### PR TITLE
Fix selected email variant in the A/B Testing dropdown url change

### DIFF
--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -32,6 +33,7 @@ class ContentPreviewSettingsType extends AbstractType
         private readonly TranslatorInterface $translator,
         private readonly CorePermissions $security,
         private readonly UserHelper $userHelper,
+        private readonly UrlGeneratorInterface $router,
     ) {
     }
 
@@ -40,9 +42,10 @@ class ContentPreviewSettingsType extends AbstractType
         $objectId     = $options['objectId'];
         $translations = $options['translations'];
         $variants     = $options['variants'];
+        $actionRoute  = $options['actionRoute'] ?? '';
 
-        $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_TRANSLATION, $translations, $objectId);
-        $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_VARIANT, $variants, $objectId);
+        $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_TRANSLATION, $translations, $objectId, $actionRoute);
+        $this->addTranslationOrVariantChoicesElement($builder, self::CHOICE_TYPE_VARIANT, $variants, $objectId, $actionRoute);
 
         if ($this->security->isAdmin()
             || $this->security->hasEntityAccess(
@@ -80,6 +83,7 @@ class ContentPreviewSettingsType extends AbstractType
                 'objectId'     => null,
                 'translations' => null,
                 'variants'     => null,
+                'actionRoute'  => null,
             ]
         );
 
@@ -96,6 +100,7 @@ class ContentPreviewSettingsType extends AbstractType
         string $type,
         array $variants,
         int $objectId,
+        string $actionRoute,
     ): void {
         if (!count($variants['children'])) {
             return;
@@ -115,13 +120,22 @@ class ContentPreviewSettingsType extends AbstractType
             $variantChoices[$this->addOrderNoToChoiceName($child, $type)] = $child->getId();
         }
 
+        if (self::CHOICE_TYPE_VARIANT === $type && '' !== $actionRoute) {
+            $onChange = sprintf(
+                "if(this.value){window.location='%s'.replace('__ID__', this.value);}",
+                $this->router->generate($actionRoute, ['objectAction' => 'view', 'objectId' => '__ID__'])
+            );
+        } else {
+            $onChange = "Mautic.contentPreviewUrlGenerator.regenerateUrl({$objectId}, this)";
+        }
+
         $builder->add(
             $type,
             ChoiceType::class,
             [
                 'choices' => $variantChoices,
                 'attr'    => [
-                    'onChange' => "Mautic.contentPreviewUrlGenerator.regenerateUrl({$objectId}, this)",
+                    'onChange' => $onChange,
                 ],
                 'placeholder'  => $this->translator->trans('mautic.core.form.chooseone'),
                 'data'         => (string) $objectId,

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -407,7 +407,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                 throw new \PHPUnit\Framework\Exception(sprintf('Method not be called for %dth time', $matcher->numberOfInvocations()));
             });
 
-        $this->routerMock->expects(self::once())
+        $this->routerMock->expects($this->once())
             ->method('generate')
             ->with('mautic_email_action', ['objectAction' => 'view', 'objectId' => '__ID__'])
             ->willReturn('/s/email/view/__ID__');
@@ -431,7 +431,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                 if (2 === $matcher->numberOfInvocations()) {
                     $this->assertSame('variant', $parameters[0]);
                     $this->assertSame(ChoiceType::class, $parameters[1]);
-                    self::assertSame([
+                    $this->assertSame([
                         'choices' => $expectedVariantChoices,
                         'attr'    => [
                             'onChange' => "if(this.value){window.location='/s/email/view/__ID__'.replace('__ID__', this.value);}",

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ContentPreviewSettingsTypeTest extends TestCase
@@ -35,6 +36,11 @@ final class ContentPreviewSettingsTypeTest extends TestCase
      * @var MockObject&UserHelper
      */
     private MockObject $userHelperMock;
+
+    /**
+     * @var UrlGeneratorInterface&MockObject
+     */
+    private MockObject $routerMock;
 
     /**
      * @var mixed[]
@@ -60,7 +66,8 @@ final class ContentPreviewSettingsTypeTest extends TestCase
         $this->translator     = $this->createMock(TranslatorInterface::class);
         $this->security       = $this->createMock(CorePermissions::class);
         $this->userHelperMock = $this->createMock(UserHelper::class);
-        $this->form           = new ContentPreviewSettingsType($this->translator, $this->security, $this->userHelperMock);
+        $this->routerMock     = $this->createMock(UrlGeneratorInterface::class);
+        $this->form           = new ContentPreviewSettingsType($this->translator, $this->security, $this->userHelperMock, $this->routerMock);
 
         parent::setUp();
     }
@@ -76,6 +83,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                     'objectId'     => null,
                     'translations' => null,
                     'variants'     => null,
+                    'actionRoute'  => null,
                 ]
             );
 
@@ -349,6 +357,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
 
         $formOptions = [
             'objectId'      => $parentEmailId,
+            'actionRoute'   => 'mautic_email_action',
             'translations'  => [
                 'parent'   => $parentEmail,
                 'children' => [
@@ -398,6 +407,11 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                 throw new \PHPUnit\Framework\Exception(sprintf('Method not be called for %dth time', $matcher->numberOfInvocations()));
             });
 
+        $this->routerMock->expects(self::once())
+            ->method('generate')
+            ->with('mautic_email_action', ['objectAction' => 'view', 'objectId' => '__ID__'])
+            ->willReturn('/s/email/view/__ID__');
+
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $matcher     = $this->exactly(3);
         $formBuilder->expects($matcher)
@@ -417,10 +431,10 @@ final class ContentPreviewSettingsTypeTest extends TestCase
                 if (2 === $matcher->numberOfInvocations()) {
                     $this->assertSame('variant', $parameters[0]);
                     $this->assertSame(ChoiceType::class, $parameters[1]);
-                    $this->assertSame([
+                    self::assertSame([
                         'choices' => $expectedVariantChoices,
                         'attr'    => [
-                            'onChange' => "Mautic.contentPreviewUrlGenerator.regenerateUrl({$parentEmailId}, this)",
+                            'onChange' => "if(this.value){window.location='/s/email/view/__ID__'.replace('__ID__', this.value);}",
                         ],
                         'placeholder'  => 'chooseone',
                         'data'         => (string) $parentEmailId,

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -466,6 +466,7 @@ class EmailController extends FormController
                             'objectId'     => $email->getId(),
                             'variants'     => $variants,
                             'translations' => $translations,
+                            'actionRoute'  => 'mautic_email_action',
                         ]
                     )->createView(),
                 ],

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -346,6 +346,7 @@ class PageController extends FormController
                         'objectId'     => $activePage->getId(),
                         'variants'     => $variants,
                         'translations' => $translations,
+                        'actionRoute'  => 'mautic_page_action',
                     ]
                 )->createView(),
             ],


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #16557 

## Description

The selected email variant in the A/B Testing dropdown is not updating the page state before the Edit button is used.

Current behaviour

Open A/B Test emails.
Email A is loaded.
Select Email B from the dropdown.
Click Edit.
It still opens Email A.
If you manually change the URL to Email B's ID and reload, then Edit correctly opens Email B.

This indicates that the dropdown is only changing the visible selection, but the page is still using Email A's ID internally until a full page reload.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create segment email using some template
3. save & close
4. In email detail view click on create a/b test
5. Create variant B with different template
6. save & close
7. click on 2 variants in email detail page and the preview changes
8. Email builder is showing correct template
