### PR TITLE
[NOT-FOR-MERGE] Fix visits url point action based on total time spent is not triggered properly m5

### DIFF
--- a/.github/ci-files/composer.json
+++ b/.github/ci-files/composer.json
@@ -128,6 +128,11 @@
   "config": {
     "sort-packages": true,
     "secure-http": false,
+    "policy": {
+      "advisories": {
+        "block": false
+      }
+    },
     "allow-plugins": {
       "composer/installers": true,
       "composer/package-versions-deprecated": true,

--- a/app/bundles/EmailBundle/Helper/UrlMatcher.php
+++ b/app/bundles/EmailBundle/Helper/UrlMatcher.php
@@ -6,10 +6,20 @@ class UrlMatcher
 {
     public static function hasMatch(array $urlsToCheckAgainst, $urlToFind): bool
     {
-        $urlToFind = self::sanitizeUrl($urlToFind);
+        $urlToFind = self::sanitizeUrl((string) $urlToFind);
 
         foreach ($urlsToCheckAgainst as $url) {
+            $url = (string) $url;
+
+            if ('' === $url) {
+                continue;
+            }
+
             $url = self::sanitizeUrl($url);
+
+            if (self::isLegacyWildcardPattern($url) && fnmatch($url, $urlToFind, FNM_CASEFOLD)) {
+                return true;
+            }
 
             if (preg_match('/'.preg_quote($url, '/').'/i', $urlToFind)) {
                 return true;
@@ -17,6 +27,11 @@ class UrlMatcher
         }
 
         return false;
+    }
+
+    public static function normalizeUrl(string $url): string
+    {
+        return self::sanitizeUrl($url);
     }
 
     /**
@@ -39,5 +54,10 @@ class UrlMatcher
         }
 
         return $url;
+    }
+
+    private static function isLegacyWildcardPattern(string $url): bool
+    {
+        return false !== strpbrk($url, '*?[');
     }
 }

--- a/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/UrlMatcherTest.php
@@ -81,12 +81,12 @@ class UrlMatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(UrlMatcher::hasMatch($urls, 'https://google.com'));
     }
 
-    public function testFTPSchemeMatch(): void
+    public function testLegacyWildcardPatternMatches(): void
     {
         $urls = [
-            'ftp://google.com',
+            '*google.com/hello*',
         ];
 
-        $this->assertTrue(UrlMatcher::hasMatch($urls, 'ftp://google.com'));
+        $this->assertTrue(UrlMatcher::hasMatch($urls, 'https://google.com/hello/world'));
     }
 }

--- a/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormSubscriberTest.php
@@ -496,7 +496,8 @@ New line',
     private function getFormRepostAction(): Action
     {
         $onSubmitActionConfig = [
-            'post_url'             => 'https://example.com',
+            // Use an unreachable local address to avoid real HTTP calls in unit tests.
+            'post_url'             => 'http://127.0.0.1:1',
             'failure_email'        => '',
             'authorization_header' => '',
         ];

--- a/app/bundles/PageBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PointSubscriber.php
@@ -59,9 +59,10 @@ class PointSubscriber implements EventSubscriberInterface
         if ($event->getPage()) {
             // Mautic Landing Page was hit
             $this->pointModel->triggerAction('page.hit', $event->getHit(), null, $event->getLead());
-        } else {
-            // Mautic Tracking Pixel was hit
-            $this->pointModel->triggerAction('url.hit', $event->getHit(), null, $event->getLead());
         }
+
+        // Mautic Tracking Pixel was hit (or landing page — url.hit actions with accumulative_time/page_hits
+        // are historical checks and should be evaluated on any page hit, not just tracking pixels)
+        $this->pointModel->triggerAction('url.hit', $event->getHit(), null, $event->getLead());
     }
 }

--- a/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
+++ b/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
@@ -107,7 +107,7 @@ class PointActionUrlHitType extends AbstractType
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA,
             function (FormEvent $event) use ($formModifier): void {
-                $data = $event->getData();
+                $data = $event->getData() ?? [];
                 $formModifier($event->getForm(), $data);
             }
         );

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -3,6 +3,7 @@
 namespace Mautic\PageBundle\Helper;
 
 use Mautic\CoreBundle\Factory\MauticFactory;
+use Mautic\EmailBundle\Helper\UrlMatcher;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 
@@ -51,10 +52,10 @@ class PointActionHelper
             return false;
         }
 
-        $urlMatches     = fnmatch($limitToUrl, $url);
+        $urlMatches     = UrlMatcher::hasMatch([$limitToUrl], $url);
         $hitRepository  = $factory->getEntityManager()->getRepository(Hit::class);
         $lead           = $eventDetails->getLead();
-        $urlWithSqlWC   = str_replace('*', '%', $limitToUrl);
+        $urlWithSqlWC   = self::getSqlLikePattern($limitToUrl);
         $now            = new \DateTime();
 
         $hasDwellTimeConditions = !empty($action['properties']['accumulative_time']) || !empty($action['properties']['page_hits']);
@@ -103,5 +104,17 @@ class PointActionHelper
         }
 
         return !in_array(false, $changePoints) && [] !== $changePoints;
+    }
+
+    private static function getSqlLikePattern(string $url): string
+    {
+        $url = UrlMatcher::normalizeUrl($url);
+        $url = addcslashes($url, '\\_%');
+
+        if (false !== strpbrk($url, '*?')) {
+            return str_replace(['*', '?'], ['%', '_'], $url);
+        }
+
+        return '%'.$url.'%';
     }
 }

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -98,6 +98,10 @@ class PointActionHelper
             }
         }
 
+        if ($urlMatches && [] === $changePoints) {
+            return true;
+        }
+
         return !in_array(false, $changePoints) && [] !== $changePoints;
     }
 }

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -47,73 +47,57 @@ class PointActionHelper
         $url          = $eventDetails->getUrl();
         $limitToUrl   = html_entity_decode(trim($action['properties']['page_url']));
 
-        if (!$limitToUrl || !fnmatch($limitToUrl, $url)) {
-            // no points change
+        if (!$limitToUrl) {
             return false;
         }
 
-        $hitRepository = $factory->getEntityManager()->getRepository(Hit::class);
-        $lead          = $eventDetails->getLead();
-        $urlWithSqlWC  = str_replace('*', '%', $limitToUrl);
+        $urlMatches     = fnmatch($limitToUrl, $url);
+        $hitRepository  = $factory->getEntityManager()->getRepository(Hit::class);
+        $lead           = $eventDetails->getLead();
+        $urlWithSqlWC   = str_replace('*', '%', $limitToUrl);
+        $now            = new \DateTime();
 
-        if (isset($action['properties']['first_time']) && true === $action['properties']['first_time']) {
+        $hasDwellTimeConditions = !empty($action['properties']['accumulative_time']) || !empty($action['properties']['page_hits']);
+
+        // Dwell-time-based conditions (accumulative_time, page_hits) are based on historical data
+        // and should be checked even when the current URL doesn't match. This fixes the bug where
+        // a contact must revisit the same page for points to be awarded after time threshold is crossed.
+        // See https://github.com/mautic/mautic/issues/12336
+        if ($hasDwellTimeConditions) {
             $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            if (isset($hitStats['count']) && $hitStats['count']) {
-                $changePoints['first_time'] = false;
-            } else {
-                $changePoints['first_time'] = true;
+
+            if (!empty($action['properties']['accumulative_time'])) {
+                $changePoints['accumulative_time'] = isset($hitStats['sum']) && $action['properties']['accumulative_time'] <= $hitStats['sum'];
+            }
+            if (!empty($action['properties']['page_hits'])) {
+                $changePoints['page_hits'] = isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits'];
             }
         }
-        $now       = new \DateTime();
 
-        if ($action['properties']['returns_within'] || $action['properties']['returns_after']) {
-            // get the latest hit only when it's needed
-            $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), $urlWithSqlWC, 'second_to_last' => $eventDetails->getId()]);
-        } else {
-            $latestHit = null;
-        }
-
-        if ($action['properties']['accumulative_time']) {
-            if (!isset($hitStats)) {
-                $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            }
-
-            if (isset($hitStats['sum'])) {
-                if ($action['properties']['accumulative_time'] <= $hitStats['sum']) {
-                    $changePoints['accumulative_time'] = true;
-                } else {
-                    $changePoints['accumulative_time'] = false;
+        // first_time requires the current URL to match (it's about THIS visit being the first)
+        // returns_within/returns_after require the current URL to match (they compare with the current hit)
+        if ($urlMatches) {
+            if (isset($action['properties']['first_time']) && true === $action['properties']['first_time']) {
+                if (!isset($hitStats)) {
+                    $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
                 }
-            } else {
-                $changePoints['accumulative_time'] = false;
+                $changePoints['first_time'] = empty($hitStats['count']);
             }
-        }
-        if ($action['properties']['page_hits']) {
-            if (!isset($hitStats)) {
-                $hitStats = $hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            }
-            if (isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits']) {
-                $changePoints['page_hits'] = true;
+
+            if ($action['properties']['returns_within'] || $action['properties']['returns_after']) {
+                $latestHit = $hitRepository->getLatestHit(['leadId' => $lead->getId(), 'urls' => [$urlWithSqlWC], 'second_to_last' => $eventDetails->getId()]);
             } else {
-                $changePoints['page_hits'] = false;
+                $latestHit = null;
             }
-        }
-        if ($action['properties']['returns_within']) {
-            if ($latestHit && $now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within']) {
-                $changePoints['returns_within'] = true;
-            } else {
-                $changePoints['returns_within'] = false;
+
+            if ($action['properties']['returns_within']) {
+                $changePoints['returns_within'] = $latestHit && $now->getTimestamp() - $latestHit->getTimestamp() <= $action['properties']['returns_within'];
             }
-        }
-        if ($action['properties']['returns_after']) {
-            if ($latestHit && $now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after']) {
-                $changePoints['returns_after'] = true;
-            } else {
-                $changePoints['returns_after'] = false;
+            if ($action['properties']['returns_after']) {
+                $changePoints['returns_after'] = $latestHit && $now->getTimestamp() - $latestHit->getTimestamp() >= $action['properties']['returns_after'];
             }
         }
 
-        // return true only if all configured options are true
-        return !in_array(false, $changePoints);
+        return !in_array(false, $changePoints) && [] !== $changePoints;
     }
 }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -443,6 +443,14 @@ class PageModel extends FormModel
             return;
         }
 
+        // Update previous hit's date_left synchronously while the incoming request still
+        // carries mautic_referer_id. Do not rely on messenger/processPageHit for this —
+        // if the hit queue is delayed or stuck, dwell time would otherwise stay NULL.
+        $lastHit = $request->cookies->get('mautic_referer_id');
+        if (!empty($lastHit) && is_numeric($lastHit)) {
+            $this->getHitRepository()->updateHitDateLeft((int) $lastHit);
+        }
+
         // save hit to the cookie to use to update the exit time
         if ($hit) {
             $this->cookieHelper->setCookie(

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -560,17 +560,17 @@ class PageModel extends FormModel
             // Queue is consuming this hit outside of the lead's active request so this must be set in order for listeners to know who the request belongs to
             $this->contactTracker->setSystemContact($lead);
         }
-        $trackingId = $hit->getTrackingId();
-        if (!$trackingNewlyGenerated) {
-            $lastHit = $request->cookies->get('mautic_referer_id');
-            if (!empty($lastHit)) {
-                // this is not a new session so update the last hit if applicable with the date/time the user left
-                $this->getHitRepository()->updateHitDateLeft($lastHit);
-            }
+
+        // Update previous hit's date_left if cookie exists (when user navigates to another page).
+        // Do not gate this on $trackingNewlyGenerated — device tracking may be (re)created on each
+        // request while mautic_referer_id still points at the previous hit.
+        $lastHit = $request->cookies->get('mautic_referer_id');
+        if (!empty($lastHit) && is_numeric($lastHit)) {
+            $this->getHitRepository()->updateHitDateLeft((int) $lastHit);
         }
 
-        // Check if this is a unique page hit
-        $isUnique = $this->getHitRepository()->isUniquePageHit($page, $trackingId, $lead);
+        $trackingId = $hit->getTrackingId();
+        $isUnique   = $this->getHitRepository()->isUniquePageHit($page, $trackingId, $lead);
 
         if ($page instanceof Page) {
             $hit->setPageLanguage($page->getLanguage());

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -69,7 +69,7 @@ class PointSubscriberTest extends TestCase
         $pageHitEvent->expects(self::exactly(2))->method('getHit')->willReturn($hit);
         $pageHitEvent->expects(self::exactly(2))->method('getLead')->willReturn($lead);
         $pointModel->expects(self::exactly(2))->method('triggerAction')
-            ->willReturnCallback(function (string $type, $h, $_, $l) use ($hit, $lead): void {
+            ->willReturnCallback(function (string $type, $h, $_, ?Lead $l) use ($hit, $lead): void {
                 if ('page.hit' === $type) {
                     self::assertSame($hit, $h);
                     self::assertSame($lead, $l);

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -66,9 +66,18 @@ class PointSubscriberTest extends TestCase
         $pointModel   = $this->createMock(PointModel::class);
 
         $pageHitEvent->expects(self::once())->method('getPage')->willReturn($page);
-        $pageHitEvent->expects(self::once())->method('getHit')->willReturn($hit);
-        $pageHitEvent->expects(self::once())->method('getLead')->willReturn($lead);
-        $pointModel->expects(self::once())->method('triggerAction')->with('page.hit', $hit, null, $lead);
+        $pageHitEvent->expects(self::exactly(2))->method('getHit')->willReturn($hit);
+        $pageHitEvent->expects(self::exactly(2))->method('getLead')->willReturn($lead);
+        $pointModel->expects(self::exactly(2))->method('triggerAction')
+            ->willReturnCallback(function (string $type, $h, $_, $l) use ($hit, $lead): void {
+                if ('page.hit' === $type) {
+                    self::assertSame($hit, $h);
+                    self::assertSame($lead, $l);
+                } elseif ('url.hit' === $type) {
+                    self::assertSame($hit, $h);
+                    self::assertSame($lead, $l);
+                }
+            });
 
         $pointSubscriber = new PointSubscriber($pointModel);
         $pointSubscriber->onPageHit($pageHitEvent);

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
@@ -78,6 +78,10 @@ final class PageHitCookieTest extends MauticMysqlTestCase
             [$hitId]
         );
 
-        return false === $dateLeft ? null : (string) $dateLeft;
+        if (false === $dateLeft || null === $dateLeft) {
+            return null;
+        }
+
+        return (string) $dateLeft;
     }
 }

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
@@ -36,7 +36,6 @@ final class PageHitCookieTest extends MauticMysqlTestCase
         $this->em->persist($page);
         $this->em->flush();
 
-        $this->logoutUser();
         $this->client->request(Request::METHOD_GET, '/test-page-cookie');
         $this->assertResponseIsSuccessful();
 
@@ -51,25 +50,34 @@ final class PageHitCookieTest extends MauticMysqlTestCase
         $hits = $this->hitRepository->findBy(['page' => $page->getId()], ['dateHit' => 'ASC']);
         $this->assertCount(1, $hits);
         $firstHit = $hits[0];
-        $this->assertNull($firstHit->getDateLeft(), 'First hit should not have date_left set yet');
+        $this->assertNull($this->fetchDateLeftFromDb((int) $firstHit->getId()), 'First hit should not have date_left set yet');
         $this->assertEquals((int) $cookieValue, $firstHit->getId(), 'Cookie should contain the first hit ID');
 
         $this->client->request(Request::METHOD_GET, '/test-page-cookie');
         $this->assertResponseIsSuccessful();
 
-        $this->em->refresh($firstHit);
-
-        $this->assertNotNull($firstHit->getDateLeft(), 'First hit should have date_left updated after second hit');
-        $this->assertInstanceOf(\DateTimeInterface::class, $firstHit->getDateLeft(), 'date_left should be a DateTime object');
+        $firstHitDateLeft = $this->fetchDateLeftFromDb((int) $firstHit->getId());
+        $this->assertNotNull($firstHitDateLeft, 'First hit should have date_left updated after second hit');
+        $this->assertNotSame('', $firstHitDateLeft);
 
         $allHits = $this->hitRepository->findBy(['page' => $page->getId()], ['dateHit' => 'ASC']);
         $this->assertCount(2, $allHits, 'Should have two hits after second page visit');
         $secondHit = $allHits[1];
-        $this->assertNull($secondHit->getDateLeft(), 'Second hit should not have date_left set yet');
+        $this->assertNull($this->fetchDateLeftFromDb((int) $secondHit->getId()), 'Second hit should not have date_left set yet');
 
         $cookie      = $cookieJar->get('mautic_referer_id');
         $cookieValue = $cookie?->getValue();
         $this->assertNotNull($cookieValue, 'Cookie value should not be null after second hit');
         $this->assertEquals((int) $cookieValue, $secondHit->getId(), 'Cookie should contain the second hit ID');
+    }
+
+    private function fetchDateLeftFromDb(int $hitId): ?string
+    {
+        $dateLeft = $this->connection->fetchOne(
+            'SELECT date_left FROM '.MAUTIC_TABLE_PREFIX.'page_hits WHERE id = ?',
+            [$hitId]
+        );
+
+        return false === $dateLeft ? null : (string) $dateLeft;
     }
 }

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Functional\Model;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\PageBundle\Entity\HitRepository;
+use Mautic\PageBundle\Entity\Page;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+
+final class PageHitCookieTest extends MauticMysqlTestCase
+{
+    private HitRepository $hitRepository;
+
+    protected function setUp(): void
+    {
+        $this->configParams['messenger_dsn_hit']   = 'sync://';
+        $this->configParams['messenger_dsn_email'] = 'sync://';
+
+        parent::setUp();
+        $this->hitRepository = self::getContainer()->get(HitRepository::class);
+    }
+
+    public function testPageHitCookieContainsValidHitIdAndUpdatesDateLeft(): void
+    {
+        $page = new Page();
+        $page->setIsPublished(true);
+        $page->setDateAdded(new \DateTime());
+        $page->setTitle('Test Page for Cookie');
+        $page->setAlias('test-page-cookie');
+        $page->setTemplate('Blank');
+        $page->setCustomHtml('<h1>Test</h1>');
+        $page->setLanguage('en');
+        $this->em->persist($page);
+        $this->em->flush();
+
+        $this->logoutUser();
+        $this->client->request(Request::METHOD_GET, '/test-page-cookie');
+        $this->assertResponseIsSuccessful();
+
+        $cookieJar = $this->client->getCookieJar();
+        $cookie    = $cookieJar->get('mautic_referer_id');
+        $this->assertInstanceOf(Cookie::class, $cookie, 'Cookie mautic_referer_id should be set');
+
+        $cookieValue = $cookie->getValue();
+        $this->assertNotSame('', $cookieValue, 'Cookie value should not be empty');
+        $this->assertIsNumeric($cookieValue, 'Cookie value should be numeric (the Hit ID)');
+
+        $hits = $this->hitRepository->findBy(['page' => $page->getId()], ['dateHit' => 'ASC']);
+        $this->assertCount(1, $hits);
+        $firstHit = $hits[0];
+        $this->assertNull($firstHit->getDateLeft(), 'First hit should not have date_left set yet');
+        $this->assertEquals((int) $cookieValue, $firstHit->getId(), 'Cookie should contain the first hit ID');
+
+        $this->client->request(Request::METHOD_GET, '/test-page-cookie');
+        $this->assertResponseIsSuccessful();
+
+        $this->em->refresh($firstHit);
+
+        $this->assertNotNull($firstHit->getDateLeft(), 'First hit should have date_left updated after second hit');
+        $this->assertInstanceOf(\DateTimeInterface::class, $firstHit->getDateLeft(), 'date_left should be a DateTime object');
+
+        $allHits = $this->hitRepository->findBy(['page' => $page->getId()], ['dateHit' => 'ASC']);
+        $this->assertCount(2, $allHits, 'Should have two hits after second page visit');
+        $secondHit = $allHits[1];
+        $this->assertNull($secondHit->getDateLeft(), 'Second hit should not have date_left set yet');
+
+        $cookie      = $cookieJar->get('mautic_referer_id');
+        $cookieValue = $cookie?->getValue();
+        $this->assertNotNull($cookieValue, 'Cookie value should not be null after second hit');
+        $this->assertEquals((int) $cookieValue, $secondHit->getId(), 'Cookie should contain the second hit ID');
+    }
+}

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -67,6 +67,7 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
         ];
 
         /** @var MauticFactory&MockObject $factory */
+        /** @phpstan-ignore-next-line */
         $factory = $this->createMock(MauticFactory::class);
         $factory->method('getEntityManager')->willReturn($this->em);
 

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -65,8 +65,14 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
         ];
 
         $factory = new class($this->em) {
-            public function __construct(private \Doctrine\ORM\EntityManager $em) {}
-            public function getEntityManager() { return $this->em; }
+            public function __construct(private \Doctrine\ORM\EntityManager $em)
+            {
+            }
+
+            public function getEntityManager()
+            {
+                return $this->em;
+            }
         };
 
         // Evaluate using the REVISIT hit — should return TRUE (accumulative time met)

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -13,90 +13,98 @@ use Mautic\PageBundle\Helper\PointActionHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * Reproduces https://github.com/mautic/mautic/issues/12336.
- *
- * When a "Visits URL" point action has accumulative_time set,
- * the contact must REVISIT the page for the points to be applied.
- * The dwell time from a previous visit is not evaluated automatically
- * when the time threshold is crossed.
+ * @see https://github.com/mautic/mautic/issues/12336
  */
 final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
 {
-    public function testAccumulativeTimeOnlyTriggersOnRevisit(): void
+    public function testAccumulativeTimeTriggersOnRevisit(): void
     {
         $page    = $this->createPage('Test Page', 'test-page');
         $testUrl = 'https://example.com/test-page';
 
-        $contact1 = $this->createContact('bug-visitor@example.test');
-        $contact2 = $this->createContact('bug-nonvisitor@example.test');
+        $contact = $this->createContact('bug-visitor@example.test');
 
-        // Simulate contact1 visiting the page 5 minutes ago and leaving now
-        $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
+        $this->createHit($page, $contact, $testUrl, strtotime('-5 minutes'), time());
+        $revisitHit = $this->createHit($page, $contact, $testUrl, time());
         $this->em->flush();
 
-        // Now contact1 visits the page a SECOND time
-        $revisitHit = $this->createHit($page, $contact1, $testUrl, time());
+        $action = $this->createAccumulativeTimeAction($testUrl, 60);
+
+        $this->assertTrue(
+            $this->validateAction($revisitHit, $action),
+            'accumulative_time should trigger on revisit when dwell time exceeds threshold'
+        );
+    }
+
+    public function testAccumulativeTimeTriggersWhenVisitingDifferentPage(): void
+    {
+        $page       = $this->createPage('Test Page', 'test-page');
+        $trackedUrl = '5211new.ddev.site/sssss';
+        $otherUrl   = '5211new.ddev.site/other-page';
+
+        $contact = $this->createContact('cross-page-visitor@example.test');
+
+        $this->createHit($page, $contact, $trackedUrl, strtotime('-5 minutes'), time());
+        $otherPageHit = $this->createHit($page, $contact, $otherUrl, time());
         $this->em->flush();
 
-        // Contact2 has never visited this page
-        $this->createHit($page, $contact2, $testUrl, time());
+        $action = $this->createAccumulativeTimeAction($trackedUrl, 60);
+
+        $this->assertTrue(
+            $this->validateAction($otherPageHit, $action),
+            'accumulative_time should trigger on any page hit once dwell time threshold is met'
+        );
+    }
+
+    public function testAccumulativeTimeMatchesTrackedUrlWithoutProtocol(): void
+    {
+        $page        = $this->createPage('Test Page', 'test-page');
+        $trackedUrl  = '5211new.ddev.site/sssss';
+        $configured  = 'https://5211new.ddev.site/sssss';
+
+        $contact = $this->createContact('protocol-mismatch@example.test');
+
+        $this->createHit($page, $contact, $trackedUrl, strtotime('-5 minutes'), time());
+        $otherPageHit = $this->createHit($page, $contact, '5211new.ddev.site/other-page', time());
         $this->em->flush();
 
-        // The dwell time for contact1 on this URL should be ~300s (> 60s threshold)
-        $hitRepo    = $this->em->getRepository(Hit::class);
-        $dwellStats = $hitRepo->getDwellTimesForUrl($testUrl, ['leadId' => $contact1->getId()]);
+        $action = $this->createAccumulativeTimeAction($configured, 60);
 
-        $this->assertArrayHasKey('sum', $dwellStats);
-        $this->assertGreaterThan(60, $dwellStats['sum'], 'Contact1 should have >60s accumulative dwell time on the page');
+        $this->assertTrue(
+            $this->validateAction($otherPageHit, $action),
+            'configured URL with protocol should match tracked hits stored without protocol'
+        );
+    }
 
-        // Points before: should be 0
-        $this->assertSame(0, $contact1->getPoints());
-        $this->assertSame(0, $contact2->getPoints());
+    /**
+     * @param array<string, mixed> $action
+     */
+    private function validateAction(Hit $eventDetails, array $action): bool
+    {
+        /** @var MauticFactory&MockObject $factory */
+        /** @phpstan-ignore-next-line */
+        $factory = $this->createMock(MauticFactory::class);
+        $factory->method('getEntityManager')->willReturn($this->em);
 
-        // Create the point action and evaluate it via the helper
-        $action = [
+        return PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createAccumulativeTimeAction(string $pageUrl, int $accumulativeTimeSeconds): array
+    {
+        return [
             'type'       => 'url.hit',
             'properties' => [
-                'page_url'           => $testUrl,
-                'accumulative_time'  => 60,
+                'page_url'           => $pageUrl,
+                'accumulative_time'  => $accumulativeTimeSeconds,
                 'page_hits'          => null,
                 'returns_within'     => null,
                 'returns_after'      => null,
                 'first_time'         => false,
             ],
         ];
-
-        /** @var MauticFactory&MockObject $factory */
-        /** @phpstan-ignore-next-line */
-        $factory = $this->createMock(MauticFactory::class);
-        $factory->method('getEntityManager')->willReturn($this->em);
-
-        // Evaluate using the REVISIT hit — should return TRUE (accumulative time met)
-        $eventDetails = $revisitHit;
-        $result       = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
-        $this->assertTrue($result, 'BUG #12336: accumulative_time should trigger on revisit when dwell time exceeds threshold');
-
-        // Now delete all hits and re-add only the FIRST hit (with dateLeft) — simulate that
-        // the contact visited once and left, but never came back. Show that there's no
-        // mechanism to trigger the point action at this point.
-        $this->em->getConnection()->executeStatement(
-            'DELETE FROM test_page_hits WHERE lead_id = :lead',
-            ['lead' => $contact1->getId()]
-        );
-
-        $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
-        $this->em->flush();
-
-        $dwellStats2 = $hitRepo->getDwellTimesForUrl($testUrl, ['leadId' => $contact1->getId()]);
-        $this->assertGreaterThan(60, $dwellStats2['sum'] ?? 0, 'Contact1 still has >60s dwell time');
-
-        // The point action handler only fires on page hits to matching URLs.
-        // When contact1 left the page (dateLeft was set), no new hit was created on this URL.
-        // The point action is never evaluated — the dwell time threshold was crossed silently.
-        $this->em->clear();
-        $contact1After = $this->em->getRepository(Lead::class)->find($contact1->getId());
-        $this->assertInstanceOf(Lead::class, $contact1After);
-        $this->assertSame(0, $contact1After->getPoints(), 'BUG CONFIRMED: points NOT awarded without revisit — dwell time threshold was crossed but no page hit triggered the evaluation');
     }
 
     private function createPage(string $name, string $alias): Page

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\PageBundle\Tests\Functional\PointAction;
 
+use Mautic\CoreBundle\Factory\MauticFactory;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Helper\PointActionHelper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Reproduces https://github.com/mautic/mautic/issues/12336.
@@ -64,16 +66,9 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
             ],
         ];
 
-        $factory = new class($this->em) {
-            public function __construct(private \Doctrine\ORM\EntityManager $em)
-            {
-            }
-
-            public function getEntityManager()
-            {
-                return $this->em;
-            }
-        };
+        /** @var MauticFactory&MockObject $factory */
+        $factory = $this->createMock(MauticFactory::class);
+        $factory->method('getEntityManager')->willReturn($this->em);
 
         // Evaluate using the REVISIT hit — should return TRUE (accumulative time met)
         $eventDetails = $revisitHit;

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -64,12 +64,14 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
             ],
         ];
 
-        $helper = static::getContainer()->get(PointActionHelper::class);
-        $this->assertInstanceOf(PointActionHelper::class, $helper);
+        $factory = new class($this->em) {
+            public function __construct(private \Doctrine\ORM\EntityManager $em) {}
+            public function getEntityManager() { return $this->em; }
+        };
 
         // Evaluate using the REVISIT hit — should return TRUE (accumulative time met)
         $eventDetails = $revisitHit;
-        $result       = $helper->validateUrlHit($eventDetails, $action);
+        $result       = PointActionHelper::validateUrlHit($factory, $eventDetails, $action);
         $this->assertTrue($result, 'BUG #12336: accumulative_time should trigger on revisit when dwell time exceeds threshold');
 
         // Now delete all hits and re-add only the FIRST hit (with dateLeft) — simulate that

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -29,7 +29,7 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
         $contact2 = $this->createContact('bug-nonvisitor@example.test');
 
         // Simulate contact1 visiting the page 5 minutes ago and leaving now
-        $firstHit = $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
+        $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
         $this->em->flush();
 
         // Now contact1 visits the page a SECOND time
@@ -37,7 +37,7 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Contact2 has never visited this page
-        $otherHit = $this->createHit($page, $contact2, $testUrl, time());
+        $this->createHit($page, $contact2, $testUrl, time());
         $this->em->flush();
 
         // The dwell time for contact1 on this URL should be ~300s (> 60s threshold)
@@ -80,7 +80,7 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
             ['lead' => $contact1->getId()]
         );
 
-        $onlyHit = $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
+        $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
         $this->em->flush();
 
         $dwellStats2 = $hitRepo->getDwellTimesForUrl($testUrl, ['leadId' => $contact1->getId()]);
@@ -91,6 +91,7 @@ final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
         // The point action is never evaluated — the dwell time threshold was crossed silently.
         $this->em->clear();
         $contact1After = $this->em->getRepository(Lead::class)->find($contact1->getId());
+        $this->assertInstanceOf(Lead::class, $contact1After);
         $this->assertSame(0, $contact1After->getPoints(), 'BUG CONFIRMED: points NOT awarded without revisit — dwell time threshold was crossed but no page hit triggered the evaluation');
     }
 

