### PR TITLE
[model] inject AuditLogModel into AbstractStandardFormController

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -39,8 +39,9 @@ class ClientController extends AbstractStandardFormController
         FlashBag $flashBag,
         RequestStack $requestStack,
         CorePermissions $security,
+        \Mautic\CoreBundle\Model\AuditLogModel $auditLogModel,
     ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security, $auditLogModel);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -124,8 +124,9 @@ class CampaignController extends AbstractStandardFormController
         CorePermissions $security,
         private EntityManager $em,
         private PublishStateService $publishStateService,
+        \Mautic\CoreBundle\Model\AuditLogModel $auditLogModel,
     ) {
-        parent::__construct($formFactory, $fieldHelper, $managerRegistry, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+        parent::__construct($formFactory, $fieldHelper, $managerRegistry, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security, $auditLogModel);
     }
 
     protected function getPermissions(): array

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -42,8 +42,9 @@ class MessageController extends AbstractStandardFormController
         FlashBag $flashBag,
         private RequestStack $requestStack,
         CorePermissions $security,
+        \Mautic\CoreBundle\Model\AuditLogModel $auditLogModel,
     ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security, $auditLogModel);
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
+use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
@@ -43,6 +44,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         FlashBag $flashBag,
         RequestStack $requestStack,
         CorePermissions $security,
+        private AuditLogModel $auditLogModel,
     ) {
         parent::__construct($managerRegistry, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -1080,7 +1082,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         $this->setListFilters();
 
         // Audit log entries
-        $logs = ($logObject) ? $this->getModel('core.auditlog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
+        $logs = ($logObject) ? $this->auditLogModel->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
 
         // Generate route
         $routeVars = [

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -119,7 +119,8 @@ final class EmailControllerTest extends TestCase
             $this->createStub(Translator::class),
             $this->createStub(FlashBag::class),
             $this->requestStack,
-            $this->corePermissionsMock
+            $this->corePermissionsMock,
+            $this->createStub(\Mautic\CoreBundle\Model\AuditLogModel::class)
         );
         $this->controller->setContainer($this->containerMock);
         $this->controller->autowireEmailController(

--- a/app/migrations/Version20211209022550.php
+++ b/app/migrations/Version20211209022550.php
@@ -7,7 +7,6 @@ namespace Mautic\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Model\RoleModel;
@@ -16,11 +15,10 @@ final class Version20211209022550 extends AbstractMauticMigration
 {
     public function postUp(Schema $schema): void
     {
-        /** @var RoleModel $model */
-        $model = $this->container->get(ModelFactory::class)->getModel('user.role');
+        $roleModel = $this->container->get(RoleModel::class);
 
         // Get all non admin roles.
-        $roles = $model->getEntities([
+        $roles = $roleModel->getEntities([
             'orderBy'       => 'r.id',
             'orderByDir'    => 'ASC',
             'filter'        => [

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -52,8 +52,9 @@ class FocusController extends AbstractStandardFormController
         FlashBag $flashBag,
         RequestStack $requestStack,
         CorePermissions $security,
+        \Mautic\CoreBundle\Model\AuditLogModel $auditLogModel,
     ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security, $auditLogModel);
     }
 
     protected function getTemplateBase(): string


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | -
| Related developer documentation PR URL | -
| Issue(s) addressed                     | -

## Description

`AbstractStandardFormController` looked the audit log model up by string on every detail view. Injecting it gives the exact type and drops the last `getModel()` string call from that class.

```diff
-        $logs = ($logObject) ? $this->getModel('core.auditlog')->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
+        $logs = ($logObject) ? $this->auditLogModel->getLogForObject($logObject, $objectId, $entity->getDateAdded(), 10, $logBundle) : [];
```

The 5 places constructing a standard form controller directly are updated to pass it through. The same treatment for a migration that reached for `ModelFactory` through the container:

```diff
-        /** @var RoleModel $model */
-        $model = $this->container->get(ModelFactory::class)->getModel('user.role');
+        $roleModel = $this->container->get(RoleModel::class);
```

---
### 📋 Steps to test this PR:

1. `vendor/bin/phpstan analyse` - green
2. Open the detail view of a campaign, email or segment - the audit log panel at the bottom must still list entries
