### PR TITLE
Improve E2E acceptance test setup

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,8 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/app/middlewares')
     ->in(__DIR__.'/app/migrations')
     ->in(__DIR__.'/plugins')
+    ->in(__DIR__.'/tests')
+    ->exclude('_support/_generated')
     ->in(__DIR__.'/utils')
     // rector rule fixtures are test data, not code, and reformatting them breaks the expected output
     ->notName('*.php.inc')

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -22,6 +22,8 @@ class AcceptanceTester extends Codeception\Actor
 {
     use _generated\AcceptanceTesterActions;
 
+    public const TIMEOUT = 30;
+
     public function login(string $name = 'admin', string $password = 'Maut1cR0cks!'): void
     {
         $I = $this;

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -39,7 +39,7 @@ class AcceptanceTester extends Codeception\Actor
         $I->fillField('#username', $name);
         $I->fillField('#password', $password);
         $I->click('button[type=submit]');
-        $I->waitForElement('h1.page-header-title', 30);
+        $I->waitForElement('h1.page-header-title', self::TIMEOUT);
         // saving snapshot
         $I->saveSessionSnapshot('login');
     }
@@ -63,7 +63,7 @@ class AcceptanceTester extends Codeception\Actor
      */
     public function ensureNotificationAppears(string $message): void
     {
-        $this->waitForElementVisible('#flashes .alert', 10);
+        $this->waitForElementVisible('#flashes .alert', self::TIMEOUT);
         $this->see($message, '#flashes .alert');
     }
 }

--- a/tests/_support/Helper/EnvHelper.php
+++ b/tests/_support/Helper/EnvHelper.php
@@ -34,9 +34,9 @@ final class EnvHelper extends Module
             return false;
         }
 
-        (new Dotenv())->load($this->envLocalPath);
+        $envVariables = (new Dotenv())->parse(file_get_contents($this->envLocalPath));
 
-        return 'test' === ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null);
+        return 'test' === ($envVariables['APP_ENV'] ?? null);
     }
 
     private function backupLocalEnv(): void

--- a/tests/_support/Helper/EnvHelper.php
+++ b/tests/_support/Helper/EnvHelper.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helper;
+
+use Codeception\Module;
+use Symfony\Component\Dotenv\Dotenv;
+
+final class EnvHelper extends Module
+{
+    private string $envLocalPath       = '.env.local';
+    private string $envLocalBackupPath = '.env.local.e2e.backup';
+    private bool $envLocalOverridden   = false;
+
+    public function _beforeSuite($settings = [])
+    {
+        if ($this->isTestEnvironment()) {
+            return;
+        }
+
+        $this->backupLocalEnv();
+        $this->useTestLocalEnv();
+    }
+
+    public function _afterSuite(): void
+    {
+        $this->restoreLocalEnv();
+    }
+
+    private function isTestEnvironment(): bool
+    {
+        if (!file_exists($this->envLocalPath)) {
+            return false;
+        }
+
+        (new Dotenv())->load($this->envLocalPath);
+
+        return 'test' === ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null);
+    }
+
+    private function backupLocalEnv(): void
+    {
+        if (file_exists($this->envLocalBackupPath)) {
+            return;
+        }
+
+        if (!file_exists($this->envLocalPath)) {
+            return;
+        }
+
+        copy($this->envLocalPath, $this->envLocalBackupPath);
+    }
+
+    private function useTestLocalEnv(): void
+    {
+        if (file_exists($this->envLocalPath)) {
+            unlink($this->envLocalPath);
+        }
+
+        file_put_contents($this->envLocalPath, "APP_ENV=test\nAPP_DEBUG=1\n");
+
+        $this->envLocalOverridden = true;
+    }
+
+    private function restoreLocalEnv(): void
+    {
+        if ($this->envLocalOverridden && file_exists($this->envLocalPath)) {
+            unlink($this->envLocalPath);
+            $this->envLocalOverridden = false;
+        }
+
+        if (!file_exists($this->envLocalBackupPath)) {
+            return;
+        }
+
+        if (file_exists($this->envLocalPath)) {
+            unlink($this->envLocalPath);
+        }
+
+        rename($this->envLocalBackupPath, $this->envLocalPath);
+    }
+}

