### PR TITLE
[symfony] move validation nested arrays to named args + move help to #[AsCommand] attribute

### DIFF
--- a/app/bundles/ApiBundle/Entity/oAuth2/Client.php
+++ b/app/bundles/ApiBundle/Entity/oAuth2/Client.php
@@ -103,11 +103,11 @@ class Client extends BaseClient
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            ['message' => 'mautic.core.name.required']
+            message: 'mautic.core.name.required'
         ));
 
         $metadata->addPropertyConstraint('redirectUris', new Assert\NotBlank(
-            ['message' => 'mautic.api.client.redirecturis.notblank']
+            message: 'mautic.api.client.redirecturis.notblank'
         ));
     }
 

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -49,9 +49,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -69,9 +67,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -133,9 +133,7 @@ class AssetType extends AbstractType
             'required'    => true,
             'constraints' => [
                 new NotBlank(
-                    [
-                        'message' => 'mautic.core.value.required',
-                    ]
+                    message: 'mautic.core.value.required'
                 ),
             ],
         ]);

--- a/app/bundles/AssetBundle/Form/Type/ConfigType.php
+++ b/app/bundles/AssetBundle/Form/Type/ConfigType.php
@@ -26,9 +26,7 @@ class ConfigType extends AbstractType
                     'tooltip' => 'mautic.asset.config.form.upload.dir.tooltip',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'mautic.core.value.required',
-                    ]),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
             ]
         );
@@ -44,9 +42,7 @@ class ConfigType extends AbstractType
                     'tooltip' => 'mautic.asset.config.form.max.size.tooltip',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'mautic.core.value.required',
-                    ]),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
             ]
         );

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -221,9 +221,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
         $metadata->addPropertyConstraint(
             'name',
             new Assert\NotBlank(
-                [
-                    'message' => 'mautic.core.name.required',
-                ]
+                message: 'mautic.core.name.required'
             )
         );
 

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -32,9 +32,7 @@ class CampaignEventJumpToEventType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -38,9 +38,7 @@ class CampaignLeadSourceType extends AbstractType
                         ],
                         'constraints' => [
                             new NotBlank(
-                                [
-                                    'message' => 'mautic.core.value.required',
-                                ]
+                                message: 'mautic.core.value.required'
                             ),
                         ],
                     ]
@@ -60,9 +58,7 @@ class CampaignLeadSourceType extends AbstractType
                         ],
                         'constraints' => [
                             new NotBlank(
-                                [
-                                    'message' => 'mautic.core.value.required',
-                                ]
+                                message: 'mautic.core.value.required'
                             ),
                         ],
                     ]

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -113,10 +113,7 @@ class ConfigType extends AbstractType
                 ],
                 'data'        => $options['data']['peak_interaction_timer_best_default_hour_start'] ?? 9,
                 'constraints' => [
-                    new Range([
-                        'min' => 0,
-                        'max' => 23,
-                    ]),
+                    new Range(min: 0, max: 23),
                 ],
             ]
         );
@@ -133,10 +130,7 @@ class ConfigType extends AbstractType
                 ],
                 'data'        => $options['data']['peak_interaction_timer_best_default_hour_end'] ?? 12,
                 'constraints' => [
-                    new Range([
-                        'min' => 0,
-                        'max' => 23,
-                    ]),
+                    new Range(min: 0, max: 23),
                     new Callback(
                         function ($hourEnd, ExecutionContextInterface $context): void {
                             $data      = $context->getRoot()->getData();
@@ -193,9 +187,7 @@ class ConfigType extends AbstractType
                 ],
                 'data'        => $options['data']['peak_interaction_timer_cache_timeout'] ?? 43800,
                 'constraints' => [
-                    new GreaterThanOrEqual([
-                        'value' => 0,
-                    ]),
+                    new GreaterThanOrEqual(value: 0),
                 ],
             ]
         );
@@ -231,9 +223,7 @@ class ConfigType extends AbstractType
                 ],
                 'data'        => $options['data']['peak_interaction_timer_fetch_limit'] ?? 50,
                 'constraints' => [
-                    new GreaterThanOrEqual([
-                        'value' => 10,
-                    ]),
+                    new GreaterThanOrEqual(value: 10),
                 ],
             ]
         );

--- a/app/bundles/CategoryBundle/Entity/Category.php
+++ b/app/bundles/CategoryBundle/Entity/Category.php
@@ -106,18 +106,14 @@ class Category extends FormEntity implements UuidInterface
         $metadata->addPropertyConstraint(
             'title',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.title.required',
-                ]
+                message: 'mautic.core.title.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'bundle',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.value.required',
-                ]
+                message: 'mautic.core.value.required'
             )
         );
     }

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -18,11 +18,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to send a scheduled broadcast.
  */
-#[AsCommand(name: 'mautic:broadcasts:send', description: 'Process contacts pending to receive a channel broadcast.', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:broadcasts:send',
+    description: 'Process contacts pending to receive a channel broadcast.',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
 
 <info>php %command.full_name% --channel=email --id=3</info>
-TXT)]
+TXT
+)]
 class SendChannelBroadcastCommand extends ModeratedCommand
 {
     public function __construct(

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -18,10 +18,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to send a scheduled broadcast.
  */
-#[AsCommand(
-    name: 'mautic:broadcasts:send',
-    description: 'Process contacts pending to receive a channel broadcast.'
-)]
+#[AsCommand(name: 'mautic:broadcasts:send', description: 'Process contacts pending to receive a channel broadcast.', help: <<<'TXT'
+                The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
+
+<info>php %command.full_name% --channel=email --id=3</info>
+TXT)]
 class SendChannelBroadcastCommand extends ModeratedCommand
 {
     public function __construct(
@@ -36,13 +37,6 @@ class SendChannelBroadcastCommand extends ModeratedCommand
     protected function configure(): void
     {
         $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
-
-<info>php %command.full_name% --channel=email --id=3</info>
-EOT
-            )
             ->setDefinition(
                 [
                     new InputOption(

--- a/app/bundles/ChannelBundle/Entity/Message.php
+++ b/app/bundles/ChannelBundle/Entity/Message.php
@@ -121,9 +121,7 @@ class Message extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ValidationClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/ChannelBundle/Form/Type/ChannelType.php
+++ b/app/bundles/ChannelBundle/Form/Type/ChannelType.php
@@ -66,9 +66,7 @@ class ChannelType extends AbstractType
                         'label'       => 'mautic.channel.message.form.message',
                         'constraints' => ($enabled) ? [
                             new NotBlank(
-                                [
-                                    'message' => 'mautic.core.value.required',
-                                ]
+                                message: 'mautic.core.value.required'
                             ),
                         ] : [],
                     ]

--- a/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
@@ -33,7 +33,7 @@ class MessageSendType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.channel.choosemessage.notblank']
+                        message: 'mautic.channel.choosemessage.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -19,10 +19,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to update the application.
  */
-#[AsCommand(
-    name: 'mautic:update:apply',
-    description: 'Updates the Mautic application'
-)]
+#[AsCommand(name: 'mautic:update:apply', description: 'Updates the Mautic application', help: <<<'TXT'
+                The <info>%command.name%</info> command updates the Mautic application.
+
+<info>php %command.full_name%</info>
+
+You can optionally specify to bypass the verification check with the --force option:
+
+<info>php %command.full_name% --force</info>
+
+To force install a local package, pass the full path to the package as follows:
+
+<info>php %command.full_name% --update-package=/path/to/updatepackage.zip</info>
+TXT)]
 class ApplyUpdatesCommand extends Command
 {
     public function __construct(
@@ -51,21 +60,6 @@ class ApplyUpdatesCommand extends Command
                         'Finalize the upgrade.'
                     ),
                 ]
-            )
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command updates the Mautic application.
-
-<info>php %command.full_name%</info>
-
-You can optionally specify to bypass the verification check with the --force option:
-
-<info>php %command.full_name% --force</info>
-
-To force install a local package, pass the full path to the package as follows:
-
-<info>php %command.full_name% --update-package=/path/to/updatepackage.zip</info>
-EOT
             );
     }
 

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -19,7 +19,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to update the application.
  */
-#[AsCommand(name: 'mautic:update:apply', description: 'Updates the Mautic application', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:update:apply',
+    description: 'Updates the Mautic application',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command updates the Mautic application.
 
 <info>php %command.full_name%</info>
@@ -31,7 +34,8 @@ You can optionally specify to bypass the verification check with the --force opt
 To force install a local package, pass the full path to the package as follows:
 
 <info>php %command.full_name% --update-package=/path/to/updatepackage.zip</info>
-TXT)]
+TXT
+)]
 class ApplyUpdatesCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -20,10 +20,34 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to purge old data per settings.
  */
-#[AsCommand(
-    name: CleanupMaintenanceCommand::NAME,
-    description: 'Updates the Mautic application'
-)]
+#[AsCommand(name: CleanupMaintenanceCommand::NAME, description: 'Updates the Mautic application', help: <<<'TXT'
+<info>%command.name%</info> purges records of anonymous contacts (<comment>unless the <info>--gdpr</info> flag is set</comment>) that are older than 365 days.
+Adjust the threshold by using <info>--days-old</info>.
+
+<comment><info>%command.name% --gdpr</info> purges records of anonymous <options=bold>and identified</> contacts.
+The command purges only identified contacts that were <options=bold>inactive for more than 3 years</> (1095 days).</comment>
+
+If you set <info>--gdpr</info> then <info>%command.name%</info> will ignore <info>--days-old</info>.
+The threshold is hard coded to <info>1095</info> days. This is security measure to prevent accidental loss of contact data.
+
+<comment>Examples:</comment>
+
+<info>php %command.full_name%</info>
+Deletes records of anonymous contacts older than 365 days.
+
+<info>php %command.full_name% --days-old=90</info>
+Deletes records of anonymous contacts older than 90 days.
+
+<info>php %command.full_name% --gdpr</info>
+Deletes records of anonymous <options=bold>and inactive identified</> contacts older than 1095 days.
+
+<comment>Add <info>--dry-run</info> to do a dry run without deleting any records.</comment>
+
+<info>php %command.full_name% --dry-run</info>
+Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
+
+The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
+TXT)]
 class CleanupMaintenanceCommand extends ModeratedCommand
 {
     public const NAME = 'mautic:maintenance:cleanup';
@@ -54,36 +78,6 @@ class CleanupMaintenanceCommand extends ModeratedCommand
                     new InputOption('dry-run', 'r', InputOption::VALUE_NONE, 'Performs a dry run. Shows no. of affected rows. Won\'t actually delete anything.'),
                     new InputOption('gdpr', 'g', InputOption::VALUE_NONE, 'Deletes records of inactive users to fulfill GDPR requirements.'),
                 ]
-            )
-            ->setHelp(
-                <<<'EOT'
-<info>%command.name%</info> purges records of anonymous contacts (<comment>unless the <info>--gdpr</info> flag is set</comment>) that are older than 365 days.
-Adjust the threshold by using <info>--days-old</info>.
-
-<comment><info>%command.name% --gdpr</info> purges records of anonymous <options=bold>and identified</> contacts.
-The command purges only identified contacts that were <options=bold>inactive for more than 3 years</> (1095 days).</comment>
-
-If you set <info>--gdpr</info> then <info>%command.name%</info> will ignore <info>--days-old</info>.
-The threshold is hard coded to <info>1095</info> days. This is security measure to prevent accidental loss of contact data.
-
-<comment>Examples:</comment>
-
-<info>php %command.full_name%</info>
-Deletes records of anonymous contacts older than 365 days.
-
-<info>php %command.full_name% --days-old=90</info>
-Deletes records of anonymous contacts older than 90 days.
-
-<info>php %command.full_name% --gdpr</info>
-Deletes records of anonymous <options=bold>and inactive identified</> contacts older than 1095 days.
-
-<comment>Add <info>--dry-run</info> to do a dry run without deleting any records.</comment>
-
-<info>php %command.full_name% --dry-run</info>
-Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
-
-The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
-EOT
             );
         parent::configure();
     }

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -20,7 +20,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to purge old data per settings.
  */
-#[AsCommand(name: CleanupMaintenanceCommand::NAME, description: 'Updates the Mautic application', help: <<<'TXT'
+#[AsCommand(
+    name: CleanupMaintenanceCommand::NAME,
+    description: 'Updates the Mautic application',
+    help: <<<'TXT'
 <info>%command.name%</info> purges records of anonymous contacts (<comment>unless the <info>--gdpr</info> flag is set</comment>) that are older than 365 days.
 Adjust the threshold by using <info>--days-old</info>.
 
@@ -47,7 +50,8 @@ Deletes records of anonymous <options=bold>and inactive identified</> contacts o
 Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
 
 The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
