### PR TITLE
[phpstan] add rule to enforce autowire method name matches its controller

### DIFF
--- a/app/bundles/AssetBundle/Controller/AjaxController.php
+++ b/app/bundles/AssetBundle/Controller/AjaxController.php
@@ -16,7 +16,7 @@ class AjaxController extends CommonAjaxController
     private AssetModel $assetModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(AssetModel $assetModel): void
+    public function autowireAjaxController(AssetModel $assetModel): void
     {
         $this->assetModel = $assetModel;
     }

--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -17,7 +17,7 @@ class UploadController extends DropzoneController
         $request  = $this->getRequest();
         $response = new EmptyResponse();
         $files    = $this->getFiles($request->files);
-        $this->setTranslator($this->container->get('translator'));
+        $this->autowireUploadController($this->container->get('translator'));
 
         if (!empty($files)) {
             foreach ($files as $file) {
@@ -40,7 +40,7 @@ class UploadController extends DropzoneController
     }
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function setTranslator(TranslatorInterface $translator): void
+    public function autowireUploadController(TranslatorInterface $translator): void
     {
         $this->translator = $translator;
     }

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -45,7 +45,7 @@ class PublicController extends CommonFormController
     private LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(LeadModel $leadModel): void
+    public function autowirePublicController(LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/app/bundles/FormBundle/Controller/ActionController.php
+++ b/app/bundles/FormBundle/Controller/ActionController.php
@@ -15,7 +15,7 @@ class ActionController extends CommonFormController
     private FormModel $formModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FormModel $formModel): void
+    public function autowireActionController(FormModel $formModel): void
     {
         $this->formModel = $formModel;
     }

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -24,7 +24,7 @@ class AjaxController extends CommonAjaxController
     private \Mautic\FormBundle\Model\FormModel $formModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\FormBundle\Model\FormModel $formModel): void
+    public function autowireAjaxController(\Mautic\FormBundle\Model\FormModel $formModel): void
     {
         $this->formModel = $formModel;
     }

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -31,7 +31,7 @@ class FieldController extends CommonFormController
     private FieldModel $fieldModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FieldModel $fieldModel): void
+    public function autowireFieldController(FieldModel $fieldModel): void
     {
         $this->fieldModel = $fieldModel;
     }

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -36,7 +36,7 @@ class FormController extends CommonFormController
     private FormModel $formModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FormModel $formModel): void
+    public function autowireFormController(FormModel $formModel): void
     {
         $this->formModel = $formModel;
     }

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -30,7 +30,7 @@ class PublicController extends CommonFormController
     private FormModel $formModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FormModel $formModel, SubmissionModel $submissionModel): void
+    public function autowirePublicController(FormModel $formModel, SubmissionModel $submissionModel): void
     {
         $this->formModel = $formModel;
         $this->submissionModel = $submissionModel;

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -38,7 +38,7 @@ class ResultController extends CommonFormController
     private FormModel $formModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FormModel $formModel, SubmissionResultLoader $submissionResultLoader, SubmissionModel $submissionModel): void
+    public function autowireResultController(FormModel $formModel, SubmissionResultLoader $submissionResultLoader, SubmissionModel $submissionModel): void
     {
         $this->formModel = $formModel;
         $this->submissionResultLoader = $submissionResultLoader;

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -43,7 +43,7 @@ class AjaxController extends CommonAjaxController
     private LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(LeadModel $leadModel): void
+    public function autowireAjaxController(LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -27,7 +27,7 @@ class CompanyController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowireCompanyController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -187,17 +187,9 @@ trait FrequencyRuleTrait
     }
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function setDoNotContactModel(\Mautic\LeadBundle\Model\DoNotContact $doNotContactModel): void
+    public function autowireFrequencyRuleTrait(\Mautic\LeadBundle\Model\DoNotContact $doNotContactModel, RequestStack $requestStack): void
     {
         $this->doNotContactModel = $doNotContactModel;
-    }
-
-    /**
-     * The name is different, so it won't collide with other setters.
-     */
-    #[\Symfony\Contracts\Service\Attribute\Required]
-    public function setRequestStackObject(RequestStack $requestStack): void
-    {
-        $this->requestStack = $requestStack;
+        $this->requestStack      = $requestStack;
     }
 }

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -68,7 +68,7 @@ class LeadController extends FormController
     private LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(LeadModel $leadModel): void
