### PR TITLE
Update `selenium/standalone-chromium`

### DIFF
--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,7 @@
 #
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    image: selenium/standalone-chromium:138.0
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,7 @@
 #
 services:
   selenium-chrome:
-    image: selenium/standalone-chromium:138.0
+    image: selenium/standalone-chromium:150.0
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -27,7 +27,10 @@ class AcceptanceTester extends Codeception\Actor
         $I = $this;
         // if snapshot exists - skipping login
         if ($I->loadSessionSnapshot('login')) {
-            return;
+            $I->amOnPage('/s/dashboard');
+            if (!str_contains($I->grabPageSource(), 'id="username"')) {
+                return;
+            }
         }
         // logging in
         $I->amOnPage('/s/login');

--- a/tests/_support/Step/Acceptance/ContactStep.php
+++ b/tests/_support/Step/Acceptance/ContactStep.php
@@ -180,7 +180,9 @@ class ContactStep extends \AcceptanceTester
         // Navigate to the contacts page
         $I->amOnPage(ContactPage::$URL);
         // Grab the contact's name and navigate to their details page
-        $contactName = $I->grabTextFrom("//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]");
+        $contactNameSelector = "//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]";
+        $I->waitForElementVisible($contactNameSelector, 10);
+        $contactName = $I->grabTextFrom($contactNameSelector);
         $I->click(['link' => $contactName]);
         // Wait for the contact's name to appear on the details page
         $I->waitForText($contactName, 10, '#app-content');
@@ -200,7 +202,9 @@ class ContactStep extends \AcceptanceTester
         // Navigate to the contacts page
         $I->amOnPage('/s/contacts');
         // Grab the contact's name and navigate to their details page
-        $contactName = $I->grabTextFrom("//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]");
+        $contactNameSelector = "//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]";
+        $I->waitForElementVisible($contactNameSelector, 10);
+        $contactName = $I->grabTextFrom($contactNameSelector);
         $I->click(['link' => $contactName]);
         // Wait for the contact's name to appear on the details page
         $I->waitForText($contactName, 10, '#app-content');

--- a/tests/_support/Step/Acceptance/EmailStep.php
+++ b/tests/_support/Step/Acceptance/EmailStep.php
@@ -22,6 +22,7 @@ class EmailStep extends \AcceptanceTester
         $I->waitForElementClickable(EmailsPage::CONTACT_SEGMENT_OPTION);
         $I->click(EmailsPage::CONTACT_SEGMENT_OPTION);
         $I->click(EmailsPage::SAVE_AND_CLOSE);
+        $I->waitForText($name, 10, 'h1.page-header-title');
     }
 
     /**
@@ -37,6 +38,7 @@ class EmailStep extends \AcceptanceTester
         $I->click(EmailsPage::SELECT_TRIGGERED_EMAIL);
         $I->fillField(EmailsPage::SUBJECT_FIELD, $name);
         $I->click(EmailsPage::SAVE_AND_CLOSE);
+        $I->waitForText($name, 10, 'h1.page-header-title');
     }
 
     /**

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -10,7 +10,7 @@ modules:
         port: 4444
         window_size: maximize
         capabilities:
-          chromeOptions:
+          "goog:chromeOptions":
             args:
               - "--ignore-certificate-errors"
               - "--disable-dev-shm-usage"

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -350,6 +350,7 @@ class ContactManagementCest
         $I->click(ContactPage::$addToTheFollowing);
         $I->click(ContactPage::$adminUser);
         $I->click(ContactPage::$changeOwnerModalSaveButton);
+        $I->ensureNotificationAppears('2 contacts affected');
 
         // Verify that the owner of the first and second contacts has been changed
         $contact->verifyOwner(1);

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -47,6 +47,10 @@ class EmailManagementCest
     {
         $I->waitForElementClickable(EmailsPage::SELECT_ALL_CHECKBOX);
         $I->click(EmailsPage::SELECT_ALL_CHECKBOX);
+        $I->waitForJS(
+            "return document.querySelectorAll('input.list-checkbox:not(:checked)').length === 0;",
+            10
+        );
         $I->seeCheckboxIsChecked(EmailsPage::SELECT_ALL_CHECKBOX);
     }
 

--- a/tests/acceptance/EmailManagementCest.php
+++ b/tests/acceptance/EmailManagementCest.php
@@ -43,7 +43,7 @@ class EmailManagementCest
         $this->verifyAllEmailsBelongTo($I, $newCategoryName);
     }
 
-    public function selectAllEmails(AcceptanceTester $I): void
+    private function selectAllEmails(AcceptanceTester $I): void
     {
         $I->waitForElementClickable(EmailsPage::SELECT_ALL_CHECKBOX);
         $I->click(EmailsPage::SELECT_ALL_CHECKBOX);


### PR DESCRIPTION
## Description
This PR updates outdated selenium/standalone-chromium for E2E tests

Updated the Selenium/Chromium image from the archived seleniarm project to the actively maintained official Selenium image. The new image supports both arm64 and amd64 and provides current Chromium releases.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. E2E tests pass

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->