-TXT)]
+TXT
+)]
 class CleanupMaintenanceCommand extends ModeratedCommand
 {
     public const NAME = 'mautic:maintenance:cleanup';

--- a/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
@@ -13,11 +13,15 @@ use Symfony\Component\Finder\Finder;
 /**
  * CLI Command to clean up obsolete files in the media folder.
  */
-#[AsCommand(name: 'mautic:assets:cleanup', description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:assets:cleanup',
+    description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is used to clean up obsolete files in the media folder that are present in the app/assets folder.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class CleanupMediaAssetsCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
@@ -13,10 +13,11 @@ use Symfony\Component\Finder\Finder;
 /**
  * CLI Command to clean up obsolete files in the media folder.
  */
-#[AsCommand(
-    name: 'mautic:assets:cleanup',
-    description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder'
-)]
+#[AsCommand(name: 'mautic:assets:cleanup', description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder', help: <<<'TXT'
+                The <info>%command.name%</info> command is used to clean up obsolete files in the media folder that are present in the app/assets folder.
+
+<info>php %command.full_name%</info>
+TXT)]
 class CleanupMediaAssetsCommand extends Command
 {
     public function __construct(
@@ -27,14 +28,6 @@ class CleanupMediaAssetsCommand extends Command
 
     protected function configure(): void
     {
-        $this
-          ->setHelp(
-              <<<'EOT'
-                The <info>%command.name%</info> command is used to clean up obsolete files in the media folder that are present in the app/assets folder.
-
-<info>php %command.full_name%</info>
-EOT
-          );
         parent::configure();
     }
 

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -12,7 +12,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI Command to convert PHP theme config to JSON.
  */
-#[AsCommand(name: 'mautic:theme:json-config', description: 'Converts theme config to JSON from PHP', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:theme:json-config',
+    description: 'Converts theme config to JSON from PHP',
+    help: <<<'TXT'
 The <info>%command.name%</info> command converts a PHP theme config file to JSON.
 
 <info>php %command.full_name%</info>
@@ -24,7 +27,8 @@ You must specify the name of the theme via the --theme parameter:
 You may opt to save the PHP config file by using the --save-php-config option.
 
 <info>php %command.full_name% --save-php-config</info>
-TXT)]
+TXT
+)]
 class ConvertConfigCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -12,10 +12,19 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI Command to convert PHP theme config to JSON.
  */
-#[AsCommand(
-    name: 'mautic:theme:json-config',
-    description: 'Converts theme config to JSON from PHP'
-)]
+#[AsCommand(name: 'mautic:theme:json-config', description: 'Converts theme config to JSON from PHP', help: <<<'TXT'
+The <info>%command.name%</info> command converts a PHP theme config file to JSON.
+
+<info>php %command.full_name%</info>
+
+You must specify the name of the theme via the --theme parameter:
+
+<info>php %command.full_name% --theme=<theme></info>
+
+You may opt to save the PHP config file by using the --save-php-config option.
+
+<info>php %command.full_name% --save-php-config</info>
+TXT)]
 class ConvertConfigCommand extends Command
 {
     public function __construct(
@@ -36,21 +45,7 @@ class ConvertConfigCommand extends Command
                     'save-php-config', null, InputOption::VALUE_NONE,
                     'When used, the theme\'s PHP config file will be saved.'
                 ),
-            ])
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command converts a PHP theme config file to JSON.
-
-<info>php %command.full_name%</info>
-
-You must specify the name of the theme via the --theme parameter:
-
-<info>php %command.full_name% --theme=<theme></info>
-
-You may opt to save the PHP config file by using the --save-php-config option.
-
-<info>php %command.full_name% --save-php-config</info>
-EOT
-            );
+            ]);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
@@ -12,10 +12,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to fetch application updates.
  */
-#[AsCommand(
-    name: 'mautic:update:find',
-    description: 'Fetches updates for Mautic'
-)]
+#[AsCommand(name: 'mautic:update:find', description: 'Fetches updates for Mautic', help: <<<'TXT'
+The <info>%command.name%</info> command checks for updates for the Mautic application.
+
+<info>php %command.full_name%</info>
+TXT)]
 class FindUpdatesCommand extends Command
 {
     public function __construct(
@@ -27,13 +28,6 @@ class FindUpdatesCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command checks for updates for the Mautic application.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
@@ -12,11 +12,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to fetch application updates.
  */
-#[AsCommand(name: 'mautic:update:find', description: 'Fetches updates for Mautic', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:update:find',
+    description: 'Fetches updates for Mautic',
+    help: <<<'TXT'
 The <info>%command.name%</info> command checks for updates for the Mautic application.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class FindUpdatesCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -20,10 +20,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to generate production assets.
  */
-#[AsCommand(
-    name: 'mautic:assets:generate',
-    description: 'Combines and minifies asset files into single production files'
-)]
+#[AsCommand(name: 'mautic:assets:generate', description: 'Combines and minifies asset files into single production files', help: <<<'TXT'
+                The <info>%command.name%</info> command builds Symfony Asset Mapper assets, combines and minifies legacy files from node_modules and each bundle's Assets/css/* and Assets/js/* folders into production files stored in root/media/css and root/media/js respectively. It also runs the command elfinder:install internally to install ElFinder assets.
+
+<info>php %command.full_name%</info>
+TXT)]
 class GenerateProductionAssetsCommand extends Command
 {
     public function __construct(
@@ -37,14 +38,6 @@ class GenerateProductionAssetsCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command builds Symfony Asset Mapper assets, combines and minifies legacy files from node_modules and each bundle's Assets/css/* and Assets/js/* folders into production files stored in root/media/css and root/media/js respectively. It also runs the command elfinder:install internally to install ElFinder assets.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -20,11 +20,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to generate production assets.
  */
-#[AsCommand(name: 'mautic:assets:generate', description: 'Combines and minifies asset files into single production files', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:assets:generate',
+    description: 'Combines and minifies asset files into single production files',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command builds Symfony Asset Mapper assets, combines and minifies legacy files from node_modules and each bundle's Assets/css/* and Assets/js/* folders into production files stored in root/media/css and root/media/js respectively. It also runs the command elfinder:install internally to install ElFinder assets.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class GenerateProductionAssetsCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -15,10 +15,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to install Mautic sample data.
  */
-#[AsCommand(
-    name: 'mautic:install:data',
-    description: 'Installs Mautic with sample data'
-)]
+#[AsCommand(name: 'mautic:install:data', description: 'Installs Mautic with sample data', help: <<<'TXT'
+The <info>%command.name%</info> command re-installs Mautic with sample data.
+
+<info>php %command.full_name%</info>
+
+You can optionally specify to bypass the verification check with the --force option:
+
+<info>php %command.full_name% --force</info>
+TXT)]
 class InstallDataCommand extends Command
 {
     public function __construct(
@@ -34,17 +39,7 @@ class InstallDataCommand extends Command
                 new InputOption(
                     'force', null, InputOption::VALUE_NONE, 'Bypasses the verification check.'
                 ),
-            ])
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command re-installs Mautic with sample data.
-
-<info>php %command.full_name%</info>
-
-You can optionally specify to bypass the verification check with the --force option:
-
-<info>php %command.full_name% --force</info>
-EOT
-            );
+            ]);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -15,7 +15,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to install Mautic sample data.
  */
-#[AsCommand(name: 'mautic:install:data', description: 'Installs Mautic with sample data', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:install:data',
+    description: 'Installs Mautic with sample data',
+    help: <<<'TXT'
 The <info>%command.name%</info> command re-installs Mautic with sample data.
 
 <info>php %command.full_name%</info>
@@ -23,7 +26,8 @@ The <info>%command.name%</info> command re-installs Mautic with sample data.
 You can optionally specify to bypass the verification check with the --force option:
 
 <info>php %command.full_name% --force</info>
-TXT)]
+TXT
+)]
 class InstallDataCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -17,7 +17,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  * CLI Command to purge data from Mautic that appears on the
  * MaxMind Do Not Sell list.
  */
-#[AsCommand(name: 'mautic:max-mind:purge', description: 'Purge data connected to MaxMind Do Not Sell list.', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:max-mind:purge',
+    description: 'Purge data connected to MaxMind Do Not Sell list.',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will purge all data from Mautic which is related to any IP found on the MaxMind Do Not Sell List.
 
 <info>php %command.full_name% --dry-run</info>
@@ -27,7 +30,8 @@ Performs a dry-run which will not actually purge any data, but will produce a li
 <info>php %command.full_name% --batch-size</info>
 
 Set the number of records to return in a batch when processing the Do Not Sell List. This option is ignored if IPs are passed as an argument.
-TXT)]
+TXT
+)]
 class MaxMindDoNotSellPurgeCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -17,10 +17,17 @@ use Symfony\Component\Console\Output\OutputInterface;
  * CLI Command to purge data from Mautic that appears on the
  * MaxMind Do Not Sell list.
  */
-#[AsCommand(
-    name: 'mautic:max-mind:purge',
-    description: 'Purge data connected to MaxMind Do Not Sell list.'
-)]
+#[AsCommand(name: 'mautic:max-mind:purge', description: 'Purge data connected to MaxMind Do Not Sell list.', help: <<<'TXT'
+The <info>%command.name%</info> command will purge all data from Mautic which is related to any IP found on the MaxMind Do Not Sell List.
+
+<info>php %command.full_name% --dry-run</info>
+
+Performs a dry-run which will not actually purge any data, but will produce a list of what would be purged.
+
+<info>php %command.full_name% --batch-size</info>
+
+Set the number of records to return in a batch when processing the Do Not Sell List. This option is ignored if IPs are passed as an argument.
+TXT)]
 class MaxMindDoNotSellPurgeCommand extends Command
 {
     public function __construct(
@@ -39,18 +46,6 @@ class MaxMindDoNotSellPurgeCommand extends Command
                 'd',
                 InputOption::VALUE_NONE,
                 'Get a list of data that will be purged.'
-            )
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command will purge all data from Mautic which is related to any IP found on the MaxMind Do Not Sell List.
-
-<info>php %command.full_name% --dry-run</info>
-
-Performs a dry-run which will not actually purge any data, but will produce a list of what would be purged.
-
-<info>php %command.full_name% --batch-size</info>
-
-Set the number of records to return in a batch when processing the Do Not Sell List. This option is ignored if IPs are passed as an argument.
-EOT
             );
     }
 

--- a/app/bundles/CoreBundle/Command/PullTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PullTransifexCommand.php
@@ -24,7 +24,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to pull language resources from Transifex.
  */
-#[AsCommand(name: PullTransifexCommand::NAME, description: 'Fetches translations for Mautic from Transifex', help: <<<'TXT'
+#[AsCommand(
+    name: PullTransifexCommand::NAME,
+    description: 'Fetches translations for Mautic from Transifex',
+    help: <<<'TXT'
 The <info>%command.name%</info> command is used to retrieve updated Mautic translations from Transifex and writes them to the filesystem.
 
 <info>php %command.full_name%</info>
@@ -32,7 +35,8 @@ The <info>%command.name%</info> command is used to retrieve updated Mautic trans
 The command can optionally only pull files for a specific language with the --language option
 
 <info>php %command.full_name% --language=<language_code></info>
-TXT)]
+TXT
+)]
 class PullTransifexCommand extends Command
 {
     public const NAME = 'mautic:transifex:pull';

--- a/app/bundles/CoreBundle/Command/PullTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PullTransifexCommand.php
@@ -24,10 +24,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to pull language resources from Transifex.
  */
-#[AsCommand(
-    name: PullTransifexCommand::NAME,
-    description: 'Fetches translations for Mautic from Transifex'
-)]
+#[AsCommand(name: PullTransifexCommand::NAME, description: 'Fetches translations for Mautic from Transifex', help: <<<'TXT'
+The <info>%command.name%</info> command is used to retrieve updated Mautic translations from Transifex and writes them to the filesystem.
+
+<info>php %command.full_name%</info>
+
+The command can optionally only pull files for a specific language with the --language option
+
+<info>php %command.full_name% --language=<language_code></info>
+TXT)]
 class PullTransifexCommand extends Command
 {
     public const NAME = 'mautic:transifex:pull';
@@ -46,17 +51,7 @@ class PullTransifexCommand extends Command
         $this
             ->addOption('language', null, InputOption::VALUE_OPTIONAL, 'Optional language to pull')
             ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle')
-            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Optional path to a directory where to store the traslations.')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to retrieve updated Mautic translations from Transifex and writes them to the filesystem.
-
-<info>php %command.full_name%</info>
-
-The command can optionally only pull files for a specific language with the --language option
-
-<info>php %command.full_name% --language=<language_code></info>
-EOT
-            );
+            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Optional path to a directory where to store the traslations.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/PushTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PushTransifexCommand.php
@@ -23,7 +23,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to push language resources to Transifex.
  */
-#[AsCommand(name: PushTransifexCommand::NAME, description: 'Pushes Mautic translation resources to Transifex', help: <<<'TXT'
+#[AsCommand(
+    name: PushTransifexCommand::NAME,
+    description: 'Pushes Mautic translation resources to Transifex',
+    help: <<<'TXT'
 The <info>%command.name%</info> command is used to push translation resources to Transifex
 
 <info>php %command.full_name%</info>