--- a/tests/_support/Step/Acceptance/CampaignStep.php
+++ b/tests/_support/Step/Acceptance/CampaignStep.php
@@ -11,13 +11,13 @@ class CampaignStep extends \AcceptanceTester
     public function addContactsToCampaign(): int
     {
         $I = $this;
-        $I->waitForElementVisible(ContactPage::$campaignsModalAddOption, 5); // Wait for the modal to appear
+        $I->waitForElementVisible(ContactPage::$campaignsModalAddOption, self::TIMEOUT); // Wait for the modal to appear
         $I->click(ContactPage::$campaignsModalAddOption); // Click into "Add to the following" option
-        $I->waitForElementVisible(ContactPage::$firstCampaignFromAddList, 10);
+        $I->waitForElementVisible(ContactPage::$firstCampaignFromAddList, self::TIMEOUT);
         $selectedCampaignText = $I->grabTextFrom(ContactPage::$firstCampaignFromAddList);
         $I->click(ContactPage::$firstCampaignFromAddList);
         $I->click(ContactPage::$campaignsModalSaveButton); // Click Save
-        $I->waitForElementNotVisible(self::MODAL_SELECTOR, 30); // Wait for modal to close
+        $I->waitForElementNotVisible(self::MODAL_SELECTOR, self::TIMEOUT); // Wait for modal to close
         $I->ensureNotificationAppears('2 contacts affected');
 
         preg_match('/\((\d+)\)\s*$/', $selectedCampaignText, $campaignIdMatch);

--- a/tests/_support/Step/Acceptance/ContactStep.php
+++ b/tests/_support/Step/Acceptance/ContactStep.php
@@ -19,7 +19,7 @@ class ContactStep extends \AcceptanceTester
     {
         $I = $this;
         // Wait for the first name field to be visible
-        $I->waitForElementVisible(ContactPage::$firstNameField, 10);
+        $I->waitForElementVisible(ContactPage::$firstNameField, self::TIMEOUT);
         // Fill in the form fields
         $I->fillField(ContactPage::$firstNameField, $firstName);
         $I->fillField(ContactPage::$lastNameField, $lastName);
@@ -56,7 +56,7 @@ class ContactStep extends \AcceptanceTester
         // Click the dropdown menu
         $I->click("//*[@id='leadTable']/tbody/tr[{$place}]/td[1]/div/div/button");
         // Select the desired option
-        $I->waitForElementClickable("//*[@id='leadTable']/tbody/tr[{$place}]/td[1]/div/div/ul/li[{$option}]/a", 30);
+        $I->waitForElementClickable("//*[@id='leadTable']/tbody/tr[{$place}]/td[1]/div/div/ul/li[{$option}]/a", self::TIMEOUT);
         $I->click("//*[@id='leadTable']/tbody/tr[{$place}]/td[1]/div/div/ul/li[{$option}]/a");
     }
 
@@ -67,7 +67,7 @@ class ContactStep extends \AcceptanceTester
     {
         $I     = $this;
         $xpath = "//*[@id='leadTable']/tbody/tr[{$place}]/td[1]/div/span/input";
-        $I->waitForElementClickable($xpath, 10);
+        $I->waitForElementClickable($xpath, self::TIMEOUT);
         $I->checkOption($xpath);
         $I->seeCheckboxIsChecked($xpath);
     }
@@ -79,7 +79,7 @@ class ContactStep extends \AcceptanceTester
     {
         $I     = $this;
         $xpath = "//*[@id='leadTable']/tbody/tr[td[2]/a/div[1][normalize-space()=\"{$contactName}\"]]/td[1]/div/span/input";
-        $I->waitForElementClickable($xpath, 10);
+        $I->waitForElementClickable($xpath, self::TIMEOUT);
         $I->checkOption($xpath);
         $I->seeCheckboxIsChecked($xpath);
     }
@@ -91,7 +91,7 @@ class ContactStep extends \AcceptanceTester
     {
         $I     = $this;
         $xpath = "//*[@id='leadTable']/tbody/tr[td[2]/a[contains(@href, '/contacts/view/{$leadId}')]]/td[1]/div/span/input";
-        $I->waitForElementClickable($xpath, 10);
+        $I->waitForElementClickable($xpath, self::TIMEOUT);
         $I->checkOption($xpath);
         $I->seeCheckboxIsChecked($xpath);
     }
@@ -104,13 +104,13 @@ class ContactStep extends \AcceptanceTester
         $I = $this;
         // Click the dropdown button for bulk actions
         $xpathDropdownButton = '//button[@id="core-options"]';
-        $I->waitForElementClickable($xpathDropdownButton, 10);
+        $I->waitForElementClickable($xpathDropdownButton, self::TIMEOUT);
         $I->click($xpathDropdownButton);
 
         // Select the desired option from the dropdown menu by label when provided.
         if (is_string($option) && !ctype_digit($option)) {
             $xpathOption = "//ul[contains(@class, 'page-list-actions') and contains(@class, 'dropdown-menu')]/li/a[contains(normalize-space(), \"{$option}\")]";
-            $I->waitForElementClickable($xpathOption, 10);
+            $I->waitForElementClickable($xpathOption, self::TIMEOUT);
             $I->click($xpathOption);
 
             return;
@@ -118,7 +118,7 @@ class ContactStep extends \AcceptanceTester
 
         $position    = (int) $option;
         $xpathOption = "//ul[contains(@class, 'page-list-actions') and contains(@class, 'dropdown-menu')]/li[{$position}]";
-        $I->waitForElementClickable($xpathOption, 10);
+        $I->waitForElementClickable($xpathOption, self::TIMEOUT);
         $I->click($xpathOption);
     }
 
@@ -181,13 +181,13 @@ class ContactStep extends \AcceptanceTester
         $I->amOnPage(ContactPage::$URL);
         // Grab the contact's name and navigate to their details page
         $contactNameSelector = "//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]";
-        $I->waitForElementVisible($contactNameSelector, 10);
+        $I->waitForElementVisible($contactNameSelector, self::TIMEOUT);
         $contactName = $I->grabTextFrom($contactNameSelector);
         $I->click(['link' => $contactName]);
         // Wait for the contact's name to appear on the details page
-        $I->waitForText($contactName, 10, '#app-content');
+        $I->waitForText($contactName, self::TIMEOUT, '#app-content');
         // Verify the owner is "Sales User"
-        $I->waitForElement('//*[@id="app-content"]/div/div[2]/div[2]/div[1]/div[4]/p[1]', 15);
+        $I->waitForElement('//*[@id="app-content"]/div/div[2]/div[2]/div[1]/div[4]/p[1]', self::TIMEOUT);
         $I->see('Sales User', '//*[@id="app-content"]/div/div[2]/div[2]/div[1]/div[4]/p[1]');
     }
 
@@ -203,13 +203,13 @@ class ContactStep extends \AcceptanceTester
         $I->amOnPage('/s/contacts');
         // Grab the contact's name and navigate to their details page
         $contactNameSelector = "//*[@id='leadTable']/tbody/tr[{$place}]/td[2]/a/div[1]";