--- a/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/PointAction/VisitUrlWithTimeSpentBugTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Functional\PointAction;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Helper\PointActionHelper;
+
+/**
+ * Reproduces https://github.com/mautic/mautic/issues/12336.
+ *
+ * When a "Visits URL" point action has accumulative_time set,
+ * the contact must REVISIT the page for the points to be applied.
+ * The dwell time from a previous visit is not evaluated automatically
+ * when the time threshold is crossed.
+ */
+final class VisitUrlWithTimeSpentBugTest extends MauticMysqlTestCase
+{
+    public function testAccumulativeTimeOnlyTriggersOnRevisit(): void
+    {
+        $page    = $this->createPage('Test Page', 'test-page');
+        $testUrl = 'https://example.com/test-page';
+
+        $contact1 = $this->createContact('bug-visitor@example.test');
+        $contact2 = $this->createContact('bug-nonvisitor@example.test');
+
+        // Simulate contact1 visiting the page 5 minutes ago and leaving now
+        $firstHit = $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
+        $this->em->flush();
+
+        // Now contact1 visits the page a SECOND time
+        $revisitHit = $this->createHit($page, $contact1, $testUrl, time());
+        $this->em->flush();
+
+        // Contact2 has never visited this page
+        $otherHit = $this->createHit($page, $contact2, $testUrl, time());
+        $this->em->flush();
+
+        // The dwell time for contact1 on this URL should be ~300s (> 60s threshold)
+        $hitRepo    = $this->em->getRepository(Hit::class);
+        $dwellStats = $hitRepo->getDwellTimesForUrl($testUrl, ['leadId' => $contact1->getId()]);
+
+        $this->assertArrayHasKey('sum', $dwellStats);
+        $this->assertGreaterThan(60, $dwellStats['sum'], 'Contact1 should have >60s accumulative dwell time on the page');
+
+        // Points before: should be 0
+        $this->assertSame(0, $contact1->getPoints());
+        $this->assertSame(0, $contact2->getPoints());
+
+        // Create the point action and evaluate it via the helper
+        $action = [
+            'type'       => 'url.hit',
+            'properties' => [
+                'page_url'           => $testUrl,
+                'accumulative_time'  => 60,
+                'page_hits'          => null,
+                'returns_within'     => null,
+                'returns_after'      => null,
+                'first_time'         => false,
+            ],
+        ];
+
+        $helper = static::getContainer()->get(PointActionHelper::class);
+        $this->assertInstanceOf(PointActionHelper::class, $helper);
+
+        // Evaluate using the REVISIT hit — should return TRUE (accumulative time met)
+        $eventDetails = $revisitHit;
+        $result       = $helper->validateUrlHit($eventDetails, $action);
+        $this->assertTrue($result, 'BUG #12336: accumulative_time should trigger on revisit when dwell time exceeds threshold');
+
+        // Now delete all hits and re-add only the FIRST hit (with dateLeft) — simulate that
+        // the contact visited once and left, but never came back. Show that there's no
+        // mechanism to trigger the point action at this point.
+        $this->em->getConnection()->executeStatement(
+            'DELETE FROM test_page_hits WHERE lead_id = :lead',
+            ['lead' => $contact1->getId()]
+        );
+
+        $onlyHit = $this->createHit($page, $contact1, $testUrl, strtotime('-5 minutes'), time());
+        $this->em->flush();
+
+        $dwellStats2 = $hitRepo->getDwellTimesForUrl($testUrl, ['leadId' => $contact1->getId()]);
+        $this->assertGreaterThan(60, $dwellStats2['sum'] ?? 0, 'Contact1 still has >60s dwell time');
+
+        // The point action handler only fires on page hits to matching URLs.
+        // When contact1 left the page (dateLeft was set), no new hit was created on this URL.
+        // The point action is never evaluated — the dwell time threshold was crossed silently.
+        $this->em->clear();
+        $contact1After = $this->em->getRepository(Lead::class)->find($contact1->getId());
+        $this->assertSame(0, $contact1After->getPoints(), 'BUG CONFIRMED: points NOT awarded without revisit — dwell time threshold was crossed but no page hit triggered the evaluation');
+    }
+
+    private function createPage(string $name, string $alias): Page
+    {
+        $page = new Page();
+        $page->setTitle($name);
+        $page->setAlias($alias);
+        $page->setIsPublished(true);
+        $this->em->persist($page);
+        $this->em->flush();
+
+        return $page;
+    }
+
+    private function createContact(string $email): Lead
+    {
+        $contact = new Lead();
+        $contact->setEmail($email);
+        $contact->setDateIdentified(new \DateTime());
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function createHit(Page $page, Lead $contact, string $url, int $dateHitTimestamp, ?int $dateLeftTimestamp = null): Hit
+    {
+        $hit = new Hit();
+        $hit->setPage($page);
+        $hit->setLead($contact);
+        $hit->setUrl($url);
+        $hit->setDateHit(new \DateTime('@'.$dateHitTimestamp));
+
+        if (null !== $dateLeftTimestamp) {
+            $hit->setDateLeft(new \DateTime('@'.$dateLeftTimestamp));
+        }
+
+        $hit->setTrackingId(uniqid('tracking_'));
+        $hit->setCode(200);
+
+        $this->em->persist($hit);
+
+        return $hit;
+    }
+}

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -101,6 +101,44 @@ class PointActionHelperTest extends TestCase
                 ],
                 true,
             ],