@@ -31,7 +34,8 @@ The <info>%command.name%</info> command is used to push translation resources to
 You can optionally choose to update resources for one bundle only with the --bundle option:
 
 <info>php %command.full_name% --bundle AssetBundle</info>
-TXT)]
+TXT
+)]
 class PushTransifexCommand extends Command
 {
     public const NAME = 'mautic:transifex:push';

--- a/app/bundles/CoreBundle/Command/PushTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PushTransifexCommand.php
@@ -23,10 +23,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to push language resources to Transifex.
  */
-#[AsCommand(
-    name: PushTransifexCommand::NAME,
-    description: 'Pushes Mautic translation resources to Transifex'
-)]
+#[AsCommand(name: PushTransifexCommand::NAME, description: 'Pushes Mautic translation resources to Transifex', help: <<<'TXT'
+The <info>%command.name%</info> command is used to push translation resources to Transifex
+
+<info>php %command.full_name%</info>
+
+You can optionally choose to update resources for one bundle only with the --bundle option:
+
+<info>php %command.full_name% --bundle AssetBundle</info>
+TXT)]
 class PushTransifexCommand extends Command
 {
     public const NAME = 'mautic:transifex:push';
@@ -42,17 +47,7 @@ class PushTransifexCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to push translation resources to Transifex
-
-<info>php %command.full_name%</info>
-
-You can optionally choose to update resources for one bundle only with the --bundle option:
-
-<info>php %command.full_name% --bundle AssetBundle</info>
-EOT
-            );
+            ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -13,10 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI Command to delete unused IP addresses.
  */
-#[AsCommand(
-    name: 'mautic:unusedip:delete',
-    description: 'Deletes IP addresses that are not used in any other database table'
-)]
+#[AsCommand(name: 'mautic:unusedip:delete', description: 'Deletes IP addresses that are not used in any other database table', help: <<<'TXT'
+                The <info>%command.name%</info> command is used to delete IP addresses that are not used in any other database table.
+
+<info>php %command.full_name%</info>
+TXT)]
 class UnusedIpDeleteCommand extends ModeratedCommand
 {
     private const DEFAULT_LIMIT = 10000;
@@ -38,13 +39,6 @@ class UnusedIpDeleteCommand extends ModeratedCommand
                 InputOption::VALUE_OPTIONAL,
                 'LIMIT for deleted rows',
                 self::DEFAULT_LIMIT
-            )
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to delete IP addresses that are not used in any other database table.
-
-<info>php %command.full_name%</info>
-EOT
             );
         parent::configure();
     }

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -13,11 +13,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI Command to delete unused IP addresses.
  */
-#[AsCommand(name: 'mautic:unusedip:delete', description: 'Deletes IP addresses that are not used in any other database table', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:unusedip:delete',
+    description: 'Deletes IP addresses that are not used in any other database table',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is used to delete IP addresses that are not used in any other database table.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class UnusedIpDeleteCommand extends ModeratedCommand
 {
     private const DEFAULT_LIMIT = 10000;

--- a/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
@@ -9,11 +9,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(name: 'mautic:donotsell:download', description: 'Fetch remote do not sell list from MaxMind', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:donotsell:download',
+    description: 'Fetch remote do not sell list from MaxMind',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class UpdateDoNotSellListCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
@@ -9,10 +9,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(
-    name: 'mautic:donotsell:download',
-    description: 'Fetch remote do not sell list from MaxMind'
-)]
+#[AsCommand(name: 'mautic:donotsell:download', description: 'Fetch remote do not sell list from MaxMind', help: <<<'TXT'
+                The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
+
+<info>php %command.full_name%</info>
+TXT)]
 class UpdateDoNotSellListCommand extends Command
 {
     public function __construct(
@@ -24,14 +25,6 @@ class UpdateDoNotSellListCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
@@ -13,10 +13,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to fetch updated Maxmind database.
  */
-#[AsCommand(
-    name: 'mautic:iplookup:download',
-    description: 'Fetch remote datastores for IP lookup services that leverage local lookups'
-)]
+#[AsCommand(name: 'mautic:iplookup:download', description: 'Fetch remote datastores for IP lookup services that leverage local lookups', help: <<<'TXT'
+                The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
+
+<info>php %command.full_name%</info>
+TXT)]
 class UpdateIpDataStoreCommand extends Command
 {
     public function __construct(
@@ -28,14 +29,6 @@ class UpdateIpDataStoreCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
@@ -13,11 +13,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to fetch updated Maxmind database.
  */
-#[AsCommand(name: 'mautic:iplookup:download', description: 'Fetch remote datastores for IP lookup services that leverage local lookups', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:iplookup:download',
+    description: 'Fetch remote datastores for IP lookup services that leverage local lookups',
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class UpdateIpDataStoreCommand extends Command
 {
     public function __construct(

--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -64,9 +64,7 @@ class ConfigType extends AbstractType
                 'default_protocol' => 'https',
                 'constraints'      => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -119,9 +117,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -139,9 +135,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -159,9 +153,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                     new Callback($this->validateImagePath(...)),
                 ],
@@ -368,12 +360,8 @@ class ConfigType extends AbstractType
                     'postaddon_text' => $this->translator->trans('mautic.core.time.minutes'),
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'mautic.core.value.required',
-                    ]),
-                    new GreaterThanOrEqual([
-                        'value' => 0,
-                    ]),
+                    new NotBlank(message: 'mautic.core.value.required'),
+                    new GreaterThanOrEqual(value: 0),
                 ],
             ]
         );
@@ -390,9 +378,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -410,9 +396,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -430,9 +414,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -450,9 +432,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/CoreBundle/Form/Type/DynamicListType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicListType.php
@@ -64,7 +64,7 @@ class DynamicListType extends AbstractType
 
                     'constraints'    => fn (Options $options): array => ($options['option_notblank']) ? [
                         new NotBlank(
-                            ['message' => 'mautic.form.lists.notblank']
+                            message: 'mautic.form.lists.notblank'
                         ),
                     ] : [],
                     'error_bubbling' => true,
@@ -73,12 +73,7 @@ class DynamicListType extends AbstractType
                 'allow_delete'    => true,
                 'prototype'       => true,
                 'constraints'     => fn (Options $options): array => ($options['option_required']) ? [
-                    new Count(
-                        [
-                            'minMessage' => 'mautic.form.lists.count',
-                            'min'        => 1,
-                        ]
-                    ),
+                    new Count(minMessage: 'mautic.form.lists.count', min: 1),
                 ] : [],
                 'error_bubbling'  => false,
             ]

--- a/app/bundles/CoreBundle/Form/Type/SortableListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SortableListType.php
@@ -22,12 +22,7 @@ class SortableListType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $constraints = ($options['option_required']) ? [
-            new Count(
-                [
-                    'minMessage' => 'mautic.form.lists.count',
-                    'min'        => 1,
-                ]
-            ),
+            new Count(minMessage: 'mautic.form.lists.count', min: 1),
         ] : [];
 
         if ($options['constraint_callback'] instanceof Callback) {
@@ -36,7 +31,7 @@ class SortableListType extends AbstractType
 
         if ($options['option_notblank']) {
             $options['option_constraint'][] = new NotBlank(
-                ['message' => 'mautic.form.lists.notblank']
+                message: 'mautic.form.lists.notblank'
             );
         }
 

--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -100,9 +100,7 @@ class Widget extends FormEntity
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('type', new NotBlank([
-            'message' => 'mautic.core.type.required',
-        ]));
+        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -231,11 +231,11 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
      */
     public static function loadValidatorMetaData(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank(['message' => 'mautic.core.name.required']));
+        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
         $metadata->addPropertyConstraint('content', new NoNesting());
 
-        $metadata->addPropertyConstraint('type', new NotBlank(['message' => 'mautic.core.type.required']));
-        $metadata->addPropertyConstraint('type', new Choice(['choices' => (new TypeList())->getChoices()]));
+        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
+        $metadata->addPropertyConstraint('type', new Choice(choices: (new TypeList())->getChoices()));
 
         $metadata->addConstraint(new SlotNameType());
 
@@ -247,9 +247,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
                         $dwc->getSlotName(),
                         [
                             new NotBlank(
-                                [
-                                    'message' => 'mautic.dynamicContent.slot_name.notblank',
-                                ]
+                                message: 'mautic.dynamicContent.slot_name.notblank'
                             ),
                         ]
                     );
@@ -261,12 +259,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
                     $violations = $validator->validate(
                         $dwc->getFilters(),
                         [
-                            new Count(
-                                [
-                                    'minMessage' => 'mautic.dynamicContent.filter.options.empty',
-                                    'min'        => 1,
-                                ]
-                            ),
+                            new Count(minMessage: 'mautic.dynamicContent.filter.options.empty', min: 1),
                         ]
                     );
                     foreach ($violations as $violation) {

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
@@ -22,7 +22,7 @@ class DynamicContentDecisionType extends DynamicContentSendType
                 ],
                 'required'    => true,
                 'constraints' => [
-                    new NotBlank(['message' => 'mautic.core.value.required']),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
             ]
         );
@@ -44,7 +44,7 @@ class DynamicContentDecisionType extends DynamicContentSendType
                 'multiple'    => false,
                 'required'    => true,
                 'constraints' => [
-                    new NotBlank(['message' => 'mautic.core.value.required']),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
             ]
         );

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentSendType.php
@@ -36,7 +36,7 @@ class DynamicContentSendType extends AbstractType
                 'multiple'    => false,
                 'required'    => true,
                 'constraints' => [
-                    new NotBlank(['message' => 'mautic.core.value.required']),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
             ]
         );

--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -13,13 +13,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI command to check for messages.
  */
-#[AsCommand(
-    name: 'mautic:email:fetch',
-    description: 'Fetch and process monitored email.',
-    aliases: [
-        'mautic:emails:fetch',
-    ]
-)]
+#[AsCommand(name: 'mautic:email:fetch', description: 'Fetch and process monitored email.', aliases: [
+    'mautic:emails:fetch',
+], help: <<<'TXT'
+                The <info>%command.name%</info> command is used to fetch and process messages such as bounces and unsubscribe requests. Configure the Monitored Email settings in Mautic's Configuration.
+
+<info>php %command.full_name%</info>
+TXT)]
 class ProcessFetchEmailCommand extends Command
 {
     public function __construct(
@@ -32,14 +32,7 @@ class ProcessFetchEmailCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.')
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to fetch and process messages such as bounces and unsubscribe requests. Configure the Monitored Email settings in Mautic's Configuration.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -13,13 +13,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * CLI command to check for messages.
  */
-#[AsCommand(name: 'mautic:email:fetch', description: 'Fetch and process monitored email.', aliases: [
-    'mautic:emails:fetch',
-], help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:email:fetch',
+    description: 'Fetch and process monitored email.',
+    aliases: [
+        'mautic:emails:fetch',
+    ],
+    help: <<<'TXT'
                 The <info>%command.name%</info> command is used to fetch and process messages such as bounces and unsubscribe requests. Configure the Monitored Email settings in Mautic's Configuration.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class ProcessFetchEmailCommand extends Command
 {
     public function __construct(

--- a/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
@@ -18,11 +18,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Sends email to winner variant after predetermined amount of time.
  */
-#[AsCommand(name: self::COMMAND_NAME, help: <<<'TXT'
+#[AsCommand(
+    name: self::COMMAND_NAME,
+    help: <<<'TXT'
 The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 final class SendWinnerEmailCommand extends ModeratedCommand
 {
     protected static string $defaultDescription = 'Send winner email variant to remaining contacts';

--- a/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
@@ -18,9 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Sends email to winner variant after predetermined amount of time.
  */
-#[AsCommand(
-    name: self::COMMAND_NAME
-)]
+#[AsCommand(name: self::COMMAND_NAME, help: <<<'TXT'
+The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
+
+<info>php %command.full_name%</info>
+TXT)]
 final class SendWinnerEmailCommand extends ModeratedCommand
 {
     protected static string $defaultDescription = 'Send winner email variant to remaining contacts';
@@ -38,13 +40,7 @@ final class SendWinnerEmailCommand extends ModeratedCommand
     protected function configure(): void
     {
         $this
-            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.');
 
         parent::configure();
     }

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -470,49 +470,30 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         $metadata->addPropertyConstraint(
             'name',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.name.required',
-                ]
+                message: 'mautic.core.name.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'name',
-            new Length(
-                [
-                    'max'        => self::MAX_NAME_SUBJECT_LENGTH,
-                    'maxMessage' => 'mautic.email.name.length',
-                ]
-            )
+            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')
         );
 
         $metadata->addPropertyConstraint(
             'subject',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.subject.required',
-                ]
+                message: 'mautic.core.subject.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'subject',
-            new Length(
-                [
-                    'max'        => self::MAX_NAME_SUBJECT_LENGTH,
-                    'maxMessage' => 'mautic.email.subject.length',
-                ]
-            )
+            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')
         );
 
         $metadata->addPropertyConstraint(
             'preheaderText',
-            new Length(
-                [
-                    'max'        => 130,
-                    'maxMessage' => 'mautic.email.preheader_text.length',
-                ]
-            )
+            new Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')
         );
 
         $metadata->addPropertyConstraint(
@@ -523,18 +504,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         $metadata->addPropertyConstraint(
             'replyToAddress',
             new \Symfony\Component\Validator\Constraints\Email(
-                [
-                    'message' => 'mautic.core.email.required',
-                ]
+                message: 'mautic.core.email.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'bccAddress',
             new \Symfony\Component\Validator\Constraints\Email(
-                [
-                    'message' => 'mautic.core.email.required',
-                ]
+                message: 'mautic.core.email.required'
             )
         );
 

--- a/app/bundles/EmailBundle/Form/Type/ConfigMonitoredMailboxesType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigMonitoredMailboxesType.php
@@ -43,9 +43,7 @@ class ConfigMonitoredMailboxesType extends AbstractType
                 ],
                 'constraints' => [
                     new Email(
-                        [
-                            'message' => 'mautic.core.email.required',
-                        ]
+                        message: 'mautic.core.email.required'
                     ),
                 ],
                 'required' => false,

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -245,9 +245,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -266,9 +264,7 @@ class ConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.email.required',
-                        ]
+                        message: 'mautic.core.email.required'
                     ),
                     new EmailOrEmailTokenList(['allowMultiple' => false]),
                 ],
