### PR TITLE
[symfony] move command help to #[AsCommand] attribute

### DIFF
--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -21,7 +21,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:broadcasts:send',
-    description: 'Process contacts pending to receive a channel broadcast.'
+    description: 'Process contacts pending to receive a channel broadcast.',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
+
+<info>php %command.full_name% --channel=email --id=3</info>
+TXT
 )]
 class SendChannelBroadcastCommand extends ModeratedCommand
 {
@@ -37,13 +42,6 @@ class SendChannelBroadcastCommand extends ModeratedCommand
     protected function configure(): void
     {
         $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is send a channel broadcast to pending contacts.
-
-<info>php %command.full_name% --channel=email --id=3</info>
-EOT
-            )
             ->setDefinition(
                 [
                     new InputOption(

--- a/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/ApplyUpdatesCommand.php
@@ -21,7 +21,20 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:update:apply',
-    description: 'Updates the Mautic application'
+    description: 'Updates the Mautic application',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command updates the Mautic application.
+
+<info>php %command.full_name%</info>
+
+You can optionally specify to bypass the verification check with the --force option:
+
+<info>php %command.full_name% --force</info>
+
+To force install a local package, pass the full path to the package as follows:
+
+<info>php %command.full_name% --update-package=/path/to/updatepackage.zip</info>
+TXT
 )]
 class ApplyUpdatesCommand extends Command
 {
@@ -51,21 +64,6 @@ class ApplyUpdatesCommand extends Command
                         'Finalize the upgrade.'
                     ),
                 ]
-            )
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command updates the Mautic application.
-
-<info>php %command.full_name%</info>
-
-You can optionally specify to bypass the verification check with the --force option:
-
-<info>php %command.full_name% --force</info>
-
-To force install a local package, pass the full path to the package as follows:
-
-<info>php %command.full_name% --update-package=/path/to/updatepackage.zip</info>
-EOT
             );
     }
 

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -23,7 +23,35 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: CleanupMaintenanceCommand::NAME,
-    description: 'Updates the Mautic application'
+    description: 'Updates the Mautic application',
+    help: <<<'TXT'
+<info>%command.name%</info> purges records of anonymous contacts (<comment>unless the <info>--gdpr</info> flag is set</comment>) that are older than 365 days.
+Adjust the threshold by using <info>--days-old</info>.
+
+<comment><info>%command.name% --gdpr</info> purges records of anonymous <options=bold>and identified</> contacts.
+The command purges only identified contacts that were <options=bold>inactive for more than 3 years</> (1095 days).</comment>
+
+If you set <info>--gdpr</info> then <info>%command.name%</info> will ignore <info>--days-old</info>.
+The threshold is hard coded to <info>1095</info> days. This is security measure to prevent accidental loss of contact data.
+
+<comment>Examples:</comment>
+
+<info>php %command.full_name%</info>
+Deletes records of anonymous contacts older than 365 days.
+
+<info>php %command.full_name% --days-old=90</info>
+Deletes records of anonymous contacts older than 90 days.
+
+<info>php %command.full_name% --gdpr</info>
+Deletes records of anonymous <options=bold>and inactive identified</> contacts older than 1095 days.
+
+<comment>Add <info>--dry-run</info> to do a dry run without deleting any records.</comment>
+
+<info>php %command.full_name% --dry-run</info>
+Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
+
+The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
+TXT
 )]
 class CleanupMaintenanceCommand extends ModeratedCommand
 {
@@ -55,36 +83,6 @@ class CleanupMaintenanceCommand extends ModeratedCommand
                     new InputOption('dry-run', 'r', InputOption::VALUE_NONE, 'Performs a dry run. Shows no. of affected rows. Won\'t actually delete anything.'),
                     new InputOption('gdpr', 'g', InputOption::VALUE_NONE, 'Deletes records of inactive users to fulfill GDPR requirements.'),
                 ]
