### PR TITLE
[phpstan] add custom rule to avoid container->get global calls with strings

### DIFF
--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -18,7 +18,6 @@ final class UploadController extends DropzoneController
         $request  = $this->getRequest();
         $response = new EmptyResponse();
         $files    = $this->getFiles($request->files);
-        $this->autowireUploadController($this->container->get('translator'));
 
         if (!empty($files)) {
             foreach ($files as $file) {

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -786,7 +786,7 @@ return [
                 'class'     => Mautic\CoreBundle\Update\Step\UpdateSchemaStep::class,
                 'arguments' => [
                     'translator',
-                    'service_container',
+                    'kernel',
                 ],
                 'tag' => 'mautic.update_step',
             ],

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -233,7 +233,7 @@ abstract class AbstractFormController extends CommonController
         $vars['returnUrl'] = $returnUrl;
 
         $urlMatcher  = explode('/s/', $returnUrl);
-        $actionRoute = $this->container->get('router')->match('/s/'.$urlMatcher[1]);
+        $actionRoute = $this->router->match('/s/'.$urlMatcher[1]);
         $objAction   = $actionRoute['objectAction'] ?? 'index';
         $routeCtrlr  = explode('\\', $actionRoute['_controller']);
 

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -31,7 +31,9 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Service\Attribute\Required;
+use Twig\Environment;
 
 class CommonController extends AbstractController implements MauticController
 {
@@ -43,13 +45,25 @@ class CommonController extends AbstractController implements MauticController
 
     private NotificationModel $notificationModel;
 
+    protected RouterInterface $router;
+
+    protected HttpKernelInterface $httpKernel;
+
+    protected Environment $twig;
+
     #[Required]
     public function autowireCommonController(
         PageModel $pageModel,
         NotificationModel $notificationModel,
+        RouterInterface $router,
+        HttpKernelInterface $httpKernel,
+        Environment $twig,
     ): void {
         $this->pageModel = $pageModel;
         $this->notificationModel = $notificationModel;
+        $this->router = $router;
+        $this->httpKernel = $httpKernel;
+        $this->twig = $twig;
     }
 
     /**
@@ -368,7 +382,7 @@ class CommonController extends AbstractController implements MauticController
             $ajaxRouteName = false;
 
             try {
-                $routeParams   = $this->container->get('router')->match($routePath);
+                $routeParams   = $this->router->match($routePath);
                 $ajaxRouteName = $routeParams['_route'];
 
                 $request->attributes->set('ajaxRoute',

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -174,7 +174,7 @@ class CommonController extends AbstractController implements MauticController
         $path['_controller'] = $controller;
         $subRequest          = $this->requestStack->getCurrentRequest()->duplicate($query, $request, $path);
 
-        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -77,7 +77,7 @@ final class ExceptionController extends CommonController
         }
 
         $template   = "@MauticCore/{$layout}/{$code}.html.twig";
-        if (!$this->container->get('twig')->getLoader()->exists($template)) {
+        if (!$this->twig->getLoader()->exists($template)) {
             $template = "@MauticCore/{$layout}/base.html.twig";
         }
 

--- a/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
+++ b/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\AbortMigration;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class AbstractMauticMigration extends AbstractMigration
@@ -64,10 +63,14 @@ abstract class AbstractMauticMigration extends AbstractMigration
         // Not supported
     }
 
-    public function setContainer(?ContainerInterface $container = null): void
+    public function setContainer(ContainerInterface $container): void
     {
         $this->container = $container;
-        $this->prefix    = (string) $container->get(CoreParametersHelper::class)->get('db_table_prefix', '');
+    }
+
+    public function setPrefix(string $prefix): void
+    {
+        $this->prefix = $prefix;
     }
 
     /**

--- a/app/bundles/CoreBundle/Doctrine/MigrationFactoryDecorator.php
+++ b/app/bundles/CoreBundle/Doctrine/MigrationFactoryDecorator.php
@@ -6,6 +6,7 @@ namespace Mautic\CoreBundle\Doctrine;
 
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -18,6 +19,7 @@ final readonly class MigrationFactoryDecorator implements MigrationFactory
     public function __construct(
         private MigrationFactory $migrationFactory,
         private ContainerInterface $container,
+        private CoreParametersHelper $coreParametersHelper,
     ) {
     }
 
@@ -27,6 +29,7 @@ final readonly class MigrationFactoryDecorator implements MigrationFactory
 
         if ($instance instanceof AbstractMauticMigration) {
             $instance->setContainer($this->container);
+            $instance->setPrefix((string) $this->coreParametersHelper->get('db_table_prefix', ''));
         }
 
         return $instance;

--- a/app/bundles/CoreBundle/Factory/ModelFactory.php
+++ b/app/bundles/CoreBundle/Factory/ModelFactory.php
@@ -3,7 +3,7 @@
 namespace Mautic\CoreBundle\Factory;
 
 use Mautic\CoreBundle\Model\MauticModelInterface;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * @template M of object
@@ -11,7 +11,7 @@ use Psr\Container\ContainerInterface;
 class ModelFactory
 {
     public function __construct(
-        private readonly ContainerInterface $container,
+        private readonly ServiceLocator $container,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
@@ -8,12 +8,12 @@ use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\PointBundle\Model\TriggerModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class ModelFactoryTest extends TestCase
 {
     /**
-     * @var MockObject&ContainerInterface
+     * @var MockObject&ServiceLocator
      */
     private MockObject $container;
 
@@ -24,7 +24,7 @@ final class ModelFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->container = $this->createMock(ContainerInterface::class);
+        $this->container = $this->createMock(ServiceLocator::class);
         $this->factory   = new ModelFactory($this->container);
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -96,7 +96,7 @@ final class UpdateSchemaStepTest extends AbstractStepTestCase
         $kernel->method('getContainer')
             ->willReturn($container);
 
-        $this->step = new UpdateSchemaStep($this->translator, $container);
+        $this->step = new UpdateSchemaStep($this->translator, $kernel);
     }
 
     public function testUpdateFailedExceptionThrownIfMigrationsFailed(): void

--- a/app/bundles/CoreBundle/Update/Step/UpdateSchemaStep.php
+++ b/app/bundles/CoreBundle/Update/Step/UpdateSchemaStep.php
@@ -9,18 +9,15 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class UpdateSchemaStep implements StepInterface
 {
-    private object $kernel;
-
     public function __construct(
         private TranslatorInterface $translator,
-        ContainerInterface $container,
+        private KernelInterface $kernel,
     ) {
-        $this->kernel = $container->get('kernel');
     }
 
     public function getOrder(): int

--- a/app/bundles/UserBundle/Security/SAML/Store/EntityDescriptorStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/EntityDescriptorStore.php
@@ -8,10 +8,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
 class EntityDescriptorStore implements EntityDescriptorStoreInterface
 {
-    /**
-     * @var EntityDescriptor
-     */
-    private $entityDescriptor;
+    private ?EntityDescriptor $entityDescriptor = null;
 
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -224,4 +224,8 @@ rules:
 	- Utils\PHPStan\Rule\NoRequiredMethodWithConstructorInControllerRule
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
+<<<<<<< HEAD
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
+=======
+	- Utils\PHPStan\Rule\NoContainerGetRule
+>>>>>>> 98fb0512f7 ([phpstan] add custom rule to avoid container->get global calls with strings)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -224,8 +224,5 @@ rules:
 	- Utils\PHPStan\Rule\NoRequiredMethodWithConstructorInControllerRule
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
-<<<<<<< HEAD
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
-=======
 	- Utils\PHPStan\Rule\NoContainerGetRule
->>>>>>> 98fb0512f7 ([phpstan] add custom rule to avoid container->get global calls with strings)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -225,4 +225,4 @@ rules:
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
-	- Utils\PHPStan\Rule\NoContainerGetRule
+	#- Utils\PHPStan\Rule\NoContainerGetRule

--- a/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
+++ b/plugins/GrapesJsBuilderBundle/Controller/GrapesJsController.php
@@ -231,9 +231,7 @@ class GrapesJsController extends CommonController
      */
     private function checkForMjmlTemplate(string $template): ?string
     {
-        $twig = $this->container->get('twig');
-
-        if ($twig->getLoader()->exists($template)) {
+        if ($this->twig->getLoader()->exists($template)) {
             return $template;
         }
 

--- a/utils/phpstan/src/Rule/NoContainerGetRule.php
+++ b/utils/phpstan/src/Rule/NoContainerGetRule.php
@@ -6,18 +6,20 @@ namespace Utils\PHPStan\Rule;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 
 /**
- * Forbid service location via $container->get(...) and $this->get(...).
+ * Forbid service location via the container, e.g. $container->get('some.service').
  *
  * Pulling a service out of the container by name hides the dependency from static analysis and returns an
- * untyped object. Inject the service through the constructor as a typed property instead. Tests may still use
- * the container to bootstrap services, so test files are skipped.
+ * untyped object. Inject the service through the constructor as a typed property instead. A scoped
+ * ServiceLocator is allowed, because it is an explicit, typed set of services rather than the whole container.
+ * Tests and migrations bootstrap services outside the DI graph, so those files are skipped.
  *
  * @implements Rule<MethodCall>
  */
@@ -29,9 +31,17 @@ final class NoContainerGetRule implements Rule
     private const GET_METHOD = 'get';
 
     /**
+     * @var string
+     */
+    private const SERVICE_LOCATOR_TYPE = 'Symfony\Component\DependencyInjection\ServiceLocator';
+
+    /**
      * @var string[]
      */
-    private const CONTAINER_VARIABLE_NAMES = ['this', 'container'];
+    private const CONTAINER_TYPES = [
+        'Psr\Container\ContainerInterface',
+        'Symfony\Component\DependencyInjection\ContainerInterface',
+    ];
 
     public function getNodeType(): string
     {
@@ -45,7 +55,7 @@ final class NoContainerGetRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($this->isTestFile($scope->getFile())) {
+        if ($this->isExemptFile($scope->getFile())) {
             return [];
         }
 
@@ -57,28 +67,39 @@ final class NoContainerGetRule implements Rule
             return [];
         }
 
-        if (!$node->var instanceof Variable || !is_string($node->var->name)) {
+        if (!$this->isContainerCaller($scope->getType($node->var))) {
             return [];
         }
 
-        if (!in_array($node->var->name, self::CONTAINER_VARIABLE_NAMES, true)) {
-            return [];
-        }
-
-        $ruleError = RuleErrorBuilder::message(sprintf(
-            'Do not fetch a service via $%s->get(...). Inject the service as a typed constructor property instead.',
-            $node->var->name
-        ))
+        $ruleError = RuleErrorBuilder::message(
+            'Do not fetch a service from the container via ->get(...). Inject the service as a typed constructor property instead.'
+        )
             ->identifier('mautic.noContainerGet')
-            ->nonIgnorable()
             ->build();
 
         return [$ruleError];
     }
 
-    private function isTestFile(string $file): bool
+    private function isContainerCaller(Type $callerType): bool
+    {
+        // a scoped ServiceLocator is an allowed, explicit set of services
+        if ((new ObjectType(self::SERVICE_LOCATOR_TYPE))->isSuperTypeOf($callerType)->yes()) {
+            return false;
+        }
+
+        foreach (self::CONTAINER_TYPES as $containerType) {
+            if ((new ObjectType($containerType))->isSuperTypeOf($callerType)->yes()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isExemptFile(string $file): bool
     {
         return str_contains($file, '/Tests/')
+            || str_contains($file, '/migrations/')
             || str_ends_with($file, 'Test.php')
             || str_ends_with($file, 'TestCase.php');
     }

--- a/utils/phpstan/src/Rule/NoContainerGetRule.php
+++ b/utils/phpstan/src/Rule/NoContainerGetRule.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Forbid service location via $container->get(...) and $this->get(...).
+ *
+ * Pulling a service out of the container by name hides the dependency from static analysis and returns an
+ * untyped object. Inject the service through the constructor as a typed property instead. Tests may still use
+ * the container to bootstrap services, so test files are skipped.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoContainerGetRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const GET_METHOD = 'get';
+
+    /**
+     * @var string[]
+     */
+    private const CONTAINER_VARIABLE_NAMES = ['this', 'container'];
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->isTestFile($scope->getFile())) {
+            return [];
+        }
+
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (self::GET_METHOD !== $node->name->toString()) {
+            return [];
+        }
+
+        if (!$node->var instanceof Variable || !is_string($node->var->name)) {
+            return [];
+        }
+
+        if (!in_array($node->var->name, self::CONTAINER_VARIABLE_NAMES, true)) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Do not fetch a service via $%s->get(...). Inject the service as a typed constructor property instead.',
+            $node->var->name
+        ))
+            ->identifier('mautic.noContainerGet')
+            ->nonIgnorable()
+            ->build();
+
+        return [$ruleError];
+    }
+
+    private function isTestFile(string $file): bool
+    {
+        return str_contains($file, '/Tests/')
+            || str_ends_with($file, 'Test.php')
+            || str_ends_with($file, 'TestCase.php');
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AllowedGetService.php
+++ b/utils/phpstan/tests/Rule/Fixture/AllowedGetService.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+// unrelated ->get() calls must be skipped
+class AllowedGetService
+{
+    /**
+     * @param ArrayCollection<int, object> $items
+     */
+    public function run(ArrayCollection $items): void
+    {
+        $items->get(0);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AllowedGetService.php
+++ b/utils/phpstan/tests/Rule/Fixture/AllowedGetService.php
@@ -6,7 +6,7 @@ namespace Utils\PHPStan\Tests\Rule\Fixture;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-// unrelated ->get() calls must be skipped
+// non-container ->get() calls must be skipped
 class AllowedGetService
 {
     /**
@@ -15,5 +15,16 @@ class AllowedGetService
     public function run(ArrayCollection $items): void
     {
         $items->get(0);
+    }
+
+    public function ownGet(): void
+    {
+        // own method named get(), not a container
+        $this->get('key');
+    }
+
+    public function get(string $key): string
+    {
+        return $key;
     }
 }

--- a/utils/phpstan/tests/Rule/Fixture/ContainerGetService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ContainerGetService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Psr\Container\ContainerInterface;
+
+// both container fetches must be reported
+class ContainerGetService
+{
+    public function viaLocalContainer(ContainerInterface $container): void
+    {
+        $container->get('mautic.helper.something');
+    }
+
+    public function viaThis(): void
+    {
+        $this->get('mautic.helper.something');
+    }
+
+    public function get(string $id): object
+    {
+        return new \stdClass();
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ContainerGetService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ContainerGetService.php
@@ -6,21 +6,20 @@ namespace Utils\PHPStan\Tests\Rule\Fixture;
 
 use Psr\Container\ContainerInterface;
 
-// both container fetches must be reported
+// container fetch must be reported
 class ContainerGetService
 {
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    public function viaProperty(): void
+    {
+        $this->container->get('mautic.helper.something');
+    }
+
     public function viaLocalContainer(ContainerInterface $container): void
     {
         $container->get('mautic.helper.something');
-    }
-
-    public function viaThis(): void
-    {
-        $this->get('mautic.helper.something');
-    }
-
-    public function get(string $id): object
-    {
-        return new \stdClass();
     }
 }

--- a/utils/phpstan/tests/Rule/Fixture/ServiceLocatorGetService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceLocatorGetService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+// a scoped ServiceLocator is allowed - must be skipped
+class ServiceLocatorGetService
+{
+    public function __construct(private ServiceLocator $locator)
+    {
+    }
+
+    public function run(): void
+    {
+        $this->locator->get('mautic.helper.something');
+    }
+}

--- a/utils/phpstan/tests/Rule/NoContainerGetRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoContainerGetRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoContainerGetRule;
+
+/**
+ * @extends RuleTestCase<NoContainerGetRule>
+ */
+final class NoContainerGetRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoContainerGetRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ContainerGetService.php'], [
+            [
+                'Do not fetch a service via $container->get(...). Inject the service as a typed constructor property instead.',
+                14,
+            ],
+            [
+                'Do not fetch a service via $this->get(...). Inject the service as a typed constructor property instead.',
+                19,
+            ],
+        ]);
+
+        // unrelated ArrayCollection->get() must be skipped
+        $this->analyse([__DIR__.'/Fixture/AllowedGetService.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoContainerGetRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoContainerGetRuleTest.php
@@ -22,16 +22,19 @@ final class NoContainerGetRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__.'/Fixture/ContainerGetService.php'], [
             [
-                'Do not fetch a service via $container->get(...). Inject the service as a typed constructor property instead.',
-                14,
+                'Do not fetch a service from the container via ->get(...). Inject the service as a typed constructor property instead.',
+                18,
             ],
             [
-                'Do not fetch a service via $this->get(...). Inject the service as a typed constructor property instead.',
-                19,
+                'Do not fetch a service from the container via ->get(...). Inject the service as a typed constructor property instead.',
+                23,
             ],
         ]);
 
-        // unrelated ArrayCollection->get() must be skipped
+        // ArrayCollection->get() and an own get() method must be skipped
         $this->analyse([__DIR__.'/Fixture/AllowedGetService.php'], []);
+
+        // a scoped ServiceLocator is an allowed, explicit set of services
+        $this->analyse([__DIR__.'/Fixture/ServiceLocatorGetService.php'], []);
     }
 }


### PR DESCRIPTION
This is follow up PR to remove all $this->get('...') and $this->container->get('...') calls.

* PHPStan rule to spot these (not enabled yet)
* use service over container
* use Kernel over container
* use parameter over whole parameter-bag service


First ~15 fixes :+1: 