### PR TITLE
[solid] finalize event subscribers

### DIFF
--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -12,11 +12,11 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ApiSubscriber implements EventSubscriberInterface
+final readonly class ApiSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly Translator $translator,
+        private CoreParametersHelper $coreParametersHelper,
+        private Translator $translator,
     ) {
     }
 

--- a/app/bundles/ApiBundle/EventListener/ClientSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ClientSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ClientSubscriber implements EventSubscriberInterface
+final readonly class ClientSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/ApiBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ConfigSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\ConfigBundle\Event\ConfigEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\GlobalSearch;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ClientModel $apiClientModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private ClientModel $apiClientModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/AssetSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/AssetSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class AssetSubscriber implements EventSubscriberInterface
+final readonly class AssetSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -14,7 +14,7 @@ use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class BuilderSubscriber implements EventSubscriberInterface
+final class BuilderSubscriber implements EventSubscriberInterface
 {
     private string $assetToken = '{assetlink=(.*?)}';
 

--- a/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/CampaignSubscriber.php
@@ -12,10 +12,10 @@ use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
 use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RealTimeExecutioner $realTimeExecutioner,
+        private RealTimeExecutioner $realTimeExecutioner,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ConfigSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\ConfigEvents;
 use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\DashboardBundle\Event\WidgetDetailEvent;
 use Mautic\DashboardBundle\EventListener\DashboardSubscriber as MainDashboardSubscriber;
 use Symfony\Component\Routing\RouterInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
@@ -10,11 +10,11 @@ use Mautic\EmailBundle\Entity\Email;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DetermineWinnerSubscriber implements EventSubscriberInterface
+final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly TranslatorInterface $translator,
+        private EntityManagerInterface $em,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/EmailSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EmailSubscriber implements EventSubscriberInterface
+final class EmailSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -19,15 +19,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetModel $assetModel,
-        protected TranslatorInterface $translator,
-        private readonly AnalyticsHelper $analyticsHelper,
-        private readonly AssetsHelper $assetsHelper,
-        private readonly ThemeHelperInterface $themeHelper,
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private AssetModel $assetModel,
+        private TranslatorInterface $translator,
+        private AnalyticsHelper $analyticsHelper,
+        private AssetsHelper $assetsHelper,
+        private ThemeHelperInterface $themeHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -12,13 +12,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetModel $assetModel,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly DownloadRepository $downloadRepository,
+        private AssetModel $assetModel,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private DownloadRepository $downloadRepository,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/PageSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\PageBundle\Event\PageBuilderEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PageSubscriber implements EventSubscriberInterface
+final class PageSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/AssetBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/PointSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PointModel $pointModel,
+        private PointModel $pointModel,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -13,16 +13,16 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_ASSET          = 'assets';
 
     public const CONTEXT_ASSET_DOWNLOAD = 'asset.downloads';
 
     public function __construct(
-        private readonly CompanyReportData $companyReportData,
-        private readonly DownloadRepository $downloadRepository,
-        private readonly DncReportService $dncReportService,
+        private CompanyReportData $companyReportData,
+        private DownloadRepository $downloadRepository,
+        private DncReportService $dncReportService,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\GlobalSearch;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetModel $assetModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private AssetModel $assetModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/AssetBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\AssetBundle\Entity\Download;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/AssetBundle/EventListener/UploadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/UploadSubscriber.php
@@ -13,12 +13,12 @@ use Oneup\UploaderBundle\UploadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class UploadSubscriber implements EventSubscriberInterface
+final readonly class UploadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly AssetModel $assetModel,
-        private readonly FileUploadValidator $fileUploadValidator,
+        private CoreParametersHelper $coreParametersHelper,
+        private AssetModel $assetModel,
+        private FileUploadValidator $fileUploadValidator,
     ) {
     }
 

--- a/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
+++ b/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
@@ -9,14 +9,14 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
-class CacheClearSubscriber implements CacheClearerInterface
+final readonly class CacheClearSubscriber implements CacheClearerInterface
 {
     /**
      * @param CacheProvider $cacheProvider
      */
     public function __construct(
-        private readonly AdapterInterface $cacheProvider,
-        private readonly LoggerInterface $logger,
+        private AdapterInterface $cacheProvider,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
@@ -14,12 +14,12 @@ use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Event\EntityValidateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterface
+final readonly class CampaignActionChangeMembershipSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly MembershipManager $membershipManager,
-        private readonly CampaignModel $campaignModel,
-        private readonly InfiniteLoopValidator $infiniteLoopValidator,
+        private MembershipManager $membershipManager,
+        private CampaignModel $campaignModel,
+        private InfiniteLoopValidator $infiniteLoopValidator,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionJumpToEventSubscriber.php
@@ -15,16 +15,16 @@ use Mautic\CampaignBundle\Form\Type\CampaignEventJumpToEventType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
+final readonly class CampaignActionJumpToEventSubscriber implements EventSubscriberInterface
 {
     public const EVENT_NAME = 'campaign.jump_to_event';
 
     public function __construct(
-        private readonly EventRepository $eventRepository,
-        private readonly EventExecutioner $eventExecutioner,
-        private readonly TranslatorInterface $translator,
-        private readonly LeadRepository $leadRepository,
-        private readonly EventScheduler $eventScheduler,
+        private EventRepository $eventRepository,
+        private EventExecutioner $eventExecutioner,
+        private TranslatorInterface $translator,
+        private LeadRepository $leadRepository,
+        private EventScheduler $eventScheduler,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventDeleteSubscriber.php
@@ -13,13 +13,13 @@ use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Model\EventModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignEventDeleteSubscriber implements EventSubscriberInterface
+final readonly class CampaignEventDeleteSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadEventLogRepository $leadEventLogRepository,
-        private readonly CampaignConfig $campaignConfig,
-        private readonly CampaignModel $campaignModel,
-        private readonly EventModel $eventModel,
+        private LeadEventLogRepository $leadEventLogRepository,
+        private CampaignConfig $campaignConfig,
+        private CampaignModel $campaignModel,
+        private EventModel $eventModel,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventSubscriber.php
@@ -23,7 +23,7 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignEventSubscriber implements EventSubscriberInterface
+final readonly class CampaignEventSubscriber implements EventSubscriberInterface
 {
     public const LOOPS_TO_FAIL = 100;
 
@@ -32,11 +32,11 @@ class CampaignEventSubscriber implements EventSubscriberInterface
     private const DISABLE_CAMPAIGN_THRESHOLD   = 0.35;
 
     public function __construct(
-        private readonly EventRepository $eventRepository,
-        private readonly CampaignModel $campaignModel,
-        private readonly LeadEventLogRepository $leadEventLogRepository,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly DateHelper $dateHelper,
+        private EventRepository $eventRepository,
+        private CampaignModel $campaignModel,
+        private LeadEventLogRepository $leadEventLogRepository,
+        private EventDispatcherInterface $eventDispatcher,
+        private DateHelper $dateHelper,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignSubscriber.php
@@ -9,12 +9,12 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly CampaignAuditService $campaignAuditService,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private CampaignAuditService $campaignAuditService,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ConfigSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\ConfigBundle\Event\ConfigEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/CampaignBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/DashboardSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\DashboardBundle\Event\WidgetDetailEvent;
 use Mautic\DashboardBundle\EventListener\DashboardSubscriber as MainDashboardSubscriber;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -18,14 +18,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EventCollector $eventCollector,
-        private readonly TranslatorInterface $translator,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly RouterInterface $router,
-        private readonly EventRepository $eventRepository,
+        private EventCollector $eventCollector,
+        private TranslatorInterface $translator,
+        private EntityManagerInterface $entityManager,
+        private RouterInterface $router,
+        private EventRepository $eventRepository,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/NotifyOfFailureSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/NotifyOfFailureSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\CampaignBundle\Event\NotifyOfFailureEvent;
 use Mautic\CampaignBundle\Executioner\Helper\NotificationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class NotifyOfFailureSubscriber implements EventSubscriberInterface
+final readonly class NotifyOfFailureSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationHelper $notificationHelper,
+        private NotificationHelper $notificationHelper,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/NotifyOfUnpublishSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/NotifyOfUnpublishSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\CampaignBundle\Event\NotifyOfUnpublishEvent;
 use Mautic\CampaignBundle\Executioner\Helper\NotificationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class NotifyOfUnpublishSubscriber implements EventSubscriberInterface
+final readonly class NotifyOfUnpublishSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationHelper $notificationHelper,
+        private NotificationHelper $notificationHelper,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/PointSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\PointBundle\Event\TriggerBuilderEvent;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final class PointSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
@@ -12,13 +12,13 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_CAMPAIGN_LEAD_EVENT_LOG = 'campaign_lead_event_log';
 
     public function __construct(
-        private readonly CompanyReportData $companyReportData,
-        private readonly DncReportService $dncReportService,
+        private CompanyReportData $companyReportData,
+        private DncReportService $dncReportService,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\GlobalSearch;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CampaignModel $campaignModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private CampaignModel $campaignModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/StatsSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/CategoryBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/CategoryBundle/EventListener/ButtonSubscriber.php
@@ -9,11 +9,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ButtonSubscriber implements EventSubscriberInterface
+final readonly class ButtonSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RouterInterface $router,
-        private readonly TranslatorInterface $translator,
+        private RouterInterface $router,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/CategoryBundle/EventListener/CategorySubscriber.php
+++ b/app/bundles/CategoryBundle/EventListener/CategorySubscriber.php
@@ -13,14 +13,14 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CategorySubscriber implements EventSubscriberInterface
+final readonly class CategorySubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly BundleHelper $bundleHelper,
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly CategoryModel $categoryModel,
-        private readonly TranslatorInterface $translator,
+        private BundleHelper $bundleHelper,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private CategoryModel $categoryModel,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ButtonSubscriber.php
@@ -9,11 +9,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ButtonSubscriber implements EventSubscriberInterface
+final readonly class ButtonSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RouterInterface $router,
-        private readonly TranslatorInterface $translator,
+        private RouterInterface $router,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
@@ -22,7 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final class CampaignSubscriber implements EventSubscriberInterface
 {
     private ?Event $pseudoEvent = null;
 

--- a/app/bundles/ChannelBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/LeadSubscriber.php
@@ -9,12 +9,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly MessageQueueRepository $messageQueueRepository,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private MessageQueueRepository $messageQueueRepository,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/EventListener/MessageSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/MessageSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\ChannelBundle\Event\MessageEvent;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class MessageSubscriber implements EventSubscriberInterface
+final readonly class MessageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AuditLogModel $auditLogModel,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
@@ -10,13 +10,13 @@ use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_MESSAGE_CHANNEL = 'message.channel';
 
     public function __construct(
-        private readonly CompanyReportData $companyReportData,
-        private readonly RouterInterface $router,
+        private CompanyReportData $companyReportData,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Service\GlobalSearch;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly MessageModel $model,
-        private readonly GlobalSearch $globalSearch,
+        private MessageModel $model,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ConfigBundle/EventListener/ConfigSubscriber.php
@@ -10,13 +10,13 @@ use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final readonly class ConfigSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ConfigChangeLogger $configChangeLogger,
-        private readonly IpAddressRepository $ipAddressRepository,
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly AuditLogRepository $auditLogRepository,
+        private ConfigChangeLogger $configChangeLogger,
+        private IpAddressRepository $ipAddressRepository,
+        private CoreParametersHelper $coreParametersHelper,
+        private AuditLogRepository $auditLogRepository,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
@@ -10,11 +10,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class AssetsSubscriber implements EventSubscriberInterface
+final readonly class AssetsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetsHelper $assetsHelper,
-        private readonly EventDispatcherInterface $dispatcher,
+        private AssetsHelper $assetsHelper,
+        private EventDispatcherInterface $dispatcher,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class BuildJsSubscriber implements EventSubscriberInterface
+final class BuildJsSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/CoreBundle/EventListener/CacheInvalidateSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CacheInvalidateSubscriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 #[AsDoctrineListener(Events::postPersist)]
 #[AsDoctrineListener(Events::postUpdate)]
 #[AsDoctrineListener(Events::postRemove)]
-class CacheInvalidateSubscriber
+final readonly class CacheInvalidateSubscriber
 {
     private const ACTION_PERSIST = 'persist';
 
@@ -26,7 +26,7 @@ class CacheInvalidateSubscriber
 
     public function __construct(
         #[Autowire(service: 'doctrine.orm.default_configuration')]
-        private readonly Configuration $ormConfiguration,
+        private Configuration $ormConfiguration,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/ConfigSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\CoreBundle\Form\Type\ConfigType;
 use Mautic\CoreBundle\Helper\LanguageHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final readonly class ConfigSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LanguageHelper $languageHelper,
+        private LanguageHelper $languageHelper,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/ConfigThemeSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/ConfigThemeSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\CoreBundle\Form\Type\ConfigThemeType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigThemeSubscriber implements EventSubscriberInterface
+final class ConfigThemeSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -23,17 +23,17 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
-class CoreSubscriber implements EventSubscriberInterface
+final readonly class CoreSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly BundleHelper $bundleHelper,
-        private readonly MenuHelper $menuHelper,
-        private readonly UserHelper $userHelper,
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly AuthorizationCheckerInterface $securityContext,
-        private readonly UserModel $userModel,
-        private readonly EventDispatcherInterface $dispatcher,
-        private readonly RequestStack $requestStack,
+        private BundleHelper $bundleHelper,
+        private MenuHelper $menuHelper,
+        private UserHelper $userHelper,
+        private CoreParametersHelper $coreParametersHelper,
+        private AuthorizationCheckerInterface $securityContext,
+        private UserModel $userModel,
+        private EventDispatcherInterface $dispatcher,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     public const TYPE_RECENT_ACTIVITY = 'recent.activity';
 

--- a/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsDoctrineListener(Events::loadClassMetadata)]
 #[AsDoctrineListener(ToolEvents::postGenerateSchema)]
-class DoctrineEventsSubscriber
+final class DoctrineEventsSubscriber
 {
     private array $deprecatedEntityTables = [];
 

--- a/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
@@ -9,12 +9,12 @@ use Mautic\CoreBundle\Event\CustomAssetsEvent;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EditorFontsSubscriber implements EventSubscriberInterface
+final readonly class EditorFontsSubscriber implements EventSubscriberInterface
 {
     public const PARAMETER_EDITOR_FONTS = 'editor_fonts';
 
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/EnvironmentSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/EnvironmentSubscriber.php
@@ -7,10 +7,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class EnvironmentSubscriber implements EventSubscriberInterface
+final readonly class EnvironmentSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MaintenanceSubscriber.php
@@ -10,12 +10,12 @@ use Mautic\UserBundle\Entity\UserTokenRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class MaintenanceSubscriber implements EventSubscriberInterface
+final readonly class MaintenanceSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Connection $db,
-        private readonly UserTokenRepositoryInterface $userTokenRepository,
-        private readonly TranslatorInterface $translator,
+        private Connection $db,
+        private UserTokenRepositoryInterface $userTokenRepository,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -15,12 +15,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-class MigrationCommandSubscriber implements EventSubscriberInterface
+final readonly class MigrationCommandSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly VersionProviderInterface $versionProvider,
-        private readonly GeneratedColumnsProviderInterface $generatedColumnsProvider,
-        private readonly Connection $connection,
+        private VersionProviderInterface $versionProvider,
+        private GeneratedColumnsProviderInterface $generatedColumnsProvider,
+        private Connection $connection,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/OptimisticLockSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\CoreBundle\Entity\OptimisticLockInterface;
 use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
 
 #[AsDoctrineListener(Events::postUpdate)]
-class OptimisticLockSubscriber
+final readonly class OptimisticLockSubscriber
 {
     public function __construct(
-        private readonly OptimisticLockServiceInterface $optimisticLockService,
+        private OptimisticLockServiceInterface $optimisticLockService,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/ReportSubscriber.php
@@ -13,12 +13,12 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_AUDIT_LOG = 'audit.log';
 
     public function __construct(
-        private readonly CorePermissions $security,
+        private CorePermissions $security,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RequestSubscriber.php
@@ -13,12 +13,12 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
-class RequestSubscriber implements EventSubscriberInterface
+final readonly class RequestSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CsrfTokenManagerInterface $tokenManager,
-        private readonly TranslatorInterface $translator,
-        private readonly Environment $twig,
+        private CsrfTokenManagerInterface $tokenManager,
+        private TranslatorInterface $translator,
+        private Environment $twig,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 
-class RouterSubscriber implements EventSubscriberInterface
+final class RouterSubscriber implements EventSubscriberInterface
 {
     private readonly string|int $httpsPort;
 

--- a/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormEvents;
 /**
  * Clean data before persisting to DB.
  */
-class CleanFormSubscriber implements EventSubscriberInterface
+final class CleanFormSubscriber implements EventSubscriberInterface
 {
     /**
      * @param string|mixed[] $masks

--- a/app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/FormExitSubscriber.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
-class FormExitSubscriber implements EventSubscriberInterface
+final class FormExitSubscriber implements EventSubscriberInterface
 {
     /**
      * @param string $model

--- a/app/bundles/CoreBundle/Test/Extensions/DbPrefix/Subscriber/ExecutionStartedSubscriber.php
+++ b/app/bundles/CoreBundle/Test/Extensions/DbPrefix/Subscriber/ExecutionStartedSubscriber.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\Test\Extensions\DbPrefix\Subscriber;
 
 use PHPUnit\Event\TestRunner\ExecutionStarted;
 
-class ExecutionStartedSubscriber extends Subscriber implements \PHPUnit\Event\TestRunner\ExecutionStartedSubscriber
+final class ExecutionStartedSubscriber extends Subscriber implements \PHPUnit\Event\TestRunner\ExecutionStartedSubscriber
 {
     public function notify(ExecutionStarted $event): void
     {

--- a/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
@@ -11,13 +11,13 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class BuildJsSubscriber implements EventSubscriberInterface
+final readonly class BuildJsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetsHelper $assetsHelper,
-        private readonly TranslatorInterface $translator,
-        private readonly RequestStack $requestStack,
-        private readonly RouterInterface $router,
+        private AssetsHelper $assetsHelper,
+        private TranslatorInterface $translator,
+        private RequestStack $requestStack,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
@@ -16,12 +16,12 @@ use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly DynamicContentModel $dynamicContentModel,
-        protected CacheProvider $cache,
-        private readonly EventDispatcherInterface $dispatcher,
+        private DynamicContentModel $dynamicContentModel,
+        private CacheProvider $cache,
+        private EventDispatcherInterface $dispatcher,
     ) {
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/ChannelSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ReportBundle\Model\ReportModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ChannelSubscriber implements EventSubscriberInterface
+final class ChannelSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -10,12 +10,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly StatRepository $statRepository,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private StatRepository $statRepository,
     ) {
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly DynamicContentModel $dynamicContentModel,
-        private readonly GlobalSearch $globalSearch,
+        private DynamicContentModel $dynamicContentModel,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/StatsSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\DynamicContentBundle\Entity\DynamicContentLeadData;
 use Mautic\DynamicContentBundle\Entity\Stat;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -11,12 +11,12 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class BroadcastSubscriber implements EventSubscriberInterface
+final readonly class BroadcastSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $model,
-        private readonly EntityManager $em,
-        private readonly TranslatorInterface $translator,
+        private EmailModel $model,
+        private EntityManager $em,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BuilderSubscriber.php
@@ -20,7 +20,7 @@ use Mautic\PageBundle\Model\TrackableModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class BuilderSubscriber implements EventSubscriberInterface
+final class BuilderSubscriber implements EventSubscriberInterface
 {
     /**
      * @var array<string, array{array{string, string}, Trackable[]|Redirect[]}>

--- a/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignConditionSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\EmailBundle\Helper\EmailValidator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
-class CampaignConditionSubscriber implements EventSubscriberInterface
+final readonly class CampaignConditionSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailValidator $validator,
+        private EmailValidator $validator,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -34,15 +34,15 @@ use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
-        private readonly RealTimeExecutioner $realTimeExecutioner,
-        private readonly SendEmailToUser $sendEmailToUser,
-        private readonly TranslatorInterface $translator,
-        private readonly LeadModel $leadModel,
-        private readonly StatRepository $statRepository,
+        private EmailModel $emailModel,
+        private RealTimeExecutioner $realTimeExecutioner,
+        private SendEmailToUser $sendEmailToUser,
+        private TranslatorInterface $translator,
+        private LeadModel $leadModel,
+        private StatRepository $statRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
@@ -17,7 +17,7 @@ const CHANNEL_COLUMN_DATE_ADDED      = 'date_added';
 const CHANNEL_COLUMN_CREATED_BY      = 'created_by';
 const CHANNEL_COLUMN_CREATED_BY_USER = 'created_by_user';
 
-class ChannelSubscriber implements EventSubscriberInterface
+final class ChannelSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ConfigSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final readonly class ConfigSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/DashboardBestHoursSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardBestHoursSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\DashboardBundle\EventListener\DashboardSubscriber as MainDashboardSub
 use Mautic\EmailBundle\Form\Type\DashboardBestHoursWidgetType;
 use Mautic\EmailBundle\Model\EmailModel;
 
-class DashboardBestHoursSubscriber extends MainDashboardSubscriber
+final class DashboardBestHoursSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
@@ -12,7 +12,7 @@ use Mautic\EmailBundle\Form\Type\DashboardSentEmailToContactsWidgetType;
 use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\Routing\RouterInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/EmailBundle/EventListener/DateTimeTokenSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DateTimeTokenSubscriber.php
@@ -9,11 +9,11 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DateTimeTokenSubscriber implements EventSubscriberInterface
+final readonly class DateTimeTokenSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly DateTimeToken $dateTokenHelper,
+        private TranslatorInterface $translator,
+        private DateTimeToken $dateTokenHelper,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\PageBundle\Entity\Hit;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DetermineWinnerSubscriber implements EventSubscriberInterface
+final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
-        private readonly TranslatorInterface $translator,
+        private EntityManagerInterface $em,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class EmailSubscriber implements EventSubscriberInterface
+final readonly class EmailSubscriber implements EventSubscriberInterface
 {
     public const PREHEADER_HTML_ELEMENT_BEFORE  = '<div class="preheader" style="font-size:1px;line-height:1px;display:none;color:#fff;max-height:0;max-width:0;opacity:0;overflow:hidden">';
 
@@ -30,12 +30,12 @@ class EmailSubscriber implements EventSubscriberInterface
     private const RETRY_COUNT = 3;
 
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly EmailModel $emailModel,
-        private readonly TranslatorInterface $translator,
-        private readonly EntityManagerInterface $entityManager,
-        private readonly EmailDraftModel $emailDraftModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private EmailModel $emailModel,
+        private TranslatorInterface $translator,
+        private EntityManagerInterface $entityManager,
+        private EmailDraftModel $emailDraftModel,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/EmailToUserSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailToUserSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\EmailBundle\Model\SendEmailToUser;
 use Mautic\PointBundle\Event\TriggerExecutedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EmailToUserSubscriber implements EventSubscriberInterface
+final readonly class EmailToUserSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SendEmailToUser $sendEmailToUser,
+        private SendEmailToUser $sendEmailToUser,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/FormSubscriber.php
@@ -13,11 +13,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
-        private readonly ContactTracker $contactTracker,
+        private EmailModel $emailModel,
+        private ContactTracker $contactTracker,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class GeneratedColumnSubscriber implements EventSubscriberInterface
+final class GeneratedColumnSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/EmailBundle/EventListener/GraphAggregateStatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/GraphAggregateStatsSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\StatsBundle\Event\AggregateStatRequestEvent;
 use Mautic\StatsBundle\StatEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class GraphAggregateStatsSubscriber implements EventSubscriberInterface
+final readonly class GraphAggregateStatsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly StatsCollectionHelper $statsCollectionHelper,
+        private StatsCollectionHelper $statsCollectionHelper,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -11,13 +11,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailReplyRepository $emailReplyRepository,
-        private readonly StatRepository $statRepository,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
+        private EmailReplyRepository $emailReplyRepository,
+        private StatRepository $statRepository,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class MessageQueueSubscriber implements EventSubscriberInterface
+final readonly class MessageQueueSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
+        private EmailModel $emailModel,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PageSubscriber.php
@@ -9,12 +9,12 @@ use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class PageSubscriber implements EventSubscriberInterface
+final readonly class PageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
-        private readonly RealTimeExecutioner $realTimeExecutioner,
-        private readonly RequestStack $requestStack,
+        private EmailModel $emailModel,
+        private RealTimeExecutioner $realTimeExecutioner,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -18,12 +18,12 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PointModel $pointModel,
-        private readonly EntityManager $entityManager,
-        private readonly PointEventHelper $pointEventHelper,
+        private PointModel $pointModel,
+        private EntityManager $entityManager,
+        private PointEventHelper $pointEventHelper,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/ProcessBounceSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessBounceSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\EmailBundle\Event\ParseEmailEvent;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ProcessBounceSubscriber implements EventSubscriberInterface
+final readonly class ProcessBounceSubscriber implements EventSubscriberInterface
 {
     public const BUNDLE     = 'EmailBundle';
 
@@ -23,7 +23,7 @@ class ProcessBounceSubscriber implements EventSubscriberInterface
     }
 
     public function __construct(
-        private readonly Bounce $bouncer,
+        private Bounce $bouncer,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/ProcessReplySubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessReplySubscriber.php
@@ -10,7 +10,7 @@ use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ProcessReplySubscriber implements EventSubscriberInterface
+final readonly class ProcessReplySubscriber implements EventSubscriberInterface
 {
     public const BUNDLE     = 'EmailBundle';
 
@@ -28,8 +28,8 @@ class ProcessReplySubscriber implements EventSubscriberInterface
     }
 
     public function __construct(
-        private readonly Reply $replier,
-        private readonly CacheStorageHelper $cache,
+        private Reply $replier,
+        private CacheStorageHelper $cache,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ProcessUnsubscribeSubscriber.php
@@ -11,7 +11,7 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\FeedbackLoop;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
+final readonly class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
 {
     public const BUNDLE     = 'EmailBundle';
 
@@ -27,9 +27,9 @@ class ProcessUnsubscribeSubscriber implements EventSubscriberInterface
     }
 
     public function __construct(
-        private readonly Unsubscribe $unsubscriber,
-        private readonly FeedbackLoop $looper,
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private Unsubscribe $unsubscriber,
+        private FeedbackLoop $looper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -24,7 +24,7 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_EMAILS       = 'emails';
 
@@ -164,13 +164,13 @@ class ReportSubscriber implements EventSubscriberInterface
     ];
 
     public function __construct(
-        private readonly Connection $db,
-        private readonly CompanyReportData $companyReportData,
-        private readonly StatRepository $statRepository,
-        private readonly EmailRepository $emailRepository,
-        private readonly GeneratedColumnsProviderInterface $generatedColumnsProvider,
-        private readonly FieldsBuilder $fieldsBuilder,
-        private readonly DncReportService $dncReportService,
+        private Connection $db,
+        private CompanyReportData $companyReportData,
+        private StatRepository $statRepository,
+        private EmailRepository $emailRepository,
+        private GeneratedColumnsProviderInterface $generatedColumnsProvider,
+        private FieldsBuilder $fieldsBuilder,
+        private DncReportService $dncReportService,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private EmailModel $emailModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
@@ -11,7 +11,7 @@ use Mautic\EmailBundle\Entity\StatDevice;
 use Mautic\EmailBundle\Entity\StatDeviceRepository;
 use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/TrackingSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\LeadBundle\Event\ContactIdentificationEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TrackingSubscriber implements EventSubscriberInterface
+final readonly class TrackingSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly StatRepository $statRepository,
+        private StatRepository $statRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/WebhookSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class WebhookSubscriber implements EventSubscriberInterface
+final readonly class WebhookSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebhookModel $webhookModel,
-        private readonly bool $includeDetails,
+        private WebhookModel $webhookModel,
+        private bool $includeDetails,
     ) {
     }
 

--- a/app/bundles/EmailBundle/Tests/Helper/EventListener/EmailValidationSubscriber.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EventListener/EmailValidationSubscriber.php
@@ -6,7 +6,7 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailValidationEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EmailValidationSubscriber implements EventSubscriberInterface
+final class EmailValidationSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -17,13 +17,13 @@ use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FormModel $formModel,
-        private readonly SubmissionModel $formSubmissionModel,
-        private readonly RealTimeExecutioner $realTimeExecutioner,
-        private readonly FormFieldHelper $formFieldHelper,
+        private FormModel $formModel,
+        private SubmissionModel $formSubmissionModel,
+        private RealTimeExecutioner $realTimeExecutioner,
+        private FormFieldHelper $formFieldHelper,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ConfigSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\FormBundle\Form\Type\ConfigFormType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Symfony\Component\Routing\RouterInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/FormBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/DetermineWinnerSubscriber.php
@@ -9,11 +9,11 @@ use Mautic\FormBundle\FormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DetermineWinnerSubscriber implements EventSubscriberInterface
+final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SubmissionRepository $submissionRepository,
-        private readonly TranslatorInterface $translator,
+        private SubmissionRepository $submissionRepository,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/EmailSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\EmailBundle\Event\EmailBuilderEvent;
 use Mautic\FormBundle\FormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EmailSubscriber implements EventSubscriberInterface
+final class EmailSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -23,17 +23,17 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
-    private readonly MailHelper $mailer;
+    private MailHelper $mailer;
 
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
         MailHelper $mailer,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly LanguageHelper $languageHelper,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private LanguageHelper $languageHelper,
     ) {
         $this->mailer = $mailer->getMailer();
     }

--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -13,11 +13,11 @@ use Mautic\FormBundle\FormEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class FormValidationSubscriber implements EventSubscriberInterface
+final readonly class FormValidationSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private TranslatorInterface $translator,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -12,14 +12,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FormModel $formModel,
-        private readonly PageModel $pageModel,
-        private readonly SubmissionRepository $submissionRepository,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
+        private FormModel $formModel,
+        private PageModel $pageModel,
+        private SubmissionRepository $submissionRepository,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -13,7 +13,7 @@ use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class PageSubscriber implements EventSubscriberInterface
+final class PageSubscriber implements EventSubscriberInterface
 {
     private string $formRegex = '{form=(.*?)}';
 

--- a/app/bundles/FormBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PointSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PointModel $pointModel,
+        private PointModel $pointModel,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -18,7 +18,7 @@ use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_FORMS           = 'forms';
 
@@ -27,13 +27,13 @@ class ReportSubscriber implements EventSubscriberInterface
     public const CONTEXT_FORM_RESULT     = 'form.results';
 
     public function __construct(
-        private readonly CompanyReportData $companyReportData,
-        private readonly SubmissionRepository $submissionRepository,
-        private readonly FormModel $formModel,
-        private readonly ReportHelper $reportHelper,
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly TranslatorInterface $translator,
-        private readonly DncReportService $dncReportService,
+        private CompanyReportData $companyReportData,
+        private SubmissionRepository $submissionRepository,
+        private FormModel $formModel,
+        private ReportHelper $reportHelper,
+        private CoreParametersHelper $coreParametersHelper,
+        private TranslatorInterface $translator,
+        private DncReportService $dncReportService,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FormModel $formModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private FormModel $formModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\FormBundle\Entity\Submission;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class WebhookSubscriber implements EventSubscriberInterface
+final readonly class WebhookSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebhookModel $webhookModel,
+        private WebhookModel $webhookModel,
     ) {
     }
 

--- a/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
+++ b/app/bundles/InstallBundle/EventListener/DoctrineEventSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\LeadBundle\Field\SchemaDefinition;
 use Mautic\LeadBundle\Model\FieldModel;
 
 #[AsDoctrineListener(ToolEvents::postGenerateSchema)]
-class DoctrineEventSubscriber
+final class DoctrineEventSubscriber
 {
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
     {

--- a/app/bundles/IntegrationsBundle/EventListener/CompanyObjectSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/CompanyObjectSubscriber.php
@@ -17,11 +17,11 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\Compan
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class CompanyObjectSubscriber implements EventSubscriberInterface
+final readonly class CompanyObjectSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CompanyObjectHelper $companyObjectHelper,
-        private readonly RouterInterface $router,
+        private CompanyObjectHelper $companyObjectHelper,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/ContactObjectSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/ContactObjectSubscriber.php
@@ -18,11 +18,11 @@ use Mautic\LeadBundle\Exception\ImportFailedException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ContactObjectSubscriber implements EventSubscriberInterface
+final readonly class ContactObjectSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ContactObjectHelper $contactObjectHelper,
-        private readonly RouterInterface $router,
+        private ContactObjectHelper $contactObjectHelper,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/ControllerSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/ControllerSubscriber.php
@@ -11,11 +11,11 @@ use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ControllerSubscriber implements EventSubscriberInterface
+final readonly class ControllerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationsHelper $integrationsHelper,
-        private readonly ControllerResolverInterface $resolver,
+        private IntegrationsHelper $integrationsHelper,
+        private ControllerResolverInterface $resolver,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/EmailSubscriber.php
@@ -13,23 +13,19 @@ use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use Mautic\IntegrationsBundle\Event\MappedIntegrationObjectTokenEvent;
 use Mautic\IntegrationsBundle\Helper\TokenParser;
 use Mautic\IntegrationsBundle\IntegrationEvents;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * This class subscribes to events related to building and providing
  * tokens for emails, particularly the IntegrationObjectToken.
  */
-class EmailSubscriber implements EventSubscriberInterface
+final readonly class EmailSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        protected TranslatorInterface $translator,
-        protected EventDispatcherInterface $eventDispatcher,
-        protected TokenParser $tokenParser,
-        protected ObjectMappingRepository $objectMappingRepository,
-        protected IntegrationHelper $integrationHelper,
+        private EventDispatcherInterface $eventDispatcher,
+        private TokenParser $tokenParser,
+        private ObjectMappingRepository $objectMappingRepository,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/LeadSubscriber.php
@@ -24,14 +24,14 @@ use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FieldChangeRepository $fieldChangeRepo,
-        private readonly ObjectMappingRepository $objectMappingRepository,
-        private readonly VariableExpresserHelperInterface $variableExpressor,
-        private readonly SyncIntegrationsHelper $syncIntegrationsHelper,
-        private readonly EventDispatcherInterface $dispatcher,
+        private FieldChangeRepository $fieldChangeRepo,
+        private ObjectMappingRepository $objectMappingRepository,
+        private VariableExpresserHelperInterface $variableExpressor,
+        private SyncIntegrationsHelper $syncIntegrationsHelper,
+        private EventDispatcherInterface $dispatcher,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/TimelineSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/TimelineSubscriber.php
@@ -10,11 +10,11 @@ use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class TimelineSubscriber implements EventSubscriberInterface
+final readonly class TimelineSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadEventLogRepository $eventLogRepository,
-        private readonly TranslatorInterface $translator,
+        private LeadEventLogRepository $eventLogRepository,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/UIContactIntegrationsTabSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/UIContactIntegrationsTabSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class UIContactIntegrationsTabSubscriber implements EventSubscriberInterface
+final readonly class UIContactIntegrationsTabSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ObjectMappingRepository $objectMappingRepository,
+        private ObjectMappingRepository $objectMappingRepository,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
@@ -10,12 +10,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ButtonSubscriber implements EventSubscriberInterface
+final readonly class ButtonSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly CorePermissions $security,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private CorePermissions $security,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/CampaignActionDNCSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignActionDNCSubscriber.php
@@ -13,11 +13,11 @@ use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignActionDNCSubscriber implements EventSubscriberInterface
+final readonly class CampaignActionDNCSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly DoNotContact $doNotContact,
-        private readonly LeadModel $leadModel,
+        private DoNotContact $doNotContact,
+        private LeadModel $leadModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/CampaignActionDeleteContactSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignActionDeleteContactSubscriber.php
@@ -10,11 +10,11 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignActionDeleteContactSubscriber implements EventSubscriberInterface
+final readonly class CampaignActionDeleteContactSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadModel $leadModel,
-        private readonly RemovedContactTracker $removedContactTracker,
+        private LeadModel $leadModel,
+        private RemovedContactTracker $removedContactTracker,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -49,7 +49,7 @@ use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\PointBundle\Model\PointGroupModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final class CampaignSubscriber implements EventSubscriberInterface
 {
     public const ACTION_LEAD_CHANGE_OWNER = 'lead.changeowner';
 
@@ -783,7 +783,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         );
     }
 
-    protected function getFields(Lead $lead): array
+    private function getFields(Lead $lead): array
     {
         if (!$this->fields) {
             $contactFields = $lead->getFields(true);

--- a/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
@@ -12,15 +12,15 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CompanySubscriber implements EventSubscriberInterface
+final readonly class CompanySubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly EntityManager $entityManager,
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly CompanyLeadRepository $companyLeadRepository,
-        private readonly CompanyModel $companyModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private EntityManager $entityManager,
+        private CoreParametersHelper $coreParametersHelper,
+        private CompanyLeadRepository $companyLeadRepository,
+        private CompanyModel $companyModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ConfigSubscriber.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Form\Type\ConfigType;
 use Mautic\LeadBundle\Form\Type\SegmentConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/LeadBundle/EventListener/ContactExportAuditLogSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ContactExportAuditLogSubscriber.php
@@ -10,11 +10,11 @@ use Mautic\LeadBundle\Event\ContactExportEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ContactExportAuditLogSubscriber implements EventSubscriberInterface
+final readonly class ContactExportAuditLogSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AuditLogModel $auditLogModel,
-        private readonly IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ContactExportSchedulerAuditLogSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ContactExportSchedulerAuditLogSubscriber.php
@@ -10,11 +10,11 @@ use Mautic\LeadBundle\Event\ContactExportSchedulerEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ContactExportSchedulerAuditLogSubscriber implements EventSubscriberInterface
+final readonly class ContactExportSchedulerAuditLogSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AuditLogModel $auditLogModel,
-        private readonly IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ContactExportSchedulerLoggerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ContactExportSchedulerLoggerSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\LeadBundle\LeadEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ContactExportSchedulerLoggerSubscriber implements EventSubscriberInterface
+final readonly class ContactExportSchedulerLoggerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LoggerInterface $logger,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ContactExportSchedulerNotificationSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ContactExportSchedulerNotificationSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ContactExportSchedulerNotificationSubscriber implements EventSubscriberInterface
+final readonly class ContactExportSchedulerNotificationSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationModel $notificationModel,
-        private readonly TranslatorInterface $translator,
-        private readonly ContactExportAdminNotification $contactExportAdminNotification,
+        private NotificationModel $notificationModel,
+        private TranslatorInterface $translator,
+        private ContactExportAdminNotification $contactExportAdminNotification,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ContactScheduledExportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ContactScheduledExportSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\ContactExportSchedulerModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ContactScheduledExportSubscriber implements EventSubscriberInterface
+final readonly class ContactScheduledExportSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ContactExportSchedulerModel $contactExportSchedulerModel,
+        private ContactExportSchedulerModel $contactExportSchedulerModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -13,7 +13,7 @@ use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DoctrineSubscriber.php
@@ -11,11 +11,11 @@ use Monolog\Logger;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsDoctrineListener(ToolEvents::postGenerateSchema)]
-class DoctrineSubscriber
+final readonly class DoctrineSubscriber
 {
     public function __construct(
         #[Autowire(service: 'monolog.logger.mautic')]
-        private readonly Logger $logger,
+        private Logger $logger,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/EmailSubscriber.php
@@ -12,7 +12,7 @@ use Mautic\LeadBundle\Helper\TokenHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class EmailSubscriber implements EventSubscriberInterface
+final class EmailSubscriber implements EventSubscriberInterface
 {
     private static string $contactFieldRegex = '{contactfield=(.*?)}';
 

--- a/app/bundles/LeadBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/FormSubscriber.php
@@ -30,16 +30,16 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PointBundle\Model\PointGroupModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        protected LeadModel $leadModel,
-        protected ContactTracker $contactTracker,
-        protected IpLookupHelper $ipLookupHelper,
-        protected LeadFieldRepository $leadFieldRepository,
-        private readonly PointGroupModel $groupModel,
-        private readonly DoNotContact $doNotContact,
-        private readonly FieldModel $leadFieldModel,
+        private LeadModel $leadModel,
+        private ContactTracker $contactTracker,
+        private IpLookupHelper $ipLookupHelper,
+        private LeadFieldRepository $leadFieldRepository,
+        private PointGroupModel $groupModel,
+        private DoNotContact $doNotContact,
+        private FieldModel $leadFieldModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/GeneratedColumnSubscriber.php
@@ -14,7 +14,7 @@ use Mautic\LeadBundle\Segment\SegmentFilterIconTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class GeneratedColumnSubscriber implements EventSubscriberInterface
+final class GeneratedColumnSubscriber implements EventSubscriberInterface
 {
     use SegmentFilterIconTrait;
 

--- a/app/bundles/LeadBundle/EventListener/ImportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\LeadBundle\Event\ImportEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ImportSubscriber implements EventSubscriberInterface
+final readonly class ImportSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -32,7 +32,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final class LeadSubscriber implements EventSubscriberInterface
 {
     use ChannelTrait;
 

--- a/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class MaintenanceSubscriber implements EventSubscriberInterface
+final readonly class MaintenanceSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Connection $db,
-        private readonly TranslatorInterface $translator,
+        private Connection $db,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -13,7 +13,7 @@ use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class OwnerSubscriber implements EventSubscriberInterface
+final class OwnerSubscriber implements EventSubscriberInterface
 {
     private const OWNER_COLUMNS = ['email', 'firstname', 'lastname', 'position', 'signature'];
 
@@ -204,10 +204,7 @@ class OwnerSubscriber implements EventSubscriberInterface
         return $tokens;
     }
 
-    /**
-     * @return array|string|string[]
-     */
-    protected function getOwnerColumnNormalized(string $ownerColumn): string|array
+    private function getOwnerColumnNormalized(string $ownerColumn): string
     {
         return str_replace(['firstname', 'lastname'], ['first_name', 'last_name'], $ownerColumn);
     }

--- a/app/bundles/LeadBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/PointSubscriber.php
@@ -10,10 +10,10 @@ use Mautic\PointBundle\Event\TriggerExecutedEvent;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadModel $leadModel,
+        private LeadModel $leadModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportDNCSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportDNCSubscriber.php
@@ -13,16 +13,16 @@ use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ReportDNCSubscriber implements EventSubscriberInterface
+final readonly class ReportDNCSubscriber implements EventSubscriberInterface
 {
     public const DNC = 'contact.dnc';
 
     public function __construct(
-        private readonly FieldsBuilder $fieldsBuilder,
-        private readonly CompanyReportData $companyReportData,
-        private readonly RouterInterface $router,
-        private readonly ChannelListHelper $channelListHelper,
-        private readonly DncFormatterHelper $dncFormatter,
+        private FieldsBuilder $fieldsBuilder,
+        private CompanyReportData $companyReportData,
+        private RouterInterface $router,
+        private ChannelListHelper $channelListHelper,
+        private DncFormatterHelper $dncFormatter,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
@@ -12,13 +12,13 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportDevicesSubscriber implements EventSubscriberInterface
+final readonly class ReportDevicesSubscriber implements EventSubscriberInterface
 {
     public const DEVICES = 'contact.devices';
 
     public function __construct(
-        private readonly FieldsBuilder $fieldsBuilder,
-        private readonly CompanyReportData $companyReportData,
+        private FieldsBuilder $fieldsBuilder,
+        private CompanyReportData $companyReportData,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportNormalizeSubscriber implements EventSubscriberInterface
+final readonly class ReportNormalizeSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FieldModel $fieldModel,
+        private FieldModel $fieldModel,
     ) {
     }
 
@@ -47,7 +47,7 @@ class ReportNormalizeSubscriber implements EventSubscriberInterface
     /**
      * @param array<string> $columns
      */
-    protected function useContactOrCompanyColumn(array $columns): bool
+    private function useContactOrCompanyColumn(array $columns): bool
     {
         foreach ($columns as $column) {
             if (str_starts_with($column, 'l.') || str_starts_with($column, 'comp.')) {

--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -23,7 +23,7 @@ use Mautic\ReportBundle\ReportEvents;
 use Mautic\StageBundle\Model\StageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_LEADS                     = 'leads';
 

--- a/app/bundles/LeadBundle/EventListener/ReportUtmTagSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportUtmTagSubscriber.php
@@ -9,13 +9,13 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportUtmTagSubscriber implements EventSubscriberInterface
+final readonly class ReportUtmTagSubscriber implements EventSubscriberInterface
 {
     public const UTM_TAG = 'lead.utmTag';
 
     public function __construct(
-        private readonly FieldsBuilder $fieldsBuilder,
-        private readonly CompanyReportData $companyReportData,
+        private FieldsBuilder $fieldsBuilder,
+        private CompanyReportData $companyReportData,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
-class SearchSubscriber implements EventSubscriberInterface
+final class SearchSubscriber implements EventSubscriberInterface
 {
     use QueryBuilderManipulatorTrait;
 

--- a/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
@@ -8,12 +8,12 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SegmentLogReportSubscriber implements EventSubscriberInterface
+final readonly class SegmentLogReportSubscriber implements EventSubscriberInterface
 {
     public const SEGMENT_LOG = 'segment.log';
 
     public function __construct(
-        private readonly FieldsBuilder $fieldsBuilder,
+        private FieldsBuilder $fieldsBuilder,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentReportSubscriber.php
@@ -8,12 +8,12 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SegmentReportSubscriber implements EventSubscriberInterface
+final readonly class SegmentReportSubscriber implements EventSubscriberInterface
 {
     public const SEGMENT_MEMBERSHIP = 'segment.membership';
 
     public function __construct(
-        private readonly FieldsBuilder $fieldsBuilder,
+        private FieldsBuilder $fieldsBuilder,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentSubscriber.php
@@ -17,16 +17,16 @@ use Mautic\LeadBundle\Validator\SegmentUsedInCampaignsValidator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class SegmentSubscriber implements EventSubscriberInterface
+final readonly class SegmentSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly ListModel $listModel,
-        private readonly SegmentUsedInCampaignsValidator $segmentUsedInCampaignsValidator,
-        private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly SegmentCountCacheHelper $segmentCountCacheHelper,
-        private readonly TranslatorInterface $translator,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private ListModel $listModel,
+        private SegmentUsedInCampaignsValidator $segmentUsedInCampaignsValidator,
+        private CoreParametersHelper $coreParametersHelper,
+        private SegmentCountCacheHelper $segmentCountCacheHelper,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SerializerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SerializerSubscriber.php
@@ -8,10 +8,10 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Mautic\LeadBundle\Entity\LeadField;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class SerializerSubscriber implements EventSubscriberInterface
+final readonly class SerializerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RequestStack $requestStack,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
@@ -11,12 +11,12 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Twig\Helper\AvatarHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SetContactAvatarFormSubscriber implements EventSubscriberInterface
+final readonly class SetContactAvatarFormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AvatarHelper $avatarHelper,
-        private readonly FormUploader $uploader,
-        private readonly LeadModel $leadModel,
+        private AvatarHelper $avatarHelper,
+        private FormUploader $uploader,
+        private LeadModel $leadModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
@@ -17,7 +17,7 @@ use Mautic\LeadBundle\Entity\PointsChangeLog;
 use Mautic\LeadBundle\Entity\StagesChangeLog;
 use Mautic\LeadBundle\Entity\UtmTag;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
@@ -14,7 +14,7 @@ use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TimelineEventLogCampaignSubscriber implements EventSubscriberInterface
+final class TimelineEventLogCampaignSubscriber implements EventSubscriberInterface
 {
     use TimelineEventLogTrait;
 

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogSegmentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogSegmentSubscriber.php
@@ -14,7 +14,7 @@ use Mautic\LeadBundle\Event\ListChangeEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TimelineEventLogSegmentSubscriber implements EventSubscriberInterface
+final class TimelineEventLogSegmentSubscriber implements EventSubscriberInterface
 {
     use TimelineEventLogTrait;
 

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TimelineEventLogSubscriber implements EventSubscriberInterface
+final class TimelineEventLogSubscriber implements EventSubscriberInterface
 {
     use TimelineEventLogTrait;
 

--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -15,11 +15,11 @@ use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class WebhookSubscriber implements EventSubscriberInterface
+final readonly class WebhookSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebhookModel $webhookModel,
-        private readonly LeadModel $leadModel,
+        private WebhookModel $webhookModel,
+        private LeadModel $leadModel,
     ) {
     }
 

--- a/app/bundles/MessengerBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/MessengerBundle/EventListener/ConfigSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\MessengerBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
@@ -10,12 +10,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class BuildJsSubscriber implements EventSubscriberInterface
+final readonly class BuildJsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationHelper $notificationHelper,
-        private readonly IntegrationHelper $integrationHelper,
-        private readonly RouterInterface $router,
+        private NotificationHelper $notificationHelper,
+        private IntegrationHelper $integrationHelper,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignConditionSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\NotificationBundle\Entity\PushID;
 use Mautic\NotificationBundle\NotificationEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignConditionSubscriber implements EventSubscriberInterface
+final class CampaignConditionSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
@@ -11,10 +11,10 @@ use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\ReportBundle\Model\ReportModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ChannelSubscriber implements EventSubscriberInterface
+final readonly class ChannelSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationHelper $integrationHelper,
+        private IntegrationHelper $integrationHelper,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ConfigSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\NotificationBundle\Form\Type\NotificationConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/NotificationSubscriber.php
@@ -14,13 +14,13 @@ use Mautic\PageBundle\Helper\TokenHelper as PageTokenHelper;
 use Mautic\PageBundle\Model\TrackableModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class NotificationSubscriber implements EventSubscriberInterface
+final readonly class NotificationSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AuditLogModel $auditLogModel,
-        private readonly TrackableModel $trackableModel,
-        private readonly PageTokenHelper $pageTokenHelper,
-        private readonly AssetTokenHelper $assetTokenHelper,
+        private AuditLogModel $auditLogModel,
+        private TrackableModel $trackableModel,
+        private PageTokenHelper $pageTokenHelper,
+        private AssetTokenHelper $assetTokenHelper,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/PageSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\PageBundle\PageEvents;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PageSubscriber implements EventSubscriberInterface
+final readonly class PageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetsHelper $assetsHelper,
-        private readonly IntegrationHelper $integrationHelper,
+        private AssetsHelper $assetsHelper,
+        private IntegrationHelper $integrationHelper,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ReportSubscriber.php
@@ -12,16 +12,16 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const MOBILE_NOTIFICATIONS       = 'mobile_notifications';
 
     public const MOBILE_NOTIFICATIONS_STATS = 'mobile_notifications.stats';
 
     public function __construct(
-        private readonly Connection $db,
-        private readonly CompanyReportData $companyReportData,
-        private readonly StatRepository $statRepository,
+        private Connection $db,
+        private CompanyReportData $companyReportData,
+        private StatRepository $statRepository,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\NotificationBundle\Model\NotificationModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly NotificationModel $model,
-        private readonly GlobalSearch $globalSearch,
+        private NotificationModel $model,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\NotificationBundle\Entity\Stat;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -414,7 +414,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
 
     public function testNotificationsSentInBatches(): void
     {
-        $subscriber                                    = new class(static::getContainer()->get('mautic.helper.integration'), static::getContainer()->get('mautic.notification.model.notification'), static::getContainer()->get('mautic.notification.api'), static::getContainer()->get('event_dispatcher'), static::getContainer()->get('mautic.lead.model.dnc'), static::getContainer()->get('translator')) extends CampaignSubscriber {
+        $subscriber = new class(static::getContainer()->get('mautic.helper.integration'), static::getContainer()->get('mautic.notification.model.notification'), static::getContainer()->get('mautic.notification.api'), static::getContainer()->get('event_dispatcher'), static::getContainer()->get('mautic.lead.model.dnc'), static::getContainer()->get('translator')) extends CampaignSubscriber {
             protected const MAX_PLAYER_IDS_PER_REQUEST = 2;
         };
         static::getContainer()->set('mautic.notification.campaignbundle.subscriber', $subscriber);

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -9,11 +9,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class BuildJsSubscriber implements EventSubscriberInterface
+final readonly class BuildJsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TrackingHelper $trackingHelper,
-        private readonly RouterInterface $router,
+        private TrackingHelper $trackingHelper,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
@@ -17,12 +17,12 @@ use Mautic\PageBundle\Helper\TrackingHelper;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadModel $leadModel,
-        private readonly TrackingHelper $trackingHelper,
-        private readonly RealTimeExecutioner $realTimeExecutioner,
+        private LeadModel $leadModel,
+        private TrackingHelper $trackingHelper,
+        private RealTimeExecutioner $realTimeExecutioner,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ConfigSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\PageBundle\Form\Type\ConfigTrackingPageType;
 use Mautic\PageBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\PageBundle\Form\Type\DashboardHitsInTimeWidgetType;
 use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\Routing\RouterInterface;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/PageBundle/EventListener/DateTimeTokenSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DateTimeTokenSubscriber.php
@@ -11,13 +11,13 @@ use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DateTimeTokenSubscriber implements EventSubscriberInterface
+final readonly class DateTimeTokenSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly DateTimeToken $dateTokenHelper,
-        private readonly CorePermissions $security,
-        private readonly ContactTracker $contactTracker,
+        private TranslatorInterface $translator,
+        private DateTimeToken $dateTokenHelper,
+        private CorePermissions $security,
+        private ContactTracker $contactTracker,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DetermineWinnerSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class DetermineWinnerSubscriber implements EventSubscriberInterface
+final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly HitRepository $hitRepository,
-        private readonly TranslatorInterface $translator,
+        private HitRepository $hitRepository,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final class LeadSubscriber implements EventSubscriberInterface
 {
     use ChannelTrait;
 

--- a/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
@@ -9,11 +9,11 @@ use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class MaintenanceSubscriber implements EventSubscriberInterface
+final readonly class MaintenanceSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Connection $db,
-        private readonly TranslatorInterface $translator,
+        private Connection $db,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -16,15 +16,15 @@ use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class PageSubscriber implements EventSubscriberInterface
+final readonly class PageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AssetsHelper $assetsHelper,
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly LanguageHelper $languageHelper,
-        private readonly PageModel $pageModel,
-        private readonly PageDraftModel $pageDraftModel,
+        private AssetsHelper $assetsHelper,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private LanguageHelper $languageHelper,
+        private PageModel $pageModel,
+        private PageDraftModel $pageDraftModel,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PointSubscriber.php
@@ -12,11 +12,11 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PointModel $pointModel,
-        private readonly PointActionHelper $pointActionHelper,
+        private PointModel $pointModel,
+        private PointActionHelper $pointActionHelper,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ReportSubscriber.php
@@ -16,7 +16,7 @@ use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_PAGES      = 'pages';
 
@@ -25,10 +25,10 @@ class ReportSubscriber implements EventSubscriberInterface
     public const CONTEXT_VIDEO_HITS = 'video.hits';
 
     public function __construct(
-        private readonly CompanyReportData $companyReportData,
-        private readonly HitRepository $hitRepository,
-        private readonly TranslatorInterface $translator,
-        private readonly DncReportService $dncReportService,
+        private CompanyReportData $companyReportData,
+        private HitRepository $hitRepository,
+        private TranslatorInterface $translator,
+        private DncReportService $dncReportService,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PageModel $pageModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private PageModel $pageModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/StatsSubscriber.php
@@ -10,7 +10,7 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Entity\VideoHit;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class WebhookSubscriber implements EventSubscriberInterface
+final readonly class WebhookSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly WebhookModel $webhookModel,
+        private WebhookModel $webhookModel,
     ) {
     }
 

--- a/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/CampaignSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\PluginBundle\Form\Type\IntegrationsListType;
 use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final class CampaignSubscriber implements EventSubscriberInterface
 {
     use PushToIntegrationTrait;
 

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\FormBundle\FormEvents;
 use Mautic\PluginBundle\Form\Type\IntegrationsListType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final class FormSubscriber implements EventSubscriberInterface
 {
     use PushToIntegrationTrait;
 

--- a/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/IntegrationSubscriber.php
@@ -13,10 +13,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * This class can provide useful debugging information for API requests and responses.
  * The information is displayed when a command is executed from the console and the -vv flag is passed to it.
  */
-class IntegrationSubscriber implements EventSubscriberInterface
+final readonly class IntegrationSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LoggerInterface $logger,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/LeadSubscriber.php
@@ -11,13 +11,13 @@ use Mautic\PluginBundle\Entity\IntegrationRepository;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     private const FEATURE_PUSH_LEAD = 'push_lead';
 
     public function __construct(
-        private readonly PluginModel $pluginModel,
-        private readonly IntegrationRepository $integrationRepository,
+        private PluginModel $pluginModel,
+        private IntegrationRepository $integrationRepository,
     ) {
     }
 

--- a/app/bundles/PluginBundle/EventListener/PluginSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/PluginSubscriber.php
@@ -10,10 +10,10 @@ use Mautic\PluginBundle\Event\PluginUpdateEvent;
 use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PluginSubscriber implements EventSubscriberInterface
+final readonly class PluginSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PluginDatabase $pluginDatabase,
+        private PluginDatabase $pluginDatabase,
     ) {
     }
 

--- a/app/bundles/PluginBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/PointSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\PointBundle\Event\TriggerBuilderEvent;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final class PointSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/PointBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/DashboardSubscriber.php
@@ -6,7 +6,7 @@ use Mautic\DashboardBundle\Event\WidgetDetailEvent;
 use Mautic\DashboardBundle\EventListener\DashboardSubscriber as MainDashboardSubscriber;
 use Mautic\PointBundle\Model\PointModel;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/PointBundle/EventListener/GroupScoreSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/GroupScoreSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\PointBundle\Model\TriggerModel;
 use Mautic\PointBundle\PointGroupEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class GroupScoreSubscriber implements EventSubscriberInterface
+final readonly class GroupScoreSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TriggerModel $triggerModel,
+        private TriggerModel $triggerModel,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -14,14 +14,14 @@ use Mautic\PointBundle\Model\TriggerModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TriggerModel $triggerModel,
-        private readonly TranslatorInterface $translator,
-        private readonly PointsChangeLogRepository $pointsChangeLogRepository,
-        private readonly LeadPointLogRepository $leadPointLogRepository,
-        private readonly LeadTriggerLogRepository $leadTriggerLogRepository,
+        private TriggerModel $triggerModel,
+        private TranslatorInterface $translator,
+        private PointsChangeLogRepository $pointsChangeLogRepository,
+        private LeadPointLogRepository $leadPointLogRepository,
+        private LeadTriggerLogRepository $leadTriggerLogRepository,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/PointSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\PointBundle\Event as Events;
 use Mautic\PointBundle\PointEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PointSubscriber implements EventSubscriberInterface
+final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/ReportSubscriber.php
@@ -10,7 +10,7 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final class ReportSubscriber implements EventSubscriberInterface
 {
     public const CONTEXT_GROUP_SCORE = 'group.score';
 

--- a/app/bundles/PointBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/SearchSubscriber.php
@@ -14,14 +14,14 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\Model\TriggerModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly PointModel $pointModel,
-        private readonly TriggerModel $pointTriggerModel,
-        private readonly PointGroupModel $pointGroupModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private PointModel $pointModel,
+        private TriggerModel $pointTriggerModel,
+        private PointGroupModel $pointGroupModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/SegmentFilterSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/SegmentFilterSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\PointBundle\Entity\GroupRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class SegmentFilterSubscriber implements EventSubscriberInterface
+final readonly class SegmentFilterSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly GroupRepository $groupRepository,
-        private readonly TypeOperatorProviderInterface $typeOperatorProvider,
-        private readonly TranslatorInterface $translator,
+        private GroupRepository $groupRepository,
+        private TypeOperatorProviderInterface $typeOperatorProvider,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/StatsSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PointBundle\Entity\LeadPointLog;
 use Mautic\PointBundle\Entity\LeadTriggerLog;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/ReportBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/ConfigSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\ReportBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
@@ -10,7 +10,7 @@ use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Form\Type\ReportWidgetType;
 use Mautic\ReportBundle\Model\ReportModel;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     private const TABLE_ROW_LIMIT = 10;
 

--- a/app/bundles/ReportBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/ReportSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\ReportBundle\Event\ReportEvent;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSubscriber implements EventSubscriberInterface
+final readonly class ReportSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/ReportBundle/EventListener/SchedulerSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/SchedulerSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\ReportBundle\ReportEvents;
 use Mautic\ReportBundle\Scheduler\Model\SendSchedule;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SchedulerSubscriber implements EventSubscriberInterface
+final readonly class SchedulerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SendSchedule $sendSchedule,
+        private SendSchedule $sendSchedule,
     ) {
     }
 

--- a/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\ReportBundle\Model\ReportModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ReportModel $reportModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private ReportModel $reportModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/ReportBundle/Scheduler/EventListener/ReportSchedulerSubscriber.php
+++ b/app/bundles/ReportBundle/Scheduler/EventListener/ReportSchedulerSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\ReportBundle\ReportEvents;
 use Mautic\ReportBundle\Scheduler\Model\SchedulerPlanner;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReportSchedulerSubscriber implements EventSubscriberInterface
+final readonly class ReportSchedulerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SchedulerPlanner $schedulerPlanner,
+        private SchedulerPlanner $schedulerPlanner,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/BroadcastSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\SmsBundle\Broadcast\BroadcastExecutioner;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class BroadcastSubscriber implements EventSubscriberInterface
+final readonly class BroadcastSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly BroadcastExecutioner $broadcastExecutioner,
+        private BroadcastExecutioner $broadcastExecutioner,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/CampaignReplySubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/CampaignReplySubscriber.php
@@ -13,13 +13,13 @@ use Mautic\SmsBundle\Sms\TransportChain;
 use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignReplySubscriber implements EventSubscriberInterface
+final readonly class CampaignReplySubscriber implements EventSubscriberInterface
 {
     public const TYPE = 'sms.reply';
 
     public function __construct(
-        private readonly TransportChain $transportChain,
-        private readonly RealTimeExecutioner $realTimeExecutioner,
+        private TransportChain $transportChain,
+        private RealTimeExecutioner $realTimeExecutioner,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/CampaignSendSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/CampaignSendSubscriber.php
@@ -13,12 +13,12 @@ use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignSendSubscriber implements EventSubscriberInterface
+final readonly class CampaignSendSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SmsModel $smsModel,
-        private readonly TransportChain $transportChain,
-        private readonly TranslatorInterface $translator,
+        private SmsModel $smsModel,
+        private TransportChain $transportChain,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
@@ -12,10 +12,10 @@ use Mautic\SmsBundle\Form\Type\SmsListType;
 use Mautic\SmsBundle\Sms\TransportChain;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ChannelSubscriber implements EventSubscriberInterface
+final readonly class ChannelSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TransportChain $transportChain,
+        private TransportChain $transportChain,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ConfigSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\SmsBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
@@ -10,12 +10,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
-        private readonly EntityManager $em,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private EntityManager $em,
     ) {
     }
 
@@ -35,7 +35,7 @@ class LeadSubscriber implements EventSubscriberInterface
         $this->addSmsEvents($event, 'failed');
     }
 
-    protected function addSmsEvents(LeadTimelineEvent $event, $state): void
+    private function addSmsEvents(LeadTimelineEvent $event, string $state): void
     {
         // Set available event types
         $eventTypeKey  = 'sms.'.$state;

--- a/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent;
 use Mautic\SmsBundle\Model\SmsModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class MessageQueueSubscriber implements EventSubscriberInterface
+final readonly class MessageQueueSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SmsModel $model,
+        private SmsModel $model,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/ReplySubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ReplySubscriber.php
@@ -13,7 +13,7 @@ use Mautic\SmsBundle\Event\ReplyEvent;
 use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ReplySubscriber implements EventSubscriberInterface
+final class ReplySubscriber implements EventSubscriberInterface
 {
     use TimelineEventLogTrait;
 

--- a/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\SmsBundle\Model\SmsModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly SmsModel $model,
-        private readonly GlobalSearch $globalSearch,
+        private SmsModel $model,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SmsSubscriber.php
@@ -15,15 +15,15 @@ use Mautic\SmsBundle\Helper\SmsHelper;
 use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SmsSubscriber implements EventSubscriberInterface
+final readonly class SmsSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AuditLogModel $auditLogModel,
-        private readonly TrackableModel $trackableModel,
-        private readonly PageTokenHelper $pageTokenHelper,
-        private readonly AssetTokenHelper $assetTokenHelper,
-        private readonly SmsHelper $smsHelper,
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private AuditLogModel $auditLogModel,
+        private TrackableModel $trackableModel,
+        private PageTokenHelper $pageTokenHelper,
+        private AssetTokenHelper $assetTokenHelper,
+        private SmsHelper $smsHelper,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\SmsBundle\Entity\Stat;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/SmsBundle/EventListener/StopSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/StopSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\SmsBundle\Event\ReplyEvent;
 use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class StopSubscriber implements EventSubscriberInterface
+final readonly class StopSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly DoNotContactModel $doNotContactModel,
+        private DoNotContactModel $doNotContactModel,
     ) {
     }
 

--- a/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/TrackingSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\SmsBundle\Entity\Stat;
 use Mautic\SmsBundle\Entity\StatRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TrackingSubscriber implements EventSubscriberInterface
+final readonly class TrackingSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly StatRepository $statRepository,
+        private StatRepository $statRepository,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/CampaignSubscriber.php
@@ -15,12 +15,12 @@ use Mautic\StageBundle\StageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadModel $leadModel,
-        private readonly StageModel $stageModel,
-        private readonly TranslatorInterface $translator,
+        private LeadModel $leadModel,
+        private StageModel $stageModel,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/DashboardSubscriber.php
@@ -6,7 +6,7 @@ use Mautic\DashboardBundle\Event\WidgetDetailEvent;
 use Mautic\DashboardBundle\EventListener\DashboardSubscriber as MainDashboardSubscriber;
 use Mautic\StageBundle\Model\StageModel;
 
-class DashboardSubscriber extends MainDashboardSubscriber
+final class DashboardSubscriber extends MainDashboardSubscriber
 {
     /**
      * Define the name of the bundle/category of the widget(s).

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -11,13 +11,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly StagesChangeLogRepository $stagesChangeLogRepository,
-        private readonly LeadStageLogRepository $leadStageLogRepository,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
+        private StagesChangeLogRepository $stagesChangeLogRepository,
+        private LeadStageLogRepository $leadStageLogRepository,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/SearchSubscriber.php
@@ -12,12 +12,12 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use Mautic\StageBundle\Model\StageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly StageModel $stageModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private StageModel $stageModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/StageSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/StageSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\StageBundle\Event as Events;
 use Mautic\StageBundle\StageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class StageSubscriber implements EventSubscriberInterface
+final readonly class StageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\StageBundle\Entity\LeadStageLog;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/UserBundle/EventListener/ApiUserSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/ApiUserSubscriber.php
@@ -15,11 +15,11 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
-class ApiUserSubscriber implements EventSubscriberInterface
+final readonly class ApiUserSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly UserProviderInterface $userProvider,
-        private readonly TokenPermissions $tokenPermissions,
+        private UserProviderInterface $userProvider,
+        private TokenPermissions $tokenPermissions,
     ) {
     }
 

--- a/app/bundles/UserBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/ConfigSubscriber.php
@@ -9,7 +9,7 @@ use Mautic\UserBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string[]

--- a/app/bundles/UserBundle/EventListener/SAMLSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SAMLSubscriber.php
@@ -8,10 +8,10 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 
-class SAMLSubscriber implements EventSubscriberInterface
+final readonly class SAMLSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RouterInterface $router,
+        private RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/UserBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SearchSubscriber.php
@@ -11,13 +11,13 @@ use Mautic\UserBundle\Model\RoleModel;
 use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly UserModel $userModel,
-        private readonly RoleModel $userRoleModel,
-        private readonly CorePermissions $security,
-        private readonly GlobalSearch $globalSearch,
+        private UserModel $userModel,
+        private RoleModel $userRoleModel,
+        private CorePermissions $security,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/app/bundles/UserBundle/EventListener/SecuritySubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SecuritySubscriber.php
@@ -8,11 +8,11 @@ use Mautic\UserBundle\Event\LoginEvent;
 use Mautic\UserBundle\UserEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SecuritySubscriber implements EventSubscriberInterface
+final readonly class SecuritySubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/UserBundle/EventListener/UserSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/UserSubscriber.php
@@ -8,11 +8,11 @@ use Mautic\UserBundle\Event as Events;
 use Mautic\UserBundle\UserEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class UserSubscriber implements EventSubscriberInterface
+final readonly class UserSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
     ) {
     }
 

--- a/app/bundles/WebhookBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/CampaignSubscriber.php
@@ -10,10 +10,10 @@ use Mautic\WebhookBundle\Helper\CampaignHelper;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CampaignHelper $campaignHelper,
+        private CampaignHelper $campaignHelper,
     ) {
     }
 

--- a/app/bundles/WebhookBundle/EventListener/ConfigSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/ConfigSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\WebhookBundle\Form\Type\ConfigType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final class ConfigSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/WebhookBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\WebhookBundle\Entity\Log;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/WebhookSubscriber.php
@@ -9,12 +9,12 @@ use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class WebhookSubscriber implements EventSubscriberInterface
+final readonly class WebhookSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IpLookupHelper $ipLookupHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly WebhookKillNotificator $webhookKillNotificator,
+        private IpLookupHelper $ipLookupHelper,
+        private AuditLogModel $auditLogModel,
+        private WebhookKillNotificator $webhookKillNotificator,
     ) {
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
@@ -12,16 +12,16 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class AssetsSubscriber implements EventSubscriberInterface
+final readonly class AssetsSubscriber implements EventSubscriberInterface
 {
     private const ASSET_DIR = 'plugins/GrapesJsBuilderBundle/Assets/library/js/dist';
 
     public function __construct(
-        private readonly Config $config,
-        private readonly InstallService $installer,
-        private readonly RequestStack $requestStack,
-        private readonly string $projectDir,
-        private readonly LoggerInterface $logger,
+        private Config $config,
+        private InstallService $installer,
+        private RequestStack $requestStack,
+        private string $projectDir,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/EmailSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/EmailSubscriber.php
@@ -12,7 +12,7 @@ use MauticPlugin\GrapesJsBuilderBundle\Integration\Config;
 use MauticPlugin\GrapesJsBuilderBundle\Model\GrapesJsBuilderModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class EmailSubscriber implements EventSubscriberInterface
+final class EmailSubscriber implements EventSubscriberInterface
 {
     private string $existingMjml = '';
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
@@ -16,14 +16,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
-class InjectCustomContentSubscriber implements EventSubscriberInterface
+final readonly class InjectCustomContentSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Config $config,
-        private readonly GrapesJsBuilderModel $grapesJsBuilderModel,
-        private readonly Environment $twig,
-        private readonly RequestStack $requestStack,
-        private readonly RouterInterface $router,
+        private Config $config,
+        private GrapesJsBuilderModel $grapesJsBuilderModel,
+        private Environment $twig,
+        private RequestStack $requestStack,
+        private RouterInterface $router,
     ) {
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/PageSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/PageSubscriber.php
@@ -10,11 +10,11 @@ use MauticPlugin\GrapesJsBuilderBundle\Integration\Config;
 use MauticPlugin\GrapesJsBuilderBundle\Model\GrapesJsBuilderModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PageSubscriber implements EventSubscriberInterface
+final readonly class PageSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Config $config,
-        private readonly GrapesJsBuilderModel $grapesJsBuilderModel,
+        private Config $config,
+        private GrapesJsBuilderModel $grapesJsBuilderModel,
     ) {
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/SerializerSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/SerializerSubscriber.php
@@ -13,11 +13,11 @@ use Mautic\EmailBundle\Entity\Email;
 use MauticPlugin\GrapesJsBuilderBundle\Integration\Config;
 use MauticPlugin\GrapesJsBuilderBundle\Model\GrapesJsBuilderModel;
 
-class SerializerSubscriber implements EventSubscriberInterface
+final readonly class SerializerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly GrapesJsBuilderModel $grapesJsBuilderModel,
-        private readonly Config $config,
+        private GrapesJsBuilderModel $grapesJsBuilderModel,
+        private Config $config,
     ) {
     }
 

--- a/plugins/MauticClearbitBundle/EventListener/ButtonSubscriber.php
+++ b/plugins/MauticClearbitBundle/EventListener/ButtonSubscriber.php
@@ -11,12 +11,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ButtonSubscriber implements EventSubscriberInterface
+final readonly class ButtonSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationHelper $helper,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
+        private IntegrationHelper $helper,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
     ) {
     }
 

--- a/plugins/MauticClearbitBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticClearbitBundle/EventListener/LeadSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\LeadBundle\LeadEvents;
 use MauticPlugin\MauticClearbitBundle\Helper\LookupHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LookupHelper $lookupHelper,
+        private LookupHelper $lookupHelper,
     ) {
     }
 

--- a/plugins/MauticCloudStorageBundle/EventListener/RemoteAssetBrowseSubscriber.php
+++ b/plugins/MauticCloudStorageBundle/EventListener/RemoteAssetBrowseSubscriber.php
@@ -8,7 +8,7 @@ use MauticPlugin\MauticCloudStorageBundle\Exception\InvalidCredentialConfigurati
 use MauticPlugin\MauticCloudStorageBundle\Integration\CloudStorageIntegration;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class RemoteAssetBrowseSubscriber implements EventSubscriberInterface
+final class RemoteAssetBrowseSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -12,12 +12,12 @@ use MauticPlugin\MauticCrmBundle\Integration\CrmAbstractIntegration;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadListSubscriber implements EventSubscriberInterface
+final readonly class LeadListSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationHelper $helper,
-        private readonly ListModel $listModel,
-        private readonly TranslatorInterface $translator,
+        private IntegrationHelper $helper,
+        private ListModel $listModel,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/plugins/MauticCrmBundle/EventListener/PluginSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/PluginSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\PluginBundle\Event\PluginInstallEvent;
 use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class PluginSubscriber implements EventSubscriberInterface
+final readonly class PluginSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly PluginDatabase $pluginDatabase,
+        private EntityManagerInterface $entityManager,
+        private PluginDatabase $pluginDatabase,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/CampaignSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/CampaignSubscriber.php
@@ -12,11 +12,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TrackingHelper $trackingHelper,
-        private readonly RouterInterface $router,
+        private TrackingHelper $trackingHelper,
+        private RouterInterface $router,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -24,17 +24,17 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 
-class FocusSubscriber implements EventSubscriberInterface
+final readonly class FocusSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly RouterInterface $router,
-        private readonly IpLookupHelper $ipHelper,
-        private readonly AuditLogModel $auditLogModel,
-        private readonly TrackableModel $trackableModel,
-        private readonly PageTokenHelper $pageTokenHelper,
-        private readonly AssetTokenHelper $assetTokenHelper,
-        private readonly FocusModel $focusModel,
-        private readonly RequestStack $requestStack,
+        private RouterInterface $router,
+        private IpLookupHelper $ipHelper,
+        private AuditLogModel $auditLogModel,
+        private TrackableModel $trackableModel,
+        private PageTokenHelper $pageTokenHelper,
+        private AssetTokenHelper $assetTokenHelper,
+        private FocusModel $focusModel,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FormSubscriber.php
@@ -7,10 +7,10 @@ use Mautic\FormBundle\FormEvents;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FocusModel $model,
+        private FocusModel $model,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
@@ -11,12 +11,12 @@ use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Translator $translator,
-        private readonly RouterInterface $router,
-        private readonly FocusModel $focusModel,
+        private Translator $translator,
+        private RouterInterface $router,
+        private FocusModel $focusModel,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/PageSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/PageSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class PageSubscriber implements EventSubscriberInterface
+final class PageSubscriber implements EventSubscriberInterface
 {
     private string $regex = '{focus=(.*?)}';
 

--- a/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FocusModel $model,
-        private readonly GlobalSearch $globalSearch,
+        private FocusModel $model,
+        private GlobalSearch $globalSearch,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
@@ -11,11 +11,11 @@ use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class StatSubscriber implements EventSubscriberInterface
+final readonly class StatSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly FocusModel $model,
-        private readonly RequestStack $requestStack,
+        private FocusModel $model,
+        private RequestStack $requestStack,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatsSubscriber.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/plugins/MauticFullContactBundle/EventListener/ButtonSubscriber.php
+++ b/plugins/MauticFullContactBundle/EventListener/ButtonSubscriber.php
@@ -11,12 +11,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ButtonSubscriber implements EventSubscriberInterface
+final readonly class ButtonSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationHelper $helper,
-        private readonly TranslatorInterface $translator,
-        private readonly RouterInterface $router,
+        private IntegrationHelper $helper,
+        private TranslatorInterface $translator,
+        private RouterInterface $router,
     ) {
     }
 

--- a/plugins/MauticFullContactBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticFullContactBundle/EventListener/LeadSubscriber.php
@@ -8,10 +8,10 @@ use Mautic\LeadBundle\LeadEvents;
 use MauticPlugin\MauticFullContactBundle\Helper\LookupHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class LeadSubscriber implements EventSubscriberInterface
+final readonly class LeadSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LookupHelper $lookupHelper,
+        private LookupHelper $lookupHelper,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/EventListener/CampaignSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/CampaignSubscriber.php
@@ -12,12 +12,12 @@ use MauticPlugin\MauticSocialBundle\SocialEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignSubscriber implements EventSubscriberInterface
+final readonly class CampaignSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly CampaignEventHelper $campaignEventHelper,
-        private readonly IntegrationHelper $integrationHelper,
-        private readonly TranslatorInterface $translator,
+        private CampaignEventHelper $campaignEventHelper,
+        private IntegrationHelper $integrationHelper,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/EventListener/ChannelSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/ChannelSubscriber.php
@@ -9,10 +9,10 @@ use Mautic\PluginBundle\Helper\IntegrationHelper;
 use MauticPlugin\MauticSocialBundle\Form\Type\TweetListType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ChannelSubscriber implements EventSubscriberInterface
+final readonly class ChannelSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly IntegrationHelper $helper,
+        private IntegrationHelper $helper,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/EventListener/ConfigSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/ConfigSubscriber.php
@@ -9,10 +9,10 @@ use MauticPlugin\MauticSocialBundle\Form\Type\ConfigType;
 use MauticPlugin\MauticSocialBundle\Integration\Config;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigSubscriber implements EventSubscriberInterface
+final readonly class ConfigSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Config $config,
+        private Config $config,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/FormSubscriber.php
@@ -8,10 +8,10 @@ use MauticPlugin\MauticSocialBundle\Form\Type\SocialLoginType;
 use MauticPlugin\MauticSocialBundle\Integration\Config;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class FormSubscriber implements EventSubscriberInterface
+final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly Config $config,
+        private Config $config,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use MauticPlugin\MauticSocialBundle\Entity\TweetStat;
 use MauticPlugin\MauticSocialBundle\Entity\TweetStatRepository;
 
-class StatsSubscriber extends CommonStatsSubscriber
+final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(CorePermissions $security, EntityManager $entityManager)
     {

--- a/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
@@ -11,11 +11,11 @@ use Mautic\CoreBundle\Service\GlobalSearch;
 use MauticPlugin\MauticTagManagerBundle\Model\TagModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class SearchSubscriber implements EventSubscriberInterface
+final readonly class SearchSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly TagModel $model,
-        private readonly GlobalSearch $globalSearch,
+        private TagModel $model,
+        private GlobalSearch $globalSearch,
     ) {
     }
 


### PR DESCRIPTION
Marks event subscribers in `app/bundles` and `plugins` as `final` (and `readonly` where all properties are promoted + immutable), and privatizes 16 `protected` members that are only used within the class.