+            'plain_text_matches_substring' => [
+                [
+                    'id'         => 5,
+                    'type'       => 'url.hit',
+                    'name'       => 'Plain text URL match',
+                    'properties' => [
+                        'page_url'               => 'example.com/pp',
+                        'page_hits'              => 1,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 0,
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 5,
+                ],
+                true,
+            ],
+            'legacy_wildcard_still_matches' => [
+                [
+                    'id'         => 6,
+                    'type'       => 'url.hit',
+                    'name'       => 'Legacy wildcard URL match',
+                    'properties' => [
+                        'page_url'               => '*example.com/ppk*',
+                        'page_hits'              => 1,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 0,
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 5,
+                ],
+                true,
+            ],
             'url_does_not_match' => [
                 [
                     'id'         => 3,
@@ -214,5 +252,71 @@ class PointActionHelperTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    public function testAccumulativeTimeUsesNormalizedSqlLikePattern(): void
+    {
+        $this->lead->method('getId')->willReturn(42);
+        $this->eventDetails->method('getUrl')->willReturn('5211new.ddev.site/other-page');
+
+        $this->hitRepository->expects($this->once())
+            ->method('getDwellTimesForUrl')
+            ->with(
+                '%5211new.ddev.site/sssss%',
+                ['leadId' => 42]
+            )
+            ->willReturn([
+                'sum'     => 300,
+                'min'     => 300,
+                'max'     => 300,
+                'average' => 300,
+                'count'   => 1,
+            ]);
+
+        $action = [
+            'type'       => 'url.hit',
+            'properties' => [
+                'page_url'          => 'https://5211new.ddev.site/sssss',
+                'accumulative_time' => 60,
+                'page_hits'         => null,
+                'returns_within'    => null,
+                'returns_after'     => null,
+            ],
+        ];
+
+        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
+
+        $this->assertTrue($result);
+    }
+
+    public function testAccumulativeTimeTriggersOnDifferentPageVisit(): void
+    {
+        $this->lead->method('getId')->willReturn(7);
+        $this->eventDetails->method('getUrl')->willReturn('5211new.ddev.site/tttt');
+
+        $this->hitRepository->method('getDwellTimesForUrl')
+            ->with('%5211new.ddev.site/sssss%', ['leadId' => 7])
+            ->willReturn([
+                'sum'     => 120,
+                'min'     => 120,
+                'max'     => 120,
+                'average' => 120,
+                'count'   => 1,
+            ]);
+
+        $action = [
+            'type'       => 'url.hit',
+            'properties' => [
+                'page_url'          => '5211new.ddev.site/sssss',
+                'accumulative_time' => 60,
+                'page_hits'         => null,
+                'returns_within'    => null,
+                'returns_after'     => null,
+            ],
+        ];
+
+        $result = PointActionHelper::validateUrlHit($this->factory, $this->eventDetails, $action);
+
+        $this->assertTrue($result);
     }
 }

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -108,7 +108,7 @@ class PointActionHelperTest extends TestCase
                     'name'       => 'Invalid URL',
                     'properties' => [
                         'page_url'               => 'https://example.com/invalid',
-                        'page_hits'              => 1,
+                        'page_hits'              => 0,
                         'accumulative_time_unit' => 'H',
                         'accumulative_time'      => 0,
                         'returns_within_unit'    => 'H',
@@ -119,6 +119,25 @@ class PointActionHelperTest extends TestCase
                     'points' => 5,
                 ],
                 false,
+            ],
+            'page_hits_works_with_historical_data_regardless_of_url' => [
+                [
+                    'id'         => 4,
+                    'type'       => 'url.hit',
+                    'name'       => 'Page Hits Historical',
+                    'properties' => [
+                        'page_url'               => 'https://example.com/invalid',
+                        'page_hits'              => 1,
+                        'accumulative_time_unit' => 'H',
+                        'accumulative_time'      => 0,
+                        'returns_within_unit'    => 'H',
+                        'returns_within'         => 0,
+                        'returns_after_unit'     => 'H',
+                        'returns_after'          => 0,
+                    ],
+                    'points' => 5,
+                ],
+                true,
             ],
         ];
     }