-            )
-            ->setHelp(
-                <<<'EOT'
-<info>%command.name%</info> purges records of anonymous contacts (<comment>unless the <info>--gdpr</info> flag is set</comment>) that are older than 365 days.
-Adjust the threshold by using <info>--days-old</info>.
-
-<comment><info>%command.name% --gdpr</info> purges records of anonymous <options=bold>and identified</> contacts.
-The command purges only identified contacts that were <options=bold>inactive for more than 3 years</> (1095 days).</comment>
-
-If you set <info>--gdpr</info> then <info>%command.name%</info> will ignore <info>--days-old</info>.
-The threshold is hard coded to <info>1095</info> days. This is security measure to prevent accidental loss of contact data.
-
-<comment>Examples:</comment>
-
-<info>php %command.full_name%</info>
-Deletes records of anonymous contacts older than 365 days.
-
-<info>php %command.full_name% --days-old=90</info>
-Deletes records of anonymous contacts older than 90 days.
-
-<info>php %command.full_name% --gdpr</info>
-Deletes records of anonymous <options=bold>and inactive identified</> contacts older than 1095 days.
-
-<comment>Add <info>--dry-run</info> to do a dry run without deleting any records.</comment>
-
-<info>php %command.full_name% --dry-run</info>
-Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
-
-The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
-EOT
             );
         parent::configure();
     }

--- a/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMediaAssetsCommand.php
@@ -15,7 +15,12 @@ use Symfony\Component\Finder\Finder;
  */
 #[AsCommand(
     name: 'mautic:assets:cleanup',
-    description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder'
+    description: 'Cleans up obsolete files in the media folder that are present in the app/assets folder',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is used to clean up obsolete files in the media folder that are present in the app/assets folder.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class CleanupMediaAssetsCommand extends Command
 {
@@ -23,19 +28,6 @@ class CleanupMediaAssetsCommand extends Command
         private readonly PathsHelper $pathsHelper,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-          ->setHelp(
-              <<<'EOT'
-                The <info>%command.name%</info> command is used to clean up obsolete files in the media folder that are present in the app/assets folder.
-
-<info>php %command.full_name%</info>
-EOT
-          );
-        parent::configure();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
+++ b/app/bundles/CoreBundle/Command/ConvertConfigCommand.php
@@ -14,7 +14,20 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'mautic:theme:json-config',
-    description: 'Converts theme config to JSON from PHP'
+    description: 'Converts theme config to JSON from PHP',
+    help: <<<'TXT'
+The <info>%command.name%</info> command converts a PHP theme config file to JSON.
+
+<info>php %command.full_name%</info>
+
+You must specify the name of the theme via the --theme parameter:
+
+<info>php %command.full_name% --theme=<theme></info>
+
+You may opt to save the PHP config file by using the --save-php-config option.
+
+<info>php %command.full_name% --save-php-config</info>
+TXT
 )]
 class ConvertConfigCommand extends Command
 {
@@ -36,21 +49,7 @@ class ConvertConfigCommand extends Command
                     'save-php-config', null, InputOption::VALUE_NONE,
                     'When used, the theme\'s PHP config file will be saved.'
                 ),