@@ -288,12 +284,7 @@ class ConfigType extends AbstractType
                 ],
                 'required'    => false,
                 'constraints' => [
-                    new Email(
-                        [
-                            'message' => 'mautic.core.email.required',
-                            'mode'    => Email::VALIDATION_MODE_HTML5,
-                        ]
-                    ),
+                    new Email(message: 'mautic.core.email.required', mode: Email::VALIDATION_MODE_HTML5),
                 ],
             ]
         );
@@ -312,9 +303,7 @@ class ConfigType extends AbstractType
                 'required'    => false,
                 'constraints' => [
                     new Email(
-                        [
-                            'message' => 'mautic.core.email.required',
-                        ]
+                        message: 'mautic.core.email.required'
                     ),
                 ],
             ]

--- a/app/bundles/EmailBundle/Form/Type/EmailSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailSendType.php
@@ -42,7 +42,7 @@ class EmailSendType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.email.chooseemail.notblank']
+                        message: 'mautic.email.chooseemail.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/EmailBundle/Form/Type/FormSubmitActionUserEmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/FormSubmitActionUserEmailType.php
@@ -39,9 +39,7 @@ class FormSubmitActionUserEmailType extends AbstractType
                 ],
                 'required'    => true,
                 'constraints' => new NotBlank(
-                    [
-                        'message' => 'mautic.core.value.required',
-                    ]
+                    message: 'mautic.core.value.required'
                 ),
             ]
         );

--- a/app/bundles/EmailBundle/Form/Type/GenerateABTestType.php
+++ b/app/bundles/EmailBundle/Form/Type/GenerateABTestType.php
@@ -41,7 +41,7 @@ final class GenerateABTestType extends AbstractType
 
             if ($options['is_parent']) {
                 $constraints[] = new NotBlank(
-                    ['message' => 'mautic.core.ab_test.winner_criteria.not_blank']
+                    message: 'mautic.core.ab_test.winner_criteria.not_blank'
                 );
             }
 
@@ -84,10 +84,7 @@ final class GenerateABTestType extends AbstractType
             'label'       => 'mautic.core.ab_test.form.send_winner_delay',
             'label_attr'  => ['class' => 'control-label'],
             'attr'        => $attr + ['postaddon_text' => $this->translator->trans('mautic.core.time.hours')],
-            'constraints' => new Range([
-                'min' => 1,
-                'max' => 24,
-            ]),
+            'constraints' => new Range(min: 1, max: 24),
             'data'        => $options['data']['sendWinnerDelay'] ?? VariantType::DEFAULT_WINNER_DELAY,
         ]);
 
@@ -95,10 +92,7 @@ final class GenerateABTestType extends AbstractType
             'label'       => 'mautic.core.ab_test.form.traffic_total_weight',
             'label_attr'  => ['class' => 'control-label'],
             'attr'        => $attr + ['postaddon_text' => '%'],
-            'constraints' => new Range([
-                'min' => 1,
-                'max' => 50,
-            ]),
+            'constraints' => new Range(min: 1, max: 50),
             'data'        => $options['data']['totalWeight'] ?? VariantType::DEFAULT_WEIGHT,
         ]);
 

--- a/app/bundles/EmailBundle/Form/Type/ScheduleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ScheduleSendType.php
@@ -36,9 +36,7 @@ final class ScheduleSendType extends AbstractType
                 'required'    => false,
                 'html5'       => false,
                 'constraints' => new NotBlank(
-                    [
-                        'message' => 'mautic.core.value.required',
-                    ]
+                    message: 'mautic.core.value.required'
                 ),
             ]
         );

--- a/app/bundles/EmailBundle/Form/Type/VariantType.php
+++ b/app/bundles/EmailBundle/Form/Type/VariantType.php
@@ -68,10 +68,7 @@ class VariantType extends AbstractType
             'label'       => 'mautic.core.ab_test.form.traffic_total_weight',
             'label_attr'  => ['class' => 'control-label'],
             'attr'        => $attr + ['postaddon_text'  => '%'],
-            'constraints' => new Assert\Range([
-                'min' => 0,
-                'max' => 100,
-            ]),
+            'constraints' => new Assert\Range(min: 0, max: 100),
         ]);
 
         $attr = [
@@ -87,10 +84,7 @@ class VariantType extends AbstractType
             'label'       => 'mautic.core.ab_test.form.send_winner_delay',
             'label_attr'  => ['class' => 'control-label'],
             'attr'        => $attr + ['postaddon_text'  => $this->translator->trans('mautic.core.time.hours')],
-            'constraints' => new Assert\Range([
-                'min' => 1,
-                'max' => 480,
-            ]),
+            'constraints' => new Assert\Range(min: 1, max: 480),
             'data' => $options['data']['sendWinnerDelay'] ?? self::DEFAULT_WINNER_DELAY,
         ]);
 
@@ -103,7 +97,7 @@ class VariantType extends AbstractType
 
             if ($options['is_parent']) {
                 $constraints[] = new NotBlank(
-                    ['message' => 'mautic.core.ab_test.winner_criteria.not_blank']
+                    message: 'mautic.core.ab_test.winner_criteria.not_blank'
                 );
             }
 

--- a/app/bundles/EmailBundle/Tests/Form/Type/FormSubmitActionUserEmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/FormSubmitActionUserEmailTypeTest.php
@@ -57,9 +57,7 @@ final class FormSubmitActionUserEmailTypeTest extends \PHPUnit\Framework\TestCas
                         ],
                         'required'    => true,
                         'constraints' => new NotBlank(
-                            [
-                                'message' => 'mautic.core.value.required',
-                            ]
+                            message: 'mautic.core.value.required'
                         ),
                     ], $parameters[2]);
                 }

--- a/app/bundles/EmailBundle/Validator/EmailListsValidator.php
+++ b/app/bundles/EmailBundle/Validator/EmailListsValidator.php
@@ -37,9 +37,7 @@ final class EmailListsValidator extends ConstraintValidator
             [
                 new LeadListAccess(),
                 new NotBlank(
-                    [
-                        'message' => 'mautic.lead.lists.required',
-                    ]
+                    message: 'mautic.lead.lists.required'
                 ),
             ]
         );

--- a/app/bundles/FormBundle/Entity/Action.php
+++ b/app/bundles/FormBundle/Entity/Action.php
@@ -145,10 +145,7 @@ class Action implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-            'groups'  => ['action'],
-        ]));
+        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['action']));
     }
 
     private function isChanged(string $prop, mixed $val): void

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -311,33 +311,17 @@ class Form extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-            'groups'  => ['form'],
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['form']));
 
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank([
-            'message' => 'mautic.form.form.postactionproperty_message.notblank',
-            'groups'  => ['messageRequired'],
-        ]));
+        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired']));
 
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank([
-            'message' => 'mautic.form.form.postactionproperty_redirect.notblank',
-            'groups'  => ['urlRequired'],
-        ]));
+        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired']));
 
         $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
 
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank([
-            'message' => 'mautic.form.form.postactionproperty_hideform.notblank',
-            'groups'  => ['hideformRequired'],
-        ]));
+        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired']));
 
-        $metadata->addPropertyConstraint('progressiveProfilingLimit', new Assert\GreaterThan([
-            'value'   => 0,
-            'message' => 'mautic.form.form.progressive_profiling_limit.error',
-            'groups'  => ['progressiveProfilingLimit'],
-        ]));
+        $metadata->addPropertyConstraint('progressiveProfilingLimit', new Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit']));
     }
 
     public static function determineValidationGroups(\Symfony\Component\Form\Form $form): array

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -39,7 +39,7 @@ class CampaignEventFormFieldValueType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -121,7 +121,7 @@ class CampaignEventFormFieldValueType extends AbstractType
                     'required'    => true,
                     'constraints' => [
                         new NotBlank(
-                            ['message' => 'mautic.core.value.required']
+                            message: 'mautic.core.value.required'
                         ),
                     ],
                 ]
@@ -141,7 +141,7 @@ class CampaignEventFormFieldValueType extends AbstractType
                         'required'    => true,
                         'constraints' => [
                             new NotBlank(
-                                ['message' => 'mautic.core.value.required']
+                                message: 'mautic.core.value.required'
                             ),
                         ],
                     ]
@@ -160,7 +160,7 @@ class CampaignEventFormFieldValueType extends AbstractType
                         'required'    => true,
                         'constraints' => [
                             new NotBlank(
-                                ['message' => 'mautic.core.value.required']
+                                message: 'mautic.core.value.required'
                             ),
                         ],
                     ]

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -205,7 +205,7 @@ class FieldType extends AbstractType
                 'attr'        => ['class' => 'form-control'],
                 'constraints' => [
                     new Assert\NotBlank(
-                        ['message' => 'mautic.form.field.label.notblank']
+                        message: 'mautic.form.field.label.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/FormBundle/Form/Type/FormFieldFileType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldFileType.php
@@ -72,7 +72,7 @@ class FormFieldFileType extends AbstractType
                     'tooltip' => $this->translator->trans('mautic.form.field.file.tooltip.allowed_size', ['%uploadSize%' => $maxUploadSize]),
                 ],
                 'data'        => $options['data'][self::PROPERTY_ALLOWED_FILE_SIZE],
-                'constraints' => [new LessThanOrEqual(['value' => $maxUploadSize])],
+                'constraints' => [new LessThanOrEqual(value: $maxUploadSize)],
             ]
         );
 

--- a/app/bundles/FormBundle/Form/Type/FormFieldPageBreakType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldPageBreakType.php
@@ -32,7 +32,7 @@ class FormFieldPageBreakType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
                 'empty_data' => $this->translator->trans('mautic.core.continue'),

--- a/app/bundles/FormBundle/Form/Type/FormFieldSliderType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldSliderType.php
@@ -45,10 +45,7 @@ final class FormFieldSliderType extends AbstractType
             'attr'        => ['class' => 'form-control'],
             'data'        => $options['data']['step'] ?? 1,
             'constraints' => [
-                new Range([
-                    'min'        => 1,
-                    'minMessage' => 'mautic.form.field.form.slider_step_min_error',
-                ]),
+                new Range(min: 1, minMessage: 'mautic.form.field.form.slider_step_min_error'),
                 new SliderStepLessThanMax([
                     'message' => 'mautic.form.field.form.slider_step_lt_max_error',
                 ]),

--- a/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
@@ -32,14 +32,10 @@ class SubmitActionRepostType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                     new Url(
-                        [
-                            'message' => 'mautic.core.valid_url_required',
-                        ]
+                        message: 'mautic.core.valid_url_required'
                     ),
                 ],
             ]
@@ -73,9 +69,7 @@ class SubmitActionRepostType extends AbstractType
                 ],
                 'required'    => false,
                 'constraints' => new Email(
-                    [
-                        'message' => 'mautic.core.email.required',
-                    ]
+                    message: 'mautic.core.email.required'
                 ),
             ]
         );

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -20,10 +20,9 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 /**
  * CLI Command to install Mautic.
  */
