### PR TITLE
Fix contact API silently discards fractional numeric field values

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -107,10 +107,8 @@ trait CustomFieldsApiControllerTrait
                 }
                 $properties = is_string($fieldDefinition['properties']) ? \Mautic\CoreBundle\Helper\Serializer::decode($fieldDefinition['properties']) : $fieldDefinition['properties'];
 
-                $fields[$group][$field]['value']           = empty($properties['scale']) ? (int) $fields[$group][$field]['value']
-                    : (float) $fields[$group][$field]['value'];
-                $fields[$group][$field]['normalizedValue'] = empty($properties['scale']) ? (int) $fields[$group][$field]['normalizedValue']
-                    : (float) $fields[$group][$field]['normalizedValue'];
+                $fields[$group][$field]['value']           = (float) $fields[$group][$field]['value'];
+                $fields[$group][$field]['normalizedValue'] = (float) $fields[$group][$field]['normalizedValue'];
 
                 $numberFields[$field] = $fields[$group][$field]['value'];
             }
@@ -191,7 +189,7 @@ trait CustomFieldsApiControllerTrait
                 $parameters,
                 function ($value): bool {
                     if (is_numeric($value)) {
-                        return 0 !== (int) $value;
+                        return 0.0 !== (float) $value;
                     }
 
                     return true;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/Api/ContactFractionalNumberApiTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/Api/ContactFractionalNumberApiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Functional\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ContactFractionalNumberApiTest extends MauticMysqlTestCase
+{
+    protected $useCleanupRollback = false;
+
+    private string $fieldAlias;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fieldAlias = 'frac_test_'.uniqid();
+
+        $fieldPayload = [
+            'label'      => 'Fraction Test',
+            'alias'      => $this->fieldAlias,
+            'type'       => 'number',
+            'group'      => 'core',
+            'object'     => 'lead',
+            'properties' => [],
+        ];
+
+        $this->client->request(Request::METHOD_POST, '/api/fields/contact/new', $fieldPayload);
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testFractionalNumericFieldIsSilentlyDiscardedOnPatch(): void
+    {
+        // Create contact with integer value
+        $payload = [
+            'firstname'       => 'FractionTest',
+            $this->fieldAlias => 1,
+        ];
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $payload);
+        $this->assertResponseIsSuccessful();
+        $response  = json_decode($this->client->getResponse()->getContent(), true);
+        $contactId = $response['contact']['id'];
+
+        // Now PATCH with fractional value as string "0.5"
+        $this->client->request(Request::METHOD_PATCH, "/api/contacts/{$contactId}/edit", [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode([
+            $this->fieldAlias => '0.5',
+        ]));
+        $this->assertResponseIsSuccessful();
+
+        // Verify
+        $this->client->request(Request::METHOD_GET, "/api/contacts/{$contactId}");
+        $contact = json_decode($this->client->getResponse()->getContent(), true);
+        $fields  = $contact['contact']['fields']['all'] ?? [];
+
+        $this->assertNotNull(
+            $fields[$this->fieldAlias] ?? null,
+            'BUG: Fractional value 0.5 was silently discarded on PATCH'
+        );
+
+        // Verify the actual stored value
+        $storedValue = $fields[$this->fieldAlias] ?? 'NOT FOUND';
+        $this->assertNotNull($storedValue);
+        // If the bug exists, stored value would be 1 (unchanged from create)
+        // If the fix works, stored value would be 0.5
+        $this->assertEquals(0.5, (float) $storedValue, sprintf('Expected 0.5, got %s', var_export($storedValue, true)));
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #16590

## Description

Updating a numeric contact field through the contacts API silently ignores fractional values between -1 and 1.

For example, setting a number field to 0.5 with PATCH /api/contacts/{id}/edit does not update the field, while setting the same field to 5 works.

---
### 📋 Steps to test this PR:

1. Create a contact number field that supports decimal values, for example last_order_value.
2. Create or select a contact.
3. Send this request, replacing the URL, contact ID, and authorization details: 

```
curl --request PATCH 'https://example.test/api/contacts/2005/edit' \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Basic REDACTED' \
    --data '{
        "last_order_value": 0.5,
        "firstname": "Updated name"
    }'
```