### PR TITLE
[model] remove unused lead.field getModel in FieldController

### DIFF
--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -195,8 +195,6 @@ class FieldController extends CommonFormController
             $passthroughVars['parent']    = $formField['parent'];
             $passthroughVars['fieldId']   = $keyId;
             $template                     = (!empty($customParams)) ? $customParams['template'] : '@MauticForm/Field/'.$fieldType.'.html.twig';
-            $leadFieldModel               = $this->getModel('lead.field');
-            \assert($leadFieldModel instanceof \Mautic\LeadBundle\Model\FieldModel);
             $passthroughVars['fieldHtml'] = $this->renderView(
                 '@MauticForm/Builder/_field_wrapper.html.twig',
                 [
@@ -339,8 +337,6 @@ class FieldController extends CommonFormController
             $blank        = $entity->convertToArray();
             $formField    = array_merge($blank, $formField);
 
-            $leadFieldModel = $this->getModel('lead.field');
-            \assert($leadFieldModel instanceof \Mautic\LeadBundle\Model\FieldModel);
             $passthroughVars['fieldHtml'] = $this->renderView(
                 '@MauticForm/Builder/_field_wrapper.html.twig',
                 [


### PR DESCRIPTION
Removes an unused `lead.field` `getModel()` lookup (dead assignment) in this controller.

Split out of #16647 (one file per PR).