-        $I->waitForElementVisible($contactNameSelector, 10);
+        $I->waitForElementVisible($contactNameSelector, self::TIMEOUT);
         $contactName = $I->grabTextFrom($contactNameSelector);
         $I->click(['link' => $contactName]);
         // Wait for the contact's name to appear on the details page
-        $I->waitForText($contactName, 10, '#app-content');
+        $I->waitForText($contactName, self::TIMEOUT, '#app-content');
         // Verify the owner is "Admin User"
-        $I->waitForElement('//*[@id="app-content"]/div[1]/div[2]/div[2]/div[1]/div[4]/p[1]', 15);
+        $I->waitForElement('//*[@id="app-content"]/div[1]/div[2]/div[2]/div[1]/div[4]/p[1]', self::TIMEOUT);
         $I->see('Admin User', '//*[@id="app-content"]/div[1]/div[2]/div[2]/div[1]/div[4]/p[1]');
     }
 }

--- a/tests/_support/Step/Acceptance/EmailStep.php
+++ b/tests/_support/Step/Acceptance/EmailStep.php
@@ -22,7 +22,7 @@ class EmailStep extends \AcceptanceTester
         $I->waitForElementClickable(EmailsPage::CONTACT_SEGMENT_OPTION);
         $I->click(EmailsPage::CONTACT_SEGMENT_OPTION);
         $I->click(EmailsPage::SAVE_AND_CLOSE);
