### PR TITLE
[phpstan] Add rule to report $this->getModel('...') string calls in controllers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13601,3 +13601,519 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/AjaxController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/CampaignBundle/Controller/Api/EventApiController.php
+
+		-
+			message: '#^Controller must not fetch the "campaign" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+
+		-
+			message: '#^Controller must not fetch the "campaign\.event" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Controller must not fetch the "campaign\.event" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/EventController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/ChannelBundle/Controller/MessageController.php
+
+		-
+			message: '#^Controller must not fetch the "page" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+
+		-
+			message: '#^Controller must not fetch the "page\.trackable" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/EmailBundle/Controller/EmailController.php
+
+		-
+			message: '#^Controller must not fetch the "email" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/EmailBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/EmailBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/EmailBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "form" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/FormBundle/Controller/Api/FormApiController.php
+
+		-
+			message: '#^Controller must not fetch the "form\.action" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/FormBundle/Controller/Api/FormApiController.php
+
+		-
+			message: '#^Controller must not fetch the "form\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/FormBundle/Controller/Api/FormApiController.php
+
+		-
+			message: '#^Controller must not fetch the "form" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
+
+		-
+			message: '#^Controller must not fetch the "form\.form" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/FormBundle/Controller/FieldController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/FormBundle/Controller/FieldController.php
+
+		-
+			message: '#^Controller must not fetch the "form\.form" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/FormBundle/Controller/FormController.php
+
+		-
+			message: '#^Controller must not fetch the "form\.submission" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/FormBundle/Controller/ResultController.php
+
+		-
+			message: '#^Controller must not fetch the "email" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AjaxController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AjaxController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.company" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/Api/DeviceApiController.php
+
+		-
+			message: '#^Controller must not fetch the "campaign" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "core\.auditlog" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "email" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 6
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.device" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.note" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "stage\.stage" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "user\.user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 5
+			path: app/bundles/LeadBundle/Controller/Api/ListApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.list" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/Api/ListApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/Api/NoteApiController.php
+
+		-
+			message: '#^Controller must not fetch the "core\.auditlog" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AuditlogController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 6
+			path: app/bundles/LeadBundle/Controller/AuditlogController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AuditlogController.php
+
+		-
+			message: '#^Controller must not fetch the "core\.auditlog" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/CompanyController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 4
+			path: app/bundles/LeadBundle/Controller/CompanyController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.company" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/CompanyController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/CompanyController.php
+
+		-
+			message: '#^Controller must not fetch the "core\.auditlog" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "email" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 7
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.field" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.list" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "stage" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "user\.user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/ListController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.list" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/ListController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/LeadBundle/Controller/NoteController.php
+
+		-
+			message: '#^Controller must not fetch the "core\.auditlog" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/TimelineController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 6
+			path: app/bundles/LeadBundle/Controller/TimelineController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/LeadBundle/Controller/TimelineController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+
+		-
+			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/NotificationController.php
+
+		-
+			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/NotificationController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
+
+		-
+			message: '#^Controller must not fetch the "point\.triggerevent" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+
+		-
+			message: '#^Controller must not fetch the "point\.trigger" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/PointBundle/Controller/TriggerController.php
+
+		-
+			message: '#^Controller must not fetch the "report" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/ReportBundle/Controller/ReportController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/SmsBundle/Controller/SmsController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 4
+			path: app/bundles/StageBundle/Controller/Api/StageApiController.php
+
+		-
+			message: '#^Controller must not fetch the "user\.user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/UserBundle/Controller/UserController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: plugins/MauticClearbitBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.company" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: plugins/MauticClearbitBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: plugins/MauticClearbitBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 4
+			path: plugins/MauticFullContactBundle/Controller/PublicController.php
+
+		-
+			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: plugins/MauticSocialBundle/Controller/MonitoringController.php
+
+		-
+			message: '#^Controller must not fetch the "social\.postcount" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: plugins/MauticSocialBundle/Controller/MonitoringController.php
+
+		-
+			message: '#^Controller must not fetch the "lead\.tag" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: plugins/MauticTagManagerBundle/Controller/TagController.php
+
+		-
+			message: '#^Controller must not fetch the "tagmanager\.tag" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 3
+			path: plugins/MauticTagManagerBundle/Controller/TagController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -223,3 +223,7 @@ services:
 		class: Utils\PHPStan\Rule\AutowireMethodNameMustMatchClassRule
 		tags:
 			- phpstan.rules.rule
