### PR TITLE
[cs] make concrete controllers final

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class ClientController extends AbstractStandardFormController
+final class ClientController extends AbstractStandardFormController
 {
     public function __construct(
         private ClientModel $clientModel,
@@ -188,7 +188,7 @@ class ClientController extends AbstractStandardFormController
     /**
      * @param mixed $objectId
      *
-     * @return array|JsonResponse|RedirectResponse|Response
+     * @return JsonResponse|RedirectResponse|Response
      */
     public function newAction(Request $request, $objectId = 0)
     {

--- a/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
@@ -18,7 +18,7 @@ use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
-class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeController
+final class AuthorizeController extends \FOS\OAuthServerBundle\Controller\AuthorizeController
 {
     private TokenStorageInterface $tokenStorage;
 

--- a/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
-class SecurityController extends CommonController
+final class SecurityController extends CommonController
 {
     public function loginAction(Request $request): Response
     {

--- a/app/bundles/AssetBundle/Controller/AjaxController.php
+++ b/app/bundles/AssetBundle/Controller/AjaxController.php
@@ -11,7 +11,7 @@ use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function categoryListAction(Request $request): \Symfony\Component\HttpFoundation\JsonResponse
     {

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class AssetController extends FormController
+final class AssetController extends FormController
 {
     public function indexAction(Request $request, CoreParametersHelper $parametersHelper, AssetModel $assetModel, int $page = 1): Response
     {

--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends AbstractFormController
+final class PublicController extends AbstractFormController
 {
     /**
      * Handles public download of assets by slug.

--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\File\Exception\UploadException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class UploadController extends DropzoneController
+final class UploadController extends DropzoneController
 {
     private TranslatorInterface $translator;
 

--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -18,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function __construct(
         private DateHelper $dateHelper,

--- a/app/bundles/CampaignBundle/Controller/CampaignMapStatsController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignMapStatsController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
-class CampaignMapStatsController extends AbstractController
+final class CampaignMapStatsController extends AbstractController
 {
     public const MAP_OPTIONS = [
         'contacts' => [

--- a/app/bundles/CampaignBundle/Controller/CampaignMetricsController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignMetricsController.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
-class CampaignMetricsController extends AbstractController
+final class CampaignMetricsController extends AbstractController
 {
     public function __construct(
         private Translator $translator,

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class EventController extends CommonFormController
+final class EventController extends CommonFormController
 {
     /**
      * @var string[]
@@ -358,7 +358,7 @@ class EventController extends CommonFormController
     /**
      * Deletes the entity.
      *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return JsonResponse
      */
     public function deleteAction(Request $request, $objectId)
     {
@@ -424,7 +424,7 @@ class EventController extends CommonFormController
     /**
      * Undeletes the entity.
      *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return JsonResponse
      */
     public function undeleteAction(Request $request, $objectId)
     {

--- a/app/bundles/CategoryBundle/Controller/AjaxController.php
+++ b/app/bundles/CategoryBundle/Controller/AjaxController.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function categoryListAction(Request $request): \Symfony\Component\HttpFoundation\JsonResponse
     {

--- a/app/bundles/CategoryBundle/Controller/BatchContactController.php
+++ b/app/bundles/CategoryBundle/Controller/BatchContactController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class BatchContactController extends AbstractFormController
+final class BatchContactController extends AbstractFormController
 {
     public function __construct(
         private ContactActionModel $actionModel,

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class CategoryController extends AbstractFormController
+final class CategoryController extends AbstractFormController
 {
     public function __construct(
         private FormFactoryInterface $formFactory,
@@ -47,7 +47,7 @@ class CategoryController extends AbstractFormController
     {
         if (method_exists($this, $objectAction.'Action')) {
             return $this->forward(
-                static::class.'::'.$objectAction.'Action',
+                self::class.'::'.$objectAction.'Action',
                 [
                     'bundle'      => $bundle,
                     'objectId'    => $objectId,

--- a/app/bundles/ChannelBundle/Controller/AjaxController.php
+++ b/app/bundles/ChannelBundle/Controller/AjaxController.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 

--- a/app/bundles/ChannelBundle/Controller/BatchContactController.php
+++ b/app/bundles/ChannelBundle/Controller/BatchContactController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class BatchContactController extends AbstractFormController
+final class BatchContactController extends AbstractFormController
 {
     public function __construct(
         private ChannelActionModel $channelActionModel,

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class MessageController extends AbstractStandardFormController
+final class MessageController extends AbstractStandardFormController
 {
     use EntityContactsTrait;
 

--- a/app/bundles/ConfigBundle/Controller/ConfigController.php
+++ b/app/bundles/ConfigBundle/Controller/ConfigController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class ConfigController extends FormController
+final class ConfigController extends FormController
 {
     /**
      * Controller action for editing the application configuration.
@@ -184,7 +184,7 @@ class ConfigController extends FormController
     }
 
     /**
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function downloadAction(Request $request, BundleHelper $bundleHelper, $objectId)
     {
@@ -223,7 +223,7 @@ class ConfigController extends FormController
     }
 
     /**
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function removeAction(BundleHelper $bundleHelper, Configurator $configurator, CacheHelper $cacheHelper, $objectId)
     {

--- a/app/bundles/ConfigBundle/Controller/SysinfoController.php
+++ b/app/bundles/ConfigBundle/Controller/SysinfoController.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class SysinfoController extends FormController
+final class SysinfoController extends FormController
 {
     public function __construct(
         FormFactoryInterface $formFactory,

--- a/app/bundles/CoreBundle/Controller/DefaultController.php
+++ b/app/bundles/CoreBundle/Controller/DefaultController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Almost all other Mautic Bundle controllers extend this default controller.
  */
-class DefaultController extends CommonController
+final class DefaultController extends CommonController
 {
     /**
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
-class ExceptionController extends CommonController
+final class ExceptionController extends CommonController
 {
     public function showAction(Request $request, \Throwable $exception, ThemeHelper $themeHelper, ?DebugLoggerInterface $logger = null)
     {

--- a/app/bundles/CoreBundle/Controller/FileController.php
+++ b/app/bundles/CoreBundle/Controller/FileController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class FileController extends AjaxController
+final class FileController extends AjaxController
 {
     public const EDITOR_CKEDITOR = 'ckeditor';
 

--- a/app/bundles/CoreBundle/Controller/JsController.php
+++ b/app/bundles/CoreBundle/Controller/JsController.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Event\BuildJsEvent;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 
-class JsController extends CommonController
+final class JsController extends CommonController
 {
     public function indexAction(
         #[Autowire(param: 'kernel.debug')]

--- a/app/bundles/CoreBundle/Controller/KeepAliveController.php
+++ b/app/bundles/CoreBundle/Controller/KeepAliveController.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
-class KeepAliveController
+final class KeepAliveController
 {
     public function keepAliveAction(): Response
     {

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class ThemeController extends FormController
+final class ThemeController extends FormController
 {
     public function indexAction(Request $request, ThemeHelperInterface $themeHelper, BuilderIntegrationsHelper $builderIntegrationsHelper, PathsHelper $pathsHelper): Response
     {

--- a/app/bundles/DashboardBundle/Controller/AjaxController.php
+++ b/app/bundles/DashboardBundle/Controller/AjaxController.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     /**
      * Count how many visitors are currently viewing a page.

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
-class DashboardController extends AbstractFormController
+final class DashboardController extends AbstractFormController
 {
     /**
      * Generates the default view.

--- a/app/bundles/DynamicContentBundle/Controller/AjaxController.php
+++ b/app/bundles/DynamicContentBundle/Controller/AjaxController.php
@@ -5,7 +5,7 @@ namespace Mautic\DynamicContentBundle\Controller;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 }

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class DynamicContentController extends FormController
+final class DynamicContentController extends FormController
 {
     protected function getPermissions(): array
     {

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -25,7 +25,7 @@ use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Address;
 use Twig\Environment;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use VariantAjaxControllerTrait;
     use AjaxLookupControllerTrait;

--- a/app/bundles/EmailBundle/Controller/BatchEmailController.php
+++ b/app/bundles/EmailBundle/Controller/BatchEmailController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class BatchEmailController extends AbstractFormController
+final class BatchEmailController extends AbstractFormController
 {
     /**
      * Adds or removes categories to multiple emails defined by email ID.

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class EmailController extends FormController
+final class EmailController extends FormController
 {
     use FormErrorMessagesTrait;
     use EntityContactsTrait;
@@ -1037,7 +1037,7 @@ class EmailController extends FormController
                             $returnUrl = $this->generateUrl('mautic_email_action', $viewParameters);
                             $template  = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
                         } else {
-                            return $this->forward(static::class.'::editAction', [
+                            return $this->forward(self::class.'::editAction', [
                                 'objectId'   => $entity->getId(),
                                 'ignorePost' => true,
                             ]);
@@ -1265,7 +1265,7 @@ class EmailController extends FormController
     /**
      * Activate the builder.
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      *
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
@@ -1326,7 +1326,7 @@ class EmailController extends FormController
     /**
      * Create an AB test.
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function abtestAction(
         Request $request,

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
-class EmailGraphStatsController extends AbstractController
+final class EmailGraphStatsController extends AbstractController
 {
     /**
      * Loads a specific form into the detailed panel.

--- a/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
@@ -13,7 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
-class EmailMapStatsController extends AbstractController
+final class EmailMapStatsController extends AbstractController
 {
     public const MAP_OPTIONS = [
         'read_count' => [

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -37,7 +37,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class PublicController extends CommonFormController
+final class PublicController extends CommonFormController
 {
     use FrequencyRuleTrait;
 
@@ -300,7 +300,7 @@ class PublicController extends CommonFormController
     {
         $request->attributes->set('unsubscribe_all', 1);
 
-        return $this->forward(static::class.'::unsubscribeAction', [
+        return $this->forward(self::class.'::unsubscribeAction', [
             'request'    => $request,
             'idHash'     => $idHash,
             'urlEmail'   => $urlEmail,

--- a/app/bundles/FormBundle/Controller/ActionController.php
+++ b/app/bundles/FormBundle/Controller/ActionController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class ActionController extends CommonFormController
+final class ActionController extends CommonFormController
 {
     /**
      * Generates new form and processes post data.

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function __construct(
         private FieldCollectorInterface $fieldCollector,

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
-class FieldController extends CommonFormController
+final class FieldController extends CommonFormController
 {
     public function __construct(
         private FormModel $formModel,

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends CommonFormController
+final class PublicController extends CommonFormController
 {
     private array $tokens = [];
 

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class ResultController extends CommonFormController
+final class ResultController extends CommonFormController
 {
     public function __construct(FormFactoryInterface $formFactory, FormFieldHelper $fieldHelper, ManagerRegistry $doctrine, ModelFactory $modelFactory, UserHelper $userHelper, CoreParametersHelper $coreParametersHelper, EventDispatcherInterface $dispatcher, Translator $translator, FlashBag $flashBag, RequestStack $requestStack, CorePermissions $security)
     {

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class InstallController extends CommonController
+final class InstallController extends CommonController
 {
     public function __construct(
         private Configurator $configurator,

--- a/app/bundles/IntegrationsBundle/Controller/AuthController.php
+++ b/app/bundles/IntegrationsBundle/Controller/AuthController.php
@@ -10,7 +10,7 @@ use Mautic\IntegrationsBundle\Exception\UnauthorizedException;
 use Mautic\IntegrationsBundle\Helper\AuthIntegrationsHelper;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthController extends CommonController
+final class AuthController extends CommonController
 {
     public function callbackAction(AuthIntegrationsHelper $authIntegrationsHelper, string $integration, Request $request)
     {

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 
-class ConfigController extends AbstractFormController
+final class ConfigController extends AbstractFormController
 {
     /**
      * @var BasicIntegration|ConfigFormInterface
@@ -48,7 +48,7 @@ class ConfigController extends AbstractFormController
     private $integrationConfiguration;
 
     /**
-     * @return array|JsonResponse|RedirectResponse|Response
+     * @return JsonResponse|RedirectResponse|Response
      */
     public function editAction(
         Request $request,

--- a/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
+++ b/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class FieldPaginationController extends CommonController
+final class FieldPaginationController extends CommonController
 {
     /**
      * @return Response

--- a/app/bundles/IntegrationsBundle/Controller/UpdateFieldController.php
+++ b/app/bundles/IntegrationsBundle/Controller/UpdateFieldController.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Controller\CommonController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class UpdateFieldController extends CommonController
+final class UpdateFieldController extends CommonController
 {
     public function updateAction(Request $request, string $integration, string $object, string $field): JsonResponse
     {

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
     use SegmentFilterIconTrait;

--- a/app/bundles/LeadBundle/Controller/AuditlogController.php
+++ b/app/bundles/LeadBundle/Controller/AuditlogController.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class AuditlogController extends CommonController
+final class AuditlogController extends CommonController
 {
     use LeadAccessTrait;
     use LeadDetailsTrait;
@@ -65,7 +65,7 @@ class AuditlogController extends CommonController
     }
 
     /**
-     * @return array|Response
+     * @return Response
      */
     public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId)
     {

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class BatchSegmentController extends AbstractFormController
+final class BatchSegmentController extends AbstractFormController
 {
     public function __construct(
         private SegmentActionModel $segmentActionModel,

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class CompanyController extends FormController
+final class CompanyController extends FormController
 {
     use LeadDetailsTrait;
 
@@ -677,7 +677,7 @@ class CompanyController extends FormController
      *
      * @param int $objectId
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function cloneAction(Request $request, $objectId)
     {
@@ -1159,7 +1159,7 @@ class CompanyController extends FormController
     /**
      * Export company's data.
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\StreamedResponse
+     * @return Response
      */
     public function companyExportAction(Request $request, ExportHelper $exportHelper, $companyId)
     {

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class FieldController extends FormController
+final class FieldController extends FormController
 {
     /**
      * Generate's default list view.

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -41,7 +41,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class ImportController extends FormController
+final class ImportController extends FormController
 {
     // Steps of the import
     public const STEP_UPLOAD_CSV      = 1;

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -60,7 +60,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class LeadController extends FormController
+final class LeadController extends FormController
 {
     use LeadDetailsTrait;
     use FrequencyRuleTrait;
@@ -2276,7 +2276,7 @@ class LeadController extends FormController
     }
 
     /**
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\StreamedResponse
+     * @return Response
      */
     public function contactExportAction(Request $request, ExportHelper $exportHelper, EventDispatcherInterface $dispatcher, $contactId)
     {

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class ListController extends FormController
+final class ListController extends FormController
 {
     use EntityContactsTrait;
 

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class NoteController extends FormController
+final class NoteController extends FormController
 {
     use LeadAccessTrait;
 

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class TimelineController extends CommonController
+final class TimelineController extends CommonController
 {
     use LeadAccessTrait;
     use LeadDetailsTrait;
@@ -187,7 +187,7 @@ class TimelineController extends CommonController
         );
     }
 
-    public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId): array|Response
+    public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId): Response
     {
         if (empty($leadId)) {
             $this->throwAccessDenied();

--- a/app/bundles/MarketplaceBundle/Controller/AjaxController.php
+++ b/app/bundles/MarketplaceBundle/Controller/AjaxController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function __construct(
         private ComposerHelper $composer,

--- a/app/bundles/MarketplaceBundle/Controller/CacheController.php
+++ b/app/bundles/MarketplaceBundle/Controller/CacheController.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class CacheController extends CommonController
+final class CacheController extends CommonController
 {
     public function __construct(
         private Config $config,

--- a/app/bundles/MarketplaceBundle/Controller/Package/DetailController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/DetailController.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class DetailController extends CommonController
+final class DetailController extends CommonController
 {
     public function __construct(
         private PackageModel $packageModel,

--- a/app/bundles/MarketplaceBundle/Controller/Package/InstallController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/InstallController.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class InstallController extends CommonController
+final class InstallController extends CommonController
 {
     public function __construct(
         private PackageModel $packageModel,

--- a/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class ListController extends CommonController
+final class ListController extends CommonController
 {
     public function __construct(
         private PluginCollector $pluginCollector,

--- a/app/bundles/MarketplaceBundle/Controller/Package/RemoveController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/RemoveController.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class RemoveController extends CommonController
+final class RemoveController extends CommonController
 {
     public function __construct(
         private PackageModel $packageModel,

--- a/app/bundles/MessengerBundle/Controller/AjaxController.php
+++ b/app/bundles/MessengerBundle/Controller/AjaxController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function sendTestMessageAction(
         Request $request,

--- a/app/bundles/NotificationBundle/Controller/AjaxController.php
+++ b/app/bundles/NotificationBundle/Controller/AjaxController.php
@@ -5,7 +5,7 @@ namespace Mautic\NotificationBundle\Controller;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 }

--- a/app/bundles/NotificationBundle/Controller/AppCallbackController.php
+++ b/app/bundles/NotificationBundle/Controller/AppCallbackController.php
@@ -10,7 +10,7 @@ use Mautic\NotificationBundle\Model\NotificationModel;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AppCallbackController extends CommonController
+final class AppCallbackController extends CommonController
 {
     public function indexAction(Request $request, EntityManagerInterface $em): JsonResponse
     {

--- a/app/bundles/NotificationBundle/Controller/JsController.php
+++ b/app/bundles/NotificationBundle/Controller/JsController.php
@@ -5,7 +5,7 @@ namespace Mautic\NotificationBundle\Controller;
 use Mautic\CoreBundle\Controller\CommonController;
 use Symfony\Component\HttpFoundation\Response;
 
-class JsController extends CommonController
+final class JsController extends CommonController
 {
     /**
      * We can't user JsonResponse here, because

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class MobileNotificationController extends FormController
+final class MobileNotificationController extends FormController
 {
     use EntityContactsTrait;
 

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class NotificationController extends AbstractFormController
+final class NotificationController extends AbstractFormController
 {
     use EntityContactsTrait;
 

--- a/app/bundles/NotificationBundle/Controller/PopupController.php
+++ b/app/bundles/NotificationBundle/Controller/PopupController.php
@@ -9,7 +9,7 @@ use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\HttpFoundation\Response;
 
-class PopupController extends CommonController
+final class PopupController extends CommonController
 {
     public function indexAction(AssetsHelper $assetsHelper): Response
     {

--- a/app/bundles/PageBundle/Controller/AjaxController.php
+++ b/app/bundles/PageBundle/Controller/AjaxController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use VariantAjaxControllerTrait;
 

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class PageController extends FormController
+final class PageController extends FormController
 {
     use FormErrorMessagesTrait;
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -39,7 +39,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class PublicController extends AbstractFormController
+final class PublicController extends AbstractFormController
 {
     /**
      * @param string $slug
@@ -312,7 +312,7 @@ class PublicController extends AbstractFormController
     }
 
     /**
-     * @return mixed[]|JsonResponse|RedirectResponse|Response
+     * @return JsonResponse|RedirectResponse|Response
      *
      * @throws FileNotFoundException
      */

--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -11,7 +11,7 @@ use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function setIntegrationFilterAction(Request $request): \Symfony\Component\HttpFoundation\JsonResponse
     {

--- a/app/bundles/PluginBundle/Controller/AuthController.php
+++ b/app/bundles/PluginBundle/Controller/AuthController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AuthController extends FormController
+final class AuthController extends FormController
 {
     /**
      * @param string $integration

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PluginController extends FormController
+final class PluginController extends FormController
 {
     public function indexAction(Request $request, IntegrationHelper $integrationHelper): Response
     {

--- a/app/bundles/PointBundle/Controller/AjaxController.php
+++ b/app/bundles/PointBundle/Controller/AjaxController.php
@@ -8,7 +8,7 @@ use Mautic\PointBundle\Form\Type\PointActionType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function reorderTriggerEventsAction(Request $request): \Symfony\Component\HttpFoundation\JsonResponse
     {

--- a/app/bundles/PointBundle/Controller/GroupController.php
+++ b/app/bundles/PointBundle/Controller/GroupController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class GroupController extends AbstractStandardFormController
+final class GroupController extends AbstractStandardFormController
 {
     protected function getTemplateBase(): string
     {

--- a/app/bundles/PointBundle/Controller/InsightController.php
+++ b/app/bundles/PointBundle/Controller/InsightController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class InsightController extends AbstractStandardFormController
+final class InsightController extends AbstractStandardFormController
 {
     protected function getTemplateBase(): string
     {

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PointController extends AbstractFormController
+final class PointController extends AbstractFormController
 {
     /**
      * @param int $page
@@ -337,7 +337,7 @@ class PointController extends AbstractFormController
      *
      * @param int $objectId
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function cloneAction(Request $request, FormFactoryInterface $formFactory, $objectId)
     {

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class TriggerController extends FormController
+final class TriggerController extends FormController
 {
     /**
      * @param int $page

--- a/app/bundles/PointBundle/Controller/TriggerEventController.php
+++ b/app/bundles/PointBundle/Controller/TriggerEventController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class TriggerEventController extends CommonFormController
+final class TriggerEventController extends CommonFormController
 {
     /**
      * Generates new form and processes post data.

--- a/app/bundles/ReportBundle/Controller/AjaxController.php
+++ b/app/bundles/ReportBundle/Controller/AjaxController.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\ReportBundle\Model\ReportModel;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     /**
      * Get updated data for context.

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-class ReportController extends FormController
+final class ReportController extends FormController
 {
     /**
      * @param int $page

--- a/app/bundles/ReportBundle/Controller/ScheduleController.php
+++ b/app/bundles/ReportBundle/Controller/ScheduleController.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\ReportBundle\Scheduler\Date\DateBuilder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-class ScheduleController extends CommonAjaxController
+final class ScheduleController extends CommonAjaxController
 {
     public function indexAction(DateBuilder $dateBuilder, $isScheduled, $scheduleUnit, $scheduleDay, $scheduleMonthFrequency): JsonResponse
     {

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 

--- a/app/bundles/SmsBundle/Controller/ReplyController.php
+++ b/app/bundles/SmsBundle/Controller/ReplyController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class ReplyController extends AbstractController
+final class ReplyController extends AbstractController
 {
     public function __construct(
         private HandlerContainer $callbackHandler,

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SmsController extends FormController
+final class SmsController extends FormController
 {
     use EntityContactsTrait;
 

--- a/app/bundles/StageBundle/Controller/AjaxController.php
+++ b/app/bundles/StageBundle/Controller/AjaxController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function getActionFormAction(Request $request, FormFactoryInterface $formFactory, Environment $twig): JsonResponse
     {

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class StageController extends AbstractFormController
+final class StageController extends AbstractFormController
 {
     /**
      * @param int $page
@@ -385,7 +385,7 @@ class StageController extends AbstractFormController
      *
      * @param int $objectId
      *
-     * @return array|JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function cloneAction(Request $request, FormFactoryInterface $formFactory, $objectId)
     {

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class ProfileController extends FormController
+final class ProfileController extends FormController
 {
     /**
      * Generate's account profile.

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-class PublicController extends FormController
+final class PublicController extends FormController
 {
     /**
      * Generates a new password for the user and emails it to them.

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 
-class RoleController extends FormController
+final class RoleController extends FormController
 {
     /**
      * @param int|string|null $objectId

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-class UserController extends FormController
+final class UserController extends FormController
 {
     /**
      * Generate's default user list.

--- a/app/bundles/WebhookBundle/Controller/AjaxController.php
+++ b/app/bundles/WebhookBundle/Controller/AjaxController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function sendHookTestAction(Request $request, Client $client, PathsHelper $pathsHelper): JsonResponse
     {

--- a/app/bundles/WebhookBundle/Controller/WebhookController.php
+++ b/app/bundles/WebhookBundle/Controller/WebhookController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class WebhookController extends FormController
+final class WebhookController extends FormController
 {
     public function __construct(FormFactoryInterface $formFactory, FormFieldHelper $fieldHelper, ManagerRegistry $doctrine, ModelFactory $modelFactory, UserHelper $userHelper, CoreParametersHelper $coreParametersHelper, EventDispatcherInterface $dispatcher, Translator $translator, FlashBag $flashBag, RequestStack $requestStack, CorePermissions $security)
     {

--- a/plugins/GrapesJsBuilderBundle/Controller/FileManagerController.php
+++ b/plugins/GrapesJsBuilderBundle/Controller/FileManagerController.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class FileManagerController extends AjaxController
+final class FileManagerController extends AjaxController
 {
     private const DEFAULT_PAGE  = 1;
     private const DEFAULT_LIMIT = 20;

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class ClearbitController extends FormController
+final class ClearbitController extends FormController
 {
     /**
      * @param string $objectId

--- a/plugins/MauticClearbitBundle/Controller/PublicController.php
+++ b/plugins/MauticClearbitBundle/Controller/PublicController.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends FormController
+final class PublicController extends FormController
 {
     /**
      * Write a notification.

--- a/plugins/MauticCrmBundle/Controller/PublicController.php
+++ b/plugins/MauticCrmBundle/Controller/PublicController.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends CommonController
+final class PublicController extends CommonController
 {
     public function contactDataAction(Request $request, LoggerInterface $mauticLogger, IntegrationHelper $integrationHelper): Response
     {

--- a/plugins/MauticFocusBundle/Controller/AjaxController.php
+++ b/plugins/MauticFocusBundle/Controller/AjaxController.php
@@ -9,7 +9,7 @@ use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     public function generatePreviewAction(Request $request): JsonResponse
     {

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
-class FocusController extends AbstractStandardFormController
+final class FocusController extends AbstractStandardFormController
 {
     /**
      * @phpstan-ignore-next-line

--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -11,10 +11,10 @@ use MauticPlugin\MauticFocusBundle\FocusEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends CommonController
+final class PublicController extends CommonController
 {
     /**
-     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function generateAction($id)
     {

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class FullContactController extends FormController
+final class FullContactController extends FormController
 {
     /**
      * @param string $objectId

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PublicController extends FormController
+final class PublicController extends FormController
 {
     /**
      * Write a notification.

--- a/plugins/MauticSocialBundle/Controller/AjaxController.php
+++ b/plugins/MauticSocialBundle/Controller/AjaxController.php
@@ -9,7 +9,7 @@ use MauticPlugin\MauticSocialBundle\Model\MonitoringModel;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class AjaxController extends CommonAjaxController
+final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 

--- a/plugins/MauticSocialBundle/Controller/JsController.php
+++ b/plugins/MauticSocialBundle/Controller/JsController.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticSocialBundle\Controller;
 use Mautic\CoreBundle\Controller\CommonController;
 use Symfony\Component\HttpFoundation\Response;
 
-class JsController extends CommonController
+final class JsController extends CommonController
 {
     public function generateAction($formName): Response
     {

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class MonitoringController extends FormController
+final class MonitoringController extends FormController
 {
     use EntityContactsTrait;
 

--- a/plugins/MauticSocialBundle/Controller/TweetController.php
+++ b/plugins/MauticSocialBundle/Controller/TweetController.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class TweetController extends FormController
+final class TweetController extends FormController
 {
     protected function getModelName(): string
     {

--- a/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class BatchTagController extends AbstractFormController
+final class BatchTagController extends AbstractFormController
 {
     public function indexAction(): Response
     {

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class TagController extends FormController
+final class TagController extends FormController
 {
     private const PERMISSION_VIEW   = 'tagManager:tagManager:view';
     private const PERMISSION_EDIT   = 'tagManager:tagManager:edit';


### PR DESCRIPTION
Marks 109 concrete controllers as `final`. They are routed endpoints, not extension points.

```diff
-class EmailController extends FormController
+final class EmailController extends FormController
```