-#[AsCommand(
-    name: InstallCommand::COMMAND,
-    description: 'Installs Mautic'
-)]
+#[AsCommand(name: InstallCommand::COMMAND, description: 'Installs Mautic', help: <<<'TXT'
+This command allows you to trigger the install process. It will try to get configuration values both from the local config file and command line options/arguments, where the latter takes precedence.
+TXT)]
 class InstallCommand extends Command
 {
     public const COMMAND = 'mautic:install';
@@ -41,7 +40,6 @@ class InstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setHelp('This command allows you to trigger the install process. It will try to get configuration values both from the local config file and command line options/arguments, where the latter takes precedence.')
             ->addArgument(
                 'site_url',
                 InputArgument::REQUIRED,

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -20,9 +20,13 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 /**
  * CLI Command to install Mautic.
  */
-#[AsCommand(name: InstallCommand::COMMAND, description: 'Installs Mautic', help: <<<'TXT'
+#[AsCommand(
+    name: InstallCommand::COMMAND,
+    description: 'Installs Mautic',
+    help: <<<'TXT'
 This command allows you to trigger the install process. It will try to get configuration values both from the local config file and command line options/arguments, where the latter takes precedence.
-TXT)]
+TXT
+)]
 class InstallCommand extends Command
 {
     public const COMMAND = 'mautic:install';

--- a/app/bundles/InstallBundle/Configurator/Form/DoctrineStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/DoctrineStepType.php
@@ -41,9 +41,7 @@ class DoctrineStepType extends AbstractType
                 ],
                 'constraints'       => [
                     new Choice(
-                        [
-                            'callback' => '\Mautic\InstallBundle\Configurator\Step\DoctrineStep::getDriverKeys',
-                        ]
+                        callback: '\Mautic\InstallBundle\Configurator\Step\DoctrineStep::getDriverKeys'
                     ),
                 ],
             ]

--- a/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
@@ -37,9 +37,7 @@ class UserStepType extends AbstractType
                 'data'        => (!empty($storedData->firstname)) ? $storedData->firstname : '',
                 'constraints' => [
                     new Assert\NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -56,9 +54,7 @@ class UserStepType extends AbstractType
                 'data'        => (!empty($storedData->lastname)) ? $storedData->lastname : '',
                 'constraints' => [
                     new Assert\NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -78,14 +74,10 @@ class UserStepType extends AbstractType
                 'data'        => (!empty($storedData->email)) ? $storedData->email : '',
                 'constraints' => [
                     new Assert\NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                     new Assert\Email(
-                        [
-                            'message' => 'mautic.core.email.required',
-                        ]
+                        message: 'mautic.core.email.required'
                     ),
                 ],
             ]
@@ -104,9 +96,7 @@ class UserStepType extends AbstractType
                 'data'        => (!empty($storedData->username)) ? $storedData->username : '',
                 'constraints' => [
                     new Assert\NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -126,16 +116,9 @@ class UserStepType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new Assert\NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
-                    new Assert\Length(
-                        [
-                            'min'        => 6,
-                            'minMessage' => 'mautic.install.password.minlength',
-                        ]
-                    ),
+                    new Assert\Length(min: 6, minMessage: 'mautic.install.password.minlength'),
                     new NotWeak([
                         'message' => 'mautic.user.user.password.weak',
                     ]),

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -412,7 +412,7 @@ class InstallService
         $emailConstraint          = new Assert\Email();
         $emailConstraint->message = $this->translator->trans('mautic.core.email.required', [], 'validators');
 
-        $passwordConstraint             = new Assert\Length(['min' => 6]);
+        $passwordConstraint             = new Assert\Length(min: 6);
         $passwordConstraint->minMessage = $this->translator->trans('mautic.install.password.minlength', [], 'validators');
 
         $validations[] = $this->validator->validate($data['email'], $emailConstraint);

--- a/app/bundles/LeadBundle/Command/DeduplicateCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateCommand.php
@@ -16,11 +16,15 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-#[AsCommand(name: DeduplicateCommand::NAME, description: 'Merge contacts based on same unique identifiers', help: <<<'TXT'
+#[AsCommand(
+    name: DeduplicateCommand::NAME,
+    description: 'Merge contacts based on same unique identifiers',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class DeduplicateCommand extends Command
 {
     public const NAME = 'mautic:contacts:deduplicate';

--- a/app/bundles/LeadBundle/Command/DeduplicateCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateCommand.php
@@ -16,10 +16,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-#[AsCommand(
-    name: DeduplicateCommand::NAME,
-    description: 'Merge contacts based on same unique identifiers'
-)]
+#[AsCommand(name: DeduplicateCommand::NAME, description: 'Merge contacts based on same unique identifiers', help: <<<'TXT'
+The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
+
+<info>php %command.full_name%</info>
+TXT)]
 class DeduplicateCommand extends Command
 {
     public const NAME = 'mautic:contacts:deduplicate';
@@ -55,13 +56,6 @@ class DeduplicateCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'The commands can run in multiple PHP processes. This option defines how many processes to run. Defaults to 1.',
                 1
-            )
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
-
-<info>php %command.full_name%</info>
-EOT
             );
     }
 

--- a/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
@@ -13,11 +13,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-#[AsCommand(name: DeduplicateIdsCommand::NAME, description: 'Merge contacts based on same unique identifiers', help: <<<'TXT'
+#[AsCommand(
+    name: DeduplicateIdsCommand::NAME,
+    description: 'Merge contacts based on same unique identifiers',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class DeduplicateIdsCommand extends Command
 {
     public const NAME = 'mautic:contacts:deduplicate:ids';

--- a/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
@@ -13,10 +13,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-#[AsCommand(
-    name: DeduplicateIdsCommand::NAME,
-    description: 'Merge contacts based on same unique identifiers'
-)]
+#[AsCommand(name: DeduplicateIdsCommand::NAME, description: 'Merge contacts based on same unique identifiers', help: <<<'TXT'
+The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
+
+<info>php %command.full_name%</info>
+TXT)]
 class DeduplicateIdsCommand extends Command
 {
     public const NAME = 'mautic:contacts:deduplicate:ids';
@@ -43,13 +44,6 @@ class DeduplicateIdsCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Comma separated list of contact IDs to deduplicate. If not provided, all contacts will be deduplicated. Example: --contact-ids=23,3,11'
-            )
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
-
-<info>php %command.full_name%</info>
-EOT
             );
     }
 

--- a/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
+++ b/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
@@ -14,10 +14,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(
-    name: DeleteContactSecondaryCompaniesCommand::NAME,
-    description: "Deletes all contact\'s secondary companies."
-)]
+#[AsCommand(name: DeleteContactSecondaryCompaniesCommand::NAME, description: "Deletes all contact\'s secondary companies.", help: <<<'TXT'
+The <info>%command.name%</info> command deletes non-primary companies of every contact.
+
+<info>php %command.full_name%</info>
+TXT)]
 class DeleteContactSecondaryCompaniesCommand extends Command
 {
     public const NAME                    = 'mautic:contact:delete:secondary-companies';
@@ -33,14 +34,6 @@ class DeleteContactSecondaryCompaniesCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command deletes non-primary companies of every contact.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
+++ b/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
@@ -14,11 +14,15 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(name: DeleteContactSecondaryCompaniesCommand::NAME, description: "Deletes all contact\'s secondary companies.", help: <<<'TXT'
+#[AsCommand(
+    name: DeleteContactSecondaryCompaniesCommand::NAME,
+    description: "Deletes all contact\'s secondary companies.",
+    help: <<<'TXT'
 The <info>%command.name%</info> command deletes non-primary companies of every contact.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class DeleteContactSecondaryCompaniesCommand extends Command
 {
     public const NAME                    = 'mautic:contact:delete:secondary-companies';

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -21,11 +21,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to import data.
  */
-#[AsCommand(name: ImportCommand::COMMAND_NAME, description: 'Imports data to Mautic', help: <<<'TXT'
+#[AsCommand(
+    name: ImportCommand::COMMAND_NAME,
+    description: 'Imports data to Mautic',
+    help: <<<'TXT'
 The <info>%command.name%</info> command starts to import CSV files when some are created.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class ImportCommand extends Command
 {
     public const COMMAND_NAME = 'mautic:import';

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -21,10 +21,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * CLI Command to import data.
  */
-#[AsCommand(
-    name: ImportCommand::COMMAND_NAME,
-    description: 'Imports data to Mautic'
-)]
+#[AsCommand(name: ImportCommand::COMMAND_NAME, description: 'Imports data to Mautic', help: <<<'TXT'
+The <info>%command.name%</info> command starts to import CSV files when some are created.
+
+<info>php %command.full_name%</info>
+TXT)]
 class ImportCommand extends Command
 {
     public const COMMAND_NAME = 'mautic:import';
@@ -44,14 +45,7 @@ class ImportCommand extends Command
     {
         $this
             ->addOption('--id', '-i', InputOption::VALUE_OPTIONAL, 'Specific ID to import. Defaults to next in the queue.', false)
-            ->addOption('--limit', '-l', InputOption::VALUE_OPTIONAL, 'Maximum number of records to import for this script execution.', 0)
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command starts to import CSV files when some are created.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--limit', '-l', InputOption::VALUE_OPTIONAL, 'Maximum number of records to import for this script execution.', 0);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -263,10 +263,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
-        $metadata->addPropertyConstraint('score', new Assert\Range([
-            'min' => 0,
-            'max' => 2147483647,
-        ]));
+        $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/ContactExportScheduler.php
+++ b/app/bundles/LeadBundle/Entity/ContactExportScheduler.php
@@ -54,7 +54,7 @@ class ContactExportScheduler
         $metadata->addPropertyConstraint(
             'scheduledDate',
             new Assert\NotBlank(
-                ['message' => 'mautic.lead.import.dir.notblank']
+                message: 'mautic.lead.import.dir.notblank'
             )
         );
     }

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -166,11 +166,11 @@ class Import extends FormEntity
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('dir', new Assert\NotBlank(
-            ['message' => 'mautic.lead.import.dir.notblank']
+            message: 'mautic.lead.import.dir.notblank'
         ));
 
         $metadata->addPropertyConstraint('file', new Assert\NotBlank(
-            ['message' => 'mautic.lead.import.file.notblank']
+            message: 'mautic.lead.import.file.notblank'
         ));
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -311,18 +311,12 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('label', new Assert\NotBlank(
-            ['message' => 'mautic.lead.field.label.notblank']
+            message: 'mautic.lead.field.label.notblank'
         ));
 
-        $metadata->addPropertyConstraint('label', new Assert\Length([
-            'max'        => 191,
-            'maxMessage' => 'mautic.lead.field.label.maxlength',
-        ]));
+        $metadata->addPropertyConstraint('label', new Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength'));
 
-        $metadata->addConstraint(new UniqueEntity([
-            'fields'  => ['alias'],
-            'message' => 'mautic.lead.field.alias.unique',
-        ]));
+        $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));
 
         $metadata->addConstraint(new Assert\Callback(
             function (LeadField $field, ExecutionContextInterface $context): void {

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -183,7 +183,7 @@ class LeadList extends FormEntity implements UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            ['message' => 'mautic.core.name.required']
+            message: 'mautic.core.name.required'
         ));
 
         $metadata->addConstraint(new UniqueUserAlias([

--- a/app/bundles/LeadBundle/Entity/LeadNote.php
+++ b/app/bundles/LeadBundle/Entity/LeadNote.php
@@ -130,7 +130,7 @@ class LeadNote extends FormEntity
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('text', new NotBlank(
-            ['message' => 'mautic.lead.note.text.notblank']
+            message: 'mautic.lead.note.text.notblank'
         ));
     }
 

--- a/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
@@ -131,7 +131,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                 'multiple'                  => true,
                 'choice_translation_domain' => false,
                 'disabled'                  => $event->filterShouldBeDisabled(),
-                'constraints'               => $event->filterShouldBeDisabled() ? [] : [new NotBlank(['message' => 'mautic.core.value.required'])],
+                'constraints'               => $event->filterShouldBeDisabled() ? [] : [new NotBlank(message: 'mautic.core.value.required')],
                 'attr'                      => [
                     'class'                => 'form-control',
                     'data-placeholder'     => $this->translator->trans('mautic.lead.tags.select_or_create'),
@@ -182,7 +182,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                 'attr'        => $displayAttr,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -200,7 +200,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                 'disabled'    => $event->filterShouldBeDisabled(),
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -256,7 +256,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                 'disabled'    => $event->filterShouldBeDisabled(),
                 'constraints' => $event->filterShouldBeRequired() ? [
                     new NotBlank(
-                        ['message' => $this->translator->trans('mautic.core.value.required')]
+                        message: $this->translator->trans('mautic.core.value.required')
                     ),
                 ] : [],
             ]
@@ -302,7 +302,7 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
                     'multiple'                  => $multiple,
                     'choice_translation_domain' => false,
                     'disabled'                  => $event->filterShouldBeDisabled(),
-                    'constraints'               => $event->filterShouldBeDisabled() ? [] : [new NotBlank(['message' => 'mautic.core.value.required'])],
+                    'constraints'               => $event->filterShouldBeDisabled() ? [] : [new NotBlank(message: 'mautic.core.value.required')],
                 ]
             );
             $event->stopPropagation();

--- a/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
@@ -22,10 +22,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(
-    name: CreateCustomFieldCommand::COMMAND_NAME,
-    description: 'Create custom field column in the background',
-)]
+#[AsCommand(name: CreateCustomFieldCommand::COMMAND_NAME, description: 'Create custom field column in the background', help: <<<'TXT'
+The <info>%command.name%</info> command will create columns in a lead_fields table if the process should run in background.
+
+<info>php %command.full_name%</info>
+TXT)]
 class CreateCustomFieldCommand extends ModeratedCommand
 {
     public const COMMAND_NAME = 'mautic:custom-field:create-column';
@@ -46,14 +47,7 @@ class CreateCustomFieldCommand extends ModeratedCommand
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_OPTIONAL, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will create columns in a lead_fields table if the process should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
@@ -22,11 +22,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(name: CreateCustomFieldCommand::COMMAND_NAME, description: 'Create custom field column in the background', help: <<<'TXT'
+#[AsCommand(
+    name: CreateCustomFieldCommand::COMMAND_NAME,
+    description: 'Create custom field column in the background',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will create columns in a lead_fields table if the process should run in background.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class CreateCustomFieldCommand extends ModeratedCommand
 {
     public const COMMAND_NAME = 'mautic:custom-field:create-column';

--- a/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
@@ -18,10 +18,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(
-    name: 'mautic:custom-field:delete-column',
-    description: 'Delete custom field column in the background'
-)]
+#[AsCommand(name: 'mautic:custom-field:delete-column', description: 'Delete custom field column in the background', help: <<<'TXT'
+The <info>%command.name%</info> command will delete a column in a lead_fields table if the proces should run in background.
+
+<info>php %command.full_name%</info>
+TXT)]
 final class DeleteCustomFieldCommand extends Command
 {
     public function __construct(
@@ -38,14 +39,7 @@ final class DeleteCustomFieldCommand extends Command
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will delete a column in a lead_fields table if the proces should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
@@ -18,11 +18,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(name: 'mautic:custom-field:delete-column', description: 'Delete custom field column in the background', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:custom-field:delete-column',
+    description: 'Delete custom field column in the background',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will delete a column in a lead_fields table if the proces should run in background.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 final class DeleteCustomFieldCommand extends Command
 {
     public function __construct(

--- a/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
@@ -17,10 +17,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(
-    name: 'mautic:custom-field:update-column',
-    description: 'Create custom field column in the background'
-)]
+#[AsCommand(name: 'mautic:custom-field:update-column', description: 'Create custom field column in the background', help: <<<'TXT'
+The <info>%command.name%</info> command will create a column in a lead_fields table if the proces should run in background.
+
+<info>php %command.full_name%</info>
+TXT)]
 class UpdateCustomFieldCommand extends Command
 {
     public function __construct(
@@ -36,14 +37,7 @@ class UpdateCustomFieldCommand extends Command
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will create a column in a lead_fields table if the proces should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
@@ -17,11 +17,15 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-#[AsCommand(name: 'mautic:custom-field:update-column', description: 'Create custom field column in the background', help: <<<'TXT'
+#[AsCommand(
+    name: 'mautic:custom-field:update-column',
+    description: 'Create custom field column in the background',
+    help: <<<'TXT'
 The <info>%command.name%</info> command will create a column in a lead_fields table if the proces should run in background.
 
 <info>php %command.full_name%</info>
-TXT)]
+TXT
+)]
 class UpdateCustomFieldCommand extends Command
 {
     public function __construct(

--- a/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
@@ -29,7 +29,7 @@ class AddToCompanyActionType extends AbstractType
                 'modal_route' => false,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.company.choosecompany.notblank']
+                        message: 'mautic.company.choosecompany.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -50,7 +50,7 @@ class CampaignEventLeadFieldValueType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]
@@ -155,7 +155,7 @@ class CampaignEventLeadFieldValueType extends AbstractType
                     'required'    => true,
                     'constraints' => [
                         new NotBlank(
-                            ['message' => 'mautic.core.value.required']
+                            message: 'mautic.core.value.required'
                         ),
                     ],
                     'auto_initialize' => false,
@@ -192,7 +192,7 @@ class CampaignEventLeadFieldValueType extends AbstractType
                         'attr'        => $attr,
                         'constraints' => ($supportsValue) ? [
                             new NotBlank(
-                                ['message' => 'mautic.core.value.required']
+                                message: 'mautic.core.value.required'
                             ),
                         ] : [],
                     ]

--- a/app/bundles/LeadBundle/Form/Type/CompanyChangeScoreActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyChangeScoreActionType.php
@@ -24,12 +24,7 @@ class CompanyChangeScoreActionType extends AbstractType
                 'scale'       => 0,
                 'data'        => $options['data']['score'] ?? 0,
                 'constraints' => [
-                    new NotEqualTo(
-                        [
-                            'value'   => 0,
-                            'message' => 'mautic.core.value.required',
-                        ]
-                    ),
+                    new NotEqualTo(value: 0, message: 'mautic.core.value.required'),
                 ],
             ]
         );

