### PR TITLE
Generate unique aliases for new and cloned forms

### DIFF
--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -137,8 +137,7 @@ class FormApiController extends CommonApiController
 
         if (empty($alias)) {
             // Set clean alias to prevent SQL errors
-            $alias = $this->model->cleanAlias($entity->getName(), '', 10);
-            $entity->setAlias($alias);
+            $entity->setAlias($this->model->generateUniqueAlias($entity->getName()));
         }
 
         // Set timestamps

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -337,8 +337,7 @@ class FormController extends CommonFormController
 
                         try {
                             // Set alias to prevent SQL errors
-                            $alias = $this->formModel->cleanAlias($entity->getName(), '', 10);
-                            $entity->setAlias($alias);
+                            $entity->setAlias($this->formModel->generateUniqueAlias($entity->getName()));
 
                             // Set timestamps
                             $this->formModel->setTimestamps($entity, true, false);
@@ -594,9 +593,11 @@ class FormController extends CommonFormController
 
                         $alias = $entity->getAlias();
 
-                        if (empty($alias)) {
-                            $alias = $this->formModel->cleanAlias($entity->getName(), '', 10);
-                            $entity->setAlias($alias);
+                        if (!$entity->getId()) {
+                            // A clone copies the source form's alias, so it always needs a fresh unique one
+                            $entity->setAlias($this->formModel->generateUniqueAlias($alias ?: $entity->getName()));
+                        } elseif (empty($alias)) {
+                            $entity->setAlias($this->formModel->generateUniqueAlias($entity->getName()));
                         }
 
                         if (!$entity->getId()) {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -285,6 +285,29 @@ class FormRepository extends CommonRepository
     }
 
     /**
+     * @param string $alias
+     * @param int[]  $ignoreIds
+     */
+    public function checkFormUniqueAlias($alias, $ignoreIds = []): int
+    {
+        $q = $this->createQueryBuilder('e')
+            ->select('count(e.id) as alias_count')
+            ->where('e.alias = :alias');
+        $q->setParameter('alias', $alias);
+
+        if (!empty($ignoreIds)) {
+            $q->andWhere(
+                $q->expr()->notIn('e.id', ':ignoreIds')
+            )
+                ->setParameter('ignoreIds', $ignoreIds);
+        }
+
+        $results = $q->getQuery()->getSingleResult();
+
+        return (int) $results['alias_count'];
+    }
+
+    /**
      * Atomically increment the submission count for a form.
      */
     public function incrementSubmissionCount(int $formId): void

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -314,13 +314,34 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         }
     }
 
+    /**
+     * Builds an alias no other form is using, by appending a counter to the cleaned source string.
+     *
+     * Only call this while an alias is being generated for a form that has no alias yet, or for a clone
+     * (which copies the source form's alias). An existing form's alias must never change: it is part of
+     * its form_results_{id}_{alias} table name and createTableSchema() has no rename path, so changing it
+     * would orphan that form's results.
+     */
+    public function generateUniqueAlias(string $source): string
+    {
+        $alias     = $this->cleanAlias($source, '', 10);
+        $testAlias = $alias;
+        $aliasTag  = 1;
+
+        while ($this->getRepository()->checkFormUniqueAlias($testAlias)) {
+            $testAlias = $alias.$aliasTag;
+            ++$aliasTag;
+        }
+
+        return $testAlias;
+    }
+
     public function saveEntity($entity, $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
         if ($isNew && !$entity->getAlias()) {
-            $alias = $this->cleanAlias($entity->getName(), '', 10);
-            $entity->setAlias($alias);
+            $entity->setAlias($this->generateUniqueAlias($entity->getName()));
         }
 
         $this->backfillReplacedPropertiesForBc($entity);

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -662,6 +662,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $clonedForm   = $forms[1];
         $this->assertSame($form->getId(), $originalForm->getId());
         $this->assertNotSame($form->getId(), $clonedForm->getId());
+        $this->assertNotSame($originalForm->getAlias(), $clonedForm->getAlias());
 
         $fields = $clonedForm->getFields()->getValues();
         $this->assertCount(3, $fields);

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -316,4 +316,38 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
 
         return $field->getId();
     }
+
+    public function testGeneratedFormAliasesAreUniqueForCollidingNames(): void
+    {
+        /** @var FormModel $formModel */
+        $formModel = static::getContainer()->get('mautic.form.model.form');
+
+        $aliases = [];
+        foreach (['One', 'Two', 'Three'] as $suffix) {
+            $form = new Form();
+            $form->setName('Unique alias test '.$suffix);
+            $form->setIsPublished(false);
+            $formModel->saveEntity($form);
+            $aliases[] = $form->getAlias();
+        }
+
+        $this->assertSame(['unique_ali', 'unique_ali1', 'unique_ali2'], $aliases);
+    }
+
+    public function testRenamingFormDoesNotChangeAlias(): void
+    {
+        /** @var FormModel $formModel */
+        $formModel = static::getContainer()->get('mautic.form.model.form');
+
+        $form = new Form();
+        $form->setName('Alias stability test');
+        $form->setIsPublished(false);
+        $formModel->saveEntity($form);
+        $this->assertSame('alias_stab', $form->getAlias());
+
+        $form->setName('A completely different name');
+        $formModel->saveEntity($form);
+
+        $this->assertSame('alias_stab', $form->getAlias());
+    }
 }


### PR DESCRIPTION
No existing issue — found while testing #16355, where `form:{alias}` contact search treats the alias as a form identifier.

| Q                                      | A
| -------------------------------------- | --------------------------
| Bug fix?                               | ✔️
| New feature/enhancement?               | ❌
| Deprecations?                          | ❌
| BC breaks?                             | ❌
| Automated tests included?              | ✔️
| Issue(s) addressed                     | none — related to #16355

## Description

Form aliases are not unique: they're the form name truncated to 10 characters with no de-duplication, and cloning copies the source form's alias outright. Unrelated forms routinely share an alias (one production DB has 27 forms aliased `formulaire`), which breaks anything using the alias as an identifier — like the `form:{alias}` search in #16355.

This PR mirrors the existing `PageModel` pattern: append a numeric suffix until the alias is free, at every place a new form's alias is generated (UI create, UI clone, API, `FormModel::saveEntity()`).

Existing forms keep their alias — it's part of the `form_results_{id}_{alias}` table name and there's no rename path, so changing it would orphan submissions. A test asserts this invariant.

### 📋 Steps to test this PR:

1. Create two forms whose names share the first 10 characters — the second gets a suffixed alias instead of a duplicate.
2. Clone a form — the clone gets a fresh alias.
3. Rename an existing form — its alias stays unchanged.

https://claude.ai/code/session_014yCKj6Ve3rX2DQVnWRjPWh