-            ])
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command converts a PHP theme config file to JSON.
-
-<info>php %command.full_name%</info>
-
-You must specify the name of the theme via the --theme parameter:
-
-<info>php %command.full_name% --theme=<theme></info>
-
-You may opt to save the PHP config file by using the --save-php-config option.
-
-<info>php %command.full_name% --save-php-config</info>
-EOT
-            );
+            ]);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
+++ b/app/bundles/CoreBundle/Command/FindUpdatesCommand.php
@@ -14,7 +14,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:update:find',
-    description: 'Fetches updates for Mautic'
+    description: 'Fetches updates for Mautic',
+    help: <<<'TXT'
+The <info>%command.name%</info> command checks for updates for the Mautic application.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class FindUpdatesCommand extends Command
 {
@@ -23,17 +28,6 @@ class FindUpdatesCommand extends Command
         private readonly UpdateHelper $updateHelper,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command checks for updates for the Mautic application.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateProductionAssetsCommand.php
@@ -22,7 +22,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:assets:generate',
-    description: 'Combines and minifies asset files into single production files'
+    description: 'Combines and minifies asset files into single production files',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command builds Symfony Asset Mapper assets, combines and minifies legacy files from node_modules and each bundle's Assets/css/* and Assets/js/* folders into production files stored in root/media/css and root/media/js respectively. It also runs the command elfinder:install internally to install ElFinder assets.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class GenerateProductionAssetsCommand extends Command
 {
@@ -33,18 +38,6 @@ class GenerateProductionAssetsCommand extends Command
         private readonly Filesystem $filesystem,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command builds Symfony Asset Mapper assets, combines and minifies legacy files from node_modules and each bundle's Assets/css/* and Assets/js/* folders into production files stored in root/media/css and root/media/js respectively. It also runs the command elfinder:install internally to install ElFinder assets.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/InstallDataCommand.php
+++ b/app/bundles/CoreBundle/Command/InstallDataCommand.php
@@ -17,7 +17,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:install:data',
-    description: 'Installs Mautic with sample data'
+    description: 'Installs Mautic with sample data',
+    help: <<<'TXT'
+The <info>%command.name%</info> command re-installs Mautic with sample data.
+
+<info>php %command.full_name%</info>
+
+You can optionally specify to bypass the verification check with the --force option:
+
+<info>php %command.full_name% --force</info>
+TXT
 )]
 class InstallDataCommand extends Command
 {
@@ -34,17 +43,7 @@ class InstallDataCommand extends Command
                 new InputOption(
                     'force', null, InputOption::VALUE_NONE, 'Bypasses the verification check.'
                 ),
-            ])
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command re-installs Mautic with sample data.
-
-<info>php %command.full_name%</info>
-
-You can optionally specify to bypass the verification check with the --force option:
-
-<info>php %command.full_name% --force</info>
-EOT
-            );
+            ]);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -19,7 +19,18 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'mautic:max-mind:purge',
-    description: 'Purge data connected to MaxMind Do Not Sell list.'
+    description: 'Purge data connected to MaxMind Do Not Sell list.',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will purge all data from Mautic which is related to any IP found on the MaxMind Do Not Sell List.
+
+<info>php %command.full_name% --dry-run</info>
+
+Performs a dry-run which will not actually purge any data, but will produce a list of what would be purged.
+
+<info>php %command.full_name% --batch-size</info>
+
+Set the number of records to return in a batch when processing the Do Not Sell List. This option is ignored if IPs are passed as an argument.
+TXT
 )]
 class MaxMindDoNotSellPurgeCommand extends Command
 {
@@ -39,18 +50,6 @@ class MaxMindDoNotSellPurgeCommand extends Command
                 'd',
                 InputOption::VALUE_NONE,
                 'Get a list of data that will be purged.'
-            )
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command will purge all data from Mautic which is related to any IP found on the MaxMind Do Not Sell List.
-
-<info>php %command.full_name% --dry-run</info>
-
-Performs a dry-run which will not actually purge any data, but will produce a list of what would be purged.
-
-<info>php %command.full_name% --batch-size</info>
-
-Set the number of records to return in a batch when processing the Do Not Sell List. This option is ignored if IPs are passed as an argument.
-EOT
             );
     }
 

--- a/app/bundles/CoreBundle/Command/PullTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PullTransifexCommand.php
@@ -26,7 +26,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: PullTransifexCommand::NAME,
-    description: 'Fetches translations for Mautic from Transifex'
+    description: 'Fetches translations for Mautic from Transifex',
+    help: <<<'TXT'
+The <info>%command.name%</info> command is used to retrieve updated Mautic translations from Transifex and writes them to the filesystem.
+
+<info>php %command.full_name%</info>
+
+The command can optionally only pull files for a specific language with the --language option
+
+<info>php %command.full_name% --language=<language_code></info>
+TXT
 )]
 class PullTransifexCommand extends Command
 {
@@ -46,17 +55,7 @@ class PullTransifexCommand extends Command
         $this
             ->addOption('language', null, InputOption::VALUE_OPTIONAL, 'Optional language to pull')
             ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle')
-            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Optional path to a directory where to store the traslations.')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to retrieve updated Mautic translations from Transifex and writes them to the filesystem.
-
-<info>php %command.full_name%</info>
-
-The command can optionally only pull files for a specific language with the --language option
-
-<info>php %command.full_name% --language=<language_code></info>
-EOT
-            );
+            ->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Optional path to a directory where to store the traslations.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/PushTransifexCommand.php
+++ b/app/bundles/CoreBundle/Command/PushTransifexCommand.php
@@ -25,7 +25,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: PushTransifexCommand::NAME,
-    description: 'Pushes Mautic translation resources to Transifex'
+    description: 'Pushes Mautic translation resources to Transifex',
+    help: <<<'TXT'
+The <info>%command.name%</info> command is used to push translation resources to Transifex
+
+<info>php %command.full_name%</info>
+
+You can optionally choose to update resources for one bundle only with the --bundle option:
+
+<info>php %command.full_name% --bundle AssetBundle</info>
+TXT
 )]
 class PushTransifexCommand extends Command
 {
@@ -42,17 +51,7 @@ class PushTransifexCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to push translation resources to Transifex
-
-<info>php %command.full_name%</info>
-
-You can optionally choose to update resources for one bundle only with the --bundle option:
-
-<info>php %command.full_name% --bundle AssetBundle</info>
-EOT
-            );
+            ->addOption('bundle', null, InputOption::VALUE_OPTIONAL, 'Optional bundle to pull. Example value: WebhookBundle');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
+++ b/app/bundles/CoreBundle/Command/UnusedIpDeleteCommand.php
@@ -16,7 +16,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[AsCommand(
     name: 'mautic:unusedip:delete',
-    description: 'Deletes IP addresses that are not used in any other database table'
+    description: 'Deletes IP addresses that are not used in any other database table',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is used to delete IP addresses that are not used in any other database table.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class UnusedIpDeleteCommand extends ModeratedCommand
 {
@@ -39,13 +44,6 @@ class UnusedIpDeleteCommand extends ModeratedCommand
                 InputOption::VALUE_OPTIONAL,
                 'LIMIT for deleted rows',
                 self::DEFAULT_LIMIT
-            )
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to delete IP addresses that are not used in any other database table.
-
-<info>php %command.full_name%</info>
-EOT
             );
         parent::configure();
     }