--- a/app/bundles/LeadBundle/Form/Type/CompanyMergeType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyMergeType.php
@@ -27,7 +27,7 @@ class CompanyMergeType extends AbstractType
                 'model_lookup_method' => $options['model_lookup_method'],
                 'constraints'         => [
                     new NotBlank(
-                        ['message' => 'mautic.company.choosecompany.notblank']
+                        message: 'mautic.company.choosecompany.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/LeadBundle/Form/Type/ConfigCompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ConfigCompanyType.php
@@ -62,7 +62,7 @@ class ConfigCompanyType extends AbstractType
                     'expanded'    => false,
                     'constraints' => [
                         new NotBlank(
-                            ['message' => 'mautic.core.value.required']
+                            message: 'mautic.core.value.required'
                         ),
                     ],
                     'data' => array_flip($orderColumns),

--- a/app/bundles/LeadBundle/Form/Type/ConfigType.php
+++ b/app/bundles/LeadBundle/Form/Type/ConfigType.php
@@ -75,9 +75,7 @@ class ConfigType extends AbstractType
             'required'    => false,
             'data'        => $options['data']['contact_export_limit'] ?? 0,
             'constraints' => [
-                new GreaterThanOrEqual([
-                    'value' => 0,
-                ]),
+                new GreaterThanOrEqual(value: 0),
             ],
         ]);
 
@@ -104,7 +102,7 @@ class ConfigType extends AbstractType
                     'expanded'    => false,
                     'constraints' => [
                         new NotBlank(
-                            ['message' => 'mautic.core.value.required']
+                            message: 'mautic.core.value.required'
                         ),
                     ],
                     'data'=> array_flip($orderColumns),

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -74,7 +74,7 @@ trait EntityFieldsBuildFormTrait
             $constraints = [];
             if ($required && empty($options['ignore_required_constraints'])) {
                 $constraints[] = new NotBlank(
-                    ['message' => 'mautic.lead.customfield.notblank']
+                    message: 'mautic.lead.customfield.notblank'
                 );
             } elseif (!empty($options['ignore_required_constraints'])) {
                 $required            = false;

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -734,8 +734,8 @@ class FieldType extends AbstractType
                      }',
                 ],
                 'constraints' => [
-                    new Assert\NotBlank(groups: 'indexableFieldWithLimits'),
-                    new Assert\Range(min: 1, max: SchemaDefinition::MAX_VARCHAR_LENGTH, groups: 'indexableFieldWithLimits'),
+                    new Assert\NotBlank(groups: ['indexableFieldWithLimits']),
+                    new Assert\Range(min: 1, max: SchemaDefinition::MAX_VARCHAR_LENGTH, groups: ['indexableFieldWithLimits']),
                 ],
             ]
         );

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -375,7 +375,7 @@ class FieldType extends AbstractType
                                             $validator  = $context->getValidator();
                                             $violations = $validator->validate(
                                                 $object,
-                                                new Assert\Regex(['pattern' => '/(2[0-3]|[01][0-9]):([0-5][0-9])/'])
+                                                new Assert\Regex(pattern: '/(2[0-3]|[01][0-9]):([0-5][0-9])/')
                                             );
 
                                             if (count($violations) > 0) {
@@ -587,7 +587,7 @@ class FieldType extends AbstractType
         $constraints = [];
 
         if (false === $options['data']->isIsindex() && false === $this->indexHelper->isNewIndexAllowed()) {
-            $constraints[] = new IsFalse(['message' => 'mautic.lead.field.form.index_count.error']);
+            $constraints[] = new IsFalse(message: 'mautic.lead.field.form.index_count.error');
         }
 
         $builder->add(
@@ -734,8 +734,8 @@ class FieldType extends AbstractType
                      }',
                 ],
                 'constraints' => [
-                    new Assert\NotBlank(['groups' => 'indexableFieldWithLimits']),
-                    new Assert\Range(['min' => 1, 'max' => SchemaDefinition::MAX_VARCHAR_LENGTH, 'groups' => 'indexableFieldWithLimits']),
+                    new Assert\NotBlank(groups: 'indexableFieldWithLimits'),
+                    new Assert\Range(min: 1, max: SchemaDefinition::MAX_VARCHAR_LENGTH, groups: 'indexableFieldWithLimits'),
                 ],
             ]
         );

--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -310,9 +310,7 @@ trait FilterTrait
             $attr['disabled'] = 'disabled';
         } elseif ($operator) {
             $customOptions['constraints'][] = new NotBlank(
-                [
-                    'message' => 'mautic.core.value.required',
-                ]
+                message: 'mautic.core.value.required'
             );
 
             if (in_array($operator, ['regexp', '!regexp']) && $this->connection) {

--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -28,12 +28,7 @@ class LeadImportType extends AbstractType
                     'class'  => 'form-control',
                 ],
                 'constraints' => [
-                    new File(
-                        [
-                            'mimeTypes'        => ['text/*', 'application/octet-stream', 'application/csv'],
-                            'mimeTypesMessage' => 'mautic.core.invalid_file_type',
-                        ]
-                    ),
+                    new File(mimeTypes: ['text/*', 'application/octet-stream', 'application/csv'], mimeTypesMessage: 'mautic.core.invalid_file_type'),
                     new EncodingValidation(
                         [
                             'encodingFormat'        => ['UTF-8'],
@@ -41,7 +36,7 @@ class LeadImportType extends AbstractType
                         ]
                     ),
                     new NotBlank(
-                        ['message' => 'mautic.import.file.required']
+                        message: 'mautic.import.file.required'
                     ),
                 ],
                 'error_bubbling' => true,
@@ -50,7 +45,7 @@ class LeadImportType extends AbstractType
 
         $constraints = [
             new NotBlank(
-                ['message' => 'mautic.core.value.required']
+                message: 'mautic.core.value.required'
             ),
         ];
 

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -79,16 +79,11 @@ class LeadType extends AbstractType
                     ],
                     'mapped'      => false,
                     'constraints' => [
-                        new File(
-                            [
-                                'mimeTypes' => [
-                                    'image/gif',
-                                    'image/jpeg',
-                                    'image/png',
-                                ],
-                                'mimeTypesMessage' => 'mautic.lead.avatar.types_invalid',
-                            ]
-                        ),
+                        new File(mimeTypes: [
+                            'image/gif',
+                            'image/jpeg',
+                            'image/png',
+                        ], mimeTypesMessage: 'mautic.lead.avatar.types_invalid'),
                     ],
                 ]
             );

--- a/app/bundles/LeadBundle/Form/Type/MergeType.php
+++ b/app/bundles/LeadBundle/Form/Type/MergeType.php
@@ -31,9 +31,7 @@ class MergeType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/LeadBundle/Form/Type/PointActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/PointActionType.php
@@ -25,12 +25,7 @@ class PointActionType extends AbstractType
                 'scale'       => 0,
                 'data'        => $options['data']['points'] ?? 0,
                 'constraints' => [
-                    new NotEqualTo(
-                        [
-                            'value'   => '0',
-                            'message' => 'mautic.core.value.required',
-                        ]
-                    ),
+                    new NotEqualTo(value: '0', message: 'mautic.core.value.required'),
                 ],
             ]
         );

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -241,7 +241,7 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
                     'multiple'                  => true,
                     'choice_translation_domain' => false,
                     'disabled'                  => false,
-                    'constraints'               => [new NotBlank(['message' => 'mautic.core.value.required'])],
+                    'constraints'               => [new NotBlank(message: 'mautic.core.value.required')],
                     'attr'                      => [
                         'class'                => 'form-control',
                         'data-placeholder'     => 'mautic.lead.tags.select_or_create',
@@ -492,7 +492,7 @@ final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
                     'multiple'                  => true,
                     'choice_translation_domain' => false,
                     'disabled'                  => false,
-                    'constraints'               => [new NotBlank(['message' => 'mautic.core.value.required'])],
+                    'constraints'               => [new NotBlank(message: 'mautic.core.value.required')],
                 ]
             );
 

--- a/app/bundles/MessengerBundle/Form/Type/ConfigType.php
+++ b/app/bundles/MessengerBundle/Form/Type/ConfigType.php
@@ -120,7 +120,7 @@ class ConfigType extends AbstractType
      */
     private function greaterThanOrEqualConstraint(int|float $value): array
     {
-        return [new GreaterThanOrEqual(['value' => $value])];
+        return [new GreaterThanOrEqual(value: $value)];
     }
 
     public function getBlockPrefix(): string

