### PR TITLE
[di] Use repository services directly over getRepository() fetch method in *Command and *Controller classes

### DIFF
--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -17,6 +17,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class PublicController extends AbstractFormController
 {
+    private \Mautic\AssetBundle\Entity\AssetRepository $assetRepository;
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowirePublicController(\Mautic\AssetBundle\Entity\AssetRepository $assetRepository): void
+    {
+        $this->assetRepository = $assetRepository;
+    }
+
     /**
      * Handles public download of assets by slug.
      *
@@ -32,7 +40,7 @@ final class PublicController extends AbstractFormController
         string $slug,
     ): Response {
         try {
-            $entity = $model->getRepository()->findOneByUuid($slug);
+            $entity = $this->assetRepository->findOneByUuid($slug);
         } catch (NonUniqueResultException|EntityNotFoundException) {
             /**
              * Legacy slug lookup fallback.

--- a/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/TriggerCampaignCommand.php
@@ -19,7 +19,6 @@ use Mautic\CoreBundle\ProcessSignal\Exception\SignalCaughtException;
 use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
 use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
-use Mautic\LeadBundle\Model\ListModel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -62,11 +61,11 @@ class TriggerCampaignCommand extends ModeratedCommand
         private InactiveExecutioner $inactiveExecutioner,
         private LoggerInterface $logger,
         private FormatterHelper $formatterHelper,
-        private ListModel $listModel,
         private SegmentCountCacheHelper $segmentCountCacheHelper,
         PathsHelper $pathsHelper,
         private CoreParametersHelper $coreParametersHelper,
         private ProcessSignalService $processSignalService,
+        private readonly \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository,
     ) {
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
@@ -417,7 +416,7 @@ class TriggerCampaignCommand extends ModeratedCommand
             if ($updateSegmentCountInBackground) {
                 $this->segmentCountCacheHelper->invalidateSegmentContactCount($segmentId);
             } else {
-                $totalLeadCount = $this->listModel->getRepository()->getLeadCount($segmentId);
+                $totalLeadCount = $this->leadListRepository->getLeadCount($segmentId);
                 $this->segmentCountCacheHelper->setSegmentContactCount($segmentId, (int) $totalLeadCount);
             }
         }

--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -35,6 +35,7 @@ final class AjaxController extends CommonAjaxController
         FlashBag $flashBag,
         RequestStack $requestStack,
         CorePermissions $security,
+        private readonly \Mautic\CampaignBundle\Entity\LeadEventLogRepository $leadEventLogRepository,
     ) {
         parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -101,7 +102,7 @@ final class AjaxController extends CommonAjaxController
                     ['%date%' => $log->getTriggerDate()->format('Y-m-d H:i:s')]
                 );
                 $log->setMetadata($metadata);
-                $this->eventLogModel->getRepository()->saveEntity($log);
+                $this->leadEventLogRepository->saveEntity($log);
 
                 $dataArray = ['success' => 1];
             }
@@ -119,7 +120,7 @@ final class AjaxController extends CommonAjaxController
         if ($contact) {
             if ($this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editother', $contact->getPermissionUser())) {
                 /** @var LeadEventLog $log */
-                $log = $this->eventLogModel->getRepository()
+                $log = $this->leadEventLogRepository
                                 ->findOneBy(
                                     [
                                         'lead'  => $contactId,

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -116,6 +116,7 @@ class CampaignController extends AbstractStandardFormController
         private PublishStateService $publishStateService,
         private CampaignModel $campaignModel,
         private EventModel $eventModel,
+        private readonly \Mautic\CampaignBundle\Entity\CampaignRepository $campaignRepository,
     ) {
         parent::__construct($formFactory, $fieldHelper, $managerRegistry, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -348,7 +349,7 @@ class CampaignController extends AbstractStandardFormController
             $dateTo   = $dateTo->modify('+1 day');
         }
 
-        $hasCampaignLeads = $this->campaignModel->getRepository()->hasCampaignLeads($objectId, (int) $this->coreParametersHelper->get('campaign_event_cache_ttl'));
+        $hasCampaignLeads = $this->campaignRepository->hasCampaignLeads($objectId, (int) $this->coreParametersHelper->get('campaign_event_cache_ttl'));
         $logCounts        = $this->processCampaignLogCounts($objectId, $dateFrom, $dateTo);
 
         $campaignLogCounts          = $logCounts['campaignLogCounts'] ?? [];
@@ -782,7 +783,7 @@ class CampaignController extends AbstractStandardFormController
             $this->setCampaignSources($isClone);
             $this->campaignModel->setLeadSources($entity, $this->campaignElements['campaignSources'], []);
             // If this is a clone, we need to save the entity first to properly build the events, sources and canvas settings
-            $this->campaignModel->getRepository()->saveEntity($entity);
+            $this->campaignRepository->saveEntity($entity);
             // Set as new so that timestamps are still hydrated
             $entity->setNew();
             $this->sessionId = $entity->getId();

--- a/app/bundles/DashboardBundle/Controller/AjaxController.php
+++ b/app/bundles/DashboardBundle/Controller/AjaxController.php
@@ -15,12 +15,17 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class AjaxController extends CommonAjaxController
 {
+    private \Mautic\DashboardBundle\Entity\WidgetRepository $widgetRepository;
+
     private DashboardModel $dashboardModel;
 
     #[Required]
-    public function autowireDashboardAjaxController(DashboardModel $dashboardModel): void
-    {
+    public function autowireDashboardAjaxController(
+        \Mautic\DashboardBundle\Entity\WidgetRepository $widgetRepository,
+        DashboardModel $dashboardModel,
+    ): void {
         $this->dashboardModel = $dashboardModel;
+        $this->widgetRepository = $widgetRepository;
     }
 
     /**
@@ -70,7 +75,7 @@ final class AjaxController extends CommonAjaxController
     public function updateWidgetOrderingAction(Request $request): JsonResponse
     {
         $data           = $request->request->all()['ordering'] ?? [];
-        $repo = $this->dashboardModel->getRepository();
+        $repo = $this->widgetRepository;
         $repo->updateOrdering(array_flip($data), $this->user->getId());
         $dataArray = ['success' => 1];
 

--- a/app/bundles/DashboardBundle/Controller/AjaxController.php
+++ b/app/bundles/DashboardBundle/Controller/AjaxController.php
@@ -75,8 +75,8 @@ final class AjaxController extends CommonAjaxController
     public function updateWidgetOrderingAction(Request $request): JsonResponse
     {
         $data           = $request->request->all()['ordering'] ?? [];
-        $repo = $this->widgetRepository;
-        $repo->updateOrdering(array_flip($data), $this->user->getId());
+
+        $this->widgetRepository->updateOrdering(array_flip($data), $this->user->getId());
         $dataArray = ['success' => 1];
 
         return $this->sendJsonResponse($dataArray);

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -41,6 +41,8 @@ final class EmailController extends FormController
     use EntityContactsTrait;
     use QuickFilterSearchTrait;
 
+    private \Mautic\LeadBundle\Entity\LeadRepository $leadRepository;
+
     private EmailModel $emailModel;
 
     private ListModel $listModel;
@@ -52,10 +54,12 @@ final class EmailController extends FormController
         ListModel $listModel,
         AuditLogModel $auditLogModel,
         EmailModel $emailModel,
+        \Mautic\LeadBundle\Entity\LeadRepository $leadRepository,
     ): void {
         $this->listModel = $listModel;
         $this->auditLogModel = $auditLogModel;
         $this->emailModel = $emailModel;
+        $this->leadRepository = $leadRepository;
     }
 
     public const EXAMPLE_EMAIL_SUBJECT_PREFIX = '[TEST]';
@@ -1760,7 +1764,7 @@ final class EmailController extends FormController
 
                 if ($previewForContactId) {
                     // We have one from request parameter
-                    $fields = $leadModel->getRepository()->getLead($previewForContactId);
+                    $fields = $this->leadRepository->getLead($previewForContactId);
                     $fields = $model->enrichedContactWithCompanies($fields);
                 }
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -610,12 +610,11 @@ final class PublicController extends CommonFormController
 
         // email is a semicolon delimited list of emails
         $emails    = explode(';', $query['email']);
-        $repo = $this->leadRepository;
 
         foreach ($emails as $email) {
-            $lead = $repo->getLeadByEmail($email);
+            $lead = $this->leadRepository->getLeadByEmail($email);
             if (null === $lead) {
-                $lead = $this->createLead($email, $repo);
+                $lead = $this->createLead($email);
                 if (null === $lead) {
                     continue;
                 }
@@ -678,7 +677,7 @@ final class PublicController extends CommonFormController
         return null;
     }
 
-    private function createLead(string $email, \Mautic\LeadBundle\Entity\LeadRepository $repo): ?array
+    private function createLead(string $email): ?array
     {
         $lead  = $this->leadModel->getEntity();
         // set custom field values
@@ -688,7 +687,7 @@ final class PublicController extends CommonFormController
         $this->leadModel->saveEntity($lead);
 
         // return entity
-        return $repo->getLeadByEmail($email);
+        return $this->leadRepository->getLeadByEmail($email);
     }
 
     public function getUnsubscribeMessage(string $idHash, $model, $stat, TranslatorInterface $translator): string

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -43,6 +43,8 @@ final class PublicController extends CommonFormController
 {
     use FrequencyRuleTrait;
 
+    private \Mautic\LeadBundle\Entity\LeadRepository $leadRepository;
+
     private EmailModel $emailModel;
 
     private LeadModel $leadModel;
@@ -51,9 +53,11 @@ final class PublicController extends CommonFormController
     public function autowirePublicController(
         LeadModel $leadModel,
         EmailModel $emailModel,
+        \Mautic\LeadBundle\Entity\LeadRepository $leadRepository,
     ): void {
         $this->leadModel = $leadModel;
         $this->emailModel = $emailModel;
+        $this->leadRepository = $leadRepository;
     }
 
     public function indexAction(Request $request, AnalyticsHelper $analyticsHelper, $idHash): Response
@@ -185,8 +189,7 @@ final class PublicController extends CommonFormController
                 // share the same session/device and the contact is known.
                 $successSessionName .= ".{$lead->getId()}";
             } elseif (empty($stat)) {
-                $leadRepo = $leadModel->getRepository();
-                $contacts = $leadRepo->getContactsByEmail($urlEmail);
+                $contacts = $this->leadRepository->getContactsByEmail($urlEmail);
                 $lead     = null;
                 if (is_array($contacts) && count($contacts) > 0) {
                     $lead  = array_pop($contacts);
@@ -506,7 +509,7 @@ final class PublicController extends CommonFormController
         if ($contactId) {
             // We have one from request parameter
             /** @var LeadModel $leadModel */
-            $contact = $leadModel->getRepository()->getLead($contactId);
+            $contact = $this->leadRepository->getLead($contactId);
             $contact = $model->enrichedContactWithCompanies($contact);
         } else {
             // Make fake contact.
@@ -607,7 +610,7 @@ final class PublicController extends CommonFormController
 
         // email is a semicolon delimited list of emails
         $emails    = explode(';', $query['email']);
-        $repo = $this->leadModel->getRepository();
+        $repo = $this->leadRepository;
 
         foreach ($emails as $email) {
             $lead = $repo->getLeadByEmail($email);

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -18,6 +18,7 @@ use Mautic\EmailBundle\Event\ManualWinnerEvent;
 use Mautic\EmailBundle\Form\Type\ExampleSendType;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Helper\FormFieldHelper;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Helper\FakeContactHelper;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
@@ -125,11 +126,14 @@ final class EmailControllerTest extends TestCase
             $this->corePermissionsMock
         );
         $this->controller->setContainer($this->containerMock);
+
         $this->controller->autowireEmailController(
             $this->createStub(ListModel::class),
             $this->createStub(AuditLogModel::class),
-            $this->modelMock
+            $this->modelMock,
+            $this->createStub(LeadRepository::class)
         );
+
         $this->sessionMock->method('getFlashBag')->willReturn($this->createStub(FlashBagInterface::class));
     }
 

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -50,6 +50,7 @@ class FormApiController extends CommonApiController
         private readonly FormModel $formModel,
         private readonly FieldModel $fieldModel,
         private readonly ActionModel $actionModel,
+        private readonly \Mautic\FormBundle\Entity\FormRepository $formRepository,
     ) {
         $this->model            = $formModel;
         $this->entityClass      = Form::class;
@@ -147,7 +148,7 @@ class FormApiController extends CommonApiController
 
             // Save the form first to get the form ID.
             // Using the repository function to not trigger the listeners twice.
-            $this->model->getRepository()->saveEntity($entity);
+            $this->formRepository->saveEntity($entity);
         }
 
         $formId             = $entity->getId();
@@ -265,7 +266,7 @@ class FormApiController extends CommonApiController
 
             // Save the form first and new actions so that new fields are available to actions.
             // Using the repository function to not trigger the listeners twice.
-            $this->model->getRepository()->saveEntity($entity);
+            $this->formRepository->saveEntity($entity);
             $this->model->setActions($entity, $actions);
         }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -50,6 +50,8 @@ class FormController extends CommonFormController
         private readonly FormModel $formModel,
         private readonly AuditLogModel $auditLogModel,
         private readonly SubmissionModel $submissionModel,
+        private readonly \Mautic\FormBundle\Entity\SubmissionRepository $submissionRepository,
+        private readonly \Mautic\FormBundle\Entity\FormRepository $formRepository,
     ) {
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -242,7 +244,7 @@ class FormController extends CommonFormController
             $activeFormFields[] = $field;
         }
 
-        $submissionCounts = $this->submissionModel->getRepository()->getSubmissionCounts($activeForm);
+        $submissionCounts = $this->submissionRepository->getSubmissionCounts($activeForm);
 
         return $this->delegateView(
             [
@@ -333,7 +335,7 @@ class FormController extends CommonFormController
                             // Save the form first and new actions so that new fields are available to actions.
                             // Using the repository function to not trigger the listeners twice.
 
-                            $this->formModel->getRepository()->saveEntity($entity);
+                            $this->formRepository->saveEntity($entity);
 
                             // Only save actions that are not to be deleted
                             $actions = array_diff_key($modifiedActions, array_flip($deletedActions));
@@ -594,7 +596,7 @@ class FormController extends CommonFormController
                         // save the form first so that new fields are available to actions
                         // use the repository method to not trigger listeners twice
                         try {
-                            $this->formModel->getRepository()->saveEntity($entity);
+                            $this->formRepository->saveEntity($entity);
 
                             if (count($actions)) {
                                 // Now set and persist the actions

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -26,6 +26,10 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class PublicController extends CommonFormController
 {
+    private \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository;
+
+    private \Mautic\FormBundle\Entity\FieldRepository $fieldRepository;
+
     private SubmissionModel $submissionModel;
 
     private FormModel $formModel;
@@ -34,9 +38,13 @@ final class PublicController extends CommonFormController
     public function autowirePublicController(
         FormModel $formModel,
         SubmissionModel $submissionModel,
+        \Mautic\FormBundle\Entity\FieldRepository $fieldRepository,
+        \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository,
     ): void {
         $this->formModel = $formModel;
         $this->submissionModel = $submissionModel;
+        $this->fieldRepository = $fieldRepository;
+        $this->companyRepository = $companyRepository;
     }
 
     private array $tokens = [];
@@ -669,10 +677,10 @@ final class PublicController extends CommonFormController
             return new JsonResponse($vagueErrorMessage, JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        if (!$fieldModel->getRepository()->fieldExistsByFormAndType($formId, 'companyLookup')) {
+        if (!$this->fieldRepository->fieldExistsByFormAndType($formId, 'companyLookup')) {
             return new JsonResponse($vagueErrorMessage, JsonResponse::HTTP_BAD_REQUEST);
         }
 
-        return new JsonResponse($companyModel->getRepository()->getCompanyLookupData($search));
+        return new JsonResponse($this->companyRepository->getCompanyLookupData($search));
     }
 }

--- a/app/bundles/LeadBundle/Command/ContactScheduledExportCommand.php
+++ b/app/bundles/LeadBundle/Command/ContactScheduledExportCommand.php
@@ -10,7 +10,6 @@ use Mautic\CoreBundle\ProcessSignal\ProcessSignalService;
 use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
 use Mautic\LeadBundle\Event\ContactExportSchedulerEvent;
 use Mautic\LeadBundle\LeadEvents;
-use Mautic\LeadBundle\Model\ContactExportSchedulerModel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,10 +28,10 @@ class ContactScheduledExportCommand extends Command
     public const COMMAND_NAME                  = 'mautic:contacts:scheduled_export';
 
     public function __construct(
-        private readonly ContactExportSchedulerModel $contactExportSchedulerModel,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly FormatterHelper $formatterHelper,
         private readonly ProcessSignalService $processSignalService,
+        private readonly \Mautic\LeadBundle\Entity\ContactExportSchedulerRepository $contactExportSchedulerRepository,
     ) {
         parent::__construct();
     }
@@ -59,9 +58,9 @@ class ContactScheduledExportCommand extends Command
         $ids = $this->formatterHelper->simpleCsvToArray($input->getOption('ids'), 'int');
 
         if ([] !== $ids) {
-            $contactExportSchedulers = $this->contactExportSchedulerModel->getRepository()->findBy(['id' => $ids]);
+            $contactExportSchedulers = $this->contactExportSchedulerRepository->findBy(['id' => $ids]);
         } else {
-            $contactExportSchedulers = $this->contactExportSchedulerModel->getRepository()
+            $contactExportSchedulers = $this->contactExportSchedulerRepository
                 ->findBy([], [], self::PICK_SCHEDULED_EXPORTS_LIMIT);
         }
 

--- a/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
+++ b/app/bundles/LeadBundle/Command/UpdateLeadListsCommand.php
@@ -29,6 +29,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
         private readonly TranslatorInterface $translator,
         PathsHelper $pathsHelper,
         CoreParametersHelper $coreParametersHelper,
+        private readonly \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository,
     ) {
         parent::__construct($pathsHelper, $coreParametersHelper);
     }
@@ -123,7 +124,7 @@ class UpdateLeadListsCommand extends ModeratedCommand
                     'force' => [
                         [
                             'expr'   => 'notIn',
-                            'column' => $this->listModel->getRepository()->getTableAlias().'.id',
+                            'column' => $this->leadListRepository->getTableAlias().'.id',
                             'value'  => $excludeSegments,
                         ],
                     ],

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -41,6 +41,20 @@ final class AjaxController extends CommonAjaxController
     use AjaxLookupControllerTrait;
     use SegmentFilterIconTrait;
 
+    private \Mautic\LeadBundle\Entity\LeadFieldRepository $leadFieldRepository;
+
+    private \Mautic\EmailBundle\Entity\EmailRepository $emailRepository;
+
+    private \Mautic\LeadBundle\Entity\LeadRepository $leadRepository;
+
+    #[Required]
+    public function autowireAjaxController(\Mautic\LeadBundle\Entity\LeadRepository $leadRepository, \Mautic\EmailBundle\Entity\EmailRepository $emailRepository, \Mautic\LeadBundle\Entity\LeadFieldRepository $leadFieldRepository): void
+    {
+        $this->leadRepository = $leadRepository;
+        $this->emailRepository = $emailRepository;
+        $this->leadFieldRepository = $leadFieldRepository;
+    }
+
     private LeadModel $leadModel;
 
     private FieldModel $leadFieldModel;
@@ -98,7 +112,7 @@ final class AjaxController extends CommonAjaxController
         $dataArray = ['items' => []];
 
         if ($field && $value) {
-            $repo                       = $leadModel->getRepository();
+            $repo                       = $this->leadRepository;
             $leads                      = $repo->getLeadsByFieldValue($field, $value, $ignore);
             $dataArray['existsMessage'] = $this->translator->trans('mautic.lead.exists.by.field').': ';
 
@@ -407,7 +421,7 @@ final class AjaxController extends CommonAjaxController
                 $this->addFlashMessage('mautic.lead.event.donotcontact_channel_contactable', ['%channel%' => $channel], FlashBag::LEVEL_SUCCESS);
                 $dataArray['flashes'] = $this->getFlashContent();
             } else {
-                $emailModel->getRepository()->deleteDoNotEmailEntry($dncId);
+                $this->emailRepository->deleteDoNotEmailEntry($dncId);
             }
 
             $dataArray['success'] = 1;
@@ -478,10 +492,10 @@ final class AjaxController extends CommonAjaxController
 
             if (!empty($count)) {
                 // Get the max ID of the latest lead added
-                $maxLeadId = $model->getRepository()->getMaxLeadId();
+                $maxLeadId = $this->leadRepository->getMaxLeadId();
 
                 // We need the EmailRepository to check if a lead is flagged as do not contact
-                $emailRepo          = $this->emailModel->getRepository();
+                $emailRepo          = $this->emailRepository;
                 $indexMode          = $request->get('view', $session->get('mautic.lead.indexmode', 'list'));
                 $template           = ('list' == $indexMode) ? 'list_rows' : 'grid_cards';
                 $dataArray['leads'] = $this->render(
@@ -663,7 +677,7 @@ final class AjaxController extends CommonAjaxController
         $changed   = InputHelper::clean($request->request->get('changed'));
         $dataArray = ['success' => 0, 'options' => null, 'optionsAttr' => [], 'operators' => null, 'disabled' => false];
 
-        $leadField = $this->leadFieldModel->getRepository()->findOneBy(['alias' => $alias]);
+        $leadField = $this->leadFieldRepository->findOneBy(['alias' => $alias]);
 
         if ($leadField) {
             $options       = null;

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -47,29 +47,19 @@ final class AjaxController extends CommonAjaxController
 
     private \Mautic\LeadBundle\Entity\LeadRepository $leadRepository;
 
-    #[Required]
-    public function autowireAjaxController(\Mautic\LeadBundle\Entity\LeadRepository $leadRepository, \Mautic\EmailBundle\Entity\EmailRepository $emailRepository, \Mautic\LeadBundle\Entity\LeadFieldRepository $leadFieldRepository): void
-    {
-        $this->leadRepository = $leadRepository;
-        $this->emailRepository = $emailRepository;
-        $this->leadFieldRepository = $leadFieldRepository;
-    }
-
     private LeadModel $leadModel;
-
-    private FieldModel $leadFieldModel;
-
-    private EmailModel $emailModel;
 
     #[Required]
     public function autowireLeadAjaxController(
+        \Mautic\LeadBundle\Entity\LeadRepository $leadRepository,
+        \Mautic\EmailBundle\Entity\EmailRepository $emailRepository,
+        \Mautic\LeadBundle\Entity\LeadFieldRepository $leadFieldRepository,
         LeadModel $leadModel,
-        FieldModel $leadFieldModel,
-        EmailModel $emailModel,
     ): void {
         $this->leadModel = $leadModel;
-        $this->leadFieldModel = $leadFieldModel;
-        $this->emailModel = $emailModel;
+        $this->leadRepository = $leadRepository;
+        $this->emailRepository = $emailRepository;
+        $this->leadFieldRepository = $leadFieldRepository;
     }
 
     public function userListAction(Request $request): JsonResponse
@@ -112,12 +102,11 @@ final class AjaxController extends CommonAjaxController
         $dataArray = ['items' => []];
 
         if ($field && $value) {
-            $repo                       = $this->leadRepository;
-            $leads                      = $repo->getLeadsByFieldValue($field, $value, $ignore);
+            $leads                      = $this->leadRepository->getLeadsByFieldValue($field, $value, $ignore);
             $dataArray['existsMessage'] = $this->translator->trans('mautic.lead.exists.by.field').': ';
 
             foreach ($leads as $lead) {
-                $fields = $repo->getFieldValues($lead->getId());
+                $fields = $this->leadRepository->getFieldValues($lead->getId());
                 $lead->setFields($fields);
                 $name = $lead->getName();
 
@@ -495,14 +484,13 @@ final class AjaxController extends CommonAjaxController
                 $maxLeadId = $this->leadRepository->getMaxLeadId();
 
                 // We need the EmailRepository to check if a lead is flagged as do not contact
-                $emailRepo          = $this->emailRepository;
                 $indexMode          = $request->get('view', $session->get('mautic.lead.indexmode', 'list'));
                 $template           = ('list' == $indexMode) ? 'list_rows' : 'grid_cards';
                 $dataArray['leads'] = $this->render(
                     "@MauticLead/Lead/{$template}.html.twig",
                     [
                         'items'         => $results['results'],
-                        'noContactList' => $emailRepo->getDoNotEmailList(array_keys($results['results'])),
+                        'noContactList' => $this->emailRepository->getDoNotEmailList(array_keys($results['results'])),
                         'permissions'   => $permissions,
                         'security'      => $this->security,
                         'highlight'     => true,

--- a/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
@@ -39,8 +39,21 @@ class FieldApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, FieldModel $fieldModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        FieldModel $fieldModel,
+        private readonly \Mautic\LeadBundle\Entity\LeadFieldRepository $leadFieldRepository,
+    ) {
         $request = $requestStack->getCurrentRequest();
         \assert(null !== $request);
 
@@ -55,7 +68,7 @@ class FieldApiController extends CommonApiController
             $this->fieldObject = 'lead';
         }
 
-        $repo                = $this->model->getRepository();
+        $repo                = $this->leadFieldRepository;
         $tableAlias          = $repo->getTableAlias();
         $this->listFilters[] = [
             'column' => $tableAlias.'.object',

--- a/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
@@ -68,8 +68,7 @@ class FieldApiController extends CommonApiController
             $this->fieldObject = 'lead';
         }
 
-        $repo                = $this->leadFieldRepository;
-        $tableAlias          = $repo->getTableAlias();
+        $tableAlias          = $this->leadFieldRepository->getTableAlias();
         $this->listFilters[] = [
             'column' => $tableAlias.'.object',
             'expr'   => 'eq',

--- a/app/bundles/LeadBundle/Controller/Api/TagApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/TagApiController.php
@@ -22,8 +22,21 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class TagApiController extends CommonApiController
 {
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, TagModel $leadTagModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        TagModel $leadTagModel,
+        private readonly \Mautic\LeadBundle\Entity\TagRepository $tagRepository,
+    ) {
         $this->model           = $leadTagModel;
         $this->entityClass     = Tag::class;
         $this->entityNameOne   = 'tag';
@@ -48,6 +61,6 @@ class TagApiController extends CommonApiController
         $tagModel = $this->model;
         \assert($tagModel instanceof TagModel);
 
-        return $tagModel->getRepository()->getTagByNameOrCreateNewOne($params[$this->entityNameOne]);
+        return $this->tagRepository->getTagByNameOrCreateNewOne($params[$this->entityNameOne]);
     }
 }

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -26,6 +26,8 @@ final class CompanyController extends FormController
 {
     use LeadDetailsTrait;
 
+    private \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository;
+
     private FieldModel $fieldModel;
 
     private CompanyModel $companyModel;
@@ -37,10 +39,12 @@ final class CompanyController extends FormController
         LeadModel $leadModel,
         CompanyModel $companyModel,
         FieldModel $fieldModel,
+        \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository,
     ): void {
         $this->leadModel = $leadModel;
         $this->companyModel = $companyModel;
         $this->fieldModel = $fieldModel;
+        $this->companyRepository = $companyRepository;
     }
 
     public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, CompanyColumnsDictionary $companyColumnsDictionary, int $page = 1): Response
@@ -112,7 +116,7 @@ final class CompanyController extends FormController
 
         $tmpl  = $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index';
         $companyIds = array_keys($companies);
-        $leadCounts = (!empty($companyIds)) ? $this->companyModel->getRepository()->getLeadCount($companyIds) : [];
+        $leadCounts = (!empty($companyIds)) ? $this->companyRepository->getLeadCount($companyIds) : [];
 
         return $this->delegateView(
             [
@@ -545,7 +549,7 @@ final class CompanyController extends FormController
         }
 
         /** @var Company $company */
-        $this->companyModel->getRepository()->refetchEntity($company);
+        $this->companyRepository->refetchEntity($company);
 
         // set some permissions
         $permissions = $this->security->isGranted(

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -66,6 +66,7 @@ final class ImportController extends FormController
         private readonly RequestStack $requestStack,
         CorePermissions $security,
         private readonly ImportModel $importModel,
+        private readonly \Mautic\LeadBundle\Entity\ImportRepository $importRepository,
     ) {
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -98,7 +99,7 @@ final class ImportController extends FormController
         $object = $this->requestStack->getSession()->get('mautic.import.object');
 
         $filter['force'][] = [
-            'column' => $this->importModel->getRepository()->getTableAlias().'.object',
+            'column' => $this->importRepository->getTableAlias().'.object',
             'expr'   => 'eq',
             'value'  => $object,
         ];

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -446,8 +446,8 @@ final class LeadController extends FormController
         $fields            = $lead->getFields();
         $socialProfiles    = (array) $integrationHelper->getUserProfiles($lead, $fields);
         $socialProfileUrls = $integrationHelper->getSocialProfileUrlRegex(false);
-        $companiesRepo = $this->companyRepository;
-        $companies     = $companiesRepo->getCompaniesByLeadId($objectId);
+
+        $companies     = $this->companyRepository->getCompaniesByLeadId($objectId);
         // Set the social profile templates
         foreach ($socialProfiles as $integration => &$details) {
             if ($integrationObject = $integrationHelper->getIntegrationObject($integration)) {

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -68,6 +68,14 @@ final class LeadController extends FormController
     use LeadDetailsTrait;
     use FrequencyRuleTrait;
 
+    private \Mautic\UserBundle\Entity\UserRepository $userRepository;
+
+    private \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository;
+
+    private \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository;
+
+    private LeadRepository $leadRepository;
+
     private NoteModel $noteModel;
 
     private CampaignModel $campaignModel;
@@ -97,6 +105,10 @@ final class LeadController extends FormController
         NoteModel $noteModel,
         FieldModel $leadFieldModel,
         UserModel $userModel,
+        LeadRepository $leadRepository,
+        \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository,
+        \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository,
+        \Mautic\UserBundle\Entity\UserRepository $userRepository,
     ): void {
         $this->leadModel = $leadModel;
         $this->stageModel = $stageModel;
@@ -107,6 +119,10 @@ final class LeadController extends FormController
         $this->noteModel = $noteModel;
         $this->leadFieldModel = $leadFieldModel;
         $this->userModel = $userModel;
+        $this->leadRepository = $leadRepository;
+        $this->companyRepository = $companyRepository;
+        $this->leadListRepository = $leadListRepository;
+        $this->userRepository = $userRepository;
     }
 
     /**
@@ -245,7 +261,7 @@ final class LeadController extends FormController
         }
 
         // Get the max ID of the latest lead added
-        $maxLeadId = $this->leadModel->getRepository()->getMaxLeadId();
+        $maxLeadId = $this->leadRepository->getMaxLeadId();
 
         \assert($leadDNCModel instanceof DoNotContactModel);
         $dncRepository = $leadDNCModel->getDncRepo();
@@ -402,7 +418,7 @@ final class LeadController extends FormController
             );
         }
 
-        $this->leadModel->getRepository()->refetchEntity($lead);
+        $this->leadRepository->refetchEntity($lead);
 
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -430,7 +446,7 @@ final class LeadController extends FormController
         $fields            = $lead->getFields();
         $socialProfiles    = (array) $integrationHelper->getUserProfiles($lead, $fields);
         $socialProfileUrls = $integrationHelper->getSocialProfileUrlRegex(false);
-        $companiesRepo = $this->companyModel->getRepository();
+        $companiesRepo = $this->companyRepository;
         $companies     = $companiesRepo->getCompaniesByLeadId($objectId);
         // Set the social profile templates
         foreach ($socialProfiles as $integration => &$details) {
@@ -453,7 +469,7 @@ final class LeadController extends FormController
 
         $integrationRepo = $this->doctrine->getRepository(IntegrationEntity::class);
 
-        $lists = $this->leadListModel->getRepository()->getLeadLists([$lead], true, true);
+        $lists = $this->leadListRepository->getLeadLists([$lead], true, true);
 
         $leadDeviceRepository = $this->doctrine->getRepository(LeadDevice::class);
 
@@ -1911,7 +1927,7 @@ final class LeadController extends FormController
                 ]
             );
         }
-        $users = $this->userModel->getRepository()->getUserList('', 0);
+        $users = $this->userRepository->getUserList('', 0);
         $items = [];
         foreach ($users as $user) {
             $items[$user['firstName'].' '.$user['lastName'].' ('.$user['id'].')'] = $user['id'];

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -32,6 +32,8 @@ final class ListController extends FormController
     use EntityContactsTrait;
     use QuickFilterSearchTrait;
 
+    private \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository;
+
     private ListModel $listModel;
 
     private LeadModel $leadModel;
@@ -40,9 +42,11 @@ final class ListController extends FormController
     public function autowireListController(
         LeadModel $leadModel,
         ListModel $listModel,
+        \Mautic\LeadBundle\Entity\LeadListRepository $leadListRepository,
     ): void {
         $this->leadModel = $leadModel;
         $this->listModel = $listModel;
+        $this->leadListRepository = $leadListRepository;
     }
 
     public const ROUTE_SEGMENT_CONTACTS = 'mautic_segment_contacts';
@@ -105,7 +109,7 @@ final class ListController extends FormController
         ];
 
         $tmpl       = $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index';
-        $tableAlias = $this->listModel->getRepository()->getTableAlias();
+        $tableAlias = $this->leadListRepository->getTableAlias();
 
         if (!$permissions[LeadPermissions::LISTS_VIEW_OTHER]) {
             $filter['where'][] = [
@@ -799,7 +803,7 @@ final class ListController extends FormController
                 'campaignStats'      => $segmentCampaignShare->getCampaignList($list->getId()),
                 'stats'              => $segmentContactsLineChartData,
                 'list'               => $list,
-                'segmentCount'       => $listModel->getRepository()->getLeadCount($list->getId()),
+                'segmentCount'       => $this->leadListRepository->getLeadCount($list->getId()),
                 'activeSegmentCount' => $listModel->getActiveSegmentContactCount($list->getId()),
                 'permissions'        => $this->security->isGranted($permissions, 'RETURN_ARRAY'),
                 'security'           => $this->security,

--- a/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
@@ -13,7 +13,6 @@ use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
 use Mautic\LeadBundle\Command\ContactScheduledExportCommand;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
 use Mautic\LeadBundle\Entity\ContactExportSchedulerRepository;
-use Mautic\LeadBundle\Model\ContactExportSchedulerModel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,7 +23,6 @@ final class ContactScheduledExportCommandTest extends TestCase
 {
     public function testForSignalCaughtException(): void
     {
-        $contactExportScheduledModel = $this->createMock(ContactExportSchedulerModel::class);
         $eventDispatcher             = $this->createMock(EventDispatcherInterface::class);
 
         $translator           = $this->createStub(TranslatorInterface::class);
@@ -45,14 +43,11 @@ final class ContactScheduledExportCommandTest extends TestCase
         $contactExportSchedulerRepository->method('findBy')
             ->willReturn([new ContactExportScheduler()]);
 
-        $contactExportScheduledModel->method('getRepository')
-            ->willReturn($contactExportSchedulerRepository);
-
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
             ->willThrowException(new SignalCaughtException(1));
 
-        $command = new class($contactExportScheduledModel, $eventDispatcher, $formatterHelper, $processSignalService) extends ContactScheduledExportCommand {
+        $command = new class($eventDispatcher, $formatterHelper, $processSignalService, $contactExportSchedulerRepository) extends ContactScheduledExportCommand {
             public function getExecute(InputInterface $input, OutputInterface $output): int
             {
                 return $this->execute($input, $output);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -66,10 +66,8 @@ final class FieldApiControllerTest extends TestCase
         $requestStack = $this->createMock(RequestStack::class);
         $requestStack->method('getCurrentRequest')
             ->willReturn($request);
-        $fieldModel      = $this->createMock(FieldModel::class);
-        $fieldModel->method('getRepository')
-            ->willReturn($this->createStub(LeadFieldRepository::class));
-        $controller   = new FieldApiController(
+
+        $controller = new FieldApiController(
             $this->createStub(CorePermissions::class),
             $this->createStub(Translator::class),
             $this->createStub(EntityResultHelper::class),
@@ -81,7 +79,8 @@ final class FieldApiControllerTest extends TestCase
             $this->createStub(ModelFactory::class),
             $this->createStub(EventDispatcherInterface::class),
             $this->createStub(CoreParametersHelper::class),
-            $fieldModel,
+            $this->createStub(FieldModel::class),
+            $this->createStub(LeadFieldRepository::class)
         );
 
         $controllerReflection = new \ReflectionClass(FieldApiController::class);

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -22,12 +22,15 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class PluginController extends FormController
 {
+    private \Mautic\PluginBundle\Entity\PluginRepository $pluginRepository;
+
     private PluginModel $pluginModel;
 
     #[Required]
-    public function autowirePluginController(PluginModel $pluginModel): void
+    public function autowirePluginController(PluginModel $pluginModel, \Mautic\PluginBundle\Entity\PluginRepository $pluginRepository): void
     {
         $this->pluginModel = $pluginModel;
+        $this->pluginRepository = $pluginRepository;
     }
 
     public function indexAction(Request $request, IntegrationHelper $integrationHelper): Response
@@ -366,7 +369,7 @@ final class PluginController extends FormController
             $this->throwAccessDenied();
         }
 
-        $bundle = $this->pluginModel->getRepository()->findOneBy(
+        $bundle = $this->pluginRepository->findOneBy(
             [
                 'bundle' => InputHelper::clean($name),
             ]

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -45,6 +45,7 @@ class TriggerApiController extends CommonApiController
         CoreParametersHelper $coreParametersHelper,
         TriggerModel $triggerModel,
         private readonly TriggerEventModel $triggerEventModel,
+        private readonly \Mautic\PointBundle\Entity\TriggerRepository $triggerRepository,
     ) {
         $this->model            = $triggerModel;
         $this->entityClass      = Trigger::class;
@@ -75,7 +76,7 @@ class TriggerApiController extends CommonApiController
 
             // Save the entitz first to get the ID.
             // Using the repository function to not trigger the listeners twice.
-            $this->model->getRepository()->saveEntity($entity);
+            $this->triggerRepository->saveEntity($entity);
         }
 
         $requestTriggerIds = [];

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -17,13 +17,16 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class StageController extends AbstractFormController
 {
+    private \Mautic\StageBundle\Entity\StageRepository $stageRepository;
+
     private StageModel $stageModel;
 
     #[Required]
     public function autowireStageController(
-        StageModel $stageModel,
+        StageModel $stageModel, \Mautic\StageBundle\Entity\StageRepository $stageRepository,
     ): void {
         $this->stageModel = $stageModel;
+        $this->stageRepository = $stageRepository;
     }
 
     public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
@@ -202,7 +205,7 @@ final class StageController extends AbstractFormController
             $themes[] = $actions['actions'][$actionType]['formTheme'];
         }
 
-        $stageWeights = $this->stageModel->getRepository()->getStageWeights();
+        $stageWeights = $this->stageRepository->getStageWeights();
 
         return $this->delegateView(
             [
@@ -355,7 +358,7 @@ final class StageController extends AbstractFormController
             $themes[] = $actions['actions'][$actionType]['formTheme'];
         }
 
-        $stageWeights = $this->stageModel->getRepository()->getStageWeights();
+        $stageWeights = $this->stageRepository->getStageWeights();
 
         return $this->delegateView(
             [
@@ -435,7 +438,7 @@ final class StageController extends AbstractFormController
             $this->throwAccessDenied();
         }
 
-        $stages = $model->getRepository()->getStages(false, (string) $secondaryStage->getId());
+        $stages = $this->stageRepository->getStages(false, (string) $secondaryStage->getId());
 
         $action = $this->generateUrl('mautic_stage_action', ['objectAction' => 'merge', 'objectId' => $secondaryStage->getId()]);
 

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -18,13 +18,16 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class PublicController extends FormController
 {
+    private \Mautic\UserBundle\Entity\UserRepository $userRepository;
+
     private UserModel $userModel;
 
     #[Required]
     public function autowirePublicController(
-        UserModel $userModel,
+        UserModel $userModel, \Mautic\UserBundle\Entity\UserRepository $userRepository,
     ): void {
         $this->userModel = $userModel;
+        $this->userRepository = $userRepository;
     }
 
     /**
@@ -41,7 +44,7 @@ final class PublicController extends FormController
             if ($isValid = $this->isFormValid($form)) {
                 // find the user
                 $data = $form->getData();
-                $user = $this->userModel->getRepository()->findByIdentifier($data['identifier']);
+                $user = $this->userRepository->findByIdentifier($data['identifier']);
 
                 /**
                  * Calculation of time to standardize fix response for vulnerability
@@ -110,7 +113,7 @@ final class PublicController extends FormController
     private function handlePasswordResetConfirm(Request $request, UserModel $model, UserPasswordHasherInterface $hasher, array $data): ?Response
     {
         $response = null;
-        $user     = $model->getRepository()->findByIdentifier($data['identifier']);
+        $user     = $this->userRepository->findByIdentifier($data['identifier']);
 
         if (null === $user) {
             $this->addFlashMessage('mautic.user.user.notice.passwordreset.success');

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -336,8 +336,7 @@ final class UserController extends FormController
 
         $userActivity       = $this->auditLogRepository->getLogsForUser($user);
         $users              = $this->userModel->getEntities();
-        $roleRepository     = $this->roleRepository;
-        $roles              = $roleRepository->getEntities();
+        $roles              = $this->roleRepository->getEntities();
 
         // set the page we came from
         $page = $request->getSession()->get('mautic.user.page', 1);

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -29,7 +29,9 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class UserController extends FormController
 {
-    private RoleModel $roleModel;
+    private \Mautic\UserBundle\Entity\RoleRepository $roleRepository;
+
+    private \Mautic\CoreBundle\Entity\AuditLogRepository $auditLogRepository;
 
     private UserModel $userModel;
 
@@ -40,10 +42,13 @@ final class UserController extends FormController
         UserModel $userModel,
         AuditLogModel $auditLogModel,
         RoleModel $roleModel,
+        \Mautic\CoreBundle\Entity\AuditLogRepository $auditLogRepository,
+        \Mautic\UserBundle\Entity\RoleRepository $roleRepository,
     ): void {
         $this->userModel = $userModel;
         $this->auditLogModel = $auditLogModel;
-        $this->roleModel = $roleModel;
+        $this->auditLogRepository = $auditLogRepository;
+        $this->roleRepository = $roleRepository;
     }
 
     /**
@@ -326,11 +331,12 @@ final class UserController extends FormController
                 ],
             ]);
         }
+
         $oldEmail = $user->getEmail();
-        $auditLogRepository = $this->auditLogModel->getRepository();
-        $userActivity       = $auditLogRepository->getLogsForUser($user);
+
+        $userActivity       = $this->auditLogRepository->getLogsForUser($user);
         $users              = $this->userModel->getEntities();
-        $roleRepository     = $this->roleModel->getRepository();
+        $roleRepository     = $this->roleRepository;
         $roles              = $roleRepository->getEntities();
 
         // set the page we came from

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -18,6 +18,10 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class PublicController extends FormController
 {
+    private \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository;
+
+    private \Mautic\LeadBundle\Entity\LeadRepository $leadRepository;
+
     private CompanyModel $companyModel;
 
     private LeadModel $leadModel;
@@ -32,11 +36,15 @@ final class PublicController extends FormController
         CompanyModel $companyModel,
         NotificationModel $notificationModel,
         UserModel $userModel,
+        \Mautic\LeadBundle\Entity\LeadRepository $leadRepository,
+        \Mautic\LeadBundle\Entity\CompanyRepository $companyRepository,
     ): void {
         $this->leadModel = $leadModel;
         $this->companyModel = $companyModel;
         $this->notificationModel = $notificationModel;
         $this->userModel = $userModel;
+        $this->leadRepository = $leadRepository;
+        $this->companyRepository = $companyRepository;
     }
 
     /**
@@ -207,7 +215,7 @@ final class PublicController extends FormController
             $lead->setSocialCache($socialCache);
 
             $this->leadModel->setFieldValues($lead, $data);
-            $this->leadModel->getRepository()->saveEntity($lead);
+            $this->leadRepository->saveEntity($lead);
 
             if ($notify && (!isset($lead->imported) || !$lead->imported)) {
                 if ($user = $this->userModel->getEntity($notify)) {
@@ -361,7 +369,7 @@ final class PublicController extends FormController
             $company->setSocialCache($socialCache);
 
             $this->companyModel->setFieldValues($company, $data);
-            $this->companyModel->getRepository()->saveEntity($company);
+            $this->companyRepository->saveEntity($company);
 
             if ($notify) {
                 if ($user = $this->userModel->getEntity($notify)) {

--- a/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
+++ b/plugins/MauticSocialBundle/Command/MauticSocialMonitoringCommand.php
@@ -2,7 +2,6 @@
 
 namespace MauticPlugin\MauticSocialBundle\Command;
 
-use MauticPlugin\MauticSocialBundle\Model\MonitoringModel;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -17,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class MauticSocialMonitoringCommand extends Command
 {
     public function __construct(
-        private readonly MonitoringModel $monitoringModel,
+        private readonly \MauticPlugin\MauticSocialBundle\Entity\MonitoringRepository $monitoringRepository,
     ) {
         parent::__construct();
     }
@@ -79,13 +78,11 @@ class MauticSocialMonitoringCommand extends Command
             'limit' => 100,
         ];
 
-        $repository = $this->monitoringModel->getRepository();
-
         if (null !== $id) {
             $filter['filter'] = [
                 'force' => [
                     [
-                        'column' => $repository->getTableAlias().'.id',
+                        'column' => $this->monitoringRepository->getTableAlias().'.id',
                         'expr'   => 'eq',
                         'value'  => (int) $id,
                     ],
@@ -93,7 +90,7 @@ class MauticSocialMonitoringCommand extends Command
             ];
         }
 
-        return $repository->getPublishedEntities($filter);
+        return $this->monitoringRepository->getPublishedEntities($filter);
     }
 
     /**

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 use MauticPlugin\MauticSocialBundle\Model\MonitoringModel;
-use MauticPlugin\MauticSocialBundle\Model\PostCountModel;
 use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -23,21 +22,21 @@ final class MonitoringController extends FormController
 {
     use EntityContactsTrait;
 
+    private \MauticPlugin\MauticSocialBundle\Entity\PostCountRepository $postCountRepository;
+
     private AuditLogModel $auditLogModel;
 
     private MonitoringModel $monitoringModel;
-
-    private PostCountModel $postCountModel;
 
     #[Required]
     public function autowireMonitoringController(
         MonitoringModel $monitoringModel,
         AuditLogModel $auditLogModel,
-        PostCountModel $postCountModel,
+        \MauticPlugin\MauticSocialBundle\Entity\PostCountRepository $postCountRepository,
     ): void {
         $this->monitoringModel = $monitoringModel;
         $this->auditLogModel = $auditLogModel;
-        $this->postCountModel = $postCountModel;
+        $this->postCountRepository = $postCountRepository;
     }
 
     /**
@@ -406,8 +405,6 @@ final class MonitoringController extends FormController
 
         $session = $request->getSession();
 
-        $postCountRepo = $this->postCountModel->getRepository();
-
         $security         = $this->security;
         $monitoringEntity = $this->monitoringModel->getEntity($objectId);
 
@@ -456,7 +453,7 @@ final class MonitoringController extends FormController
         $dateTo          = new \DateTime($dateRangeForm['date_to']->getData());
 
         $chart     = new LineChart(null, $dateFrom, $dateTo);
-        $leadStats = $postCountRepo->getLeadStatsPost(
+        $leadStats = $this->postCountRepository->getLeadStatsPost(
             $dateFrom,
             $dateTo,
             ['monitor_id' => $monitoringEntity->getId()]

--- a/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
@@ -12,13 +12,13 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class BatchTagController extends AbstractFormController
 {
-    private TagModel $tagModel;
+    private \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository;
 
     #[Required]
     public function autowireBatchTagController(
-        TagModel $tagModel,
+        TagModel $tagModel, \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository,
     ): void {
-        $this->tagModel = $tagModel;
+        $this->tagRepository = $tagRepository;
     }
 
     public function indexAction(): Response
@@ -89,11 +89,11 @@ final class BatchTagController extends AbstractFormController
         }
 
         if (!empty($tagsToAdd)) {
-            $this->tagModel->getRepository()->addTagsToLeads($ids, $tagsToAdd);
+            $this->tagRepository->addTagsToLeads($ids, $tagsToAdd);
         }
 
         if (!empty($tagsToRemove)) {
-            $this->tagModel->getRepository()->removeTagsFromLeads($ids, $tagsToRemove);
+            $this->tagRepository->removeTagsFromLeads($ids, $tagsToRemove);
         }
 
         $this->addFlashMessage('mautic.lead.batch_leads_affected', [

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -22,6 +22,8 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class TagController extends FormController
 {
+    private \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository;
+
     private TagModel $leadTagModel;
 
     private TagManagerModel $tagManagerModel;
@@ -30,9 +32,11 @@ final class TagController extends FormController
     public function autowireTagController(
         TagModel $leadTagModel,
         TagManagerModel $tagManagerModel,
+        \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository,
     ): void {
         $this->leadTagModel = $leadTagModel;
         $this->tagManagerModel = $tagManagerModel;
+        $this->tagRepository = $tagRepository;
     }
 
     private const PERMISSION_VIEW   = 'tagManager:tagManager:view';
@@ -127,7 +131,7 @@ final class TagController extends FormController
         $session->set('mautic.tagmanager.page', $page);
 
         $tagIds    = array_map(fn (Tag $tag) => $tag->getId(), iterator_to_array($items->getIterator()));
-        $tagsCount = (!empty($tagIds)) ? $this->tagManagerModel->getRepository()->countByLeads($tagIds) : [];
+        $tagsCount = (!empty($tagIds)) ? $this->tagRepository->countByLeads($tagIds) : [];
 
         $parameters = [
             'items'       => $items,
@@ -201,7 +205,7 @@ final class TagController extends FormController
         if (!$cancelled = $this->isFormCancelled($form)) {
             if ($valid = $this->isFormValid($form)) {
                 // form is valid so process the data
-                $found = $model->getRepository()->countOccurrences($tag->getTag());
+                $found = $this->tagRepository->countOccurrences($tag->getTag());
                 if (0 !== $found) {
                     $valid = false;
                     $this->addFlashMessage('mautic.core.notice.updated', [
@@ -386,7 +390,7 @@ final class TagController extends FormController
 
     private function isTagUnique(Tag $tag): bool
     {
-        $existingTags = $this->tagManagerModel->getRepository()->getTagsByName([$tag->getTag()]);
+        $existingTags = $this->tagRepository->getTagsByName([$tag->getTag()]);
         foreach ($existingTags as $existingTag) {
             if ($existingTag->getId() != $tag->getId()) {
                 return false;

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@ use Rector\Symfony\CodeQuality\Rector\ClassMethod\ResponseReturnTypeControllerAc
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictStringReturnsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
+use Utils\Rector\ModelGetRepositoryToRepositoryServiceRector;
 use Utils\Rector\UnserializeToSerializerDecodeRector;
 
 return RectorConfig::configure()
@@ -61,6 +62,9 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony61\Rector\Class_\CommandConfigureToAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\CommandHelpToAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector::class,
+
+        // DI
+        ModelGetRepositoryToRepositoryServiceRector::class,
     ])
     ->reportUnusedSkips()
     ->withComposerBased(phpunit: true)

--- a/rector.php
+++ b/rector.php
@@ -64,7 +64,7 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony73\Rector\Class_\ConstraintOptionsToNamedArgumentsRector::class,
 
         // DI
-        ModelGetRepositoryToRepositoryServiceRector::class,
+        // ModelGetRepositoryToRepositoryServiceRector::class,
     ])
     ->reportUnusedSkips()
     ->withComposerBased(phpunit: true)

--- a/tests/acceptance/MauticScriptSplitCest.php
+++ b/tests/acceptance/MauticScriptSplitCest.php
@@ -10,7 +10,9 @@ final class MauticScriptSplitCest
 
     private bool $corsConfigExisted = false;
 
-    /** @var array<string, mixed>|null */
+    /**
+     * @var array<string, mixed>|null
+     */
     private ?array $corsConfigParameters = null;
 
     public function _before(\AcceptanceTester $I): void

--- a/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
+++ b/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
@@ -1,0 +1,344 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\PropertyItem;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\NodeFinder;
+use PHPStan\Type\ObjectType;
+use Rector\NodeManipulator\ClassDependencyManipulator;
+use Rector\PhpParser\AstResolver;
+use Rector\PostRector\ValueObject\PropertyMetadata;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces the argument-less $model->getRepository() service locator with the concrete repository service.
+ *
+ * Mautic models expose getRepository() returning their custom repository, e.g.
+ * FormModel::getRepository(): FormRepository { return $this->formRepository; }. Going through the model
+ * just to reach its repository hides the repository dependency and couples the caller to the whole model.
+ *
+ * Only external calls are refactored - an object reaching another model's repository gets the repository
+ * injected and drops the model hop:
+ *
+ *   $this->formModel->getRepository()->findOneById(...)  ->  $this->formRepository->findOneById(...)
+ *
+ * with "private readonly FormRepository $formRepository" added to the constructor.
+ *
+ * Left alone:
+ *   - $this->getRepository() - the model reaching its own repository
+ *   - test cases - a test cannot take a service through its PHPUnit-owned constructor
+ *
+ * Only argument-less getRepository() calls on an AbstractCommonModel are matched; the Doctrine entity
+ * manager's getRepository(SomeEntity::class) is handled by GetRepositoryToRepositoryServiceRector instead.
+ */
+final class ModelGetRepositoryToRepositoryServiceRector extends AbstractRector
+{
+    /**
+     * Any class extending this is a test and is left alone.
+     */
+    private const TEST_CASE = 'PHPUnit\Framework\TestCase';
+
+    private const ABSTRACT_COMMON_MODEL = 'Mautic\CoreBundle\Model\AbstractCommonModel';
+
+    /**
+     * Generic repository bases - a model that does not override getRepository() resolves to one of these,
+     * and there is no dedicated service to depend on.
+     */
+    private const GENERIC_REPOSITORIES = [
+        'Doctrine\ORM\EntityRepository',
+        'Mautic\CoreBundle\Entity\CommonRepository',
+    ];
+
+    public function __construct(
+        private readonly AstResolver $astResolver,
+        private readonly ClassDependencyManipulator $classDependencyManipulator,
+        private readonly NodeFinder $nodeFinder,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace argument-less $model->getRepository() with the concrete repository service',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+$form = $this->formModel->getRepository()->findOneById($id);
+CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+$form = $this->formRepository->findOneById($id);
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Class_) {
+            return null;
+        }
+
+        if ($node->isAbstract() || $node->isAnonymous()) {
+            return null;
+        }
+
+        if ($this->isObjectType($node, new ObjectType(self::TEST_CASE))) {
+            return null;
+        }
+
+        $getRepositoryCalls = $this->findModelGetRepositoryCalls($node);
+        if ([] === $getRepositoryCalls) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($getRepositoryCalls as $getRepositoryCall) {
+            $repositoryClass = $this->resolveRepositoryClass($getRepositoryCall);
+            if (null === $repositoryClass) {
+                continue;
+            }
+
+            $replacement = $this->resolveReplacement($node, $repositoryClass);
+
+            $this->replaceNode($node, $getRepositoryCall, $replacement);
+            $hasChanged = true;
+        }
+
+        return $hasChanged ? $node : null;
+    }
+
+    /**
+     * Collects every argument-less $model->getRepository() call on another object's AbstractCommonModel.
+     *
+     * @return MethodCall[]
+     */
+    private function findModelGetRepositoryCalls(Class_ $class): array
+    {
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $this->nodeFinder->findInstanceOf($class, MethodCall::class);
+
+        return array_values(array_filter($methodCalls, function (MethodCall $methodCall): bool {
+            if (!$this->isName($methodCall->name, 'getRepository')) {
+                return false;
+            }
+
+            // The entity manager form takes an argument and is handled by the sibling rule.
+            if ([] !== $methodCall->args) {
+                return false;
+            }
+
+            // The model reaching its own repository is left alone.
+            if ($this->isCallOnThis($methodCall)) {
+                return false;
+            }
+
+            return $this->isObjectType($methodCall->var, new ObjectType(self::ABSTRACT_COMMON_MODEL));
+        }));
+    }
+
+    /**
+     * The static type of $model->getRepository() is the concrete repository - unless the model leaves it
+     * as a generic base, in which case there is no dedicated service to depend on.
+     */
+    private function resolveRepositoryClass(MethodCall $methodCall): ?string
+    {
+        $classNames = $this->getType($methodCall)->getObjectClassNames();
+        if (1 !== count($classNames)) {
+            return null;
+        }
+
+        $repositoryClass = $classNames[0];
+        if (in_array($repositoryClass, self::GENERIC_REPOSITORIES, true)) {
+            return null;
+        }
+
+        return $repositoryClass;
+    }
+
+    /**
+     * Builds the repository property fetch and injects the repository as a side effect.
+     */
+    private function resolveReplacement(Class_ $class, string $repositoryClass): PropertyFetch
+    {
+        $propertyName = $this->resolvePropertyName($repositoryClass);
+
+        $this->injectRepository($class, $repositoryClass, $propertyName);
+
+        return new PropertyFetch(new Variable('this'), $propertyName);
+    }
+
+    private function isCallOnThis(MethodCall $methodCall): bool
+    {
+        return $methodCall->var instanceof Variable && $this->isName($methodCall->var, 'this');
+    }
+
+    /**
+     * Adds the repository dependency, via constructor promotion or - when the class only inherits a
+     * constructor it would otherwise have to override - via a #[Required] autowire method.
+     */
+    private function injectRepository(Class_ $class, string $repositoryClass, string $propertyName): void
+    {
+        if ($this->shouldUseAutowireMethod($class)) {
+            $this->addAutowireDependency($class, $repositoryClass, $propertyName);
+
+            return;
+        }
+
+        $this->classDependencyManipulator->addConstructorDependency(
+            $class,
+            new PropertyMetadata($propertyName, new ObjectType($repositoryClass))
+        );
+    }
+
+    /**
+     * A class without its own constructor that inherits one cannot gain a promoted property without
+     * declaring a full constructor override that forwards every parent argument. Mautic injects into
+     * such classes with an autowire method instead.
+     */
+    private function shouldUseAutowireMethod(Class_ $class): bool
+    {
+        // Its own constructor can take one more promoted parameter safely.
+        if ($class->getMethod('__construct') instanceof ClassMethod) {
+            return false;
+        }
+
+        if (!$class->extends instanceof Name) {
+            return false;
+        }
+
+        $parentClass = $this->getName($class->extends);
+        if ('' === (string) $parentClass) {
+            return false;
+        }
+
+        // Only an inherited constructor would have to be overridden.
+        return $this->astResolver->resolveClassMethod($parentClass, '__construct') instanceof ClassMethod;
+    }
+
+    /**
+     * Injects through "autowire<ShortClassName>()", reusing that method when the class already has one.
+     */
+    private function addAutowireDependency(Class_ $class, string $repositoryClass, string $propertyName): void
+    {
+        // Already injected by an earlier call for the same repository.
+        if ($class->getProperty($propertyName) instanceof Property) {
+            return;
+        }
+
+        $param      = new Param(
+            new Variable($propertyName),
+            null,
+            new FullyQualified($repositoryClass)
+        );
+        $assignment = new Expression(
+            new Assign(new PropertyFetch(new Variable('this'), $propertyName), new Variable($propertyName))
+        );
+
+        $autowireClassMethod = $this->resolveAutowireClassMethod($class);
+
+        if ($autowireClassMethod instanceof ClassMethod) {
+            $autowireClassMethod->params[] = $param;
+            $autowireClassMethod->stmts[]  = $assignment;
+        } else {
+            $autowireClassMethod = $this->createAutowireClassMethod($class, $param, $assignment);
+            array_unshift($class->stmts, $autowireClassMethod);
+        }
+
+        array_unshift($class->stmts, $this->createProperty($repositoryClass, $propertyName));
+    }
+
+    private function resolveAutowireClassMethod(Class_ $class): ?ClassMethod
+    {
+        $autowireMethodName = $this->resolveAutowireMethodName($class);
+
+        foreach ($class->getMethods() as $classMethod) {
+            if ($this->isName($classMethod->name, $autowireMethodName)) {
+                return $classMethod;
+            }
+        }
+
+        return null;
+    }
+
+    private function createAutowireClassMethod(Class_ $class, Param $param, Expression $assignment): ClassMethod
+    {
+        $classMethod             = new ClassMethod($this->resolveAutowireMethodName($class));
+        $classMethod->flags      = Modifiers::PUBLIC;
+        $classMethod->params     = [$param];
+        $classMethod->returnType = new Identifier('void');
+        $classMethod->stmts      = [$assignment];
+
+        // Symfony calls every #[Required] method on service instantiation.
+        $classMethod->attrGroups = [
+            new AttributeGroup([new Attribute(new FullyQualified('Symfony\Contracts\Service\Attribute\Required'))]),
+        ];
+
+        return $classMethod;
+    }
+
+    private function createProperty(string $repositoryClass, string $propertyName): Property
+    {
+        $property       = new Property(Modifiers::PRIVATE, [new PropertyItem($propertyName)]);
+        $property->type = new FullyQualified($repositoryClass);
+
+        return $property;
+    }
+
+    /**
+     * The name is fixed by AutowireMethodNameMustMatchClassRule: "autowire" + the short class name.
+     */
+    private function resolveAutowireMethodName(Class_ $class): string
+    {
+        return 'autowire'.$class->name?->toString();
+    }
+
+    /**
+     * Mautic\FormBundle\Entity\FormRepository -> formRepository.
+     */
+    private function resolvePropertyName(string $repositoryClass): string
+    {
+        $shortName = (string) strrchr('\\'.$repositoryClass, '\\');
+
+        return lcfirst(ltrim($shortName, '\\'));
+    }
+
+    /**
+     * Swaps the matched call for its replacement, in place, wherever it sits in the class.
+     */
+    private function replaceNode(Class_ $class, MethodCall $oldNode, Node $newNode): void
+    {
+        $this->traverseNodesWithCallable($class, static function (Node $node) use ($oldNode, $newNode): ?Node {
+            return $node === $oldNode ? $newNode : null;
+        });
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/service_injects_model_repository.php.inc
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/service_injects_model_repository.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Fixture;
+
+use Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeModel;
+
+final class ServiceInjectsModelRepository
+{
+    public function __construct(private readonly SomeModel $someModel)
+    {
+    }
+
+    public function findThing(int $id): ?object
+    {
+        return $this->someModel->getRepository()->findThing($id);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Fixture;
+
+use Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeModel;
+
+final class ServiceInjectsModelRepository
+{
+    public function __construct(private readonly SomeModel $someModel, private readonly \Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeRepository $someRepository)
+    {
+    }
+
+    public function findThing(int $id): ?object
+    {
+        return $this->someRepository->findThing($id);
+    }
+}
+
+?>

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_model_uses_own_repository.php.inc
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_model_uses_own_repository.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Fixture;
+
+use Mautic\CoreBundle\Model\AbstractCommonModel;
+use Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeRepository;
+
+class SkipModelUsesOwnRepository extends AbstractCommonModel
+{
+    public function __construct(private readonly SomeRepository $someRepository)
+    {
+    }
+
+    public function getRepository(): SomeRepository
+    {
+        return $this->someRepository;
+    }
+
+    public function findThing(int $id): ?object
+    {
+        return $this->getRepository()->findThing($id);
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_non_model_get_repository.php.inc
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_non_model_get_repository.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Fixture;
+
+use Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeRepository;
+
+final class SkipNonModelGetRepository
+{
+    public function getRepository(): SomeRepository
+    {
+        return new SomeRepository();
+    }
+
+    public function findThing(int $id): ?object
+    {
+        return $this->getRepository()->findThing($id);
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_test_case.php.inc
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Fixture/skip_test_case.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source\SomeModel;
+
+final class SkipTestCase extends TestCase
+{
+    public function testThing(): void
+    {
+        $someModel = $this->createMock(SomeModel::class);
+
+        $someModel->getRepository()->findThing(1);
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/ModelGetRepositoryToRepositoryServiceRectorTest.php
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/ModelGetRepositoryToRepositoryServiceRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ModelGetRepositoryToRepositoryServiceRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/AbstractParentWithModel.php
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/AbstractParentWithModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source;
+
+abstract class AbstractParentWithModel
+{
+    public function __construct(
+        protected SomeModel $someModel,
+    ) {
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/SomeModel.php
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/SomeModel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source;
+
+use Mautic\CoreBundle\Model\AbstractCommonModel;
+
+/**
+ * @extends AbstractCommonModel<object>
+ */
+class SomeModel extends AbstractCommonModel
+{
+    public function __construct(
+        private readonly SomeRepository $someRepository,
+    ) {
+    }
+
+    public function getRepository(): SomeRepository
+    {
+        return $this->someRepository;
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/SomeRepository.php
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/Source/SomeRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ModelGetRepositoryToRepositoryServiceRector\Source;
+
+use Mautic\CoreBundle\Entity\CommonRepository;
+
+/**
+ * @extends CommonRepository<object>
+ */
+final class SomeRepository extends CommonRepository
+{
+    public function findThing(int $id): ?object
+    {
+        return $this->find($id);
+    }
+}

--- a/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/config/configured_rule.php
+++ b/utils/rector/tests/ModelGetRepositoryToRepositoryServiceRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\ModelGetRepositoryToRepositoryServiceRector;
+
+return RectorConfig::configure()
+    ->withRules([ModelGetRepositoryToRepositoryServiceRector::class]);


### PR DESCRIPTION
Adds a Rector rule `ModelGetRepositoryToRepositoryServiceRector` that replaces the argument-less `$model->getRepository()` service-locator hop with the concrete repository service.

Going through a model just to reach its repository hides the repository dependency and couples the caller to the whole model. The rule injects the repository instead and drops the model hop.

This PR only adds the rule + tests, and runs on `Controller` and `Command` classes :+1: 

<br>

### What the rule changes

An external `$someModel->getRepository()` call gets the repository injected into the constructor:

```diff
 final class ServiceInjectsModelRepository
 {
-    public function __construct(private readonly SomeModel $someModel)
+    public function __construct(private readonly SomeModel $someModel, private readonly SomeRepository $someRepository)
     {
     }

     public function findThing(int $id): ?object
     {
-        return $this->someModel->getRepository()->findThing($id);
+        return $this->someRepository->findThing($id);
     }
 }
```

If the class has no constructor of its own but inherits one, the dependency is added through a `#[Required]` autowire method instead, so no constructor override forwarding every parent argument is needed.