--- a/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateDoNotSellListCommand.php
@@ -11,7 +11,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsCommand(
     name: 'mautic:donotsell:download',
-    description: 'Fetch remote do not sell list from MaxMind'
+    description: 'Fetch remote do not sell list from MaxMind',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class UpdateDoNotSellListCommand extends Command
 {
@@ -20,18 +25,6 @@ class UpdateDoNotSellListCommand extends Command
         private readonly TranslatorInterface $translator,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to update MaxMind Do Not Sell list.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
+++ b/app/bundles/CoreBundle/Command/UpdateIpDataStoreCommand.php
@@ -15,7 +15,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: 'mautic:iplookup:download',
-    description: 'Fetch remote datastores for IP lookup services that leverage local lookups'
+    description: 'Fetch remote datastores for IP lookup services that leverage local lookups',
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class UpdateIpDataStoreCommand extends Command
 {
@@ -24,18 +29,6 @@ class UpdateIpDataStoreCommand extends Command
         private readonly AbstractLookup $ipService,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to update local IP lookup data if applicable.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/ProcessFetchEmailCommand.php
@@ -18,7 +18,12 @@ use Symfony\Component\Console\Output\OutputInterface;
     description: 'Fetch and process monitored email.',
     aliases: [
         'mautic:emails:fetch',
-    ]
+    ],
+    help: <<<'TXT'
+                The <info>%command.name%</info> command is used to fetch and process messages such as bounces and unsubscribe requests. Configure the Monitored Email settings in Mautic's Configuration.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class ProcessFetchEmailCommand extends Command
 {
@@ -32,14 +37,7 @@ class ProcessFetchEmailCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.')
-            ->setHelp(
-                <<<'EOT'
-                The <info>%command.name%</info> command is used to fetch and process messages such as bounces and unsubscribe requests. Configure the Monitored Email settings in Mautic's Configuration.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--message-limit', '-m', InputOption::VALUE_OPTIONAL, 'Limit number of messages to process at a time.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
+++ b/app/bundles/EmailBundle/Command/SendWinnerEmailCommand.php
@@ -19,7 +19,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Sends email to winner variant after predetermined amount of time.
  */
 #[AsCommand(
-    name: self::COMMAND_NAME
+    name: self::COMMAND_NAME,
+    help: <<<'TXT'
+The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
+
+<info>php %command.full_name%</info>
+TXT
 )]
 final class SendWinnerEmailCommand extends ModeratedCommand
 {
@@ -38,13 +43,7 @@ final class SendWinnerEmailCommand extends ModeratedCommand
     protected function configure(): void
     {
         $this
-            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.')
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.');
 
         parent::configure();
     }

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -22,7 +22,10 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 #[AsCommand(
     name: InstallCommand::COMMAND,
-    description: 'Installs Mautic'
+    description: 'Installs Mautic',
+    help: <<<'TXT'
+This command allows you to trigger the install process. It will try to get configuration values both from the local config file and command line options/arguments, where the latter takes precedence.
+TXT
 )]
 class InstallCommand extends Command
 {
@@ -41,7 +44,6 @@ class InstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setHelp('This command allows you to trigger the install process. It will try to get configuration values both from the local config file and command line options/arguments, where the latter takes precedence.')
             ->addArgument(
                 'site_url',
                 InputArgument::REQUIRED,

--- a/app/bundles/LeadBundle/Command/DeduplicateCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateCommand.php
@@ -18,7 +18,12 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 #[AsCommand(
     name: DeduplicateCommand::NAME,
-    description: 'Merge contacts based on same unique identifiers'
+    description: 'Merge contacts based on same unique identifiers',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class DeduplicateCommand extends Command
 {
@@ -55,13 +60,6 @@ class DeduplicateCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'The commands can run in multiple PHP processes. This option defines how many processes to run. Defaults to 1.',
                 1
-            )
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
-
-<info>php %command.full_name%</info>
-EOT
             );
     }
 

--- a/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
+++ b/app/bundles/LeadBundle/Command/DeduplicateIdsCommand.php
@@ -15,7 +15,12 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
 #[AsCommand(
     name: DeduplicateIdsCommand::NAME,
-    description: 'Merge contacts based on same unique identifiers'
+    description: 'Merge contacts based on same unique identifiers',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class DeduplicateIdsCommand extends Command
 {
@@ -43,13 +48,6 @@ class DeduplicateIdsCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Comma separated list of contact IDs to deduplicate. If not provided, all contacts will be deduplicated. Example: --contact-ids=23,3,11'
-            )
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will dedpulicate contacts based on unique identifier values. 
-
-<info>php %command.full_name%</info>
-EOT
             );
     }
 

