### PR TITLE
[model] inject model in CampaignApiController

### DIFF
--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -22,6 +22,7 @@ use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Controller\LeadAccessTrait;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -62,6 +63,7 @@ class CampaignApiController extends CommonApiController
         private EventModel $eventModel,
         private CampaignContactCountHelper $contactCountHelper,
         CampaignModel $campaignModel,
+        private LeadModel $leadModel,
     ) {
         $this->model             = $campaignModel;
         $this->entityClass       = Campaign::class;
@@ -122,8 +124,7 @@ class CampaignApiController extends CommonApiController
     {
         $entity = $this->model->getEntity($id);
         if (null !== $entity) {
-            $leadModel = $this->getModel('lead');
-            $lead      = $leadModel->getEntity($leadId);
+            $lead = $this->leadModel->getEntity($leadId);
 
             if (null == $lead) {
                 return $this->notFound();


### PR DESCRIPTION
Replaces `$this->getModel(...)` string lookups with a directly injected model in this controller.

Split out of #16647 (one file per PR).