### PR TITLE
[phpstan] in tests - assign property directly instead of getRepository() service locator

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\Enum\RepublishBehavior;
 use Mautic\CampaignBundle\Executioner\InactiveExecutioner;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;
@@ -15,7 +17,7 @@ use Mautic\CampaignBundle\Tests\CampaignAuditLogTrait;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Command\SegmentCountCacheCommand;
 use Mautic\LeadBundle\Entity\Lead as Contact;
-use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\LeadBundle\Entity\ListLeadRepository;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
 use PHPUnit\Framework\Assert;
 
@@ -704,11 +706,11 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
      */
     public function testCampaignInfiniteLoop(): void
     {
-        $campaignMemberRepo = $this->em->getRepository(Lead::class);
+        $campaignMemberRepo = self::getContainer()->get(LeadRepository::class);
 
-        $segmentMemberRepo = $this->em->getRepository(ListLead::class);
+        $segmentMemberRepo = self::getContainer()->get(ListLeadRepository::class);
 
-        $campaignRepo = $this->em->getRepository(Campaign::class);
+        $campaignRepo = self::getContainer()->get(CampaignRepository::class);
 
         // Clear the campaign and segment members as those are manually_added.
         $campaignMemberRepo->deleteEntities($campaignMemberRepo->findAll());

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -19,7 +19,7 @@ final class LeadEventLogRepositoryTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->repository = $this->em->getRepository(LeadEventLog::class);
+        $this->repository = self::getContainer()->get(LeadEventLogRepository::class);
     }
 
     public function testThatRemoveEventLogsByCampaignIdMethodRemovesLogs(): void

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -4,6 +4,7 @@ namespace Mautic\CoreBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -52,6 +53,7 @@ EOT
         $force   = $options['force'];
 
         if (!$force) {
+            /** @var QuestionHelper $helper */
             $helper         = $this->getHelper('question');
             $questionString = $this->translator->trans('mautic.core.command.install_data_confirm').' (y = '.$this->translator->trans('mautic.core.form.yes').', n = '.$this->translator->trans('mautic.core.form.no').'): ';
             $question       = new ConfirmationQuestion($questionString, false);

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
@@ -6,6 +6,7 @@ namespace Mautic\CoreBundle\Tests\Functional\Doctrine\Paginator;
 
 use Mautic\CoreBundle\Doctrine\Paginator\SimplePaginator;
 use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 
@@ -42,7 +43,7 @@ final class SimplePaginatorTest extends MauticMysqlTestCase
         $this->em->persist($ipAddress3);
         $this->em->flush();
 
-        $repository = $this->em->getRepository(IpAddress::class);
+        $repository = self::getContainer()->get(IpAddressRepository::class);
 
         $paginator  = $repository->getEntities([
             'use_simple_paginator' => true,

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -17,6 +17,7 @@ use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -115,7 +116,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->clear(Page::class);
 
-        $entity = $this->em->getRepository(Page::class)->getEntity($stat->getEmail()->getPreferenceCenter()->getId());
+        $entity = self::getContainer()->get(PageRepository::class)->getEntity($stat->getEmail()->getPreferenceCenter()->getId());
         $this->assertSame(1, $entity->getHits(), $this->client->getResponse()->getContent());
     }
 

--- a/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
@@ -6,6 +6,7 @@ namespace Mautic\EmailBundle\Tests\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -21,7 +22,7 @@ final class PendingQueryFunctionalTest extends MauticMysqlTestCase
 {
     public function testDelayedSends(): void
     {
-        $emailRepository = $this->em->getRepository(Email::class);
+        $emailRepository = self::getContainer()->get(EmailRepository::class);
 
         $contactCount  = 4;
         $oneBatchCount = $contactCount / 2;

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
@@ -22,7 +22,7 @@ final class FieldChangeRepositoryTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = $this->em->getRepository(FieldChange::class);
+        $this->repository = self::getContainer()->get(FieldChangeRepository::class);
     }
 
     public function testThatFindChangesBeforeMethodReturnsChangesInCorrectOrder(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Tests\Functional\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\IntegrationsBundle\Entity\FieldChange;
 use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
 use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
 use Mautic\LeadBundle\Entity\Lead;
@@ -24,7 +23,7 @@ final class LeadSubscriberTest extends MauticMysqlTestCase
         parent::setUp();
 
         $this->dispatcher            = static::getContainer()->get('event_dispatcher');
-        $this->fieldChangeRepository = $this->em->getRepository(FieldChange::class);
+        $this->fieldChangeRepository = self::getContainer()->get(FieldChangeRepository::class);
 
         static::getContainer()->set(
             'mautic.integrations.helper.sync_integrations',

--- a/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Schema\Column;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Symfony\Component\HttpFoundation\Request;
 
 final class FieldControllerTest extends MauticMysqlTestCase
@@ -49,7 +50,7 @@ final class FieldControllerTest extends MauticMysqlTestCase
         $field->setAlias('field_to_be_cloned');
         $field->setType('text');
 
-        $this->em->getRepository(LeadField::class)->saveEntity($field);
+        self::getContainer()->get(LeadFieldRepository::class)->saveEntity($field);
         $this->em->clear();
 
         $field = $this->em->getRepository(LeadField::class)->findOneBy(['alias' => 'field_to_be_cloned']);

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Controller;
 
+use Mautic\CoreBundle\Entity\NotificationRepository;
 use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\ImportCommand;
@@ -466,7 +467,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
 
     private function assertNotificationMessageContainsForUser(int $userId, string $expectedSubstring): void
     {
-        $notificationRepo = $this->em->getRepository(\Mautic\CoreBundle\Entity\Notification::class);
+        $notificationRepo = self::getContainer()->get(NotificationRepository::class);
         $notifications    = $notificationRepo->getNotifications($userId);
         $found            = false;
         foreach ($notifications as $notification) {
@@ -481,7 +482,7 @@ final class ImportControllerTest extends MauticMysqlTestCase
 
     private function assertNotificationMessageDoesNotContainForUser(int $userId, string $expectedSubstring): void
     {
-        $notificationRepo = $this->em->getRepository(\Mautic\CoreBundle\Entity\Notification::class);
+        $notificationRepo = self::getContainer()->get(NotificationRepository::class);
         $notifications    = $notificationRepo->getNotifications($userId);
 
         foreach ($notifications as $notification) {

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Entity;
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 
 final class LeadListRepositoryFunctionalTest extends AbstractMauticTestCase
@@ -20,7 +21,7 @@ final class LeadListRepositoryFunctionalTest extends AbstractMauticTestCase
         $this->createSegmentMember($segmentA, $lead);
         $this->createSegmentMember($segmentB, $lead, true);
 
-        $leadListRepository = $this->em->getRepository(LeadList::class);
+        $leadListRepository = self::getContainer()->get(LeadListRepository::class);
 
         $result = $leadListRepository->checkLeadSegmentsByIds($lead, [$segmentA->getId()]);
         $this->assertTrue($result);

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -114,7 +114,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->assertArrayNotHasKey('points', $changes);
         // Points should remain the same
         $model->saveEntity($this->lead);
-        $this->em->getRepository(Lead::class)->saveEntity($this->lead);
+        self::getContainer()->get(LeadRepository::class)->saveEntity($this->lead);
         $this->assertEquals(220, $this->lead->getPoints());
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -86,7 +86,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
         parent::setUp();
 
-        $this->contactRepository = $this->em->getRepository(Lead::class);
+        $this->contactRepository = self::getContainer()->get(LeadRepository::class);
     }
 
     protected function beforeBeginTransaction(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Functional\Entity;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -35,7 +36,7 @@ final class LeadRepositoryTest extends MauticMysqlTestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('joinIpAddressesProvider')]
     public function testSaveIpAddressToContacts(array $args): void
     {
-        $contactRepo = $this->em->getRepository(Lead::class);
+        $contactRepo = self::getContainer()->get(LeadRepository::class);
 
         $ip      = new IpAddress('127.0.0.1');
         $contact = new Lead();

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -6,7 +6,7 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Traits\ControllerTrait;
-use Mautic\LeadBundle\Entity\UtmTag;
+use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData;
 use Mautic\PageBundle\DataFixtures\ORM\LoadPageData;
 use Mautic\PageBundle\Entity\Page;
@@ -160,7 +160,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
-        $allUtmTags = $this->em->getRepository(UtmTag::class)->getEntities();
+        $allUtmTags = self::getContainer()->get(UtmTagRepository::class)->getEntities();
         $this->assertNotCount(0, $allUtmTags);
 
         foreach ($allUtmTags as $utmTag) {

--- a/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
@@ -22,7 +22,7 @@ final class HitRepositoryTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->hitRepository = $this->em->getRepository(Hit::class);
+        $this->hitRepository = self::getContainer()->get(HitRepository::class);
     }
 
     public function testGetLatestHitDateByLead(): void

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\PageBundle\Tests\Functional\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +19,7 @@ final class PageHitCookieTest extends MauticMysqlTestCase
         $this->configParams['messenger_dsn_email'] = 'sync://';
 
         parent::setUp();
-        $this->hitRepository = $this->em->getRepository(Hit::class);
+        $this->hitRepository = self::getContainer()->get(HitRepository::class);
     }
 
     public function testPageHitCookieContainsValidHitIdAndUpdatesDateLeft(): void

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
@@ -44,7 +44,7 @@ final class PageModelTest extends MauticMysqlTestCase
         $this->configParams['bot_helper_blocked_user_agents']  = self::BOT_BLOCKED_USER_AGENTS;
         $this->configParams['site_url']                        = 'https://mautic-cloud.local';
         parent::setUp();
-        $this->pageHitRepository = $this->em->getRepository(Hit::class);
+        $this->pageHitRepository = self::getContainer()->get(HitRepository::class);
         $this->logoutUser();
     }
 

--- a/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
+++ b/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
@@ -28,7 +28,7 @@ final class IntegrationEntityRepositoryTest extends MauticMysqlTestCase
     {
         parent::setUp();
         $this->prefix                      = static::getContainer()->getParameter('mautic.db_table_prefix');
-        $this->integrationEntityRepository = $this->em->getRepository(IntegrationEntity::class);
+        $this->integrationEntityRepository = self::getContainer()->get(IntegrationEntityRepository::class);
     }
 
     public function testThatGetIntegrationsEntityIdReturnsCorrectValues(): void

--- a/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
@@ -19,7 +19,7 @@ final class GroupScoreRepositoryFunctionalTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = $this->em->getRepository(GroupContactScore::class);
+        $this->repository = self::getContainer()->get(GroupContactScoreRepository::class);
     }
 
     public function testCompareScore(): void

--- a/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\UserBundle\Tests\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
-use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Form\Validator\Constraints\NotWeak;
@@ -25,7 +24,7 @@ final class PasswordStrengthEstimatorModelTest extends MauticMysqlTestCase
     {
         parent::setUp();
         $this->passwordHasher = self::getContainer()->get('security.password_hasher_factory');
-        $this->roleRepository = $this->em->getRepository(Role::class);
+        $this->roleRepository = self::getContainer()->get(RoleRepository::class);
         $this->validator      = static::getContainer()->get('validator');
     }
 

--- a/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
@@ -7,7 +7,6 @@ namespace Mautic\WebhookBundle\Tests\Functional;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
-use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Entity\NotificationRepository;
 use Mautic\CoreBundle\Test\Guzzle\ClientMockTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
@@ -52,8 +51,8 @@ final class WebhookFunctionalTest extends MauticMysqlTestCase
 
         $this->truncateTables('leads', 'webhooks', 'webhook_queue', 'webhook_events');
 
-        $this->webhookQueueRepository       = $this->em->getRepository(WebhookQueue::class);
-        $this->notificationRepository       = $this->em->getRepository(Notification::class);
+        $this->webhookQueueRepository       = self::getContainer()->get(WebhookQueueRepository::class);
+        $this->notificationRepository       = self::getContainer()->get(NotificationRepository::class);
         $this->webhhokRepository            = $this->em->getRepository(Webhook::class);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4948,12 +4948,6 @@ parameters:
 			path: app/bundles/FormBundle/Controller/FieldController.php
 
 		-
-			message: '#^Controller must not fetch the "form\.form" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 1
-			path: app/bundles/FormBundle/Controller/FormController.php
-
-		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 6
@@ -5962,12 +5956,6 @@ parameters:
 			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 4
-			path: app/bundles/LeadBundle/Controller/CompanyController.php
-
-		-
-			message: '#^Controller must not fetch the "lead\.company" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 1
 			path: app/bundles/LeadBundle/Controller/CompanyController.php
 
 		-
@@ -8263,30 +8251,12 @@ parameters:
 			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
 
 		-
-<<<<<<< HEAD
-			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 1
-			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
-
-		-
-=======
->>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 1
 			path: app/bundles/NotificationBundle/Controller/NotificationController.php
 
 		-
-<<<<<<< HEAD
-			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 1
-			path: app/bundles/NotificationBundle/Controller/NotificationController.php
-
-		-
-=======
->>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Method Mautic\\NotificationBundle\\Entity\\Notification\:\:setButton\(\) has parameter \$button with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10039,15 +10009,6 @@ parameters:
 			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
 
 		-
-<<<<<<< HEAD
-=======
-			message: '#^Controller must not fetch the "point\.triggerevent" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 2
-			path: app/bundles/PointBundle/Controller/Api/TriggerApiController.php
-
-		-
->>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Controller must not fetch the "point\.trigger" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 2
@@ -10142,12 +10103,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/bundles/PointBundle/Model/TriggerModel.php
-
-		-
-			message: '#^Controller must not fetch the "report" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 1
-			path: app/bundles/ReportBundle/Controller/ReportController.php
 
 		-
 			message: '#^Method Mautic\\ReportBundle\\Controller\\ReportController\:\:downloadAction\(\) should return Symfony\\Component\\HttpFoundation\\BinaryFileResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
@@ -13339,12 +13294,6 @@ parameters:
 			path: plugins/MauticFullContactBundle/Controller/FullContactController.php
 
 		-
-			message: '#^Controller must not fetch the "user" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noGetModelWithStringInController
-			count: 4
-			path: plugins/MauticFullContactBundle/Controller/PublicController.php
-
-		-
 			message: '#^Property Mautic\\LeadBundle\\Entity\\Lead\:\:\$imported \(bool\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 2
@@ -13965,11 +13914,7 @@ parameters:
 		-
 			message: '#^Controller must not fetch the "tagmanager\.tag" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
-<<<<<<< HEAD
-			count: 3
-=======
 			count: 1
->>>>>>> cf831adfe9 (udpate baseline)
 			path: plugins/MauticTagManagerBundle/Controller/TagController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8263,24 +8263,30 @@ parameters:
 			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
 
 		-
+<<<<<<< HEAD
 			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 1
 			path: app/bundles/NotificationBundle/Controller/MobileNotificationController.php
 
 		-
+=======
+>>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Controller must not fetch the "lead" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 1
 			path: app/bundles/NotificationBundle/Controller/NotificationController.php
 
 		-
+<<<<<<< HEAD
 			message: '#^Controller must not fetch the "notification" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 1
 			path: app/bundles/NotificationBundle/Controller/NotificationController.php
 
 		-
+=======
+>>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Method Mautic\\NotificationBundle\\Entity\\Notification\:\:setButton\(\) has parameter \$button with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10033,6 +10039,15 @@ parameters:
 			path: app/bundles/PointBundle/Controller/Api/PointApiController.php
 
 		-
+<<<<<<< HEAD
+=======
+			message: '#^Controller must not fetch the "point\.triggerevent" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 2
+			path: app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+
+		-
+>>>>>>> cf831adfe9 (udpate baseline)
 			message: '#^Controller must not fetch the "point\.trigger" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
 			count: 2
@@ -10127,6 +10142,12 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/bundles/PointBundle/Model/TriggerModel.php
+
+		-
+			message: '#^Controller must not fetch the "report" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noGetModelWithStringInController
+			count: 1
+			path: app/bundles/ReportBundle/Controller/ReportController.php
 
 		-
 			message: '#^Method Mautic\\ReportBundle\\Controller\\ReportController\:\:downloadAction\(\) should return Symfony\\Component\\HttpFoundation\\BinaryFileResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
@@ -13944,7 +13965,11 @@ parameters:
 		-
 			message: '#^Controller must not fetch the "tagmanager\.tag" model by string\. Inject the model as a typed property instead, to make the dependency and its type explicit\.$#'
 			identifier: mautic.noGetModelWithStringInController
+<<<<<<< HEAD
 			count: 3
+=======
+			count: 1
+>>>>>>> cf831adfe9 (udpate baseline)
 			path: plugins/MauticTagManagerBundle/Controller/TagController.php
 
 		-

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -3,3 +3,4 @@
 define('MAUTIC_ENV', '');
 define('MAUTIC_VERSION', '');
 define('MAUTIC_TABLE_PREFIX', '');
+define('MAUTIC_DB_SERVER_VERSION', '8.0.0');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
-#includes:
-#    - phpstan-baseline.neon
+includes:
+    - phpstan-baseline.neon
 
 parameters:
 	tmpDir: ./var/phpstan-cache

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
-includes:
-    - phpstan-baseline.neon
+#includes:
+#    - phpstan-baseline.neon
 
 parameters:
 	tmpDir: ./var/phpstan-cache


### PR DESCRIPTION
Since all repositories are registered as services, we can inject them directly and get exact type without dependency on entity manager :+1: 

This only updates tests, to make it step-by-step safe process.