### PR TITLE
Update `selenium/standalone-chromium` 138

### DIFF
--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,7 @@
 #
 services:
   selenium-chrome:
-    image: seleniarm/standalone-chromium:4.1.4-20220429
+    image: selenium/standalone-chromium:138.0
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
     expose:
       #      The internal noVNC port, which operates over HTTP so it can be exposed

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -10,7 +10,7 @@ modules:
         port: 4444
         window_size: maximize
         capabilities:
-          chromeOptions:
+          "goog:chromeOptions":
             args:
               - "--ignore-certificate-errors"
               - "--disable-dev-shm-usage"


### PR DESCRIPTION
TEST: Update to 138

## Description
This PR updates outdated selenium/standalone-chromium for E2E tests

Updated the Selenium/Chromium image from the archived seleniarm project to the actively maintained official Selenium image. The new image supports both arm64 and amd64 and provides current Chromium releases.

---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. E2E tests pass

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->