--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -253,27 +253,21 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
         $metadata->addPropertyConstraint(
             'name',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.name.required',
-                ]
+                message: 'mautic.core.name.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'heading',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.heading.required',
-                ]
+                message: 'mautic.core.heading.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'message',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.message.required',
-                ]
+                message: 'mautic.core.message.required'
             )
         );
 
@@ -291,9 +285,7 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
                                 ]
                             ),
                             new NotBlank(
-                                [
-                                    'message' => 'mautic.lead.lists.required',
-                                ]
+                                message: 'mautic.lead.lists.required'
                             ),
                         ]
                     );

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
@@ -35,7 +35,7 @@ class MobileNotificationSendType extends AbstractType
                 'multiple'    => false,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.notification.choosenotification.notblank']
+                        message: 'mautic.notification.choosenotification.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/NotificationBundle/Form/Type/NotificationConfigType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationConfigType.php
@@ -45,7 +45,7 @@ class NotificationConfigType extends AbstractType
                     'data-show-on' => '{"config_notification_config_campaign_send_notification_to_author_0":"checked"}',
                 ],
                 'constraints' => [
-                    new NotBlank(['groups' => ['campaign_email_list']]),
+                    new NotBlank(groups: ['campaign_email_list']),
                     new MultipleEmailsValid(),
                 ],
             ]
@@ -77,7 +77,7 @@ class NotificationConfigType extends AbstractType
                 ],
                 'constraints' => [
                     new MultipleEmailsValid(),
-                    new NotBlank(['groups' => ['webhook_email_list']]),
+                    new NotBlank(groups: ['webhook_email_list']),
                 ],
             ]
         );

--- a/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
@@ -35,7 +35,7 @@ class NotificationSendType extends AbstractType
                 'multiple'    => false,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.notification.choosenotification.notblank']
+                        message: 'mautic.notification.choosenotification.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -320,9 +320,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('title', new NotBlank([
-            'message' => 'mautic.core.title.required',
-        ]));
+        $metadata->addPropertyConstraint('title', new NotBlank(message: 'mautic.core.title.required'));
 
         $metadata->addConstraint(new Callback(
             function (Page $page, ExecutionContextInterface $context): void {
@@ -333,7 +331,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
                         $page->getRedirectUrl(),
                         [
                             new Assert\Url(),
-                            new NotBlank(['message' => 'mautic.core.value.required']),
+                            new NotBlank(message: 'mautic.core.value.required'),
                         ],
                     );
 

--- a/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
+++ b/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
@@ -35,7 +35,7 @@ class TrackingPixelSendType extends AbstractType
             'placeholder' => 'mautic.core.form.chooseone',
             'constraints' => [
                 new NotBlank(
-                    ['message' => 'mautic.core.ab_test.winner_criteria.not_blank']
+                    message: 'mautic.core.ab_test.winner_criteria.not_blank'
                 ),
             ],
         ]);

--- a/app/bundles/PageBundle/Form/Type/VariantType.php
+++ b/app/bundles/PageBundle/Form/Type/VariantType.php
@@ -34,7 +34,7 @@ class VariantType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.page.variant.weight.notblank']
+                        message: 'mautic.page.variant.weight.notblank'
                     ),
                 ],
             ]
@@ -61,7 +61,7 @@ class VariantType extends AbstractType
                     'placeholder' => 'mautic.core.form.chooseone',
                     'constraints' => [
                         new NotBlank(
-                            ['message' => 'mautic.core.ab_test.winner_criteria.not_blank']
+                            message: 'mautic.core.ab_test.winner_criteria.not_blank'
                         ),
                     ],
                 ]

--- a/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
@@ -55,7 +55,7 @@ class IntegrationsListType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/PointBundle/Entity/Group.php
+++ b/app/bundles/PointBundle/Entity/Group.php
@@ -42,9 +42,7 @@ class Group extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -172,22 +172,13 @@ class Point extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
 
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank([
-            'message' => 'mautic.point.type.notblank',
-        ]));
+        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.point.type.notblank'));
 
-        $metadata->addPropertyConstraint('delta', new Assert\NotBlank([
-            'message' => 'mautic.point.delta.notblank',
-        ]));
+        $metadata->addPropertyConstraint('delta', new Assert\NotBlank(message: 'mautic.point.delta.notblank'));
 