+	-
+		class: Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule
+		tags:
+			- phpstan.rules.rule

--- a/utils/phpstan/src/Rule/NoGetModelWithStringInControllerRule.php
+++ b/utils/phpstan/src/Rule/NoGetModelWithStringInControllerRule.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A controller must not fetch a model by its string name, e.g. $this->getModel('lead').
+ *
+ * The string hides the real model class from static analysis and from the IDE, so the returned type is only the
+ * generic MauticModelInterface. Injecting the model as a typed property gives the exact type and makes the
+ * dependency visible.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoGetModelWithStringInControllerRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const GET_MODEL_METHOD = 'getModel';
+
+    /**
+     * @var string
+     */
+    private const CONTROLLER_SUFFIX = 'Controller.php';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!str_ends_with($scope->getFile(), self::CONTROLLER_SUFFIX)) {
+            return [];
+        }
+
+        if (!$node->var instanceof Variable || 'this' !== $node->var->name) {
+            return [];
+        }
+
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (self::GET_MODEL_METHOD !== $node->name->toString()) {
+            return [];
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg) {
+            return [];
+        }
+
+        if (!$firstArg->value instanceof String_) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Controller must not fetch the "%s" model by string. Inject the model as a typed property instead, to make the dependency and its type explicit.',
+            $firstArg->value->value
+        ))
+            ->identifier('mautic.noGetModelWithStringInController')
+            ->build();
+
+        return [$ruleError];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/GetModelByStringController.php
+++ b/utils/phpstan/tests/Rule/Fixture/GetModelByStringController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+// the model is fetched by string - must be reported
+class GetModelByStringController
+{
+    public function indexAction(): void
+    {
+        $this->getModel('lead');
+    }
+
+    public function otherAction(string $modelName): void
+    {
+        // dynamic name is not known, nothing to inject
+        $this->getModel($modelName);
+    }
+
+    public function getModel(string $modelNameKey): object
+    {
+        return new \stdClass();
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/GetModelByStringService.php
+++ b/utils/phpstan/tests/Rule/Fixture/GetModelByStringService.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+// not a controller - must be skipped
+class GetModelByStringService
+{
+    public function run(): void
+    {
+        $this->getModel('lead');
+    }
+
+    public function getModel(string $modelNameKey): object
+    {
+        return new \stdClass();
+    }
+}

--- a/utils/phpstan/tests/Rule/NoGetModelWithStringInControllerRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoGetModelWithStringInControllerRuleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule;
+
+/**
+ * @extends RuleTestCase<NoGetModelWithStringInControllerRule>
+ */
+final class NoGetModelWithStringInControllerRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoGetModelWithStringInControllerRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/GetModelByStringController.php'], [
+            [
+                'Controller must not fetch the "lead" model by string. Inject the model as a typed property instead, to make the dependency and its type explicit.',
+                12,
+            ],
+        ]);
+
+        $this->analyse([__DIR__.'/Fixture/GetModelByStringService.php'], []);
+    }
+}


### PR DESCRIPTION
Controllers fetch models by string name. The string hides the real model class from PHPStan and the IDE — the return type is only the generic `MauticModelInterface`. This rule reports those calls so they can be replaced by property injection over time.

The rule only reports, it does not change any code. All 152 current occurrences are added to the baseline.

## Bad

```php
final class LeadController extends FormController
{
    public function indexAction(): Response
    {
        $leadModel = $this->getModel('lead');
        // ^ Controller must not fetch the "lead" model by string.
    }
}
```

## Good

```php
final class LeadController extends FormController
{
    #[Required]
    public function autowireLeadController(LeadModel $leadModel): void
    {
        $this->leadModel = $leadModel;
    }

    public function indexAction(): Response
    {
        $this->leadModel->...
    }
}
```

Dynamic calls like `$this->getModel($modelName)` are skipped, as there is no known model to inject.