### PR TITLE
[model] inject lead model in StageApiController

### DIFF
--- a/app/bundles/StageBundle/Controller/Api/StageApiController.php
+++ b/app/bundles/StageBundle/Controller/Api/StageApiController.php
@@ -26,8 +26,21 @@ class StageApiController extends CommonApiController
 {
     use LeadAccessTrait;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, \Mautic\StageBundle\Model\StageModel $stageModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        \Mautic\StageBundle\Model\StageModel $stageModel,
+        private LeadModel $leadModel,
+    ) {
         $this->model            = $stageModel;
         $this->entityClass      = Stage::class;
         $this->entityNameOne    = 'stage';
@@ -63,9 +76,7 @@ class StageApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $leadModel = $this->getModel('lead');
-        \assert($leadModel instanceof LeadModel);
-        $leadModel->addToStages($contact, $stage)->saveEntity($contact);
+        $this->leadModel->addToStages($contact, $stage)->saveEntity($contact);
 
         return $this->handleView($this->view(['success' => 1], Response::HTTP_OK));
     }
@@ -96,9 +107,7 @@ class StageApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $leadModel = $this->getModel('lead');
-        \assert($leadModel instanceof LeadModel);
-        $leadModel->removeFromStages($contact, $stage)->saveEntity($contact);
+        $this->leadModel->removeFromStages($contact, $stage)->saveEntity($contact);
 
         return $this->handleView($this->view(['success' => 1], Response::HTTP_OK));
     }


### PR DESCRIPTION
Replaces `$this->getModel(...)` string lookups with a directly injected `LeadModel` in `StageApiController`.

Split out of #16647 (one file per PR).