### PR TITLE
[model] inject model in NotificationApiController

### DIFF
--- a/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
+++ b/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Helper\AppVersion;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Model\NotificationModel;
@@ -39,6 +40,7 @@ class NotificationApiController extends CommonApiController
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
         NotificationModel $notificationModel,
+        private readonly LeadModel $leadModel,
     ) {
         $this->model           = $notificationModel;
         $this->entityClass     = Notification::class;
@@ -55,12 +57,9 @@ class NotificationApiController extends CommonApiController
     {
         $osid = $request->get('osid');
         if ($osid) {
-            /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
-            $leadModel = $this->getModel('lead');
-
             if ($currentLead = $this->contactTracker->getContact()) {
                 $currentLead->addPushIDEntry($osid);
-                $leadModel->saveEntity($currentLead);
+                $this->leadModel->saveEntity($currentLead);
             }
 
             return new JsonResponse(['success' => true, 'osid' => $osid], 200, ['Access-Control-Allow-Origin' => '*']);


### PR DESCRIPTION
Replaces `$this->getModel(...)` string lookups with a directly injected model in this controller.

Split out of #16647 (one file per PR).