-        $metadata->addPropertyConstraint('delta', new Assert\Range([
-            'min' => IntHelper::MIN_INTEGER_VALUE,
-            'max' => IntHelper::MAX_INTEGER_VALUE,
-        ]));
+        $metadata->addPropertyConstraint('delta', new Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -89,17 +89,11 @@ class PointInsight extends FormEntity
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
 
-        $metadata->addPropertyConstraint('insightType', new Assert\NotBlank([
-            'message' => 'mautic.point.insight.type.required',
-        ]));
+        $metadata->addPropertyConstraint('insightType', new Assert\NotBlank(message: 'mautic.point.insight.type.required'));
 
-        $metadata->addPropertyConstraint('insightAction', new Assert\NotBlank([
-            'message' => 'mautic.point.insight.action.required',
-        ]));
+        $metadata->addPropertyConstraint('insightAction', new Assert\NotBlank(message: 'mautic.point.insight.action.required'));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/Trigger.php
+++ b/app/bundles/PointBundle/Entity/Trigger.php
@@ -165,9 +165,7 @@ class Trigger extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     /**

--- a/app/bundles/ProjectBundle/Entity/Project.php
+++ b/app/bundles/ProjectBundle/Entity/Project.php
@@ -112,7 +112,7 @@ class Project extends FormEntity implements UuidInterface
     {
         $metadata->addPropertyConstraint(
             'name',
-            new NotBlank(['message' => 'mautic.core.name.required'])
+            new NotBlank(message: 'mautic.core.name.required')
         );
         $metadata->addConstraint(new UniqueName());
     }

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -219,9 +219,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
 
         $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
 

--- a/app/bundles/SmsBundle/Form/Type/SmsSendType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsSendType.php
@@ -40,7 +40,7 @@ class SmsSendType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.sms.choosesms.notblank']
+                        message: 'mautic.sms.choosesms.notblank'
                     ),
                 ],
             ]

--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -135,14 +135,9 @@ class Stage extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank([
-            'message' => 'mautic.core.name.required',
-        ]));
+        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
 
-        $metadata->addConstraint(new UniqueEntity([
-            'fields'  => ['weight'],
-            'message' => 'mautic.stage.weight.unique',
-        ]));
+        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 
     /**

--- a/app/bundles/StageBundle/Form/Type/StageActionChangeType.php
+++ b/app/bundles/StageBundle/Form/Type/StageActionChangeType.php
@@ -25,7 +25,7 @@ class StageActionChangeType extends AbstractType
             'required'    => true,
             'constraints' => [
                 new NotBlank(
-                    ['message' => 'mautic.core.value.required']
+                    message: 'mautic.core.value.required'
                 ),
             ],
         ]);

--- a/app/bundles/StageBundle/Form/Type/StageMergeType.php
+++ b/app/bundles/StageBundle/Form/Type/StageMergeType.php
@@ -32,12 +32,9 @@ final class StageMergeType extends AbstractType
                 'placeholder' => 'mautic.core.form.chooseone',
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.core.value.required']
+                        message: 'mautic.core.value.required'
                     ),
-                    new Choice([
-                        'choices' => array_values($stageChoices),
-                        'message' => 'mautic.core.value.invalid',
-                    ]),
+                    new Choice(choices: array_values($stageChoices), message: 'mautic.core.value.invalid'),
                 ],
             ]
         );

--- a/app/bundles/UserBundle/Entity/Role.php
+++ b/app/bundles/UserBundle/Entity/Role.php
@@ -129,7 +129,7 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            ['message' => 'mautic.core.name.required']
+            message: 'mautic.core.name.required'
         ));
     }
 

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -229,70 +229,36 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('username', new Assert\NotBlank(
-            ['message' => 'mautic.user.user.username.notblank']
+            message: 'mautic.user.user.username.notblank'
         ));
 
-        $metadata->addConstraint(new UniqueEntity(
-            [
-                'fields'           => ['username'],
-                'message'          => 'mautic.user.user.username.unique',
-                'repositoryMethod' => 'checkUniqueUsernameEmail',
-            ]
-        ));
+        $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
 
         $metadata->addPropertyConstraint('firstName', new Assert\NotBlank(
-            ['message' => 'mautic.user.user.firstname.notblank']
+            message: 'mautic.user.user.firstname.notblank'
         ));
 
         $metadata->addPropertyConstraint('lastName', new Assert\NotBlank(
-            ['message' => 'mautic.user.user.lastname.notblank']
+            message: 'mautic.user.user.lastname.notblank'
         ));
 
         $metadata->addPropertyConstraint('email', new Assert\NotBlank(
-            ['message' => 'mautic.user.user.email.valid']
+            message: 'mautic.user.user.email.valid'
         ));
 
-        $metadata->addPropertyConstraint('email', new Assert\Email(
-            [
-                'message' => 'mautic.user.user.email.valid',
-                'groups'  => ['SecondPass'],
-            ]
-        ));
+        $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
 
-        $metadata->addConstraint(new UniqueEntity(
-            [
-                'fields'           => ['email'],
-                'message'          => 'mautic.user.user.email.unique',
-                'repositoryMethod' => 'checkUniqueUsernameEmail',
-                'groups'           => ['User', 'SecondPass'],
-            ]
-        ));
+        $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
 
-        $metadata->addPropertyConstraint('position', new Assert\Length(
-            [
-                'max'        => 191,
-                'maxMessage' => 'mautic.user.user.position.toolong',
-            ]
-        ));
+        $metadata->addPropertyConstraint('position', new Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong'));
 
         $metadata->addPropertyConstraint('role', new Assert\NotBlank(
-            ['message' => 'mautic.user.user.role.notblank']
+            message: 'mautic.user.user.role.notblank'
         ));
 
-        $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(
-            [
-                'message' => 'mautic.user.user.password.notblank',
-                'groups'  => ['CheckPasswordNotBlank'],
-            ]
-        ));
+        $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank']));
 
-        $metadata->addPropertyConstraint('plainPassword', new Assert\Length(
-            [
-                'min'        => 6,
-                'minMessage' => 'mautic.user.user.password.minlength',
-                'groups'     => ['CheckPassword'],
-            ]
-        ));
+        $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
 
         $metadata->addPropertyConstraint('plainPassword', new NotWeak(
             [

--- a/app/bundles/UserBundle/Form/Type/ConfigType.php
+++ b/app/bundles/UserBundle/Form/Type/ConfigType.php
@@ -56,12 +56,7 @@ class ConfigType extends AbstractType
                 ],
                 'required'    => false,
                 'constraints' => [
-                    new File(
-                        [
-                            'mimeTypes'        => ['text/plain', 'text/xml', 'application/xml'],
-                            'mimeTypesMessage' => 'mautic.core.invalid_file_type',
-                        ]
-                    ),
+                    new File(mimeTypes: ['text/plain', 'text/xml', 'application/xml'], mimeTypesMessage: 'mautic.core.invalid_file_type'),
                 ],
             ]
         );
@@ -78,12 +73,7 @@ class ConfigType extends AbstractType
                 ],
                 'required'    => false,
                 'constraints' => [
-                    new File(
-                        [
-                            'mimeTypes'        => ['text/plain'],
-                            'mimeTypesMessage' => 'mautic.core.invalid_file_type',
-                        ]
-                    ),
+                    new File(mimeTypes: ['text/plain'], mimeTypesMessage: 'mautic.core.invalid_file_type'),
                 ],
             ]
         );
@@ -100,12 +90,7 @@ class ConfigType extends AbstractType
                 ],
                 'required'    => false,
                 'constraints' => [
-                    new File(
-                        [
-                            'mimeTypes'        => ['text/plain'],
-                            'mimeTypesMessage' => 'mautic.core.invalid_file_type',
-                        ]
-                    ),
+                    new File(mimeTypes: ['text/plain'], mimeTypesMessage: 'mautic.core.invalid_file_type'),
                 ],
             ]
         );

--- a/app/bundles/UserBundle/Form/Type/ContactType.php
+++ b/app/bundles/UserBundle/Form/Type/ContactType.php
@@ -31,8 +31,8 @@ class ContactType extends AbstractType
                     'label_attr'  => ['class' => 'control-label'],
                     'attr'        => ['class' => 'form-control'],
                     'constraints' => [
-                        new NotBlank(['message' => 'Subject should not be blank.']),
-                        new Length(['min' => 3]),
+                        new NotBlank(message: 'Subject should not be blank.'),
+                        new Length(min: 3),
                     ],
                 ]
             )
@@ -47,8 +47,8 @@ class ContactType extends AbstractType
                         'rows'  => 10,
                     ],
                     'constraints' => [
-                        new NotBlank(['message' => 'Message should not be blank.']),
-                        new Length(['min' => 5]),
+                        new NotBlank(message: 'Message should not be blank.'),
+                        new Length(min: 5),
                     ],
                 ]
             )

--- a/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
+++ b/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
@@ -34,7 +34,7 @@ class PasswordResetConfirmType extends AbstractType
                 ],
                 'required'    => true,
                 'constraints' => [
-                    new Assert\NotBlank(['message' => 'mautic.user.user.passwordreset.notblank']),
+                    new Assert\NotBlank(message: 'mautic.user.user.passwordreset.notblank'),
                 ],
             ]
         );
@@ -57,11 +57,8 @@ class PasswordResetConfirmType extends AbstractType
                     'required'       => true,
                     'error_bubbling' => false,
                     'constraints'    => [
-                        new Assert\NotBlank(['message' => 'mautic.user.user.passwordreset.notblank']),
-                        new Assert\Length([
-                            'min'        => 6,
-                            'minMessage' => 'mautic.user.user.password.minlength',
-                        ]),
+                        new Assert\NotBlank(message: 'mautic.user.user.passwordreset.notblank'),
+                        new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength'),
                         new NotWeak([
                             'message' => 'mautic.user.user.password.weak',
                         ]),
@@ -81,7 +78,7 @@ class PasswordResetConfirmType extends AbstractType
                     'required'       => true,
                     'error_bubbling' => false,
                     'constraints'    => [
-                        new Assert\NotBlank(['message' => 'mautic.user.user.passwordreset.notblank']),
+                        new Assert\NotBlank(message: 'mautic.user.user.passwordreset.notblank'),
                     ],
                 ],
                 'type'            => PasswordType::class,

--- a/app/bundles/UserBundle/Form/Type/PasswordResetType.php
+++ b/app/bundles/UserBundle/Form/Type/PasswordResetType.php
@@ -30,7 +30,7 @@ class PasswordResetType extends AbstractType
                     'placeholder' => 'mautic.user.auth.form.loginusername',
                 ],
                 'constraints' => [
-                    new Assert\NotBlank(['message' => 'mautic.user.user.passwordreset.notblank']),
+                    new Assert\NotBlank(message: 'mautic.user.user.passwordreset.notblank'),
                 ],
             ]
         );

--- a/app/bundles/UserBundle/Form/Type/UserInviteType.php
+++ b/app/bundles/UserBundle/Form/Type/UserInviteType.php
@@ -31,12 +31,8 @@ final class UserInviteType extends AbstractType
                     'placeholder' => 'mautic.user.invite.email.label',
                 ],
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'mautic.user.invite.error.email_required',
-                    ]),
-                    new Email([
-                        'message' => 'mautic.user.invite.error.email_invalid',
-                    ]),
+                    new NotBlank(message: 'mautic.user.invite.error.email_required'),
+                    new Email(message: 'mautic.user.invite.error.email_invalid'),
                 ],
             ]
         );
@@ -57,9 +53,7 @@ final class UserInviteType extends AbstractType
                     ->where('r.isPublished = true')
                     ->orderBy('r.name', 'ASC'),
                 'constraints' => [
-                    new NotBlank([
-                        'message' => 'mautic.user.invite.error.role_required',
-                    ]),
+                    new NotBlank(message: 'mautic.user.invite.error.role_required'),
                 ],
             ]
         );

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -198,27 +198,21 @@ class Webhook extends FormEntity implements SkipModifiedInterface
         $metadata->addPropertyConstraint(
             'name',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.name.required',
-                ]
+                message: 'mautic.core.name.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'webhookUrl',
             new Assert\Url(
-                [
-                    'message' => 'mautic.core.valid_url_required',
-                ]
+                message: 'mautic.core.valid_url_required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'webhookUrl',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.valid_url_required',
-                ]
+                message: 'mautic.core.valid_url_required'
             )
         );
 

--- a/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
@@ -33,9 +33,7 @@ class CampaignEventSendWebhookType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/app/bundles/WebhookBundle/Form/Type/ConfigType.php
+++ b/app/bundles/WebhookBundle/Form/Type/ConfigType.php
@@ -31,9 +31,7 @@ class ConfigType extends AbstractType
             'placeholder' => false,
             'constraints' => [
                 new NotBlank(
-                    [
-                        'message' => 'mautic.core.value.required',
-                    ]
+                    message: 'mautic.core.value.required'
                 ),
             ],
         ]);

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "symfony/phpunit-bridge": "~7.4.0",
     "symfony/var-dumper": "~7.4.0",
     "symfony/web-profiler-bundle": "~7.4.0",
-    "symplify/easy-coding-standard": "^13.2.16",
+    "symplify/easy-coding-standard": "^13.2.17",
     "tomasvotruba/type-coverage": "^2.2.1"
   },
   "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "287f004ef077a07a7fc918c0e6a375a8",
+    "content-hash": "1761d151537514c597492bce5121259b",
     "packages": [
         {
             "name": "api-platform/core",
@@ -19301,16 +19301,16 @@
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "13.2.16",
+            "version": "13.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ecsphp/ecs.git",
-                "reference": "5176cf0092e9a381d568bbeffd744c17a6f4993f"
+                "reference": "f5f8131520fb7d3efcf348b72205372ea619fe0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ecsphp/ecs/zipball/5176cf0092e9a381d568bbeffd744c17a6f4993f",
-                "reference": "5176cf0092e9a381d568bbeffd744c17a6f4993f",
+                "url": "https://api.github.com/repos/ecsphp/ecs/zipball/f5f8131520fb7d3efcf348b72205372ea619fe0e",
+                "reference": "f5f8131520fb7d3efcf348b72205372ea619fe0e",
                 "shasum": ""
             },
             "require": {
@@ -19345,9 +19345,9 @@
                 "static analysis"
             ],
             "support": {
-                "source": "https://github.com/ecsphp/ecs/tree/13.2.16"
+                "source": "https://github.com/ecsphp/ecs/tree/13.2.17"
             },
-            "time": "2026-07-22T19:18:33+00:00"
+            "time": "2026-07-22T20:02:43+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/ecs.php
+++ b/ecs.php
@@ -29,6 +29,7 @@ return ECSConfig::configure()
     ])
     ->withRules([
         Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer::class,
+        Symplify\CodingStandard\Fixer\Spacing\StandaloneLineSymfonyAttributeParamFixer::class,
     ])
     ->withPreparedSets(
         comments: true,

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -925,9 +925,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 ],
                 'label'             => 'mautic.sugarcrm.form.version',
                 'constraints'       => [
-                    new NotBlank([
-                        'message' => 'mautic.core.value.required',
-                    ]),
+                    new NotBlank(message: 'mautic.core.value.required'),
                 ],
                 'required' => true,
             ]);

--- a/plugins/MauticFocusBundle/Entity/Focus.php
+++ b/plugins/MauticFocusBundle/Entity/Focus.php
@@ -145,23 +145,21 @@ class Focus extends FormEntity implements UuidInterface
         $metadata->addPropertyConstraint(
             'name',
             new NotBlank(
-                [
-                    'message' => 'mautic.core.name.required',
-                ]
+                message: 'mautic.core.name.required'
             )
         );
 
         $metadata->addPropertyConstraint(
             'type',
             new NotBlank(
-                ['message' => 'mautic.focus.error.select_type']
+                message: 'mautic.focus.error.select_type'
             )
         );
 
         $metadata->addPropertyConstraint(
             'style',
             new NotBlank(
-                ['message' => 'mautic.focus.error.select_style']
+                message: 'mautic.focus.error.select_style'
             )
         );
     }

--- a/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
@@ -36,7 +36,7 @@ class FocusShowType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.focus.choosefocus.notblank']
+                        message: 'mautic.focus.choosefocus.notblank'
                     ),
                 ],
                 'data' => $options['data']['focus'] ?? null,

--- a/plugins/MauticSocialBundle/Entity/Monitoring.php
+++ b/plugins/MauticSocialBundle/Entity/Monitoring.php
@@ -141,11 +141,11 @@ class Monitoring extends FormEntity implements UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('title', new Assert\NotBlank(
-            ['message' => 'mautic.core.title.required']
+            message: 'mautic.core.title.required'
         ));
 
         $metadata->addPropertyConstraint('networkType', new Assert\NotBlank(
-            ['message' => 'mautic.social.network.type']
+            message: 'mautic.social.network.type'
         ));
     }
 

--- a/plugins/MauticSocialBundle/Entity/Tweet.php
+++ b/plugins/MauticSocialBundle/Entity/Tweet.php
@@ -186,9 +186,7 @@ class Tweet extends FormEntity
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('text', new Assert\Length(
-            [
-                'max' => 280,
-            ]
+            max: 280
         ));
     }
 

--- a/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
@@ -36,7 +36,7 @@ class TweetSendType extends AbstractType
                 'required'    => true,
                 'constraints' => [
                     new NotBlank(
-                        ['message' => 'mautic.integration.Twitter.send.selecttweet.notblank']
+                        message: 'mautic.integration.Twitter.send.selecttweet.notblank'
                     ),
                 ],
             ]

--- a/plugins/MauticSocialBundle/Form/Type/TweetType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetType.php
@@ -43,9 +43,7 @@ class TweetType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.name.required',
-                        ]
+                        message: 'mautic.core.name.required'
                     ),
                 ],
             ]
@@ -78,9 +76,7 @@ class TweetType extends AbstractType
                 ],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/plugins/MauticTagManagerBundle/Form/Type/BatchTagType.php
+++ b/plugins/MauticTagManagerBundle/Form/Type/BatchTagType.php
@@ -21,9 +21,7 @@ class BatchTagType extends AbstractType
                 'required'    => false,
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/plugins/MauticTagManagerBundle/Form/Type/TagEntityType.php
+++ b/plugins/MauticTagManagerBundle/Form/Type/TagEntityType.php
@@ -33,9 +33,7 @@ class TagEntityType extends AbstractType
                 'attr'        => ['class' => 'form-control', 'readonly' => $tagReadOnly],
                 'constraints' => [
                     new NotBlank(
-                        [
-                            'message' => 'mautic.core.value.required',
-                        ]
+                        message: 'mautic.core.value.required'
                     ),
                 ],
             ]

--- a/plugins/MauticTagManagerBundle/Form/Type/TagMergeType.php
+++ b/plugins/MauticTagManagerBundle/Form/Type/TagMergeType.php
@@ -37,7 +37,7 @@ final class TagMergeType extends AbstractType
                     return $qb;
                 },
                 'constraints'     => [
-                    new NotBlank(['message' => 'mautic.tagmanager.tag.choose.notblank']),
+                    new NotBlank(message: 'mautic.tagmanager.tag.choose.notblank'),
                 ],
             ]
         );

--- a/rector.php
+++ b/rector.php
@@ -57,9 +57,11 @@ return RectorConfig::configure()
         // symfony
         Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
+        Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector::class,
     ])
     ->reportUnusedSkips()
     ->withCodingStyleLevel(3)
+    // ->withComposerBased(symfony: true)
     ->withSkip([
         __DIR__.'/plugins/*/node_modules/*',
 

--- a/rector.php
+++ b/rector.php
@@ -62,7 +62,7 @@ return RectorConfig::configure()
     ])
     ->reportUnusedSkips()
     ->withCodingStyleLevel(3)
-    //->withComposerBased(symfony: true)
+    // ->withComposerBased(symfony: true)
     ->withSkip([
         __DIR__.'/plugins/*/node_modules/*',
 

--- a/rector.php
+++ b/rector.php
@@ -58,10 +58,11 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector::class,
+        Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector::class,
     ])
     ->reportUnusedSkips()
     ->withCodingStyleLevel(3)
-    // ->withComposerBased(symfony: true)
+    //->withComposerBased(symfony: true)
     ->withSkip([
         __DIR__.'/plugins/*/node_modules/*',
 


### PR DESCRIPTION
This PR adopts two Symfony 7.3 modernizations across the codebase.

## 1. Validation constraints via named arguments

The associative-array syntax for constraints is deprecated in 7.3 in favor of named arguments.

Blog: [New in Symfony 7.3: Validator Improvements](https://symfony.com/blog/new-in-symfony-7-3-validator-improvements)

```diff
             'constraints' => [
                 new NotBlank(
-                    [
-                        'message' => 'mautic.core.value.required',
-                    ]
+                    message: 'mautic.core.value.required'
                 ),
             ],
```

## 2. Command help in `#[AsCommand]`

The `#[AsCommand]` attribute now takes `help`, so help text no longer needs a separate `setHelp()` call in `configure()`.

Blog: [New in Symfony 7.3: Invokable Commands and Input Attributes](https://symfony.com/blog/new-in-symfony-7-3-invokable-commands-and-input-attributes)

```diff
-#[AsCommand(
-    name: self::COMMAND_NAME
-)]
+#[AsCommand(name: self::COMMAND_NAME, help: <<<'TXT'
+The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
+
+<info>php %command.full_name%</info>
+TXT)]
 final class SendWinnerEmailCommand extends ModeratedCommand
 {
     protected function configure(): void
     {
         $this
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
-
-<info>php %command.full_name%</info>
-EOT
-            )
            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.');

         parent::configure();
     }
```