-        $I->waitForText($name, 10, 'h1.page-header-title');
+        $I->waitForText($name, self::TIMEOUT, 'h1.page-header-title');
     }
 
     /**
@@ -38,7 +38,7 @@ class EmailStep extends \AcceptanceTester
         $I->click(EmailsPage::SELECT_TRIGGERED_EMAIL);
         $I->fillField(EmailsPage::SUBJECT_FIELD, $name);
         $I->click(EmailsPage::SAVE_AND_CLOSE);
-        $I->waitForText($name, 10, 'h1.page-header-title');
+        $I->waitForText($name, self::TIMEOUT, 'h1.page-header-title');
     }
 
     /**

--- a/tests/_support/Step/Acceptance/FormStep.php
+++ b/tests/_support/Step/Acceptance/FormStep.php
@@ -27,11 +27,11 @@ class FormStep extends \AcceptanceTester
 
         $I->click(FormPage::$ADD_NEW_FIELD_BUTTON_TEXT);
         $I->click($fieldType);
-        $I->waitForText($modalHeader, 5);
-        $I->waitForElementVisible($labelSelector, 10);
+        $I->waitForText($modalHeader, self::TIMEOUT);
+        $I->waitForElementVisible($labelSelector, self::TIMEOUT);
         $I->fillField($labelSelector, $label);
-        $I->waitForElementClickable($saveButtonSelector, 10);
+        $I->waitForElementClickable($saveButtonSelector, self::TIMEOUT);
         $I->click($saveButtonSelector);
-        $I->waitForElementNotVisible($labelSelector, 10); // modal closed
+        $I->waitForElementNotVisible($labelSelector, self::TIMEOUT); // modal closed
     }
 }

--- a/tests/_support/Step/Acceptance/MenuStep.php
+++ b/tests/_support/Step/Acceptance/MenuStep.php
@@ -18,9 +18,9 @@ class MenuStep extends \AcceptanceTester
     {
         $I = $this;
         $I->click(MenuPage::$POINTS);
-        $I->waitForElementClickable(MenuPage::$MANAGE_GROUPS_ID, 10);
+        $I->waitForElementClickable(MenuPage::$MANAGE_GROUPS_ID, self::TIMEOUT);
         $I->click(MenuPage::$MANAGE_GROUPS);
-        $I->waitForElementVisible(MenuPage::$ACTIVE_NAV_GROUP, 10);
+        $I->waitForElementVisible(MenuPage::$ACTIVE_NAV_GROUP, self::TIMEOUT);
         $I->seeElement(MenuPage::$ACTIVE_NAV_GROUP);
     }
 }

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -2,6 +2,7 @@ actor: AcceptanceTester
 modules:
   enabled:
     - Asserts
+    - \Helper\EnvHelper
     - \Helper\DbHelper
     - WebDriver:
         url: "https://web:443"

--- a/tests/acceptance/ContactManagementCest.php
+++ b/tests/acceptance/ContactManagementCest.php
@@ -24,11 +24,11 @@ class ContactManagementCest
         $I->amOnPage(ContactPage::$URL);
 
         // Click on "Quick Add" button
-        $I->waitForElementClickable(ContactPage::$quickAddButton, 30);
+        $I->waitForElementClickable(ContactPage::$quickAddButton, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$quickAddButton);
 
         // Wait for the Quick Add Form to appear
-        $I->waitForElementVisible(ContactPage::$quickAddModal, 30);
+        $I->waitForElementVisible(ContactPage::$quickAddModal, AcceptanceTester::TIMEOUT);
         $I->see('Quick Add', 'h4.modal-title');
         $I->waitForJS(
             "return !document.querySelector('#MauticSharedModal .modal-loading-bar').classList.contains('active')"
@@ -43,7 +43,7 @@ class ContactManagementCest
 
         // Submit the form
         $I->executeJS("document.querySelector('button[name=\"lead[buttons][save]\"]').click();");
-        $I->waitForElementNotVisible('#MauticSharedModal', 30);
+        $I->waitForElementNotVisible('#MauticSharedModal', AcceptanceTester::TIMEOUT);
 
         $I->ensureNotificationAppears('has been created');
     }
@@ -57,9 +57,9 @@ class ContactManagementCest
         $I->amOnPage(ContactPage::$URL);
 
         // Click on "+New" button
-        $I->waitForElementClickable(ContactPage::$newContactButton, 30);
+        $I->waitForElementClickable(ContactPage::$newContactButton, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$newContactButton);
-        $I->waitForText('New Contact', 30);
+        $I->waitForText('New Contact', AcceptanceTester::TIMEOUT);
 
         // Fill out the contact form
         $contact->fillContactForm('FirstName', 'LastName', $email, 'TestTag');
@@ -71,7 +71,7 @@ class ContactManagementCest
         $I->executeJS("document.querySelector('button[name=\"lead[buttons][save]\"]').click();");
 
         // Confirm the contact is created
-        $I->waitForElementVisible('.page-header-title .span-block', 30);
+        $I->waitForElementVisible('.page-header-title .span-block', AcceptanceTester::TIMEOUT);
         $I->see('FirstName LastName', '.page-header-title .span-block');
 
         // Check the database for the created contact
@@ -91,7 +91,7 @@ class ContactManagementCest
         $contact->selectOptionFromDropDown(1, 1);
 
         // Wait for the edit form to be visible
-        $I->waitForElementVisible(ContactPage::$editForm, 30);
+        $I->waitForElementVisible(ContactPage::$editForm, AcceptanceTester::TIMEOUT);
         $I->see("Edit {$contactName}");
 
         // Close the edit form (No changes are made)
@@ -111,7 +111,7 @@ class ContactManagementCest
         $I->click(['link' => $contactName]);
 
         // Wait for the contact details page to load and confirm we're on the correct page
-        $I->waitForText($contactName, 30);
+        $I->waitForText($contactName, AcceptanceTester::TIMEOUT);
         $I->see($contactName);
 
         // Click on the edit button
@@ -119,7 +119,7 @@ class ContactManagementCest
         $I->click(ContactPage::$editButton);
 
         // Wait for the edit form to be visible
-        $I->waitForElementVisible(ContactPage::$editForm, 30);
+        $I->waitForElementVisible(ContactPage::$editForm, AcceptanceTester::TIMEOUT);
         $I->see("Edit {$contactName}");
 
         // Edit the first and last names
@@ -127,11 +127,11 @@ class ContactManagementCest
         $I->fillField(ContactPage::$lastNameField, 'Edited-Last-Name');
 
         // Save and close the form
-        $I->waitForElementClickable(ContactPage::$saveAndCloseButton, 30);
+        $I->waitForElementClickable(ContactPage::$saveAndCloseButton, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$saveAndCloseButton);
 
         // Verify the update message
-        $I->waitForText('Edited-First-Name Edited-Last-Name has been updated!', 30);
+        $I->waitForText('Edited-First-Name Edited-Last-Name has been updated!', AcceptanceTester::TIMEOUT);
         $I->see('Edited-First-Name Edited-Last-Name has been updated!');
     }
 
@@ -148,11 +148,11 @@ class ContactManagementCest
         $contact->selectOptionFromDropDown(1, 4);
 
         // Wait for the modal to show and confirm deletion
-        $I->waitForElementVisible(ContactPage::$ConfirmDelete, 5);
+        $I->waitForElementVisible(ContactPage::$ConfirmDelete, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$ConfirmDelete);
 
         // Wait for the delete confirmation message
-        $I->waitForText("{$contactName} has been deleted!", 30);
+        $I->waitForText("{$contactName} has been deleted!", AcceptanceTester::TIMEOUT);
         $I->see("{$contactName} has been deleted!");
     }
 
@@ -169,17 +169,17 @@ class ContactManagementCest
         $I->click(['link' => $contactName]);
 
         // Wait for the contact details page to load and confirm we're on the correct page
-        $I->waitForText($contactName, 30);
+        $I->waitForText($contactName, AcceptanceTester::TIMEOUT);
         $I->see($contactName);
 
         // Ensure the dropdown button is visible on the page
-        $I->waitForElementVisible(ContactPage::$dropDown, 10);
+        $I->waitForElementVisible(ContactPage::$dropDown, AcceptanceTester::TIMEOUT);
 
         // Scroll to the dropdown button to bring it into view
         $I->scrollTo(ContactPage::$dropDown, 0, -100);
 
         // Wait until the dropdown button is clickable
-        $I->waitForElementClickable(ContactPage::$dropDown, 10);
+        $I->waitForElementClickable(ContactPage::$dropDown, AcceptanceTester::TIMEOUT);
 
         // Click the dropdown caret to show the delete option
         $I->click(ContactPage::$dropDown);
@@ -188,11 +188,11 @@ class ContactManagementCest
         $I->click(ContactPage::$delete);
 
         // Wait for the modal to show and confirm deletion
-        $I->waitForElementVisible(ContactPage::$ConfirmDelete, 5);
+        $I->waitForElementVisible(ContactPage::$ConfirmDelete, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$ConfirmDelete);
 
         // Wait for the delete confirmation message
-        $I->waitForText("{$contactName} has been deleted!", 30);
+        $I->waitForText("{$contactName} has been deleted!", AcceptanceTester::TIMEOUT);
         $I->see("{$contactName} has been deleted!");
     }
 
@@ -214,7 +214,7 @@ class ContactManagementCest
         $I->click('//*[@id="delete"]');
 
         // Wait for the modal to become visible and click on the button to confirm delete
-        $I->waitForElementVisible(ContactPage::$ConfirmDelete, 5);
+        $I->waitForElementVisible(ContactPage::$ConfirmDelete, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$ConfirmDelete);
         $I->wait(5);
 
@@ -238,9 +238,9 @@ class ContactManagementCest
 
         // Navigate to the campaign page and click the Contacts tab
         $I->amOnPage(CampaignPage::$URL);
-        $I->waitForElementClickable(CampaignPage::$contactsTab, 10);
+        $I->waitForElementClickable(CampaignPage::$contactsTab, AcceptanceTester::TIMEOUT);
         $I->click(CampaignPage::$contactsTab);
-        $I->waitForElement(CampaignPage::$contactsTabContainer, 15);
+        $I->waitForElement(CampaignPage::$contactsTabContainer, AcceptanceTester::TIMEOUT);
         $I->waitForJS('return document.querySelector("#leads-container .contact-cards") !== null || document.querySelector("#leads-container h4") !== null;', 15);
 
         // Return to the contacts page
@@ -259,9 +259,9 @@ class ContactManagementCest
 
         // Navigate to the campaign page and click the Contacts tab
         $I->amOnPage(CampaignPage::$URL);
-        $I->waitForElementClickable(CampaignPage::$contactsTab, 10);
+        $I->waitForElementClickable(CampaignPage::$contactsTab, AcceptanceTester::TIMEOUT);
         $I->click(CampaignPage::$contactsTab);
-        $I->waitForElement(CampaignPage::$contactsTabContainer, 15);
+        $I->waitForElement(CampaignPage::$contactsTabContainer, AcceptanceTester::TIMEOUT);
         $I->waitForJS('return document.querySelector("#leads-container .contact-cards") !== null || document.querySelector("#leads-container h4") !== null;', 15);
 
         // Verify the tab content load checks completed without timeout.
@@ -306,21 +306,21 @@ class ContactManagementCest
         $contact->selectOptionFromDropDownForMultipleSelections('Change Campaigns');
 
         // Wait for the modal to appear and click the "Remove from campaign" option
-        $I->waitForElementVisible(ContactPage::$campaignsModalAddOption, 5);
+        $I->waitForElementVisible(ContactPage::$campaignsModalAddOption, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$campaignsModalRemoveOption);
 
         // Select the campaign and click save
-        $I->waitForElementVisible(ContactPage::$firstCampaignFromRemoveList, 10);
+        $I->waitForElementVisible(ContactPage::$firstCampaignFromRemoveList, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$firstCampaignFromRemoveList);
         $I->click(ContactPage::$campaignsModalSaveButton);
-        $I->waitForElementNotVisible('#MauticSharedModal', 30);
+        $I->waitForElementNotVisible('#MauticSharedModal', AcceptanceTester::TIMEOUT);
         $I->ensureNotificationAppears('2 contacts affected');
 
         // Navigate to the campaign page and click the Contacts tab
         $I->amOnPage(CampaignPage::$URL);
-        $I->waitForElementClickable(CampaignPage::$contactsTab, 10);
+        $I->waitForElementClickable(CampaignPage::$contactsTab, AcceptanceTester::TIMEOUT);
         $I->click(CampaignPage::$contactsTab);
-        $I->waitForElement(CampaignPage::$contactsTabContainer, 15);
+        $I->waitForElement(CampaignPage::$contactsTabContainer, AcceptanceTester::TIMEOUT);
         $I->waitForJS('return document.querySelector("#leads-container .contact-cards") !== null || document.querySelector("#leads-container h4") !== null;', 15);
 
         // Mautic soft-deletes campaign membership: the row is kept with manually_removed=1 rather than deleted.
@@ -347,7 +347,7 @@ class ContactManagementCest
         $contact->selectOptionFromDropDownForMultipleSelections('Change Owner');
 
         // Wait for the modal to appear
-        $I->waitForElementClickable(ContactPage::$addToTheFollowing, 5);
+        $I->waitForElementClickable(ContactPage::$addToTheFollowing, AcceptanceTester::TIMEOUT);
 
         // Select the new owner as "Admin User" from the options
         $I->click(ContactPage::$addToTheFollowing);
@@ -382,7 +382,7 @@ class ContactManagementCest
 
         // Clear the search bar
         $I->click(ContactPage::$clearSearch);
-        $I->waitForElementVisible('#leadTable', 10); // Wait for the contact list to be visible
+        $I->waitForElementVisible('#leadTable', AcceptanceTester::TIMEOUT); // Wait for the contact list to be visible
 
         // Select the first and second contacts from the list
         $contact->selectContactFromList(1);
@@ -392,7 +392,7 @@ class ContactManagementCest
         $contact->selectOptionFromDropDownForMultipleSelections('Change Segments');
 
         // Wait for the "Add to the following segment" modal to appear and click it
-        $I->waitForElementClickable(ContactPage::$addToTheFollowingSegment, 10);
+        $I->waitForElementClickable(ContactPage::$addToTheFollowingSegment, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$addToTheFollowingSegment);
         // Fill in the segment name and save
         $I->fillField(ContactPage::$addToTheFollowingSegmentInput, 'Segment Test 3');
@@ -406,7 +406,7 @@ class ContactManagementCest
         $I->scrollTo(ContactPage::$searchBar, 0, -100);
 
         // Wait until the search Bar is clickable
-        $I->waitForElementClickable(ContactPage::$searchBar, 10);
+        $I->waitForElementClickable(ContactPage::$searchBar, AcceptanceTester::TIMEOUT);
 
         // Search again for contacts in the "Segment Test 3" segment
         $I->fillField(ContactPage::$searchBar, 'segment:segment-test-3');
@@ -420,7 +420,7 @@ class ContactManagementCest
 
         // Clear the search bar
         $I->click(ContactPage::$clearSearch);
-        $I->waitForElementVisible('#leadTable', 10);
+        $I->waitForElementVisible('#leadTable', AcceptanceTester::TIMEOUT);
 
         // Now lets remove the contacts we just added to the "segment test 3"
 
@@ -434,7 +434,7 @@ class ContactManagementCest
         $contact->selectOptionFromDropDownForMultipleSelections('Change Segments');
 
         // Wait for the "Remove from the following segment" modal to appear and click it
-        $I->waitForElementClickable(ContactPage::$removeFromTheFollowingSegment, 10);
+        $I->waitForElementClickable(ContactPage::$removeFromTheFollowingSegment, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$removeFromTheFollowingSegment);
         // Fill in the segment name and save
         $I->fillField(ContactPage::$removeFromTheFollowingSegmentInput, 'Segment Test 3');
@@ -448,7 +448,7 @@ class ContactManagementCest
         $I->scrollTo(ContactPage::$searchBar, 0, -100);
 
         // Wait until the search Bar is clickable
-        $I->waitForElementClickable(ContactPage::$searchBar, 10);
+        $I->waitForElementClickable(ContactPage::$searchBar, AcceptanceTester::TIMEOUT);
 
         // Search for contacts in the "Segment Test 3" segment
         $I->fillField(ContactPage::$searchBar, 'segment:segment-test-3');
@@ -461,7 +461,7 @@ class ContactManagementCest
 
         // Clear the search bar
         $I->click(ContactPage::$clearSearch);
-        $I->waitForElementVisible('#leadTable', 10);
+        $I->waitForElementVisible('#leadTable', AcceptanceTester::TIMEOUT);
     }
 
     public function batchSetDoNotContact(
@@ -479,17 +479,17 @@ class ContactManagementCest
         // Select change segment option from dropdown for multiple selections
         $contact->selectOptionFromDropDownForMultipleSelections('Set Do Not Contact');
 
-        $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, 10);
+        $I->waitForElementClickable(ContactPage::$doNotContactSaveButton, AcceptanceTester::TIMEOUT);
         $I->click(ContactPage::$doNotContactSaveButton);
 
         $I->ensureNotificationAppears('2 contacts affected');
 
         $I->reloadPage();
 
-        $I->waitForElementVisible(ContactPage::$firstContactDoNotContact, 15);
+        $I->waitForElementVisible(ContactPage::$firstContactDoNotContact, AcceptanceTester::TIMEOUT);
         $I->seeElement(ContactPage::$firstContactDoNotContact);
 
-        $I->waitForElementVisible(ContactPage::$secondContactDoNotContact, 15);
+        $I->waitForElementVisible(ContactPage::$secondContactDoNotContact, AcceptanceTester::TIMEOUT);
         $I->seeElement(ContactPage::$secondContactDoNotContact);
     }
 
@@ -506,7 +506,7 @@ class ContactManagementCest
         $contact->selectOptionFromDropDownContactsPage('Import');
 
         // Wait for the import page to load
-        $I->waitForText('Import Contacts', 30, 'h1.page-header-title');
+        $I->waitForText('Import Contacts', AcceptanceTester::TIMEOUT, 'h1.page-header-title');
         $I->seeElement(ContactPage::$importModal);
 
         // Click 'Choose file' and select a file
@@ -516,7 +516,7 @@ class ContactManagementCest
         $I->click(ContactPage::$uploadButton);
 
         // Wait for the new form to open
-        $I->waitForElement(ContactPage::$importForm, 30);
+        $I->waitForElement(ContactPage::$importForm, AcceptanceTester::TIMEOUT);
 
         // Fill in the form
         $I->seeElement(ContactPage::$importFormFields);
@@ -526,7 +526,7 @@ class ContactManagementCest
         $I->click(ContactPage::$importInBrowser);
 
         // Wait for import completion message
-        $I->waitForElement(ContactPage::$importProgressComplete, 30);
+        $I->waitForElement(ContactPage::$importProgressComplete, AcceptanceTester::TIMEOUT);
         $I->see('Successful import', 'h2');
 
         // Extract the number of contacts created from the progress message

--- a/tests/acceptance/DisplayTestCest.php
+++ b/tests/acceptance/DisplayTestCest.php
@@ -18,7 +18,7 @@ class DisplayTestCest
         $I->amOnPage('/s/contacts/batchCampaigns');
 
         // Wait for the form to load
-        $I->waitForElementVisible('#lead_batch_add', 5);
+        $I->waitForElementVisible('#lead_batch_add', \AcceptanceTester::TIMEOUT);
 
         // Grab the options inside the dropdown
         $campaigns = $I->grabMultiple('#lead_batch_add option');
@@ -35,7 +35,7 @@ class DisplayTestCest
         $I->amOnPage('/s/categories/batch/contact/view');
 
         // Wait for the form to load
-        $I->waitForElementVisible('#lead_batch_add', 5);
+        $I->waitForElementVisible('#lead_batch_add', \AcceptanceTester::TIMEOUT);
 
         // Grab the options inside the dropdown
         $categories = $I->grabMultiple('#lead_batch_add option');
@@ -52,7 +52,7 @@ class DisplayTestCest
         $I->amOnPage('/s/contacts/batchOwners');
 
         // Wait for the dropdown to be visible
-        $I->waitForElementVisible('#lead_batch_owner_addowner', 5);
+        $I->waitForElementVisible('#lead_batch_owner_addowner', \AcceptanceTester::TIMEOUT);
 
         // Grab the owner options from the dropdown
         $owners = $I->grabMultiple('#lead_batch_owner_addowner option');
@@ -72,7 +72,7 @@ class DisplayTestCest
         $I->amOnPage('/s/segments/batch/contact/view');
 
         // Wait for the form to load
-        $I->waitForElementVisible('#lead_batch_add', 5);
+        $I->waitForElementVisible('#lead_batch_add', \AcceptanceTester::TIMEOUT);
 
         // Grab the options inside the dropdown
         $segments = $I->grabMultiple('#lead_batch_add option');
@@ -89,7 +89,7 @@ class DisplayTestCest
         $I->amOnPage('/s/contacts/batchStages');
 
         // Wait for the form to load
-        $I->waitForElementVisible('#lead_batch_stage_addstage', 5);
+        $I->waitForElementVisible('#lead_batch_stage_addstage', \AcceptanceTester::TIMEOUT);
 
         // Grab the options inside the dropdown
         $stages = $I->grabMultiple('#lead_batch_stage_addstage option');
@@ -109,7 +109,7 @@ class DisplayTestCest
         $I->amOnPage('/s/points/triggers/new');
 
         // Wait for the dropdown to be visible
-        $I->waitForElementVisible('#pointtrigger_group_chosen', 5);
+        $I->waitForElementVisible('#pointtrigger_group_chosen', \AcceptanceTester::TIMEOUT);
 
         // Grab the point group options from the dropdown
         $pointGroups = $I->grabMultiple('#pointtrigger_group_chosen option');
@@ -126,13 +126,13 @@ class DisplayTestCest
         $I->amOnPage('/s/emails/new');
 
         // Wait for the select button to appear
-        $I->waitForElementVisible(EmailsPage::SELECT_SEGMENT_EMAIL, 5);
+        $I->waitForElementVisible(EmailsPage::SELECT_SEGMENT_EMAIL, \AcceptanceTester::TIMEOUT);
 
         // Click the "Select" button to choose the email type
         $I->click(EmailsPage::SELECT_SEGMENT_EMAIL);
 
         // Wait for the dropdown to be visible
-        $I->waitForElementVisible('#emailform_unsubscribeForm_chosen', 5);
+        $I->waitForElementVisible('#emailform_unsubscribeForm_chosen', \AcceptanceTester::TIMEOUT);
 
         // Grab the point group options from the dropdown
         $I->click('#emailform_unsubscribeForm_chosen a.chosen-single');

--- a/tests/acceptance/EmailScheduleCest.php
+++ b/tests/acceptance/EmailScheduleCest.php
@@ -22,17 +22,17 @@ final class EmailScheduleCest
         $I->click(EmailsPage::NEW_BUTTON);
 
         // Wait for email type modal
-        $I->waitForElementVisible(EmailsPage::EMAIL_TYPE_MODAL, 10);
+        $I->waitForElementVisible(EmailsPage::EMAIL_TYPE_MODAL, AcceptanceTester::TIMEOUT);
 
         // Click "Triggered email"
         $I->waitForElementClickable(EmailsPage::SELECT_TRIGGERED_EMAIL);
         $I->click(EmailsPage::SELECT_TRIGGERED_EMAIL);
 
         // Wait until modal closes
-        $I->waitForElementNotVisible(EmailsPage::EMAIL_TYPE_MODAL, 10);
+        $I->waitForElementNotVisible(EmailsPage::EMAIL_TYPE_MODAL, AcceptanceTester::TIMEOUT);
 
         // Assert schedule container is visible
-        $I->waitForElementVisible('#scheduleOptions', 10);
+        $I->waitForElementVisible('#scheduleOptions', AcceptanceTester::TIMEOUT);
         $I->seeElement('#scheduleOptions');
 
         // Assert publish up/down datetime fields exist
@@ -52,12 +52,12 @@ final class EmailScheduleCest
         $I->click(EmailsPage::NEW_BUTTON);
 
         // Wait for email type modal
-        $I->waitForElementVisible(EmailsPage::EMAIL_TYPE_MODAL, 10);
+        $I->waitForElementVisible(EmailsPage::EMAIL_TYPE_MODAL, AcceptanceTester::TIMEOUT);
 
         // Click "Segment email"
         $I->waitForElementClickable(EmailsPage::SELECT_SEGMENT_EMAIL);
         $I->click(EmailsPage::SELECT_SEGMENT_EMAIL);
-        $I->waitForElementNotVisible(EmailsPage::EMAIL_TYPE_MODAL, 10);
+        $I->waitForElementNotVisible(EmailsPage::EMAIL_TYPE_MODAL, AcceptanceTester::TIMEOUT);
 
         // Schedule options should exist in DOM but be hidden (class "hide")
         $I->seeElementInDOM('#scheduleOptions');
@@ -75,17 +75,17 @@ final class EmailScheduleCest
         $email->createTriggeredEmail($name);
 
         // Wait for redirect to email detail page
-        $I->waitForText($name, 10, 'h1.page-header-title');
+        $I->waitForText($name, AcceptanceTester::TIMEOUT, 'h1.page-header-title');
 
         // Assert the header contains the created email name
         $I->see($name, 'h1.page-header-title');
 
         // Click on Edit button
-        $I->waitForElementClickable(EmailsPage::EDIT_BUTTON, 10);
+        $I->waitForElementClickable(EmailsPage::EDIT_BUTTON, AcceptanceTester::TIMEOUT);
         $I->click(EmailsPage::EDIT_BUTTON);
 
         // Assert schedule container is visible
-        $I->waitForElementVisible('#scheduleOptions', 10);
+        $I->waitForElementVisible('#scheduleOptions', AcceptanceTester::TIMEOUT);
         $I->seeElement('#scheduleOptions');
 
         // Assert publish up/down datetime fields exist
@@ -107,17 +107,17 @@ final class EmailScheduleCest
         $email->createSegmentEmail($segmentEmailName);
 
         // Wait for redirect to email detail page
-        $I->waitForText($segmentEmailName, 10, 'h1.page-header-title');
+        $I->waitForText($segmentEmailName, AcceptanceTester::TIMEOUT, 'h1.page-header-title');
 
         // Assert the header contains the created email name
         $I->see($segmentEmailName, 'h1.page-header-title');
 
         // Click on Edit button
-        $I->waitForElementClickable(EmailsPage::EDIT_BUTTON, 10);
+        $I->waitForElementClickable(EmailsPage::EDIT_BUTTON, AcceptanceTester::TIMEOUT);
         $I->click(EmailsPage::EDIT_BUTTON);
 
         // Assert schedule container is visible
-        $I->waitForElementVisible('#scheduleOptions', 10);
+        $I->waitForElementVisible('#scheduleOptions', AcceptanceTester::TIMEOUT);
         $I->seeElement('#scheduleOptions');
 
         // Assert publish up/down datetime fields does not exist
@@ -152,11 +152,11 @@ final class EmailScheduleCest
         $email->createSegmentEmail($segmentEmailName);
 
         // Confirm we're on the email view page for the created email
-        $I->waitForText($segmentEmailName, 10, 'h1.page-header-title');
+        $I->waitForText($segmentEmailName, AcceptanceTester::TIMEOUT, 'h1.page-header-title');
         $I->see($segmentEmailName, 'h1.page-header-title');
 
         // Assert Schedule button exists on view page
-        $I->waitForElementVisible(EmailsPage::SCHEDULE_BUTTON, 10);
+        $I->waitForElementVisible(EmailsPage::SCHEDULE_BUTTON, AcceptanceTester::TIMEOUT);
         $I->seeElement(EmailsPage::SCHEDULE_BUTTON);
 
         // Verify it links to scheduleSend/<id>

--- a/tests/acceptance/FormActionSendToUserCest.php
+++ b/tests/acceptance/FormActionSendToUserCest.php
@@ -23,7 +23,7 @@ class FormActionSendToUserCest
 
         // Add First Name field
         $I->click('Fields');
-        $I->waitForText('Add a new field', 3);
+        $I->waitForText('Add a new field', AcceptanceTester::TIMEOUT);
 
         // Add First Name field
         $form->createFormField(FormPage::$FORM_FIELD_TEXT_SHORT_ANSWER_SELECTOR, 'Text: Short answer', 'First Name');
@@ -34,10 +34,10 @@ class FormActionSendToUserCest
         // Add "Send form results" action
         $I->click('Actions');
 
-        $I->waitForText('Add a new submit action', 3);
+        $I->waitForText('Add a new submit action', AcceptanceTester::TIMEOUT);
         $I->click('Add a new submit action');
         $I->click('//li[contains(text(), "Send form results")]');
-        $I->waitForText('Send form results', 2);
+        $I->waitForText('Send form results', AcceptanceTester::TIMEOUT);
 
         // Assert token insertion
         $message = $I->grabValueFrom('#formaction_properties_message');
@@ -53,8 +53,8 @@ class FormActionSendToUserCest
         $I->assertEquals(1, substr_count($message, '<strong>Email Address</strong>: {formfield=email_address}'));
 
         // Save the action
-        $I->waitForElement(FormPage::$actionModalSaveButton, 10);
+        $I->waitForElement(FormPage::$actionModalSaveButton, AcceptanceTester::TIMEOUT);
         $I->executeJS('document.querySelector(\'button[name="formaction[buttons][save]"]\').click();');
-        $I->waitForElementNotVisible(FormPage::$actionModalSelector, 10);
+        $I->waitForElementNotVisible(FormPage::$actionModalSelector, AcceptanceTester::TIMEOUT);
     }
 }

--- a/tests/acceptance/ThemeManagementCest.php
+++ b/tests/acceptance/ThemeManagementCest.php
@@ -11,16 +11,16 @@ class ThemeManagementCest
         $I->login('admin', 'Maut1cR0cks!');
 
         $I->click(ThemesPage::$dropDown); // gear icon
-        $I->waitForElementVisible(ThemesPage::$dropDown_Themes, 30);
+        $I->waitForElementVisible(ThemesPage::$dropDown_Themes, \AcceptanceTester::TIMEOUT);
 
         $I->click(ThemesPage::$dropDown_Themes);
-        $I->waitForText('Themes', 30); // let the page render
+        $I->waitForText('Themes', \AcceptanceTester::TIMEOUT); // let the page render
     }
 
     public function themesHaveNoBlankActions(\AcceptanceTester $I): void
     {
         $I->amOnPage(ThemesPage::$URL);
-        $I->waitForElementVisible(ThemesPage::$themeTable, 30);
+        $I->waitForElementVisible(ThemesPage::$themeTable, \AcceptanceTester::TIMEOUT);
 
         $rows = $I->grabMultiple(ThemesPage::$themeRows);
         for ($i = 1; $i <= count($rows); ++$i) {


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️❌
| Deprecations?                          | ✔️❌
| BC breaks? (use the c.x branch)        | ✔️❌
| Automated tests included?              | ✔️❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

By default, the `.env.local` file contains `APP_ENV=dev`, which causes most E2E tests to fail when run locally. Although the `ddev composer e2e-test` command sets `APP_ENV=test`, the E2E tests are still executed in the `dev` environment.

This PR introduces an `EnvHelper` that temporarily changes `APP_ENV` from `dev` to `test` in the `.env.local` file before running the E2E tests, then restores the original value once the tests have finished.

This PR also adds the `tests` folder to PHP CS Fixer, so code style issues in that folder are checked and fixed as well.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run the E2E tests by executing `ddev composer e2e-test` and verify that they complete successfully. Also, confirm that the `.env.local` file is restored after the tests finish.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->