### PR TITLE
[model] inject model in ListApiController

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -36,7 +36,18 @@ class ListApiController extends CommonApiController
     protected $model;
 
     public function __construct(
-        CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, ListModel $listModel,
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        ListModel $listModel,
         private LeadModel $leadModel,
     ) {
         $this->model            = $listModel;

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -35,8 +35,10 @@ class ListApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, ListModel $listModel)
-    {
+    public function __construct(
+        CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, ListModel $listModel,
+        private LeadModel $leadModel,
+    ) {
         $this->model            = $listModel;
         $this->entityClass      = LeadList::class;
         $this->entityNameOne    = 'list';
@@ -156,9 +158,7 @@ class ListApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $leadModel = $this->getModel('lead');
-        \assert($leadModel instanceof LeadModel);
-        $leadModel->addToLists($leadId, $entity);
+        $this->leadModel->addToLists($leadId, $entity);
 
         $view = $this->view(['success' => 1], Response::HTTP_OK);
 
@@ -199,10 +199,7 @@ class ListApiController extends CommonApiController
             if ($contact instanceof Response) {
                 $responseDetail[$contactId] = ['success' => false];
             } else {
-                $leadModel = $this->getModel('lead');
-                \assert($leadModel instanceof LeadModel);
-                /** @var \Mautic\LeadBundle\Entity\Lead $contact */
-                $leadModel->addToLists($contact, $entity);
+                $this->leadModel->addToLists($contact, $entity);
                 $responseDetail[$contact->getId()] = ['success' => true];
             }
         }
@@ -239,9 +236,7 @@ class ListApiController extends CommonApiController
             return $this->accessDenied();
         }
 
-        $leadModel = $this->getModel('lead');
-        \assert($leadModel instanceof LeadModel);
-        $leadModel->removeFromLists($leadId, $entity);
+        $this->leadModel->removeFromLists($leadId, $entity);
 
         $view = $this->view(['success' => 1], Response::HTTP_OK);
 


### PR DESCRIPTION
Replaces `$this->getModel(...)` string lookups with a directly injected model in this controller.

Split out of #16647 (one file per PR).