+    public function autowireLeadController(LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -34,7 +34,7 @@ class ListController extends FormController
     private LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(LeadModel $leadModel): void
+    public function autowireListController(LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -23,7 +23,7 @@ class AjaxController extends CommonAjaxController
     private SmsModel $smsModel;
 
     #[Required]
-    public function autowire(SmsModel $smsModel): void
+    public function autowireAjaxController(SmsModel $smsModel): void
     {
         $this->smsModel = $smsModel;
     }

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -25,7 +25,7 @@ class SmsController extends FormController
     private SmsModel $smsModel;
 
     #[Required]
-    public function autowire(SmsModel $smsModel): void
+    public function autowireSmsController(SmsModel $smsModel): void
     {
         $this->smsModel = $smsModel;
     }

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -21,7 +21,7 @@ class ProfileController extends FormController
     private UserModel $userModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(UserModel $userModel): void
+    public function autowireProfileController(UserModel $userModel): void
     {
         $this->userModel = $userModel;
     }

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -20,7 +20,7 @@ class PublicController extends FormController
     private UserModel $userModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(UserModel $userModel): void
+    public function autowirePublicController(UserModel $userModel): void
     {
         $this->userModel = $userModel;
     }

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -17,7 +17,7 @@ class RoleController extends FormController
     private RoleModel $roleModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(RoleModel $roleModel): void
+    public function autowireRoleController(RoleModel $roleModel): void
     {
         $this->roleModel = $roleModel;
     }

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -31,7 +31,7 @@ class UserController extends FormController
     private UserModel $userModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(UserModel $userModel): void
+    public function autowireUserController(UserModel $userModel): void
     {
         $this->userModel = $userModel;
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -191,3 +191,7 @@ services:
 		class: MauticPhpStan\Rule\NoTablePrefixDefinitionInTestsRule
 		tags:
 			- phpstan.rules.rule
+	-
+		class: MauticPhpStan\Rule\AutowireMethodNameMustMatchClassRule
+		tags:
+			- phpstan.rules.rule

--- a/phpstan/Rule/AutowireMethodNameMustMatchClassRule.php
+++ b/phpstan/Rule/AutowireMethodNameMustMatchClassRule.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A controller method with the #[Required] attribute must be named "autowire" + the short name of the class it lives in.
+ *
+ * Symfony calls every #[Required] method on service instantiation. A parent and a child controller that both define
+ * a method of the same name collide: the child silently overrides the parent, so the parent dependency is never
+ * injected and the typed property stays uninitialized. Naming the method after its own class keeps it unique.
+ *
+ * Controllers extend each other deeply, which is where the collisions happen, so only they are checked.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class AutowireMethodNameMustMatchClassRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const REQUIRED_ATTRIBUTE = 'Symfony\Contracts\Service\Attribute\Required';
+
+    /**
+     * @var string
+     */
+    private const AUTOWIRE_PREFIX = 'autowire';
+
+    /**
+     * @var string
+     */
+    private const CONTROLLER_SUFFIX = 'Controller.php';
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$this->isInController($scope)) {
+            return [];
+        }
+
+        if (!$this->hasRequiredAttribute($node)) {
+            return [];
+        }
+
+        $shortClassName = $this->resolveShortClassName($scope);
+        if (null === $shortClassName) {
+            return [];
+        }
+
+        $currentMethodName  = $node->name->toString();
+        $expectedMethodName = self::AUTOWIRE_PREFIX.$shortClassName;
+
+        if ($currentMethodName === $expectedMethodName) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Method "%s()" has the #[Required] attribute, so it must be named "%s()". Rename it to keep the autowired method unique in the class hierarchy.',
+            $currentMethodName,
+            $expectedMethodName
+        ))
+            ->identifier('mautic.autowireMethodName')
+            ->build();
+
+        return [$ruleError];
+    }
+
+    /**
+     * The file that declares the method decides. Inside a trait the scope file is the class using the trait,
+     * so a trait method would otherwise be checked once per controller using it.
+     */
+    private function isInController(Scope $scope): bool
+    {
+        if ($scope->isInTrait()) {
+            $declaringFile = $scope->getTraitReflection()->getFileName();
+        } else {
+            $declaringFile = $scope->getFile();
+        }
+
+        if (null === $declaringFile) {
+            return false;
+        }
+
+        return str_ends_with($declaringFile, self::CONTROLLER_SUFFIX);
+    }
+
+    private function hasRequiredAttribute(ClassMethod $classMethod): bool
+    {
+        foreach ($classMethod->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (self::REQUIRED_ATTRIBUTE === $attr->name->toString()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A trait is named after itself, as the method is defined there, not in the classes using it.
+     */
+    private function resolveShortClassName(Scope $scope): ?string
+    {
+        if ($scope->isInTrait()) {
+            return $scope->getTraitReflection()->getNativeReflection()->getShortName();
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return null;
+        }
+
+        // an anonymous class has no name to derive the method name from
+        if ($classReflection->isAnonymous()) {
+            return null;
+        }
+
+        return $classReflection->getNativeReflection()->getShortName();
+    }
+}

--- a/phpstan/Tests/Rule/AutowireMethodNameMustMatchClassRuleTest.php
+++ b/phpstan/Tests/Rule/AutowireMethodNameMustMatchClassRuleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule;
+
+use MauticPhpStan\Rule\AutowireMethodNameMustMatchClassRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<AutowireMethodNameMustMatchClassRule>
+ */
+final class AutowireMethodNameMustMatchClassRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new AutowireMethodNameMustMatchClassRule();
+    }
+
+    public function testPlainAutowireName(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/CollidingAutowireController.php'], [
+            [
+                'Method "autowire()" has the #[Required] attribute, so it must be named "autowireCollidingAutowireController()". Rename it to keep the autowired method unique in the class hierarchy.',
+                11,
+            ],
+        ]);
+    }
+
+    public function testSetterName(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SetterAutowireController.php'], [
+            [
+                'Method "setSomeModel()" has the #[Required] attribute, so it must be named "autowireSetterAutowireController()". Rename it to keep the autowired method unique in the class hierarchy.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testSkipCorrectlyNamedMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/NamedAutowireController.php'], []);
+    }
+
+    public function testSkipMethodWithoutRequiredAttribute(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/PlainSetterController.php'], []);
+    }
+
+    public function testSkipClassOutsideController(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SomeAutowireService.php'], []);
+    }
+
+    /**
+     * The trait declares the method, so its own file decides. A controller using it does not drag it into the check.
+     */
+    public function testSkipTraitUsedByController(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SomeAutowireTrait.php', __DIR__.'/Fixture/TraitUsingController.php'], []);
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/CollidingAutowireController.php
+++ b/phpstan/Tests/Rule/Fixture/CollidingAutowireController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+class CollidingAutowireController
+{
+    #[Required]
+    public function autowire(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/NamedAutowireController.php
+++ b/phpstan/Tests/Rule/Fixture/NamedAutowireController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+class NamedAutowireController
+{
+    #[Required]
+    public function autowireNamedAutowireController(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/PlainSetterController.php
+++ b/phpstan/Tests/Rule/Fixture/PlainSetterController.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+class PlainSetterController
+{
+    public function setSomeModel(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/SetterAutowireController.php
+++ b/phpstan/Tests/Rule/Fixture/SetterAutowireController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+class SetterAutowireController
+{
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function setSomeModel(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/SomeAutowireService.php
+++ b/phpstan/Tests/Rule/Fixture/SomeAutowireService.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+class SomeAutowireService
+{
+    #[Required]
+    public function setSomeModel(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/SomeAutowireTrait.php
+++ b/phpstan/Tests/Rule/Fixture/SomeAutowireTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\Service\Attribute\Required;
+
+trait SomeAutowireTrait
+{
+    #[Required]
+    public function setSomeModelOnTrait(SomeModel $someModel): void
+    {
+    }
+}

--- a/phpstan/Tests/Rule/Fixture/SomeModel.php
+++ b/phpstan/Tests/Rule/Fixture/SomeModel.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+class SomeModel
+{
+}

--- a/phpstan/Tests/Rule/Fixture/TraitUsingController.php
+++ b/phpstan/Tests/Rule/Fixture/TraitUsingController.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPhpStan\Tests\Rule\Fixture;
+
+class TraitUsingController
+{
+    use SomeAutowireTrait;
+}

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -17,7 +17,7 @@ class ClearbitController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowireClearbitController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -14,7 +14,7 @@ class AjaxController extends CommonAjaxController
     private FocusModel $focusModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FocusModel $focusModel): void
+    public function autowireAjaxController(FocusModel $focusModel): void
     {
         $this->focusModel = $focusModel;
     }

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -29,7 +29,7 @@ class FocusController extends AbstractStandardFormController
     private FocusModel $focusModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(FocusModel $focusModel): void
+    public function autowireFocusController(FocusModel $focusModel): void
     {
         $this->focusModel = $focusModel;
     }

--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -16,7 +16,7 @@ class PublicController extends CommonController
     private \MauticPlugin\MauticFocusBundle\Model\FocusModel $focusModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\MauticPlugin\MauticFocusBundle\Model\FocusModel $focusModel): void
+    public function autowirePublicController(\MauticPlugin\MauticFocusBundle\Model\FocusModel $focusModel): void
     {
         $this->focusModel = $focusModel;
     }

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -17,7 +17,7 @@ class FullContactController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowireFullContactController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -17,7 +17,7 @@ class PublicController extends FormController
     private \Mautic\LeadBundle\Model\LeadModel $leadModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
+    public function autowirePublicController(\Mautic\LeadBundle\Model\LeadModel $leadModel): void
     {
         $this->leadModel = $leadModel;
     }

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -24,7 +24,7 @@ class MonitoringController extends FormController
     private MonitoringModel $monitoringModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(MonitoringModel $monitoringModel): void
+    public function autowireMonitoringController(MonitoringModel $monitoringModel): void
     {
         $this->monitoringModel = $monitoringModel;
     }

--- a/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
@@ -14,7 +14,7 @@ class BatchTagController extends AbstractFormController
     private TagModel $tagModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowire(TagModel $tagModel): void
+    public function autowireBatchTagController(TagModel $tagModel): void
     {
         $this->tagModel = $tagModel;
     }

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -31,7 +31,7 @@ class TagController extends FormController
     private TagModel $leadTagModel;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function setLeadTagModel(TagModel $leadTagModel): void
+    public function autowireTagController(TagModel $leadTagModel): void
     {
         $this->leadTagModel = $leadTagModel;
     }


### PR DESCRIPTION
## Why

Symfony calls **every** `#[Required]` method on service instantiation. When a parent and a child controller both declare a method with the same name, the child silently overrides the parent — the parent's dependency is never injected and its typed property stays uninitialized.