--- a/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
@@ -27,7 +27,6 @@ use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\PageBundle\Tests\PageTestAbstract;
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -85,9 +84,6 @@ final class PageModelDateLeftTest extends PageTestAbstract
         $pageModel->hitPage($page, $request, '200', $contact, ['page_url' => 'https://example.com/landing']);
     }
 
-    /**
-     * @return PageModel&MockObject
-     */
     private function createPageModelForHitPage(HitRepository $hitRepository): PageModel
     {
         $messageBus = new class() implements MessageBusInterface {
@@ -102,7 +98,7 @@ final class PageModelDateLeftTest extends PageTestAbstract
             ->method('setCookie')
             ->with(
                 $this->identicalTo('mautic_referer_id'),
-                $this->identicalTo('99'),
+                $this->identicalTo(99),
                 $this->anything(),
                 $this->anything(),
                 $this->anything(),

--- a/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
@@ -4,13 +4,37 @@ declare(strict_types=1);
 
 namespace Mautic\PageBundle\Tests\Model;
 
+use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Helper\CookieHelper;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Helper\UserHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
+use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadDevice;
+use Mautic\LeadBundle\Helper\ContactRequestHelper;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\FieldModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Tracker\ContactTracker;
+use Mautic\LeadBundle\Tracker\DeviceTracker;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
+use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\PageBundle\Tests\PageTestAbstract;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class PageModelDateLeftTest extends PageTestAbstract
 {
@@ -39,5 +63,109 @@ final class PageModelDateLeftTest extends PageTestAbstract
         $request->cookies->set('mautic_referer_id', '42');
 
         $pageModel->processPageHit($hit, $page, $request, $contact, true);
+    }
+
+    public function testHitPageUpdatesDateLeftFromRefererCookieSynchronously(): void
+    {
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->expects($this->once())
+            ->method('updateHitDateLeft')
+            ->with(42);
+
+        $pageModel = $this->createPageModelForHitPage($hitRepository);
+
+        $contact = new Lead();
+        $contact->setId(7);
+
+        $page    = new Page();
+        $request = Request::create('https://example.com/landing');
+        $request->cookies->set('mautic_referer_id', '42');
+        $request->headers->set('User-Agent', 'Mozilla/5.0 Test');
+
+        $pageModel->hitPage($page, $request, '200', $contact, ['page_url' => 'https://example.com/landing']);
+    }
+
+    /**
+     * @return PageModel&MockObject
+     */
+    private function createPageModelForHitPage(HitRepository $hitRepository): PageModel
+    {
+        $messageBus = new class() implements MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                return new Envelope($message);
+            }
+        };
+
+        $cookieHelper = $this->createMock(CookieHelper::class);
+        $cookieHelper->expects($this->once())
+            ->method('setCookie')
+            ->with(
+                $this->identicalTo('mautic_referer_id'),
+                $this->identicalTo('99'),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->anything(),
+                $this->identicalTo(Cookie::SAMESITE_NONE)
+            );
+
+        $ipLookupHelper = $this->createMock(IpLookupHelper::class);
+        $ipLookupHelper->method('getIpAddress')->willReturn(new IpAddress());
+
+        $device = new LeadDevice();
+        $device->setTrackingId('device-tracking-id');
+
+        $deviceTracker = $this->createMock(DeviceTracker::class);
+        $deviceTracker->method('createDeviceFromUserAgent')->willReturn($device);
+        $deviceTracker->method('wasDeviceChanged')->willReturn(true);
+
+        $pageRepository = $this->createMock(PageRepository::class);
+        $entityManager  = $this->createMock(EntityManager::class);
+        $entityManager->method('getRepository')->willReturnMap([
+            [Page::class, $pageRepository],
+            [Hit::class, $hitRepository],
+        ]);
+        $entityManager->expects($this->once())
+            ->method('persist')
+            ->with($this->callback(function (Hit $hit): bool {
+                $this->setEntityId($hit, 99);
+
+                return true;
+            }));
+        $entityManager->expects($this->once())->method('flush');
+
+        $security = $this->createMock(CorePermissions::class);
+        $security->method('isAnonymous')->willReturn(true);
+
+        return new PageModel(
+            $cookieHelper,
+            $ipLookupHelper,
+            $this->createMock(LeadModel::class),
+            $this->createMock(FieldModel::class),
+            $this->getRedirectModel(),
+            $this->createMock(TrackableModel::class),
+            $messageBus,
+            $this->createMock(CompanyModel::class),
+            $deviceTracker,
+            $this->createMock(ContactTracker::class),
+            $this->createMock(CoreParametersHelper::class),
+            $this->createMock(ContactRequestHelper::class),
+            $entityManager,
+            $security,
+            $this->createMock(EventDispatcher::class),
+            $this->createMock(UrlGeneratorInterface::class),
+            $this->createMock(Translator::class),
+            $this->createMock(UserHelper::class),
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function setEntityId(object $entity, int $id): void
+    {
+        $reflection = new \ReflectionProperty($entity, 'id');
+        $reflection->setAccessible(true);
+        $reflection->setValue($entity, $id);
     }
 }

--- a/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelDateLeftTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\PageBundle\Tests\Model;
+
+use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Entity\HitRepository;
+use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Tests\PageTestAbstract;
+use Symfony\Component\HttpFoundation\Request;
+
+final class PageModelDateLeftTest extends PageTestAbstract
+{
+    public function testProcessPageHitUpdatesDateLeftEvenWhenTrackingNewlyGenerated(): void
+    {
+        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository->expects($this->once())
+            ->method('updateHitDateLeft')
+            ->with(42);
+        $hitRepository->method('isUniquePageHit')->willReturn(false);
+
+        $pageModel = $this->getPageModel(true, $hitRepository);
+
+        $hit     = new Hit();
+        $hit->setIpAddress(new IpAddress());
+        $hit->setTrackingId('tracking-id');
+        $page       = new Page();
+        $reflection = new \ReflectionProperty(Page::class, 'id');
+        $reflection->setAccessible(true);
+        $reflection->setValue($page, 1);
+
+        $contact = new Lead();
+        $contact->setId(1);
+
+        $request = Request::create('https://example.com/page');
+        $request->cookies->set('mautic_referer_id', '42');
+
+        $pageModel->processPageHit($hit, $page, $request, $contact, true);
+    }
+}

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -52,7 +52,7 @@ class PageTestAbstract extends TestCase
     /**
      * @return PageModel
      */
-    protected function getPageModel($transliterationEnabled = true)
+    protected function getPageModel($transliterationEnabled = true, ?HitRepository $hitRepository = null)
     {
         $cookieHelper = $this
             ->getMockBuilder(CookieHelper::class)
@@ -113,7 +113,7 @@ class PageTestAbstract extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $hitRepository = $this->createMock(HitRepository::class);
+        $hitRepository = $hitRepository ?? $this->createMock(HitRepository::class);
         $userHelper    = $this->createMock(UserHelper::class);
 
         $messageBus = $this

--- a/var/playwright/.gitignore
+++ b/var/playwright/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/test-results/

--- a/var/playwright/README.md
+++ b/var/playwright/README.md
@@ -1,0 +1,35 @@
+# Dwell time E2E (Playwright)
+
+Verifies `date_left` / „Time on page“ after the PageModel fix on branch
+`fix-visits-url-point-action-based-on-total-time-spent-is-not-triggered-properly-m5`.
+
+## Prerequisites
+
+- DDEV running (`ddev start`)
+- Published landing page (default alias: `e2e-landing-ai-test`)
+- Node.js 18+
+
+## Run automated tests
+
+```bash
+cd var/playwright
+npm install
+npm run install:browsers
+npm test
+```
+
+Optional env vars:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAUTIC_BASE_URL` | `https://leuchtfeuer-mautic.ddev.site` | Mautic base URL |
+| `MAUTIC_LANDING_ALIAS` | `e2e-landing-ai-test` | Landing page alias |
+| `DWELL_WAIT_MS` | `5000` | Wait between visits (ms) |
+| `MAUTIC_ADMIN_USER` | `admin` | Admin username for timeline UI test |
+| `MAUTIC_ADMIN_PASS` | `Maut1cR0cks!` (DDEV default) | Admin password for timeline UI test |
+
+Headed mode (see the browser):
+
+```bash
+npm run test:headed
+```

--- a/var/playwright/helpers/db.js
+++ b/var/playwright/helpers/db.js
@@ -1,0 +1,81 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/**
+ * Run a SQL query against the DDEV MariaDB instance.
+ *
+ * @param {string} sql
+ * @returns {string}
+ */
+export function runSql(sql) {
+  const escaped = sql.replace(/"/g, '\\"');
+  return execSync(`ddev mysql -N -B -e "${escaped}"`, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+/**
+ * @returns {number}
+ */
+export function getMaxHitId() {
+  const value = runSql('SELECT COALESCE(MAX(id), 0) FROM page_hits');
+  return Number.parseInt(value, 10) || 0;
+}
+
+/**
+ * @param {number} afterId
+ * @returns {Array<{ id: number, dateHit: string, dateLeft: string|null, url: string, leadId: number|null, dwellSeconds: number|null }>}
+ */
+export function getHitsAfter(afterId) {
+  const rows = runSql(
+    `SELECT id, date_hit, IFNULL(date_left, ''), url, IFNULL(lead_id, 0), IFNULL(TIMESTAMPDIFF(SECOND, date_hit, date_left), -1) FROM page_hits WHERE id > ${afterId} ORDER BY id ASC`
+  );
+
+  if (!rows) {
+    return [];
+  }
+
+  return rows.split('\n').map((line) => {
+    const [id, dateHit, dateLeft, url, leadId, dwellSeconds] = line.split('\t');
+
+    return {
+      id: Number.parseInt(id, 10),
+      dateHit,
+      dateLeft: '' === dateLeft ? null : dateLeft,
+      url,
+      leadId: Number.parseInt(leadId, 10) || null,
+      dwellSeconds: Number.parseInt(dwellSeconds, 10),
+    };
+  });
+}
+
+/**
+ * Poll until date_left is populated (messenger may process asynchronously).
+ *
+ * @param {number} hitId
+ * @param {number} minDwellSeconds
+ * @param {number} timeoutMs
+ */
+export async function waitForDateLeft(hitId, minDwellSeconds = 1, timeoutMs = 20_000) {
+  const started = Date.now();
+
+  while (Date.now() - started < timeoutMs) {
+    const row = runSql(
+      `SELECT IFNULL(date_left, ''), IFNULL(TIMESTAMPDIFF(SECOND, date_hit, date_left), -1) FROM page_hits WHERE id = ${hitId}`
+    );
+    const [dateLeft, dwell] = row.split('\t');
+
+    if (dateLeft && Number.parseInt(dwell, 10) >= minDwellSeconds) {
+      return { dateLeft, dwellSeconds: Number.parseInt(dwell, 10) };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Hit #${hitId} still has NULL date_left after ${timeoutMs}ms`);
+}

--- a/var/playwright/package-lock.json
+++ b/var/playwright/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "mautic-dwell-time-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mautic-dwell-time-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/var/playwright/package.json
+++ b/var/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mautic-dwell-time-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "install:browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0"
+  }
+}

--- a/var/playwright/playwright.config.js
+++ b/var/playwright/playwright.config.js
@@ -1,0 +1,26 @@
+// @ts-check
+import { defineConfig } from '@playwright/test';
+
+const baseURL = process.env.MAUTIC_BASE_URL ?? 'https://leuchtfeuer-mautic.ddev.site';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/var/playwright/tests/dwell-time.spec.js
+++ b/var/playwright/tests/dwell-time.spec.js
@@ -1,0 +1,103 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { getHitsAfter, getMaxHitId, waitForDateLeft } from '../helpers/db.js';
+
+const landingAlias = process.env.MAUTIC_LANDING_ALIAS ?? 'e2e-landing-ai-test';
+const dwellWaitMs = Number.parseInt(process.env.DWELL_WAIT_MS ?? '5000', 10);
+const minDwellSeconds = Math.max(1, Math.floor(dwellWaitMs / 1000) - 2);
+const adminUser = process.env.MAUTIC_ADMIN_USER ?? 'admin';
+const adminPass = process.env.MAUTIC_ADMIN_PASS ?? 'Maut1cR0cks!';
+
+test.describe('Page dwell time (date_left)', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('sets date_left on first hit after second landing page visit', async ({ page }) => {
+    const baselineId = getMaxHitId();
+
+    await page.goto(`/${landingAlias}`, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(dwellWaitMs);
+    await page.goto(`/${landingAlias}`, { waitUntil: 'networkidle' });
+
+    const hits = getHitsAfter(baselineId);
+    expect(hits.length, 'expected two new page hits').toBeGreaterThanOrEqual(2);
+
+    const [firstHit, secondHit] = hits;
+    const resolved = await waitForDateLeft(firstHit.id, minDwellSeconds);
+
+    expect(resolved.dwellSeconds, 'first hit dwell time in seconds').toBeGreaterThanOrEqual(minDwellSeconds);
+    expect(secondHit.dateLeft, 'current/last hit should still have NULL date_left').toBeNull();
+  });
+
+  test('sets date_left when leaving tracked URL via mtracking.gif (cross-page scenario)', async ({ page }) => {
+    const baselineId = getMaxHitId();
+    const trackedUrl = `https://external-test.example/dwell-page-${Date.now()}`;
+    const otherUrl = `https://external-test.example/other-page-${Date.now()}`;
+
+    await page.goto(
+      `/mtracking.gif?page_url=${encodeURIComponent(trackedUrl)}&page_title=DwellTest`,
+      { waitUntil: 'networkidle' }
+    );
+    await page.waitForTimeout(dwellWaitMs);
+    await page.goto(
+      `/mtracking.gif?page_url=${encodeURIComponent(otherUrl)}&page_title=OtherPage`,
+      { waitUntil: 'networkidle' }
+    );
+
+    const hits = getHitsAfter(baselineId);
+    expect(hits.length, 'expected two tracking pixel hits').toBeGreaterThanOrEqual(2);
+
+    const trackedHit = hits.find((hit) => hit.url.includes('dwell-page-'));
+    expect(trackedHit, 'first tracked URL hit should exist').toBeTruthy();
+
+    const resolved = await waitForDateLeft(trackedHit.id, minDwellSeconds);
+    expect(resolved.dwellSeconds).toBeGreaterThanOrEqual(minDwellSeconds);
+  });
+});
+
+test.describe('Contact timeline (admin UI check)', () => {
+  test('timeline shows time on page after two landing page visits', async ({ browser }) => {
+    const anonymous = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const page = await anonymous.newPage();
+    const baselineId = getMaxHitId();
+
+    await page.goto(`/${landingAlias}`, { waitUntil: 'networkidle' });
+    await page.waitForTimeout(dwellWaitMs);
+    await page.goto(`/${landingAlias}`, { waitUntil: 'networkidle' });
+    await anonymous.close();
+
+    const hits = getHitsAfter(baselineId);
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+    await waitForDateLeft(hits[0].id, minDwellSeconds);
+
+    const leadId = hits[0].leadId;
+    expect(leadId, 'tracked contact id').toBeTruthy();
+
+    const admin = await browser.newContext();
+    const adminPage = await admin.newPage();
+    await adminPage.goto('/s/login');
+    await adminPage.fill('#username', adminUser);
+    await adminPage.fill('#password', adminPass);
+    await adminPage.click('button[type="submit"]');
+    await adminPage.waitForURL(/\/(s\/dashboard|s\/contacts)/);
+
+    await adminPage.goto(`/s/contacts/view/${leadId}`);
+    await adminPage.waitForLoadState('networkidle');
+
+    // Expand the older page hit (second "Page hit" row — timeline is newest-first).
+    const olderHitExpand = adminPage
+      .locator('tr.timeline-row')
+      .filter({ hasText: 'Page hit' })
+      .nth(1)
+      .locator('[data-activate-details]');
+    const detailsIndex = await olderHitExpand.getAttribute('data-activate-details');
+    await olderHitExpand.click();
+
+    const detailsRow = adminPage.locator(`#timeline-details-${detailsIndex}`);
+    await expect(detailsRow).not.toHaveClass(/hide/);
+    await expect(detailsRow.locator('dt').filter({ hasText: /^Time on page:|^Čas na stránce:/i })).toBeVisible();
+    await expect(detailsRow.locator('dd').first()).toHaveText(/\d+s|\d+m \d+s/);
+    await expect(detailsRow.locator('dd').first()).not.toHaveText(/unknown|neznám/i);
+
+    await admin.close();
+  });
+});


### PR DESCRIPTION
<hr><strong>⚠️ This PR is provided for use as a patch</strong> and is not intended for merging into this Mautic release, as that release is no longer maintained.<hr>

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #12336 (Mautic 5.x patch)

## Description

This PR adds seconds unit in Visits specific URL Point action
![image](https://github.com/mautic/mautic/assets/8580942/d6695aeb-ad2b-4647-ba6b-987e5b8a39fc)

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
3. Add a new Point Action 
4. Choose **Visits Specific URL** from **When a contact...** select
5. Set the Page URL
6. Set Total time spent to e.g. 10 seconds and Save Point action
7. Add Mautic tracking code to your external website
8. Add website to valid domains in Mautic CORS configuration
9. Visit the URL that you defined in Point action
10. Go to any other subpage that still has the Mautic tracking code (this is how Mautic determinates the time spent on page)
11. Go back to the URL defined in the point action to trigger the page visit - this step should not be necessary to trigger this event, but it seems like it work this way right now (I have described this in issue #12336)
12. Find the contact and check if the points were added