### PR TITLE
[model] fix PHP fatal from colliding autowire() methods

### DIFF
--- a/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
@@ -21,14 +21,14 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         /** @var FormModel $formModel */
         $formModel = static::getContainer()->get('mautic.form.model.form');
         $form      = $formModel->getEntity($formId);
-        self::assertInstanceOf(Form::class, $form);
+        $this->assertInstanceOf(Form::class, $form);
 
         $html = $formModel->generateHtml($form, false);
-        self::assertStringContainsString('mauticform-honeypot', $html);
+        $this->assertStringContainsString('mauticform-honeypot', $html);
 
         $honeypotRow = [];
         if (preg_match('/<div[^>]*id="mauticform_[^"]*honeypot"[^>]*>/', $html, $honeypotRow)) {
-            self::assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
+            $this->assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
         } else {
             self::fail('Honeypot captcha row not found in generated HTML.');
         }
@@ -42,12 +42,8 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         self::assertResponseIsSuccessful();
 
         $honeypotRow = $crawler->filter('[id$="_honeypot"]');
-        self::assertGreaterThan(0, $honeypotRow->count());
-        self::assertStringContainsString(
-            'mauticform-honeypot',
-            (string) $honeypotRow->attr('class'),
-            $crawler->html()
-        );
+        $this->assertGreaterThan(0, $honeypotRow->count());
+        $this->assertStringContainsString('mauticform-honeypot', (string) $honeypotRow->attr('class'), $crawler->html());
     }
 
     public function testHoneypotCaptchaFieldMergesHoneypotClassWithExistingContainerClasses(): void
@@ -57,15 +53,15 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         /** @var FormModel $formModel */
         $formModel = static::getContainer()->get('mautic.form.model.form');
         $form      = $formModel->getEntity($formId);
-        self::assertInstanceOf(Form::class, $form);
+        $this->assertInstanceOf(Form::class, $form);
 
         $html = $formModel->generateHtml($form, false);
 
         preg_match('/<div[^>]*\bid="mauticform_[^"]*honeypot"[^>]*>/', $html, $honeypotRow);
-        self::assertNotEmpty($honeypotRow, $html);
-        self::assertStringContainsString('custom-class', $honeypotRow[0], $html);
-        self::assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
-        self::assertSame(1, substr_count($honeypotRow[0], 'class="'), $html);
+        $this->assertNotEmpty($honeypotRow, $html);
+        $this->assertStringContainsString('custom-class', $honeypotRow[0], $html);
+        $this->assertStringContainsString('mauticform-honeypot', $honeypotRow[0], $html);
+        $this->assertSame(1, substr_count($honeypotRow[0], 'class="'), $html);
     }
 
     private function createFormWithHoneypotCaptcha(string $containerAttributes = ''): int

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -17,7 +17,7 @@ class ClearbitController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowireClearbitController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -17,7 +17,7 @@ class FullContactController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowireFullContactController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -17,7 +17,7 @@ class PublicController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowirePublicController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }


### PR DESCRIPTION
Three plugin controllers extend `Mautic\FormBundle\Controller\FormController`, which gained an `autowire(FormModel $formModel)` in #16587. Each of them declares its own `autowire()` with a different signature, which PHP rejects:

```
Declaration of MauticPlugin\MauticClearbitBundle\Controller\ClearbitController::autowire(
  Mautic\LeadBundle\Model\LeadModel $leadModel): void
must be compatible with Mautic\FormBundle\Controller\FormController::autowire(
  Mautic\FormBundle\Model\FormModel $formModel): void
```
