### PR TITLE
[symfony] make use of as twig function/filter attributes

### DIFF
--- a/app/bundles/CampaignBundle/Twig/Extension/CampaignEventIconExtension.php
+++ b/app/bundles/CampaignBundle/Twig/Extension/CampaignEventIconExtension.php
@@ -4,21 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-
-final class CampaignEventIconExtension extends AbstractExtension
+final class CampaignEventIconExtension
 {
-    /**
-     * @see Twig_Extension::getFunctions()
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getCampaignEventIcon', $this->getCampaignEventIcon(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'getCampaignEventIcon')]
     public function getCampaignEventIcon(string $eventType): string
     {
         return match ($eventType) {

--- a/app/bundles/ChannelBundle/Twig/ChannelExtension.php
+++ b/app/bundles/ChannelBundle/Twig/ChannelExtension.php
@@ -7,10 +7,8 @@ namespace Mautic\ChannelBundle\Twig;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\LeadBundle\Exception\UnknownDncReasonException;
 use Mautic\LeadBundle\Twig\Helper\DncReasonHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class ChannelExtension extends AbstractExtension
+class ChannelExtension
 {
     public function __construct(
         private readonly DncReasonHelper $dncReasonHelper,
@@ -18,17 +16,7 @@ class ChannelExtension extends AbstractExtension
     ) {
     }
 
-    /**
-     * @return TwigFunction[]
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getChannelDncText', $this->getChannelDncText(...)),
-            new TwigFunction('getChannelLabel', $this->getChannelLabel(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'getChannelDncText')]
     public function getChannelDncText(int $reasonId): string
     {
         try {
@@ -38,6 +26,7 @@ class ChannelExtension extends AbstractExtension
         }
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'getChannelLabel')]
     public function getChannelLabel(string $channel): string
     {
         return $this->channelListHelper->getChannelLabel($channel);

--- a/app/bundles/CoreBundle/Tests/Twig/TwigIntegrationTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/TwigIntegrationTest.php
@@ -22,7 +22,7 @@ final class TwigIntegrationTest extends \Twig\Test\IntegrationTestCase
     use TwigIntegrationTestTrait;
 
     /**
-     * @return ExtensionInterface[]
+     * @return ExtensionInterface[]|object[]
      */
     public function getExtensions(): array
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
@@ -9,7 +9,6 @@ use Mautic\CoreBundle\Twig\Extension\DateExtension;
 use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\TwigFunction;
 
 final class DateExtensionTest extends TestCase
 {
@@ -49,22 +48,15 @@ final class DateExtensionTest extends TestCase
 
     public function testGetFunctions(): void
     {
-        $functions = $this->dateExtension->getFunctions();
-
-        $this->assertContainsOnlyInstancesOf(TwigFunction::class, $functions);
-        $this->assertCount(9, $functions);
-
-        $functionNames = array_map(fn (TwigFunction $function): string => $function->getName(), $functions);
-
-        $this->assertContains('dateToText', $functionNames);
-        $this->assertContains('dateToFull', $functionNames);
-        $this->assertContains('dateToFullConcat', $functionNames);
-        $this->assertContains('dateToDate', $functionNames);
-        $this->assertContains('dateToTime', $functionNames);
-        $this->assertContains('dateToShort', $functionNames);
-        $this->assertContains('dateFormatRange', $functionNames);
-        $this->assertContains('dateToHumanized', $functionNames);
-        $this->assertContains('dateToTextShort', $functionNames);
+        $this->assertTrue(method_exists($this->dateExtension, 'toText'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toFull'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toFullConcat'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toDate'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toTime'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toShort'));
+        $this->assertTrue(method_exists($this->dateExtension, 'formatRange'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toHumanized'));
+        $this->assertTrue(method_exists($this->dateExtension, 'toTextShort'));
     }
 
     public function testToText(): void

--- a/app/bundles/CoreBundle/Twig/Extension/AnalyticsExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AnalyticsExtension.php
@@ -5,23 +5,15 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\AnalyticsHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class AnalyticsExtension extends AbstractExtension
+class AnalyticsExtension
 {
     public function __construct(
         protected AnalyticsHelper $helper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('analyticsGetCode', $this->getCode(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'analyticsGetCode', isSafe: ['all'])]
     public function getCode(): string
     {
         return (string) $this->helper->getCode();

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
+use Twig\Extension\AbstractExtension;
 
-class AssetExtension
+class AssetExtension extends AbstractExtension
 {
     public function __construct(
         protected AssetsHelper $assetsHelper,

--- a/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/AssetExtension.php
@@ -5,40 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class AssetExtension extends AbstractExtension
+class AssetExtension
 {
     public function __construct(
         protected AssetsHelper $assetsHelper,
     ) {
-    }
-
-    /**
-     * @see Twig_Extension::getFunctions()
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('outputScripts', $this->outputScripts(...), ['is_safe' => ['all']]),
-            new TwigFunction('includeScript', $this->includeScript(...), ['is_safe' => ['all']]),
-            new TwigFunction('includeStylesheet', $this->includeStylesheet(...), ['is_safe' => ['all']]),
-            new TwigFunction('outputHeadDeclarations', $this->outputHeadDeclarations(...), ['is_safe' => ['all']]),
-            new TwigFunction('getAssetUrl', $this->getAssetUrl(...), ['is_safe' => ['html']]),
-            new TwigFunction('getOverridableUrl', $this->getOverridableUrl(...), ['is_safe' => ['html']]),
-            new TwigFunction('addAssetScript', $this->addScript(...), ['is_safe' => ['html']]),
-            new TwigFunction('outputStyles', $this->outputStyles(...), ['is_safe' => ['html']]),
-            new TwigFunction('outputSystemScripts', $this->outputSystemScripts(...), ['is_safe' => ['html']]),
-            new TwigFunction('outputSystemStylesheets', $this->outputSystemStylesheets(...), ['is_safe' => ['html']]),
-            new TwigFunction('assetsGetImagesPath', $this->getImagesPath(...)),
-            new TwigFunction('assetsGetPrefix', $this->getAssetPrefix(...)),
-            new TwigFunction('assetAddScriptDeclaration', $this->addScriptDeclaration(...)),
-            new TwigFunction('assetAddCustomDeclaration', $this->addCustomDeclaration(...)),
-            new TwigFunction('assetGetCountryFlag', $this->getCountryFlag(...)),
-            new TwigFunction('assetGetBaseUrl', $this->getBaseUrl(...), ['is_safe' => ['html']]),
-            new TwigFunction('assetMakeLinks', $this->makeLinks(...), ['is_safe' => ['html']]),
-        ];
     }
 
     public function getName(): string
@@ -46,6 +18,7 @@ class AssetExtension extends AbstractExtension
         return 'coreasset';
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'outputSystemStylesheets', isSafe: ['html'])]
     public function outputSystemStylesheets(): string
     {
         ob_start();
@@ -58,11 +31,13 @@ class AssetExtension extends AbstractExtension
     /**
      * Loads an addon JS script file.
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'includeScript', isSafe: ['all'])]
     public function includeScript(string $assetFilePath, string $onLoadCallback = '', string $alreadyLoadedCallback = ''): string
     {
         return $this->assetsHelper->includeScript($assetFilePath, $onLoadCallback, $alreadyLoadedCallback);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'includeStylesheet', isSafe: ['all'])]
     public function includeStylesheet(string $assetFilePath): string
     {
         return $this->assetsHelper->includeStylesheet($assetFilePath);
@@ -71,6 +46,7 @@ class AssetExtension extends AbstractExtension
     /**
      * @param bool $includeEditor
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'outputSystemScripts', isSafe: ['html'])]
     public function outputSystemScripts($includeEditor = false): string
     {
         ob_start();
@@ -80,6 +56,7 @@ class AssetExtension extends AbstractExtension
         return ob_get_clean();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'outputScripts', isSafe: ['all'])]
     public function outputScripts(string $name): string
     {
         ob_start();
@@ -89,6 +66,7 @@ class AssetExtension extends AbstractExtension
         return ob_get_clean();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'outputStyles', isSafe: ['html'])]
     public function outputStyles(): string
     {
         ob_start();
@@ -98,6 +76,7 @@ class AssetExtension extends AbstractExtension
         return ob_get_clean();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'outputHeadDeclarations', isSafe: ['all'])]
     public function outputHeadDeclarations(): string
     {
         ob_start();
@@ -107,6 +86,7 @@ class AssetExtension extends AbstractExtension
         return ob_get_clean();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'addAssetScript', isSafe: ['html'])]
     public function addScript(string $script, string $location = 'head', bool $async = false, ?string $name = null): AssetsHelper
     {
         return $this->assetsHelper->addScript($script, $location, $async, $name);
@@ -116,6 +96,7 @@ class AssetExtension extends AbstractExtension
      * @param bool $absolute
      * @param bool $ignorePrefix
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getAssetUrl', isSafe: ['html'])]
     public function getAssetUrl(string $path, ?string $packageName = null, ?string $version = null, $absolute = false, $ignorePrefix = false): string
     {
         return $this->assetsHelper->getUrl($path, $packageName, $version, $absolute, $ignorePrefix);
@@ -125,21 +106,25 @@ class AssetExtension extends AbstractExtension
      * @param string     $path
      * @param bool|false $absolute
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getOverridableUrl', isSafe: ['html'])]
     public function getOverridableUrl($path, $absolute = false): string
     {
         return $this->assetsHelper->getOverridableUrl($path, $absolute);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetsGetImagesPath')]
     public function getImagesPath(): string
     {
         return $this->assetsHelper->getImagesPath();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetsGetPrefix')]
     public function getAssetPrefix(bool $includeEndingslash = false): string
     {
         return $this->assetsHelper->getAssetPrefix($includeEndingslash);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetAddScriptDeclaration')]
     public function addScriptDeclaration(string $script, string $location = 'head'): string
     {
         $this->assetsHelper->addScriptDeclaration($script, $location);
@@ -147,6 +132,7 @@ class AssetExtension extends AbstractExtension
         return '';
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetAddCustomDeclaration')]
     public function addCustomDeclaration(string $script, string $location): string
     {
         $this->assetsHelper->addCustomDeclaration($script, $location);
@@ -157,11 +143,13 @@ class AssetExtension extends AbstractExtension
     /**
      * @see Mautic\CoreBundle\Twig\Helper\AssetsHelper::getCountryFlag
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetGetCountryFlag')]
     public function getCountryFlag(string $country, bool $urlOnly = true, string $class = ''): string
     {
         return $this->assetsHelper->getCountryFlag($country, $urlOnly, $class);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetGetBaseUrl', isSafe: ['html'])]
     public function getBaseUrl(): string
     {
         return (string) $this->assetsHelper->getBaseUrl();
@@ -171,6 +159,7 @@ class AssetExtension extends AbstractExtension
      * @param array<string> $protocols
      * @param array<mixed>  $attributes
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'assetMakeLinks', isSafe: ['html'])]
     public function makeLinks(string $text, array $protocols = ['http', 'mail'], array $attributes = []): string
     {
         return $this->assetsHelper->makeLinks($text, $protocols, $attributes);

--- a/app/bundles/CoreBundle/Twig/Extension/BarChartExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/BarChartExtension.php
@@ -5,21 +5,13 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\Chart\BarChart;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-final class BarChartExtension extends AbstractExtension
+final class BarChartExtension
 {
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('barChartInitialize', $this->createNewChart(...)),
-        ];
-    }
-
     /**
      * @param array<string> $labels
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'barChartInitialize')]
     public function createNewChart(array $labels): BarChart
     {
         return new BarChart($labels);

--- a/app/bundles/CoreBundle/Twig/Extension/ButtonExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ButtonExtension.php
@@ -8,10 +8,8 @@ use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class ButtonExtension extends AbstractExtension
+class ButtonExtension
 {
     public function __construct(
         protected ButtonHelper $buttonHelper,
@@ -21,21 +19,7 @@ class ButtonExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('buttonReset', $this->reset(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonAdd', $this->addButton(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonSetMenuLink', $this->setMenuLink(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonSetWrappingTags', $this->setWrappingTags(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonSetGroupType', $this->setGroupType(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonGetCount', $this->getButtonCount(...)),
-            new TwigFunction('buttonsRender', $this->render(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonsAdd', $this->addButtons(...), ['is_safe' => ['all']]),
-            new TwigFunction('buttonsAddFromTemplate', $this->addButtonsFromTemplate(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonReset', isSafe: ['all'])]
     public function reset(string $location, string $groupType = ButtonHelper::TYPE_GROUP, $item = null): void
     {
         $this->buttonHelper->reset(
@@ -49,26 +33,31 @@ class ButtonExtension extends AbstractExtension
     /**
      * @param array<string,mixed> $button
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonAdd', isSafe: ['all'])]
     public function addButton(array $button): void
     {
         $this->buttonHelper->addButton($button);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonSetMenuLink', isSafe: ['all'])]
     public function setMenuLink(?string $menuLink): void
     {
         $this->buttonHelper->setMenuLink($menuLink);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonSetWrappingTags', isSafe: ['all'])]
     public function setWrappingTags(?string $wrapOpeningTag, ?string $wrapClosingTag): void
     {
         $this->buttonHelper->setWrappingTags($wrapOpeningTag, $wrapClosingTag);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonSetGroupType', isSafe: ['all'])]
     public function setGroupType(string $groupType): void
     {
         $this->buttonHelper->setGroupType($groupType);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonGetCount')]
     public function getButtonCount(): int
     {
         return $this->buttonHelper->getButtonCount();
@@ -77,11 +66,13 @@ class ButtonExtension extends AbstractExtension
     /**
      * @param array<array<string,mixed>> $buttons
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonsAdd', isSafe: ['all'])]
     public function addButtons(array $buttons): void
     {
         $this->buttonHelper->addButtons($buttons);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonsRender', isSafe: ['all'])]
     public function render(string $dropdownHtml = '', string $closingDropdownHtml = ''): string
     {
         return $this->buttonHelper->renderButtons($dropdownHtml, $closingDropdownHtml);
@@ -94,6 +85,7 @@ class ButtonExtension extends AbstractExtension
      * @param array<string,string> $routeVars
      * @param mixed                $item
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'buttonsAddFromTemplate', isSafe: ['all'])]
     public function addButtonsFromTemplate(
         array $templateButtons,
         array $query,

--- a/app/bundles/CoreBundle/Twig/Extension/ConfigExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ConfigExtension.php
@@ -5,21 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\ConfigHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class ConfigExtension extends AbstractExtension
+class ConfigExtension
 {
     public function __construct(
         private readonly ConfigHelper $configHelper,
     ) {
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('configGetParameter', $this->get(...)),
-        ];
     }
 
     /**
@@ -27,6 +18,7 @@ class ConfigExtension extends AbstractExtension
      *
      * @return mixed
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'configGetParameter')]
     public function get(string $name, $default = null)
     {
         return $this->configHelper->get($name, $default);

--- a/app/bundles/CoreBundle/Twig/Extension/ContentExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ContentExtension.php
@@ -5,23 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\ContentHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class ContentExtension extends AbstractExtension
+class ContentExtension
 {
     public function __construct(
         protected ContentHelper $contentHelper,
     ) {
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('customContent', $this->getCustomContent(...), ['is_safe' => ['all']]),
-            new TwigFunction('showScriptTags', $this->showScriptTags(...), ['is_safe' => ['all']]),
-            new TwigFunction('getSortedEditorFonts', $this->sortEditorFonts(...)),
-        ];
     }
 
     /**
@@ -31,6 +20,7 @@ class ContentExtension extends AbstractExtension
      * @param array<string,mixed> $vars     twig vars
      * @param ?string             $viewName The main identifier for the content requested. Will be etracted from $vars if get_defined
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'customContent', isSafe: ['all'])]
     public function getCustomContent($context = null, array $vars = [], ?string $viewName = null): string
     {
         return $this->contentHelper->getCustomContent($context, $vars, $viewName);
@@ -40,6 +30,7 @@ class ContentExtension extends AbstractExtension
      * Replaces HTML script tags with non HTML tags so the JS inside them won't
      * execute and will be readable.
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'showScriptTags', isSafe: ['all'])]
     public function showScriptTags(string $html): string
     {
         return $this->contentHelper->showScriptTags($html);
@@ -50,6 +41,7 @@ class ContentExtension extends AbstractExtension
      *
      * @return array<mixed>
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getSortedEditorFonts')]
     public function sortEditorFonts(array $fonts): array
     {
         usort($fonts, static function (array $fontA, array $fontB): int {

--- a/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateExtension.php
@@ -5,29 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\DateHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class DateExtension extends AbstractExtension
+class DateExtension
 {
     public function __construct(
         protected DateHelper $dateHelper,
     ) {
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('dateToText', $this->toText(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToFull', $this->toFull(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToFullConcat', $this->toFullConcat(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToDate', $this->toDate(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToTime', $this->toTime(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToShort', $this->toShort(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateFormatRange', $this->formatRange(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToHumanized', $this->toHumanized(...), ['is_safe' => ['all']]),
-            new TwigFunction('dateToTextShort', $this->toTextShort(...), ['is_safe' => ['all']]),
-        ];
     }
 
     /**
@@ -36,6 +19,7 @@ class DateExtension extends AbstractExtension
      * @param mixed $datetime
      * @param bool  $forceDateForNonText If true, return as full date/time rather than "29 days ago"
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToText', isSafe: ['all'])]
     public function toText($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s', bool $forceDateForNonText = false): string
     {
         return $this->dateHelper->toText($datetime, $timezone, $fromFormat, $forceDateForNonText);
@@ -46,6 +30,7 @@ class DateExtension extends AbstractExtension
      *
      * @param \DateTime|string $datetime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToHumanized', isSafe: ['all'])]
     public function toHumanized($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s'): string
     {
         return $this->dateHelper->toHumanized($datetime, $timezone, $fromFormat);
@@ -56,6 +41,7 @@ class DateExtension extends AbstractExtension
      *
      * @param \DateTime|string $datetime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToFull', isSafe: ['all'])]
     public function toFull($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s'): string
     {
         return $this->dateHelper->toFull($datetime, $timezone, $fromFormat);
@@ -68,6 +54,7 @@ class DateExtension extends AbstractExtension
      *
      * @return string
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToFullConcat', isSafe: ['all'])]
     public function toFullConcat($datetime, string $timezone = 'local', ?string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->dateHelper->toFullConcat($datetime, $timezone, $fromFormat);
@@ -80,6 +67,7 @@ class DateExtension extends AbstractExtension
      *
      * @return string
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToDate', isSafe: ['all'])]
     public function toDate($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s')
     {
         return $this->dateHelper->toDate($datetime, $timezone, $fromFormat);
@@ -90,6 +78,7 @@ class DateExtension extends AbstractExtension
      *
      * @param \DateTime|string $datetime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToTime', isSafe: ['all'])]
     public function toTime($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s'): string
     {
         return $this->dateHelper->toTime($datetime, $timezone, $fromFormat);
@@ -100,6 +89,7 @@ class DateExtension extends AbstractExtension
      *
      * @param \DateTime|string $datetime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToShort', isSafe: ['all'])]
     public function toShort($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s'): string
     {
         return $this->dateHelper->toShort($datetime, $timezone, $fromFormat);
@@ -110,6 +100,7 @@ class DateExtension extends AbstractExtension
      *
      * @param \DateTime|string $datetime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateToTextShort', isSafe: ['all'])]
     public function toTextShort($datetime, string $timezone = 'local', string $fromFormat = 'Y-m-d H:i:s'): string
     {
         return $this->dateHelper->toTextShort($datetime, $timezone, $fromFormat);
@@ -118,6 +109,7 @@ class DateExtension extends AbstractExtension
     /**
      * @see DateHelper::formatRange
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateFormatRange', isSafe: ['all'])]
     public function formatRange(\DateInterval $range): string
     {
         return $this->dateHelper->formatRange($range);

--- a/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
@@ -3,26 +3,18 @@
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class DateTimeExtension extends AbstractExtension
+class DateTimeExtension
 {
     public function __construct(
         private readonly DateTimeHelper $helper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('dateTimeGetUtcDateTime', $this->getUtcDateTime(...), ['is_safe' => ['all']]),
-        ];
-    }
-
     /**
      * @see DateTimeHelper::getUtcDateTime
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dateTimeGetUtcDateTime', isSafe: ['all'])]
     public function getUtcDateTime(): \DateTimeInterface
     {
         return $this->helper->getUtcDateTime();

--- a/app/bundles/CoreBundle/Twig/Extension/ExceptionExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ExceptionExtension.php
@@ -4,21 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-
-class ExceptionExtension extends AbstractExtension
+class ExceptionExtension
 {
-    /**
-     * @return TwigFunction[]
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getRootPath', $this->getRoot(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'getRootPath', isSafe: ['all'])]
     public function getRoot(): string
     {
         return realpath(__DIR__.'/../../../../../../');

--- a/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
@@ -6,8 +6,9 @@ namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Symfony\Component\Form\FormView;
+use Twig\Extension\AbstractExtension;
 
-class FormExtension
+class FormExtension extends AbstractExtension
 {
     /**
      * @param array<string> $v

--- a/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormExtension.php
@@ -6,22 +6,13 @@ namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Symfony\Component\Form\FormView;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class FormExtension extends AbstractExtension
+class FormExtension
 {
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('formFieldFormatList', $this->formatList(...), ['is_safe' => ['all']]),
-            new TwigFunction('formContainsErrors', $this->containsErrors(...), ['is_safe' => ['all']]),
-        ];
-    }
-
     /**
      * @param array<string> $v
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'formFieldFormatList', isSafe: ['all'])]
     public function formatList(string $format, array $v): string
     {
         return FormFieldHelper::formatList($format, $v);
@@ -32,6 +23,7 @@ class FormExtension extends AbstractExtension
      *
      * @param array<string> $excluding
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'formContainsErrors', isSafe: ['all'])]
     public function containsErrors(FormView $form, array $excluding = []): bool
     {
         if (count($form->vars['errors'])) {

--- a/app/bundles/CoreBundle/Twig/Extension/GravatarExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/GravatarExtension.php
@@ -5,23 +5,15 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\GravatarHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class GravatarExtension extends AbstractExtension
+class GravatarExtension
 {
     public function __construct(
         protected GravatarHelper $gravatarHelper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('gravatarGetImage', $this->getImage(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'gravatarGetImage', isSafe: ['all'])]
     public function getImage(string $email, string $size = '250', ?string $default = null): string
     {
         return $this->gravatarHelper->getImage($email, $size, $default);

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -4,19 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-
-final class HtmlExtension extends AbstractExtension
+final class HtmlExtension
 {
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('htmlAttributesStringToArray', $this->convertHtmlAttributesToArray(...)),
-            new TwigFunction('htmlEntityDecode', $this->htmlEntityDecode(...)),
-        ];
-    }
-
     /**
      * Takes a string of HTML attributes and returns them as a key => value array.
      * Attribute strings which represent a single value are still output as a string
@@ -34,6 +23,7 @@ final class HtmlExtension extends AbstractExtension
      *
      * @return array<string, mixed>
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'htmlAttributesStringToArray')]
     public function convertHtmlAttributesToArray(string $attributes): array
     {
         if (empty($attributes)) {
@@ -74,6 +64,7 @@ final class HtmlExtension extends AbstractExtension
         return $attributes;
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'htmlEntityDecode')]
     public function htmlEntityDecode(string $content): string
     {
         return html_entity_decode($content);

--- a/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
@@ -8,18 +8,11 @@ use Symfony\Component\Intl\Languages;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
-class LanguageExtension extends AbstractExtension
+class LanguageExtension
 {
     public function __construct(
         private readonly Security $security,
     ) {
-    }
-
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('language_name', $this->getLanguageName(...)),
-        ];
     }
 
     /**
@@ -30,6 +23,7 @@ class LanguageExtension extends AbstractExtension
      *
      * @return string The language name
      */
+    #[\Twig\Attribute\AsTwigFilter(name: 'language_name')]
     public function getLanguageName(string $code, ?string $displayLocale = null): string
     {
         if (null === $displayLocale) {

--- a/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
@@ -5,8 +5,6 @@ namespace Mautic\CoreBundle\Twig\Extension;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Intl\Languages;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
 
 class LanguageExtension
 {

--- a/app/bundles/CoreBundle/Twig/Extension/MautibotExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/MautibotExtension.php
@@ -5,26 +5,18 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\MautibotHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class MautibotExtension extends AbstractExtension
+class MautibotExtension
 {
     public function __construct(
         protected MautibotHelper $mautibotHelper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('mautibotGetImage', $this->getImage(...), ['is_safe' => ['all']]),
-        ];
-    }
-
     /**
      * @param string $image One of openMouth | smile | wave
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'mautibotGetImage', isSafe: ['all'])]
     public function getImage(string $image): string
     {
         return $this->mautibotHelper->getImage($image);

--- a/app/bundles/CoreBundle/Twig/Extension/MenuExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/MenuExtension.php
@@ -7,23 +7,12 @@ namespace Mautic\CoreBundle\Twig\Extension;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\MatcherInterface;
 use Mautic\CoreBundle\Twig\Helper\MenuHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class MenuExtension extends AbstractExtension
+class MenuExtension
 {
     public function __construct(
         protected MenuHelper $menuHelper,
     ) {
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('menuRender', $this->menuRender(...), ['is_safe' => ['all']]),
-            new TwigFunction('parseMenuAttributes', $this->parseMenuAttributes(...), ['is_safe' => ['all']]),
-            new TwigFunction('buildMenuClasses', $this->buildMenuClasses(...), ['is_safe' => ['all']]),
-        ];
     }
 
     /**
@@ -32,6 +21,7 @@ class MenuExtension extends AbstractExtension
      * @param ItemInterface|string|array<mixed> $menu
      * @param array<mixed>                      $options
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'menuRender', isSafe: ['all'])]
     public function menuRender($menu, array $options = [], ?string $renderer = null): string
     {
         return $this->menuHelper->render($menu, $options, $renderer);
@@ -43,6 +33,7 @@ class MenuExtension extends AbstractExtension
      * @param array<string,string> $attributes
      * @param array<string,string> $overrides
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'parseMenuAttributes', isSafe: ['all'])]
     public function parseMenuAttributes(array $attributes, array $overrides = []): string
     {
         return $this->menuHelper->parseAttributes($attributes, $overrides);
@@ -55,6 +46,7 @@ class MenuExtension extends AbstractExtension
      *
      * @return array<mixed>
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'buildMenuClasses', isSafe: ['all'])]
     public function buildMenuClasses(ItemInterface $item, ?MatcherInterface $matcher, array $options, ?string $extraClasses): array
     {
         $isAncestor = null !== $matcher && $matcher->isAncestor($item, (int) $options['matchingDepth']);

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -9,14 +9,28 @@ use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
+use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
+use Twig\TwigFunction;
 
-final readonly class OverrideIncludeExtension
+final class OverrideIncludeExtension extends AbstractExtension
 {
     public function __construct(
-        private EventDispatcherInterface $eventDispatcher,
-        private RequestStack $requestStack,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly RequestStack $requestStack,
     ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            // Override the built-in include function with higher priority
+            new TwigFunction('include', $this->includeWithEvent(...), [
+                'needs_environment' => true,
+                'needs_context'     => true,
+                'is_safe'           => ['html'],
+            ]),
+        ];
     }
 
     /**
@@ -26,7 +40,6 @@ final readonly class OverrideIncludeExtension
      * @param string|string[] $template
      * @param mixed[]         $variables
      */
-    #[\Twig\Attribute\AsTwigFunction(name: 'include', needsEnvironment: true, needsContext: true, isSafe: ['html'])]
     public function includeWithEvent(Environment $env, array $context, $template, array $variables = [], bool $withContext = true, bool $ignoreMissing = false, bool $sandboxed = false): string
     {
         if ($withContext) {

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -9,28 +9,14 @@ use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
-use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
-use Twig\TwigFunction;
 
-final class OverrideIncludeExtension extends AbstractExtension
+final class OverrideIncludeExtension
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly RequestStack $requestStack,
     ) {
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            // Override the built-in include function with higher priority
-            new TwigFunction('include', $this->includeWithEvent(...), [
-                'needs_environment' => true,
-                'needs_context'     => true,
-                'is_safe'           => ['html'],
-            ]),
-        ];
     }
 
     /**
@@ -40,6 +26,7 @@ final class OverrideIncludeExtension extends AbstractExtension
      * @param string|string[] $template
      * @param mixed[]         $variables
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'include', needsEnvironment: true, needsContext: true, isSafe: ['html'])]
     public function includeWithEvent(Environment $env, array $context, $template, array $variables = [], bool $withContext = true, bool $ignoreMissing = false, bool $sandboxed = false): string
     {
         if ($withContext) {

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -11,11 +11,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
 
-final class OverrideIncludeExtension
+final readonly class OverrideIncludeExtension
 {
     public function __construct(
-        private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly RequestStack $requestStack,
+        private EventDispatcherInterface $eventDispatcher,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
@@ -7,15 +7,9 @@ namespace Mautic\CoreBundle\Twig\Extension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
-final class PurifyExtension extends AbstractExtension
+final class PurifyExtension
 {
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('purify_allow_target_blank', $this->purifyAllowTargetBlank(...), ['is_safe' => ['html']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFilter(name: 'purify_allow_target_blank', isSafe: ['html'])]
     public function purifyAllowTargetBlank(?string $html): string
     {
         $config = \HTMLPurifier_Config::createDefault();

--- a/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
-
 final class PurifyExtension
 {
     #[\Twig\Attribute\AsTwigFilter(name: 'purify_allow_target_blank', isSafe: ['html'])]

--- a/app/bundles/CoreBundle/Twig/Extension/SearchCommandListExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SearchCommandListExtension.php
@@ -5,26 +5,18 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Service\SearchCommandListInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class SearchCommandListExtension extends AbstractExtension
+class SearchCommandListExtension
 {
     public function __construct(
         protected SearchCommandListInterface $searchCommandList,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('searchCommandList', $this->getSearchCommandList(...), ['is_safe' => ['all']]),
-        ];
-    }
-
     /**
      * @return mixed[]
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'searchCommandList', isSafe: ['all'])]
     public function getSearchCommandList(): array
     {
         return $this->searchCommandList->getList();

--- a/app/bundles/CoreBundle/Twig/Extension/SecurityExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SecurityExtension.php
@@ -6,31 +6,21 @@ namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\SecurityHelper;
 use Mautic\UserBundle\Entity\User;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class SecurityExtension extends AbstractExtension
+class SecurityExtension
 {
     public function __construct(
         private readonly SecurityHelper $securityHelper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('securityGetAuthenticationContext', $this->getContext(...)),
-            new TwigFunction('securityGetCsrfToken', $this->getCsrfToken(...)),
-            new TwigFunction('securityHasEntityAccess', $this->hasEntityAccess(...)),
-            new TwigFunction('securityIsGranted', $this->isGranted(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'securityGetAuthenticationContext')]
     public function getContext(): string
     {
         return $this->securityHelper->getAuthenticationContent();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'securityGetCsrfToken')]
     public function getCsrfToken(string $intention): string
     {
         return $this->securityHelper->getCsrfToken($intention);
@@ -43,11 +33,13 @@ class SecurityExtension extends AbstractExtension
      * @param string|bool $otherPermission
      * @param User|int    $ownerId
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'securityHasEntityAccess')]
     public function hasEntityAccess($ownPermission, $otherPermission, $ownerId): bool
     {
         return $this->securityHelper->hasEntityAccess($ownPermission, $otherPermission, $ownerId);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'securityIsGranted')]
     public function isGranted(string $permission): bool
     {
         return $this->securityHelper->isGranted($permission);

--- a/app/bundles/CoreBundle/Twig/Extension/StorageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/StorageExtension.php
@@ -4,33 +4,23 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-
 /**
  * The main goal of this function is to save Twig's context into memory
  * from child templates, so that it can be restored by parent templates.
  * This is a workaround as Twig doesn't support passing back variables
  * from child to parent templates.
  */
-class StorageExtension extends AbstractExtension
+class StorageExtension
 {
     /**
      * @var array<string,mixed>
      */
     protected array $storage = [];
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('save', $this->save(...), ['needs_context' => true]),
-            new TwigFunction('restore', $this->restore(...), ['needs_context' => true]),
-        ];
-    }
-
     /**
      * @param mixed $context
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'save', needsContext: true)]
     public function save($context, string $name): void
     {
         $this->storage[$name] = $context;
@@ -39,6 +29,7 @@ class StorageExtension extends AbstractExtension
     /**
      * @param mixed $context
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'restore', needsContext: true)]
     public function restore(&$context, string $name): void
     {
         $context = array_merge($context, $this->storage[$name]);

--- a/app/bundles/CoreBundle/Twig/Extension/ThemeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ThemeExtension.php
@@ -6,10 +6,8 @@ namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\ThemeHelper;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class ThemeExtension extends AbstractExtension
+class ThemeExtension
 {
     public function __construct(
         private readonly ThemeHelper $themeHelper,
@@ -17,16 +15,10 @@ class ThemeExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getThemeName', $this->getThemeName(...)),
-        ];
-    }
-
     /**
      * Get the theme display name for the specified theme.
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getThemeName')]
     public function getThemeName(string $theme = 'current'): string
     {
         // Special case for Code Mode

--- a/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
@@ -5,31 +5,21 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-final class ThemesExtension extends AbstractExtension
+final class ThemesExtension
 {
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getTextOnBrandColor', $this->getTextOnBrandColor(...)),
-            new TwigFunction('getTextOnBrandHelperColor', $this->getTextOnBrandHelperColor(...)),
-            new TwigFunction('getBrandPrimaryColor', $this->getBrandPrimaryColor(...)),
-            new TwigFunction('getRoundedCorners', $this->getRoundedCorners(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'getBrandPrimaryColor')]
     public function getBrandPrimaryColor(): string
     {
         return $this->coreParametersHelper->get('primary_brand_color', '000000');
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'getTextOnBrandColor')]
     public function getTextOnBrandColor(): string
     {
         $primaryColor = $this->getBrandPrimaryColor();
@@ -45,11 +35,13 @@ final class ThemesExtension extends AbstractExtension
         return $brightness > 125 ? '000000' : 'ffffff';
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'getTextOnBrandHelperColor')]
     public function getTextOnBrandHelperColor(): string
     {
         return '000000' === $this->getTextOnBrandColor() ? '6d6d6d' : 'b3b3b3';
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'getRoundedCorners')]
     public function getRoundedCorners(string $size = 'lg'): int
     {
         $baseRadius = (int) $this->coreParametersHelper->get('rounded_corners', 0);

--- a/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ThemesExtension.php
@@ -6,10 +6,10 @@ namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-final class ThemesExtension
+final readonly class ThemesExtension
 {
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Twig/Extension/TranslatorExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/TranslatorExtension.php
@@ -5,31 +5,21 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Translation\Translator;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class TranslatorExtension extends AbstractExtension
+class TranslatorExtension
 {
     public function __construct(
         private readonly Translator $translator,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('translatorGetJsLang', $this->getJsLang(...)),
-            new TwigFunction('translatorHasId', $this->translatorHasId(...)),
-            new TwigFunction('translatorConditional', $this->translatorConditional(...)),
-            new TwigFunction('translatorGetHelper', $this->getHelper(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'translatorGetJsLang')]
     public function getJsLang(): string
     {
         return $this->translator->getJsLang();
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'translatorHasId')]
     public function translatorHasId(string $id, ?string $domain = null, ?string $locale = null): bool
     {
         return $this->translator->hasId($id, $domain, $locale);
@@ -41,11 +31,13 @@ class TranslatorExtension extends AbstractExtension
      *
      * @param array<mixed> $parameters
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'translatorConditional')]
     public function translatorConditional(string $preferred, string $alternative, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         return $this->translator->transConditional($preferred, $alternative, $parameters, $domain, $locale);
     }
 
+    #[\Twig\Attribute\AsTwigFunction(name: 'translatorGetHelper')]
     public function getHelper(): Translator
     {
         return $this->translator;

--- a/app/bundles/CoreBundle/Twig/Extension/VersionExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/VersionExtension.php
@@ -5,23 +5,15 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Helper\AppVersion;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class VersionExtension extends AbstractExtension
+class VersionExtension
 {
     public function __construct(
         private readonly AppVersion $appVersion,
     ) {
     }
 
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('mauticAppVersion', $this->getVersion(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'mauticAppVersion')]
     public function getVersion(): string
     {
         return $this->appVersion->getVersion();

--- a/app/bundles/CoreBundle/Twig/Helper/EntityHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/EntityHelper.php
@@ -5,25 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Helper;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class EntityHelper extends AbstractExtension
+class EntityHelper
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
     ) {
-    }
-
-    /**
-     * Registers the custom Twig functions.
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('getEntity', $this->getEntity(...)),
-            new TwigFunction('getEntities', $this->getEntities(...)),
-        ];
     }
 
     /**
@@ -34,6 +21,7 @@ class EntityHelper extends AbstractExtension
      *
      * @return object|null The retrieved entity or null if not found
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getEntity')]
     public function getEntity(string $entityName, int|string|null $id): ?object
     {
         return null !== $id ? $this->entityManager->getRepository($entityName)->find($id) : null;
@@ -47,6 +35,7 @@ class EntityHelper extends AbstractExtension
      *
      * @return object[] The array of retrieved entities
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'getEntities')]
     public function getEntities(string $entityName, array $ids): array
     {
         return $this->entityManager->getRepository($entityName)->findBy(['id' => $ids]);

--- a/app/bundles/InstallBundle/Twig/TwigExtension.php
+++ b/app/bundles/InstallBundle/Twig/TwigExtension.php
@@ -8,20 +8,9 @@ use Twig\TwigFilter;
 /**
  * TwigExtension class.
  */
-class TwigExtension extends AbstractExtension
+class TwigExtension
 {
-    /**
-     * getFilters function.
-     *
-     * @return mixed[]
-     */
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('phpversion', $this->phpversion(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFilter(name: 'phpversion')]
     public function phpversion(string $value = ''): string|bool
     {
         return phpversion($value);

--- a/app/bundles/InstallBundle/Twig/TwigExtension.php
+++ b/app/bundles/InstallBundle/Twig/TwigExtension.php
@@ -2,9 +2,6 @@
 
 namespace Mautic\InstallBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
-
 /**
  * TwigExtension class.
  */

--- a/app/bundles/LeadBundle/Twig/Extension/DncReasonExtension.php
+++ b/app/bundles/LeadBundle/Twig/Extension/DncReasonExtension.php
@@ -6,10 +6,8 @@ namespace Mautic\LeadBundle\Twig\Extension;
 
 use Mautic\LeadBundle\Exception\UnknownDncReasonException;
 use Mautic\LeadBundle\Twig\Helper\DncReasonHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class DncReasonExtension extends AbstractExtension
+class DncReasonExtension
 {
     public function __construct(
         protected DncReasonHelper $helper,
@@ -17,20 +15,11 @@ class DncReasonExtension extends AbstractExtension
     }
 
     /**
-     * @see Twig_Extension::getFunctions()
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('dncReasonToText', $this->toText(...)),
-        ];
-    }
-
-    /**
      * Convert DNC reason ID to text.
      *
      * @throws UnknownDncReasonException
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'dncReasonToText')]
     public function toText(int $reasonId): string
     {
         return $this->helper->toText($reasonId);

--- a/app/bundles/LeadBundle/Twig/Extension/LeadExtension.php
+++ b/app/bundles/LeadBundle/Twig/Extension/LeadExtension.php
@@ -6,10 +6,8 @@ namespace Mautic\LeadBundle\Twig\Extension;
 
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Twig\Helper\AvatarHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class LeadExtension extends AbstractExtension
+class LeadExtension
 {
     public function __construct(
         protected AvatarHelper $avatarHelper,
@@ -17,20 +15,11 @@ class LeadExtension extends AbstractExtension
     }
 
     /**
-     * @see Twig_Extension::getFunctions()
-     */
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('leadGetAvatar', $this->getAvatar(...)),
-        ];
-    }
-
-    /**
      * @see AvatarHelper::getAvatar
      *
      * @return mixed
      */
+    #[\Twig\Attribute\AsTwigFunction(name: 'leadGetAvatar')]
     public function getAvatar(Lead $lead)
     {
         return $this->avatarHelper->getAvatar($lead);

--- a/rector.php
+++ b/rector.php
@@ -57,8 +57,11 @@ return RectorConfig::configure()
         // symfony
         Rector\Symfony\Symfony73\Rector\Class_\CommandDefaultNameAndDescriptionToAsCommandAttributeRector::class,
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
+
+        Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
     ])
     ->reportUnusedSkips()
+    // ->withComposerBased(symfony: true)
     ->withCodingStyleLevel(3)
     ->withSkip([
         __DIR__.'/plugins/*/node_modules/*',

--- a/rector.php
+++ b/rector.php
@@ -59,6 +59,7 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
 
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
+        \Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
     ])
     ->reportUnusedSkips()
     // ->withComposerBased(symfony: true)

--- a/rector.php
+++ b/rector.php
@@ -59,7 +59,7 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
 
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
-        \Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
+        Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
     ])
     ->reportUnusedSkips()
     // ->withComposerBased(symfony: true)
@@ -79,6 +79,11 @@ return RectorConfig::configure()
         // to be fixed in dev-main
         Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector::class => [
             '*Command.php',
+        ],
+
+        // special override case, fixed in rector dev-main
+        Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class => [
+            __DIR__.'/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php',
         ],
 
         // skip as might be overriden by 3rd party controllers


### PR DESCRIPTION
Makes use of the new Twig extension attributes introduced in **Symfony 7.3**.

Instead of extending `AbstractExtension` and registering functions via `getFunctions()`, functions are declared directly on the method with `#[AsTwigFunction]`. Less boilerplate, no base class needed.

See the Symfony blog: [New in Symfony 7.3: Twig Extension Attributes](https://symfony.com/blog/new-in-symfony-7-3-twig-extension-attributes)

## Example diff

```diff
 use Mautic\CoreBundle\Twig\Helper\GravatarHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;

-class GravatarExtension extends AbstractExtension
+class GravatarExtension
 {
     public function __construct(
         protected GravatarHelper $gravatarHelper,
     ) {
     }

-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('gravatarGetImage', $this->getImage(...), ['is_safe' => ['all']]),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'gravatarGetImage', isSafe: ['all'])]
     public function getImage(string $email, string $size = '250', ?string $default = null): string
     {
         return $this->gravatarHelper->getImage($email, $size, $default);
     }
 }
```
