### PR TITLE
[ci] skip code coverage on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,16 @@ jobs:
 
     name: PHPUnit ${{ matrix.php-versions }} ${{ matrix.db-types }}
 
+    env:
+      # Collecting coverage roughly doubles the runtime of this job (~10 min -> ~19 min), so we only
+      # do it where the report is actually uploaded: on the mautic/mautic repository, for merges and
+      # for the nightly schedule. Pull requests skip it, which also stops fork PRs from generating a
+      # coverage report that is then discarded.
+      COVERAGE: ${{ matrix.php-versions == '8.2'
+        && matrix.db-types == 'mariadb:10.11'
+        && github.repository == 'mautic/mautic'
+        && (github.event_name == 'push' || github.event_name == 'schedule') }}
+
     services:
       database:
         image: ${{ matrix.db-types }}
@@ -104,14 +114,14 @@ jobs:
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
-        if [[ "${{ matrix.php-versions }}" == "8.2" ]] && [[ "${{ matrix.db-types }}" == "mariadb:10.11" ]]; then
+        if [[ "$COVERAGE" == "true" ]]; then
           php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
         else
           php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
         fi
 
     - name: Upload coverage report
-      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
+      if: ${{ env.COVERAGE == 'true' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage.xml
@@ -120,7 +130,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Save test results for future steps
-      if: ${{ matrix.php-versions == '8.2' && matrix.db-types == 'mariadb:10.11' && github.repository == 'mautic/mautic' }}
+      if: ${{ env.COVERAGE == 'true' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test-results


### PR DESCRIPTION
I've noticed CI on all PRs, even the simplest ones, takes **19 minutes** to finish.
If there is one rebase or merge, it's nearly 40 mins :cry: 

I've checked why is that, and there is always one job delaying it for everyone. That's because it runs code coverage, very costly process to run on every single commit. In other project we run this nightly to streamline PR contribution and focus on the important parts - tests + PHPStan.

I wonder if you'd be open to cutting **19 mins to 11 min** by running the coverage on cron/main branch only. 
This would increase our merge rate significantly and make PRs more fun as well :pray: 