--- a/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
+++ b/app/bundles/LeadBundle/Command/DeleteContactSecondaryCompaniesCommand.php
@@ -16,7 +16,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsCommand(
     name: DeleteContactSecondaryCompaniesCommand::NAME,
-    description: "Deletes all contact\'s secondary companies."
+    description: "Deletes all contact\'s secondary companies.",
+    help: <<<'TXT'
+The <info>%command.name%</info> command deletes non-primary companies of every contact.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class DeleteContactSecondaryCompaniesCommand extends Command
 {
@@ -29,18 +34,6 @@ class DeleteContactSecondaryCompaniesCommand extends Command
         private readonly CompanyLeadRepository $companyLeadsRepository,
     ) {
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command deletes non-primary companies of every contact.
-
-<info>php %command.full_name%</info>
-EOT
-            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Command/ImportCommand.php
+++ b/app/bundles/LeadBundle/Command/ImportCommand.php
@@ -23,7 +23,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[AsCommand(
     name: ImportCommand::COMMAND_NAME,
-    description: 'Imports data to Mautic'
+    description: 'Imports data to Mautic',
+    help: <<<'TXT'
+The <info>%command.name%</info> command starts to import CSV files when some are created.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class ImportCommand extends Command
 {
@@ -44,14 +49,7 @@ class ImportCommand extends Command
     {
         $this
             ->addOption('--id', '-i', InputOption::VALUE_OPTIONAL, 'Specific ID to import. Defaults to next in the queue.', false)
-            ->addOption('--limit', '-l', InputOption::VALUE_OPTIONAL, 'Maximum number of records to import for this script execution.', 0)
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command starts to import CSV files when some are created.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--limit', '-l', InputOption::VALUE_OPTIONAL, 'Maximum number of records to import for this script execution.', 0);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/CreateCustomFieldCommand.php
@@ -25,6 +25,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AsCommand(
     name: CreateCustomFieldCommand::COMMAND_NAME,
     description: 'Create custom field column in the background',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will create columns in a lead_fields table if the process should run in background.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class CreateCustomFieldCommand extends ModeratedCommand
 {
@@ -46,14 +51,7 @@ class CreateCustomFieldCommand extends ModeratedCommand
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_OPTIONAL, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will create columns in a lead_fields table if the process should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/DeleteCustomFieldCommand.php
@@ -20,7 +20,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsCommand(
     name: 'mautic:custom-field:delete-column',
-    description: 'Delete custom field column in the background'
+    description: 'Delete custom field column in the background',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will delete a column in a lead_fields table if the proces should run in background.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 final class DeleteCustomFieldCommand extends Command
 {
@@ -38,14 +43,7 @@ final class DeleteCustomFieldCommand extends Command
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will delete a column in a lead_fields table if the proces should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/UpdateCustomFieldCommand.php
@@ -19,7 +19,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsCommand(
     name: 'mautic:custom-field:update-column',
-    description: 'Create custom field column in the background'
+    description: 'Create custom field column in the background',
+    help: <<<'TXT'
+The <info>%command.name%</info> command will create a column in a lead_fields table if the proces should run in background.
+
+<info>php %command.full_name%</info>
+TXT
 )]
 class UpdateCustomFieldCommand extends Command
 {
@@ -36,14 +41,7 @@ class UpdateCustomFieldCommand extends Command
 
         $this
             ->addOption('--id', '-i', InputOption::VALUE_REQUIRED, 'LeadField ID.')
-            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.')
-            ->setHelp(
-                <<<'EOT'
-The <info>%command.name%</info> command will create a column in a lead_fields table if the proces should run in background.
-
-<info>php %command.full_name%</info>
-EOT
-            );
+            ->addOption('--user', '-u', InputOption::VALUE_OPTIONAL, 'User ID - User which receives a notification.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "symfony/phpunit-bridge": "~7.4.0",
     "symfony/var-dumper": "~7.4.0",
     "symfony/web-profiler-bundle": "~7.4.0",
-    "symplify/easy-coding-standard": "^13.2.16",
+    "symplify/easy-coding-standard": "^13.2.17",
     "tomasvotruba/type-coverage": "^2.2.1"
   },
   "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "287f004ef077a07a7fc918c0e6a375a8",
+    "content-hash": "1761d151537514c597492bce5121259b",
     "packages": [
         {
             "name": "api-platform/core",
@@ -19301,16 +19301,16 @@
         },
         {
             "name": "symplify/easy-coding-standard",
-            "version": "13.2.16",
+            "version": "13.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ecsphp/ecs.git",
-                "reference": "5176cf0092e9a381d568bbeffd744c17a6f4993f"
+                "reference": "f5f8131520fb7d3efcf348b72205372ea619fe0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ecsphp/ecs/zipball/5176cf0092e9a381d568bbeffd744c17a6f4993f",
-                "reference": "5176cf0092e9a381d568bbeffd744c17a6f4993f",
+                "url": "https://api.github.com/repos/ecsphp/ecs/zipball/f5f8131520fb7d3efcf348b72205372ea619fe0e",
+                "reference": "f5f8131520fb7d3efcf348b72205372ea619fe0e",
                 "shasum": ""
             },
             "require": {
@@ -19345,9 +19345,9 @@
                 "static analysis"
             ],
             "support": {
-                "source": "https://github.com/ecsphp/ecs/tree/13.2.16"
+                "source": "https://github.com/ecsphp/ecs/tree/13.2.17"
             },
-            "time": "2026-07-22T19:18:33+00:00"
+            "time": "2026-07-22T20:02:43+00:00"
         },
         {
             "name": "symplify/phpstan-rules",

--- a/ecs.php
+++ b/ecs.php
@@ -29,6 +29,7 @@ return ECSConfig::configure()
     ])
     ->withRules([
         Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer::class,
+        Symplify\CodingStandard\Fixer\Spacing\StandaloneLineSymfonyAttributeParamFixer::class,
     ])
     ->withPreparedSets(
         comments: true,

--- a/rector.php
+++ b/rector.php
@@ -57,6 +57,7 @@ return RectorConfig::configure()
         // symfony
         Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
+        Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector::class,
     ])
     ->reportUnusedSkips()
     ->withCodingStyleLevel(3)


### PR DESCRIPTION
Moves command help text into the `#[AsCommand]` attribute, dropping the separate `setHelp()` call in `configure()`. The `#[AsCommand]` attribute takes `help` since Symfony 7.3.

Blog: [New in Symfony 7.3: Invokable Commands and Input Attributes](https://symfony.com/blog/new-in-symfony-7-3-invokable-commands-and-input-attributes)

Automated with Rector via `CommandHelpToAttributeRector` (added to `rector.php`). Also adds the matching ecs `StandaloneLineSymfonyAttributeParamFixer` and bumps `easy-coding-standard`.

```diff
-#[AsCommand(
-    name: self::COMMAND_NAME
-)]
+#[AsCommand(name: self::COMMAND_NAME, help: <<<'TXT'
+The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
+
+<info>php %command.full_name%</info>
+TXT)]
 final class SendWinnerEmailCommand extends ModeratedCommand
 {
     protected function configure(): void
     {
         $this
-            ->setHelp(<<<'EOT'
-The <info>%command.name%</info> command is used to send winner email variant to remaining contacts after predetermined amount of time
-
-<info>php %command.full_name%</info>
-EOT
-            )
            ->addOption('--id', null, InputOption::VALUE_OPTIONAL, 'Parent variant email id.');

         parent::configure();
     }
```

Split out of #16720.
