### PR TITLE
Preserve Twig Markup return type in OverrideIncludeExtension

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/OverrideIncludeExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/OverrideIncludeExtensionTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Markup;
 
 final class OverrideIncludeExtensionTest extends TestCase
 {
@@ -31,6 +32,7 @@ final class OverrideIncludeExtensionTest extends TestCase
         // Twig 3.28 returns the rendered output as a Twig\Markup instance instead of a string.
         $result = $this->extension->includeWithEvent($this->environment, [], 'included.html.twig');
 
+        $this->assertInstanceOf(Markup::class, $result);
         $this->assertSame('included content', (string) $result);
     }
 
@@ -38,6 +40,7 @@ final class OverrideIncludeExtensionTest extends TestCase
     {
         $result = $this->extension->includeWithEvent($this->environment, [], ['first.html.twig', 'included.html.twig']);
 
+        $this->assertInstanceOf(Markup::class, $result);
         $this->assertSame('first content', (string) $result);
     }
 }

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
+use Twig\Markup;
 use Twig\TwigFunction;
 
 final class OverrideIncludeExtension extends AbstractExtension
@@ -40,7 +41,7 @@ final class OverrideIncludeExtension extends AbstractExtension
      * @param string|string[] $template
      * @param mixed[]         $variables
      */
-    public function includeWithEvent(Environment $env, array $context, $template, array $variables = [], bool $withContext = true, bool $ignoreMissing = false, bool $sandboxed = false): string
+    public function includeWithEvent(Environment $env, array $context, $template, array $variables = [], bool $withContext = true, bool $ignoreMissing = false, bool $sandboxed = false): string|Markup
     {
         if ($withContext) {
             $variables = array_merge($context, $variables);
@@ -54,18 +55,18 @@ final class OverrideIncludeExtension extends AbstractExtension
                 $templates[] = $event->getTemplate();
             }
 
-            // Use Twig's original include for array handling. Twig >= 3.28 returns
-            // Twig\Markup here; cast to keep the string return type. Escaping is
-            // unaffected as the function is registered with 'is_safe' => ['html'].
-            return (string) CoreExtension::include($env, $context, $templates, $event->getVars(), $withContext, $ignoreMissing, $sandboxed);
+            // Use Twig's original include for array handling. Return Twig's value as-is:
+            // a string on Twig < 3.28, a Twig\Markup on >= 3.28. Escaping is unaffected
+            // as the function is registered with 'is_safe' => ['html'].
+            return CoreExtension::include($env, $context, $templates, $event->getVars(), $withContext, $ignoreMissing, $sandboxed);
         }
 
         // Handle single template
         $event = $this->dispatchCustomTemplateEvent((string) $template, $variables);
 
-        // Use Twig's original include functionality. Twig >= 3.28 returns Twig\Markup;
-        // cast to keep the string return type (escaping handled via 'is_safe' above).
-        return (string) CoreExtension::include($env, $context, $event->getTemplate(), $event->getVars(), $withContext, $ignoreMissing, $sandboxed);
+        // Use Twig's original include functionality. Return Twig's value as-is: a string
+        // on Twig < 3.28, a Twig\Markup on >= 3.28 (escaping handled via 'is_safe' above).
+        return CoreExtension::include($env, $context, $event->getTemplate(), $event->getVars(), $withContext, $ignoreMissing, $sandboxed);
     }
 
     public function getName(): string


### PR DESCRIPTION
## Context

Twig ≥ 3.28 changed `CoreExtension::include()` to return `string|Twig\Markup`
instead of `string`. `OverrideIncludeExtension::includeWithEvent()` overrides
Twig's `include()` and returned that value directly while declaring a `string`
return type — so on Twig ≥ 3.28 it throws a `TypeError` and takes the whole
site down.

That `TypeError` was already fixed on `7.x` by #16487 (issue #16468, merged
2026-07-09), which casts the result to `(string)`. The fix is not in any
release yet: the latest stable (7.1.3, released 2026-07-07) is still affected.
This PR builds on #16487 with a small but more correct approach.

## What this changes

Instead of casting Twig's return value to `(string)`, widen the declared return
type to `string|Markup` and return the value as-is.

- Return type `string` → `string|Markup`
- Remove the `(string)` cast on both the single-template and array-of-templates paths
- Add `use Twig\Markup;`
- Extend the unit tests to assert a `Twig\Markup` instance is returned

## Why preserve the Markup instead of casting

For direct output (`{{ include(...) }}`) both approaches render identically,
since the function is registered with `is_safe => ['html']`.

They differ when the result is stored and re-emitted:

    {% set html = include('...') %}
    {{ html }}

Twig's autoescaper emits a `Twig\Markup` instance verbatim (already safe) but
escapes a plain `string`, so casting to `(string)` causes the included HTML to
be double-escaped in that pattern. Returning the `Markup` as Twig 3.28 produces
it keeps this correct and makes the declared return type match reality.

If maintainers prefer to keep the simpler `(string)` cast from #16487, feel free
to close — the `TypeError` itself is already resolved there.

## Type of change

- [x] Bug fix / correctness improvement (no change for direct output)